### PR TITLE
Validate first cargo-cultist prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 `cargo-cultist` is an experiment in repository-aware analysis for Rust codebases.
 
+> Status: very early prototype. The current analyzer is deterministic, local, and read-only.
+
 Traditional linters are strongest when a rule is already known. `cargo-cultist` starts one step earlier: it gathers facts about what a repository actually does, identifies deviations or unexplained patterns, and raises questions without pretending every observation is an error.
 
 The long-term model is deliberately split into three layers:

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,10 +39,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         return Err("expected at most one path argument; try `cargo cultist --help`".into());
     }
 
-    let root = args
-        .pop()
-        .map(PathBuf::from)
-        .unwrap_or(env::current_dir()?);
+    let root = args.pop().map(PathBuf::from).unwrap_or(env::current_dir()?);
     let root = root.canonicalize()?;
 
     println!("cargo-cultist {VERSION}");

--- a/src/test_modules.rs
+++ b/src/test_modules.rs
@@ -122,7 +122,10 @@ pub fn print_test_module_report(root: &Path, report: &TestModuleReport) {
 fn print_local_mixes(root: &Path, report: &TestModuleReport) {
     let mut by_file = BTreeMap::<&PathBuf, Vec<&TestModuleOccurrence>>::new();
     for occurrence in &report.occurrences {
-        by_file.entry(&occurrence.path).or_default().push(occurrence);
+        by_file
+            .entry(&occurrence.path)
+            .or_default()
+            .push(occurrence);
     }
 
     let mixed_files: Vec<_> = by_file
@@ -154,11 +157,7 @@ fn print_local_mixes(root: &Path, report: &TestModuleReport) {
     println!("  Is the local mix deliberate, or would one name make the file easier to read?");
 }
 
-fn print_one_off_names(
-    root: &Path,
-    report: &TestModuleReport,
-    counts: &[(&str, usize)],
-) {
+fn print_one_off_names(root: &Path, report: &TestModuleReport, counts: &[(&str, usize)]) {
     let one_off_names: Vec<_> = counts
         .iter()
         .filter(|(_, count)| *count == 1)
@@ -172,7 +171,10 @@ fn print_one_off_names(
     println!("\nONE-OFF NAMES");
     for occurrence in &report.occurrences {
         if one_off_names.contains(&occurrence.name.as_str()) {
-            let path = occurrence.path.strip_prefix(root).unwrap_or(&occurrence.path);
+            let path = occurrence
+                .path
+                .strip_prefix(root)
+                .unwrap_or(&occurrence.path);
             println!(
                 "  {}:{}  mod {}",
                 path.display(),
@@ -183,7 +185,9 @@ fn print_one_off_names(
     }
 
     println!("\nQUESTION");
-    println!("  Are these one-off names intentionally scoped, or accidental deviations from local precedent?");
+    println!(
+        "  Are these one-off names intentionally scoped, or accidental deviations from local precedent?"
+    );
 }
 
 fn print_parse_failures(root: &Path, report: &TestModuleReport) {


### PR DESCRIPTION
Validates the initial deterministic repository analyzer with CI and folds in the formatter output it caught. Also documents that the current prototype is deterministic, local, and read-only.

Validation:
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`