### PR TITLE
Add diff-aware precedent analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Install stable Rust
         run: |
           rustup toolchain install stable --profile minimal --component rustfmt,clippy
@@ -22,3 +24,15 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
       - name: Test
         run: cargo test
+      - name: Dogfood repository scan
+        run: cargo run -- .
+      - name: Dogfood pull request diff
+        if: github.event_name == 'pull_request'
+        env:
+          CULTIST_BASE: ${{ github.event.pull_request.base.sha }}
+        run: cargo run -- diff --base "$CULTIST_BASE" .
+      - name: Dogfood push diff
+        if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
+        env:
+          CULTIST_BASE: ${{ github.event.before }}
+        run: cargo run -- diff --base "$CULTIST_BASE" .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,16 @@ jobs:
         env:
           CULTIST_BASE: ${{ github.event.pull_request.base.sha }}
         run: cargo run -- diff --base "$CULTIST_BASE" .
+      - name: Dogfood Cloud Hypervisor PR 8734
+        if: github.event_name == 'pull_request'
+        env:
+          CH_BASE: 1b004a7459ac752e1d7ad5a48237a1cb8608003b
+          CH_HEAD: 439ff52249e819f41570a5f3f3bf535d4bfb3e6e
+        run: |
+          git clone --filter=blob:none --no-checkout https://github.com/cloud-hypervisor/cloud-hypervisor.git /tmp/cloud-hypervisor
+          git -C /tmp/cloud-hypervisor fetch origin "$CH_BASE" "$CH_HEAD"
+          git -C /tmp/cloud-hypervisor checkout "$CH_HEAD"
+          cargo run -- diff --base "$CH_BASE" /tmp/cloud-hypervisor
       - name: Dogfood push diff
         if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,16 +31,6 @@ jobs:
         env:
           CULTIST_BASE: ${{ github.event.pull_request.base.sha }}
         run: cargo run -- diff --base "$CULTIST_BASE" .
-      - name: Dogfood Cloud Hypervisor PR 8734
-        if: github.event_name == 'pull_request'
-        env:
-          CH_BASE: 1b004a7459ac752e1d7ad5a48237a1cb8608003b
-          CH_HEAD: 439ff52249e819f41570a5f3f3bf535d4bfb3e6e
-        run: |
-          git clone --filter=blob:none --no-checkout https://github.com/cloud-hypervisor/cloud-hypervisor.git /tmp/cloud-hypervisor
-          git -C /tmp/cloud-hypervisor fetch origin "$CH_BASE" "$CH_HEAD"
-          git -C /tmp/cloud-hypervisor checkout "$CH_HEAD"
-          cargo run -- diff --base "$CH_BASE" /tmp/cloud-hypervisor
       - name: Dogfood push diff
         if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
         env:

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ The long-term model is deliberately split into three layers:
 - **Observations** — repository-specific patterns and deviations derived from those facts.
 - **Explanations** — optional interpretation of why those patterns may exist. This layer may eventually use an LLM, but the tool should not require one to discover that something is interesting.
 
-## First prototype
+## Current checks
 
-The first check looks at `#[cfg(test)]` modules and reports the names a repository actually uses. It also calls out one-off names and files that mix multiple test-module names.
+### Repository test-module conventions
 
-Example:
+The default command looks at `#[cfg(test)]` modules and reports the names a repository actually uses. It also calls out one-off names and files that mix multiple test-module names.
 
 ```text
 $ cargo cultist
@@ -38,6 +38,40 @@ QUESTION
   Are these one-off names intentionally scoped, or accidental deviations from local precedent?
 ```
 
+### Diff-aware precedent
+
+`cargo cultist diff` looks only at test-module declarations added or renamed by the current change and compares them with both repository-wide and same-file precedent.
+
+By default it compares staged and unstaged work against `HEAD`:
+
+```bash
+cargo cultist diff
+```
+
+For a branch or pull request, provide a base revision:
+
+```bash
+cargo cultist diff --base origin/main
+```
+
+A finding can look like:
+
+```text
+FINDING 1: test-module precedent
+  pci/src/vfio.rs:2675 adds `mod mmio_region_range_tests` behind a test cfg.
+
+FACTS
+  `mmio_region_range_tests` appears 1 time(s) across 53 test-gated modules.
+  Repository counts: `unit_tests`=31, `tests`=21, `mmio_region_range_tests`=1.
+  The same file also uses: `tests`.
+
+OBSERVATION
+  The new name differs from this file's existing precedent and is unique in the repository.
+
+QUESTION
+  Is the distinct module name intentional, or should it follow nearby precedent?
+```
+
 That distinction is the point: the primitive is a **finding**, not a lint error.
 
 ## Usage
@@ -46,6 +80,7 @@ From this repository while developing:
 
 ```bash
 cargo run -- /path/to/a/rust/repository
+cargo run -- diff --base origin/main /path/to/a/rust/repository
 ```
 
 After installing locally:
@@ -54,17 +89,25 @@ After installing locally:
 cargo install --path .
 cd /path/to/a/rust/repository
 cargo cultist
+cargo cultist diff
 ```
 
 You can also invoke the binary directly:
 
 ```bash
 cargo-cultist /path/to/a/rust/repository
+cargo-cultist diff --base origin/main /path/to/a/rust/repository
 ```
+
+## Dogfooding
+
+CI runs formatting, Clippy, and tests, then runs `cargo-cultist` against its own repository. Pull-request and push CI also run the diff analyzer against the relevant base commit.
+
+The tool is expected to be able to inspect its own changes without special treatment.
 
 ## Near-term ideas
 
-- Compare a diff against nearby repository precedent.
+- Extend diff analysis beyond test-module names.
 - Flag test-only global state and show nearby alternatives.
 - Find duplicated local mechanisms when a common helper already exists.
 - Connect unusual constants or workarounds to Git history.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ By default it compares staged and unstaged work against `HEAD`:
 cargo cultist diff
 ```
 
-For a branch or pull request, provide a base revision:
+For a branch or pull request, provide a base revision. `cargo-cultist` finds the merge base between that revision and `HEAD`, then compares the current working tree from that point so the result follows branch/PR semantics and still includes local staged or unstaged work:
 
 ```bash
 cargo cultist diff --base origin/main

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -62,7 +62,10 @@ pub fn print_diff_report(
         Some(base) => println!("  comparing against: {base}"),
         None => println!("  comparing working tree against: HEAD"),
     }
-    println!("  Rust files with added lines: {}", changed.rust_file_count());
+    println!(
+        "  Rust files with added lines: {}",
+        changed.rust_file_count()
+    );
 
     if changed_modules.is_empty() {
         println!("\nOBSERVATION");
@@ -138,7 +141,9 @@ pub fn print_diff_report(
         }
 
         println!("\nQUESTION");
-        println!("  Is the distinct module name intentional, or should it follow nearby precedent?");
+        println!(
+            "  Is the distinct module name intentional, or should it follow nearby precedent?"
+        );
     }
 
     if finding_count == 0 {

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,328 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::test_modules::{TestModuleOccurrence, TestModuleReport};
+
+#[derive(Debug, Default, Eq, PartialEq)]
+struct ChangedLines {
+    by_path: BTreeMap<PathBuf, BTreeSet<usize>>,
+}
+
+impl ChangedLines {
+    fn insert(&mut self, path: &Path, line: usize) {
+        self.by_path
+            .entry(path.to_path_buf())
+            .or_default()
+            .insert(line);
+    }
+
+    fn contains(&self, path: &Path, line: usize) -> bool {
+        self.by_path
+            .get(path)
+            .is_some_and(|lines| lines.contains(&line))
+    }
+
+    fn rust_file_count(&self) -> usize {
+        self.by_path
+            .keys()
+            .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("rs"))
+            .count()
+    }
+}
+
+pub fn git_repo_root(path: &Path) -> Result<PathBuf, Box<dyn Error>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("{path:?} is not inside a Git repository: {stderr}").into());
+    }
+
+    let stdout = String::from_utf8(output.stdout)?;
+    Ok(PathBuf::from(stdout.trim()).canonicalize()?)
+}
+
+pub fn print_diff_report(
+    root: &Path,
+    base: Option<&str>,
+    report: &TestModuleReport,
+) -> Result<(), Box<dyn Error>> {
+    let patch = git_diff(root, base)?;
+    let changed = parse_changed_lines(&patch);
+    let changed_modules = changed_test_modules(root, report, &changed);
+
+    println!("DIFF PRECEDENT");
+    match base {
+        Some(base) => println!("  comparing against: {base}"),
+        None => println!("  comparing working tree against: HEAD"),
+    }
+    println!("  Rust files with added lines: {}", changed.rust_file_count());
+
+    if changed_modules.is_empty() {
+        println!("\nOBSERVATION");
+        println!("  No added or renamed test-gated module declarations were found.");
+        return Ok(());
+    }
+
+    println!("\nCHANGED TEST MODULES");
+    for occurrence in &changed_modules {
+        let path = relative_path(root, &occurrence.path);
+        println!(
+            "  {}:{}  mod {}",
+            path.display(),
+            occurrence.line,
+            occurrence.name
+        );
+    }
+
+    let counts = module_name_counts(report);
+    let mut finding_count = 0;
+
+    for occurrence in changed_modules {
+        let local_names = same_file_names(report, occurrence);
+        let different_local_names: Vec<_> = local_names
+            .iter()
+            .filter(|name| name.as_str() != occurrence.name)
+            .collect();
+        let repository_count = counts.get(&occurrence.name).copied().unwrap_or_default();
+        let one_off = repository_count == 1 && report.occurrences.len() > 1;
+
+        if different_local_names.is_empty() && !one_off {
+            continue;
+        }
+
+        finding_count += 1;
+        let path = relative_path(root, &occurrence.path);
+        println!("\nFINDING {finding_count}: test-module precedent");
+        println!(
+            "  {}:{} adds `mod {}` behind a test cfg.",
+            path.display(),
+            occurrence.line,
+            occurrence.name
+        );
+        println!("\nFACTS");
+        println!(
+            "  `{}` appears {} time(s) across {} test-gated modules.",
+            occurrence.name,
+            repository_count,
+            report.occurrences.len()
+        );
+        print_top_counts(&counts);
+
+        if !different_local_names.is_empty() {
+            println!(
+                "  The same file also uses: {}.",
+                different_local_names
+                    .iter()
+                    .map(|name| format!("`{name}`"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+
+        println!("\nOBSERVATION");
+        if !different_local_names.is_empty() && one_off {
+            println!(
+                "  The new name differs from this file's existing precedent and is unique in the repository."
+            );
+        } else if !different_local_names.is_empty() {
+            println!("  The new name differs from this file's existing test-module precedent.");
+        } else {
+            println!("  The new name is unique among the repository's test-gated modules.");
+        }
+
+        println!("\nQUESTION");
+        println!("  Is the distinct module name intentional, or should it follow nearby precedent?");
+    }
+
+    if finding_count == 0 {
+        println!("\nOBSERVATION");
+        println!("  The changed test-module names match existing repository precedent.");
+    }
+
+    Ok(())
+}
+
+fn git_diff(root: &Path, base: Option<&str>) -> Result<String, Box<dyn Error>> {
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(root)
+        .args([
+            "-c",
+            "core.quotepath=false",
+            "diff",
+            "--unified=0",
+            "--no-ext-diff",
+            "--no-color",
+            "--no-prefix",
+        ])
+        .arg(base.unwrap_or("HEAD"))
+        .arg("--");
+
+    let output = command.output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git diff failed: {stderr}").into());
+    }
+
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+fn parse_changed_lines(patch: &str) -> ChangedLines {
+    let mut changed = ChangedLines::default();
+    let mut current_path: Option<PathBuf> = None;
+    let mut current_new_line: Option<usize> = None;
+
+    for line in patch.lines() {
+        if let Some(path) = line.strip_prefix("+++ ") {
+            current_path = (path != "/dev/null").then(|| PathBuf::from(path));
+            current_new_line = None;
+            continue;
+        }
+
+        if line.starts_with("@@") {
+            current_new_line = hunk_new_start(line);
+            continue;
+        }
+
+        let Some(new_line) = current_new_line else {
+            continue;
+        };
+
+        if line.starts_with('+') && !line.starts_with("+++") {
+            if let Some(path) = &current_path {
+                changed.insert(path, new_line);
+            }
+            current_new_line = Some(new_line + 1);
+        } else if line.starts_with('-') && !line.starts_with("---") {
+            // Deleted lines do not advance the line number in the new file.
+        } else if !line.starts_with('\\') {
+            current_new_line = Some(new_line + 1);
+        }
+    }
+
+    changed
+}
+
+fn hunk_new_start(header: &str) -> Option<usize> {
+    let range = header
+        .split_whitespace()
+        .find(|part| part.starts_with('+'))?
+        .trim_start_matches('+');
+    let start = range.split_once(',').map_or(range, |(start, _)| start);
+    start.parse().ok()
+}
+
+fn changed_test_modules<'a>(
+    root: &Path,
+    report: &'a TestModuleReport,
+    changed: &ChangedLines,
+) -> Vec<&'a TestModuleOccurrence> {
+    report
+        .occurrences
+        .iter()
+        .filter(|occurrence| {
+            occurrence
+                .path
+                .strip_prefix(root)
+                .is_ok_and(|path| changed.contains(path, occurrence.line))
+        })
+        .collect()
+}
+
+fn module_name_counts(report: &TestModuleReport) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for occurrence in &report.occurrences {
+        *counts.entry(occurrence.name.clone()).or_default() += 1;
+    }
+    counts
+}
+
+fn same_file_names(report: &TestModuleReport, target: &TestModuleOccurrence) -> BTreeSet<String> {
+    report
+        .occurrences
+        .iter()
+        .filter(|occurrence| {
+            occurrence.path == target.path
+                && (occurrence.line != target.line || occurrence.name != target.name)
+        })
+        .map(|occurrence| occurrence.name.clone())
+        .collect()
+}
+
+fn print_top_counts(counts: &BTreeMap<String, usize>) {
+    let mut counts: Vec<_> = counts.iter().collect();
+    counts.sort_by(|(name_a, count_a), (name_b, count_b)| {
+        count_b.cmp(count_a).then(name_a.cmp(name_b))
+    });
+
+    let summary = counts
+        .into_iter()
+        .take(5)
+        .map(|(name, count)| format!("`{name}`={count}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!("  Repository counts: {summary}.");
+}
+
+fn relative_path<'a>(root: &'a Path, path: &'a Path) -> &'a Path {
+    path.strip_prefix(root).unwrap_or(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_added_lines_from_zero_context_diff() {
+        let patch = r#"diff --git src/a.rs src/a.rs
+--- src/a.rs
++++ src/a.rs
+@@ -10,0 +11,2 @@
++#[cfg(test)]
++mod special_tests {}
+@@ -30 +32 @@
+-old
++new
+"#;
+
+        let changed = parse_changed_lines(patch);
+        assert!(changed.contains(Path::new("src/a.rs"), 11));
+        assert!(changed.contains(Path::new("src/a.rs"), 12));
+        assert!(changed.contains(Path::new("src/a.rs"), 32));
+        assert!(!changed.contains(Path::new("src/a.rs"), 31));
+    }
+
+    #[test]
+    fn selects_test_modules_whose_declaration_line_was_added() {
+        let root = Path::new("/repo");
+        let report = TestModuleReport {
+            occurrences: vec![
+                TestModuleOccurrence {
+                    name: "tests".to_string(),
+                    path: root.join("src/lib.rs"),
+                    line: 20,
+                },
+                TestModuleOccurrence {
+                    name: "special_tests".to_string(),
+                    path: root.join("src/lib.rs"),
+                    line: 40,
+                },
+            ],
+            parse_failures: Vec::new(),
+        };
+        let mut changed = ChangedLines::default();
+        changed.insert(Path::new("src/lib.rs"), 40);
+
+        let selected = changed_test_modules(root, &report, &changed);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].name, "special_tests");
+    }
+}

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -59,7 +59,7 @@ pub fn print_diff_report(
 
     println!("DIFF PRECEDENT");
     match base {
-        Some(base) => println!("  comparing against: {base}"),
+        Some(base) => println!("  comparing changes from merge base with: {base}"),
         None => println!("  comparing working tree against: HEAD"),
     }
     println!(
@@ -155,8 +155,12 @@ pub fn print_diff_report(
 }
 
 fn git_diff(root: &Path, base: Option<&str>) -> Result<String, Box<dyn Error>> {
-    let mut command = Command::new("git");
-    command
+    let anchor = match base {
+        Some(base) => merge_base(root, base)?,
+        None => "HEAD".to_string(),
+    };
+
+    let output = Command::new("git")
         .arg("-C")
         .arg(root)
         .args([
@@ -168,16 +172,31 @@ fn git_diff(root: &Path, base: Option<&str>) -> Result<String, Box<dyn Error>> {
             "--no-color",
             "--no-prefix",
         ])
-        .arg(base.unwrap_or("HEAD"))
-        .arg("--");
+        .arg(anchor)
+        .arg("--")
+        .output()?;
 
-    let output = command.output()?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("git diff failed: {stderr}").into());
     }
 
     Ok(String::from_utf8(output.stdout)?)
+}
+
+fn merge_base(root: &Path, base: &str) -> Result<String, Box<dyn Error>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["merge-base", base, "HEAD"])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("could not find merge base for `{base}` and HEAD: {stderr}").into());
+    }
+
+    Ok(String::from_utf8(output.stdout)?.trim().to_string())
 }
 
 fn parse_changed_lines(patch: &str) -> ChangedLines {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod diff;
 mod test_modules;
 
 use std::env;
@@ -5,6 +6,7 @@ use std::error::Error;
 use std::path::PathBuf;
 use std::process;
 
+use diff::{git_repo_root, print_diff_report};
 use test_modules::{analyze_test_modules, print_test_module_report};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -23,6 +25,11 @@ fn run() -> Result<(), Box<dyn Error>> {
     // Accept direct invocation (`cargo-cultist`) too.
     if args.first().is_some_and(|arg| arg == "cultist") {
         args.remove(0);
+    }
+
+    if args.first().is_some_and(|arg| arg == "diff") {
+        args.remove(0);
+        return run_diff(args);
     }
 
     if args.iter().any(|arg| arg == "-h" || arg == "--help") {
@@ -51,12 +58,101 @@ fn run() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+fn run_diff(args: Vec<String>) -> Result<(), Box<dyn Error>> {
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_diff_help();
+        return Ok(());
+    }
+
+    let (base, path) = parse_diff_args(args)?;
+    let requested_root = path.unwrap_or(env::current_dir()?);
+    let requested_root = requested_root.canonicalize()?;
+    let root = git_repo_root(&requested_root)?;
+
+    println!("cargo-cultist {VERSION}");
+    println!("repository: {}\n", root.display());
+
+    let report = analyze_test_modules(&root)?;
+    print_diff_report(&root, base.as_deref(), &report)?;
+
+    Ok(())
+}
+
+fn parse_diff_args(args: Vec<String>) -> Result<(Option<String>, Option<PathBuf>), Box<dyn Error>> {
+    let mut base = None;
+    let mut path = None;
+    let mut args = args.into_iter();
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--base" => {
+                if base.is_some() {
+                    return Err("`--base` may only be specified once".into());
+                }
+                base = Some(
+                    args.next()
+                        .ok_or("`--base` requires a Git revision")?,
+                );
+            }
+            _ if arg.starts_with('-') => {
+                return Err(format!("unknown diff option `{arg}`; try `cargo cultist diff --help`").into());
+            }
+            _ => {
+                if path.is_some() {
+                    return Err(
+                        "expected at most one path argument; try `cargo cultist diff --help`"
+                            .into(),
+                    );
+                }
+                path = Some(PathBuf::from(arg));
+            }
+        }
+    }
+
+    Ok((base, path))
+}
+
 fn print_help() {
     println!(
         "cargo-cultist {VERSION}\n\
 Repository-aware analysis for Rust codebases.\n\n\
-USAGE:\n    cargo cultist [PATH]\n    cargo-cultist [PATH]\n\n\
-The first prototype inspects test-gated module names and reports\n\
-what the repository actually does, without inventing a universal rule."
+USAGE:\n    cargo cultist [PATH]\n    cargo cultist diff [--base REV] [PATH]\n    cargo-cultist [PATH]\n    cargo-cultist diff [--base REV] [PATH]\n\n\
+COMMANDS:\n    diff    Inspect changed Rust code against repository precedent.\n\n\
+Without a command, cargo-cultist inspects repository-wide test-module naming\n\
+conventions without inventing a universal rule."
     );
+}
+
+fn print_diff_help() {
+    println!(
+        "cargo-cultist diff\n\n\
+USAGE:\n    cargo cultist diff [--base REV] [PATH]\n\n\
+By default, compares the working tree (including staged changes) against HEAD.\n\
+With --base REV, compares the current working tree against that Git revision.\n\n\
+The first diff-aware check looks for added or renamed #[cfg(test)] modules and\n\
+compares their names with repository-wide and same-file precedent."
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_diff_base_and_path() {
+        let (base, path) = parse_diff_args(vec![
+            "--base".to_string(),
+            "origin/main".to_string(),
+            ".".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(base.as_deref(), Some("origin/main"));
+        assert_eq!(path, Some(PathBuf::from(".")));
+    }
+
+    #[test]
+    fn rejects_multiple_diff_paths() {
+        assert!(parse_diff_args(vec!["a".to_string(), "b".to_string()]).is_err());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,13 +89,13 @@ fn parse_diff_args(args: Vec<String>) -> Result<(Option<String>, Option<PathBuf>
                 if base.is_some() {
                     return Err("`--base` may only be specified once".into());
                 }
-                base = Some(
-                    args.next()
-                        .ok_or("`--base` requires a Git revision")?,
-                );
+                base = Some(args.next().ok_or("`--base` requires a Git revision")?);
             }
             _ if arg.starts_with('-') => {
-                return Err(format!("unknown diff option `{arg}`; try `cargo cultist diff --help`").into());
+                return Err(format!(
+                    "unknown diff option `{arg}`; try `cargo cultist diff --help`"
+                )
+                .into());
             }
             _ => {
                 if path.is_some() {


### PR DESCRIPTION
Adds `cargo cultist diff` for deterministic, change-focused precedent analysis. The first diff-aware check finds test-module declarations added or renamed by the current change and compares them with repository-wide and same-file precedent.

CI now dogfoods both the repository scan and the diff analyzer against cargo-cultist itself.

### Dogfooding

Self-analysis on this PR found the two added `mod tests` declarations and correctly reported that they match cargo-cultist's existing local precedent.

A temporary CI run also analyzed Cloud Hypervisor PR #8734, the case that inspired this feature. It found one changed Rust file, saw the newly added `mod unit_tests`, observed that `unit_tests` is dominant repository-wide (89 of 128 test-gated modules) while the same `vfio.rs` file also uses `tests`, and raised a question instead of declaring either convention wrong.

That external run also caught a bug in the first implementation: `--base` initially compared two snapshots directly, which included unrelated base-branch movement. `--base` now finds the merge base with `HEAD` and diffs the current working tree from there, matching branch/PR semantics while retaining staged and unstaged changes.

The Cloud Hypervisor-specific CI step was removed after the dogfood run; permanent CI only analyzes cargo-cultist itself.

### Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (6 tests)
- `cargo run -- .`
- `cargo run -- diff --base <PR base> .`

All pass in the final cleaned workflow.