### PR TITLE
[superseded by #39] Prototype historical co-change precedent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
         run: cargo run -- .
       - name: Dogfood repository JSON
         run: cargo run --quiet -- --format json . | python -m json.tool >/dev/null
+      - name: Dogfood historical co-change
+        run: cargo run -- cochange src/main.rs
+      - name: Dogfood historical co-change JSON
+        run: cargo run --quiet -- cochange --format json src/main.rs | python -m json.tool >/dev/null
       - name: Dogfood pull request diff
         if: github.event_name == 'pull_request'
         env:

--- a/src/cochange.rs
+++ b/src/cochange.rs
@@ -1,0 +1,370 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::finding::{AnalysisReport, Claim, ClaimKind, Evidence, Finding, Location};
+
+pub const DEFAULT_HISTORY_LIMIT: usize = 100;
+pub const DEFAULT_MAX_FILES_PER_COMMIT: usize = 40;
+const MAX_REPORTED_COMPANIONS: usize = 20;
+const MAX_EXAMPLE_COMMITS: usize = 3;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CochangeCompanion {
+    pub path: String,
+    pub support: usize,
+    pub opportunities: usize,
+    pub exemplars: Vec<String>,
+    pub counterexamples: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CochangeReport {
+    pub target: String,
+    pub considered_commits: usize,
+    pub broad_commits_skipped: usize,
+    pub companions: Vec<CochangeCompanion>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct HistoryCommit {
+    sha: String,
+    paths: BTreeSet<String>,
+}
+
+pub fn analyze_cochange(
+    root: &Path,
+    target: &Path,
+    history_limit: usize,
+    max_files_per_commit: usize,
+) -> Result<CochangeReport, Box<dyn Error>> {
+    let target = normalize_target(root, target)?;
+    let shas = history_shas(root, &target, history_limit)?;
+    let mut commits = Vec::with_capacity(shas.len());
+
+    for sha in shas {
+        commits.push(HistoryCommit {
+            paths: commit_paths(root, &sha)?,
+            sha,
+        });
+    }
+
+    Ok(summarize_history(
+        &target,
+        &commits,
+        max_files_per_commit,
+    ))
+}
+
+pub fn build_cochange_analysis_report(root: &Path, report: &CochangeReport) -> AnalysisReport {
+    let mut analysis =
+        AnalysisReport::new("historical-cochange", root.to_string_lossy().into_owned());
+
+    analysis.claims.push(Claim::new(
+        ClaimKind::Derived,
+        format!(
+            "The history query kept {} focused non-merge commit(s) touching `{}` and skipped {} broad commit(s).",
+            report.considered_commits, report.target, report.broad_commits_skipped
+        ),
+    ));
+    analysis.claims.push(Claim::new(
+        ClaimKind::Unknown,
+        "Historical co-change frequency alone does not establish that two paths must change together.",
+    ));
+
+    for companion in &report.companions {
+        let percent = support_percent(companion.support, companion.opportunities);
+        let mut claim = Claim::new(
+            ClaimKind::Observed,
+            format!(
+                "`{}` changed with `{}` in {} of {} focused commit(s) ({percent:.1}%).",
+                report.target, companion.path, companion.support, companion.opportunities
+            ),
+        )
+        .with_evidence(Evidence::at(
+            format!("Historical companion path: `{}`.", companion.path),
+            Location::new(companion.path.clone(), None),
+        ));
+
+        if !companion.exemplars.is_empty() {
+            claim = claim.with_evidence(Evidence::new(format!(
+                "Exemplar commit(s): {}.",
+                companion.exemplars.join(", ")
+            )));
+        }
+        if !companion.counterexamples.is_empty() {
+            claim = claim.with_evidence(Evidence::new(format!(
+                "Counterexample commit(s): {}.",
+                companion.counterexamples.join(", ")
+            )));
+        }
+
+        analysis.findings.push(
+            Finding::new("historical-cochange-precedent", "Historical co-change precedent")
+                .at(Location::new(report.target.clone(), None))
+                .with_claim(claim)
+                .with_claim(Claim::new(
+                    ClaimKind::Unknown,
+                    "The repository history does not by itself explain whether this companion is required, generated, incidental, or obsolete.",
+                ))
+                .with_question(format!(
+                    "When `{}` changes, is `{}` an expected companion for the same reason as the historical examples?",
+                    report.target, companion.path
+                )),
+        );
+    }
+
+    if report.companions.is_empty() {
+        analysis.claims.push(Claim::new(
+            ClaimKind::Observed,
+            "No historical companion paths were found in the focused commit cohort.",
+        ));
+    }
+
+    analysis
+}
+
+pub fn print_cochange_report(report: &CochangeReport) {
+    println!("HISTORICAL CO-CHANGE");
+    println!("  target                  {}", report.target);
+    println!("  focused commits         {}", report.considered_commits);
+    println!(
+        "  broad commits skipped   {}",
+        report.broad_commits_skipped
+    );
+
+    if report.companions.is_empty() {
+        println!("\n  No companion paths found in the focused history.");
+        return;
+    }
+
+    println!("\nCOMPANIONS");
+    for companion in &report.companions {
+        let percent = support_percent(companion.support, companion.opportunities);
+        println!(
+            "  {:>3}/{:<3} {:>5.1}%  {}",
+            companion.support, companion.opportunities, percent, companion.path
+        );
+        if !companion.exemplars.is_empty() {
+            println!("      exemplars: {}", companion.exemplars.join(", "));
+        }
+        if !companion.counterexamples.is_empty() {
+            println!(
+                "      counterexamples: {}",
+                companion.counterexamples.join(", ")
+            );
+        }
+    }
+
+    println!("\nQUESTION");
+    println!(
+        "  Which companions reflect a durable project convention, and which are incidental history?"
+    );
+}
+
+fn normalize_target(root: &Path, target: &Path) -> Result<String, Box<dyn Error>> {
+    let absolute = if target.is_absolute() {
+        target.canonicalize()?
+    } else {
+        root.join(target).canonicalize()?
+    };
+    let relative = absolute
+        .strip_prefix(root)
+        .map_err(|_| format!("target `{}` is outside the repository", absolute.display()))?;
+
+    Ok(relative.to_string_lossy().replace('\\', "/"))
+}
+
+fn history_shas(
+    root: &Path,
+    target: &str,
+    history_limit: usize,
+) -> Result<Vec<String>, Box<dyn Error>> {
+    let args = vec![
+        "log".to_string(),
+        "--no-merges".to_string(),
+        format!("--max-count={history_limit}"),
+        "--format=%H".to_string(),
+        "--".to_string(),
+        target.to_string(),
+    ];
+    let output = run_git(root, &args)?;
+    Ok(String::from_utf8_lossy(&output)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect())
+}
+
+fn commit_paths(root: &Path, sha: &str) -> Result<BTreeSet<String>, Box<dyn Error>> {
+    let args = vec![
+        "diff-tree".to_string(),
+        "--root".to_string(),
+        "--no-commit-id".to_string(),
+        "--name-only".to_string(),
+        "-r".to_string(),
+        "-z".to_string(),
+        sha.to_string(),
+    ];
+    let output = run_git(root, &args)?;
+
+    Ok(output
+        .split(|byte| *byte == 0)
+        .filter(|chunk| !chunk.is_empty())
+        .map(|chunk| String::from_utf8_lossy(chunk).into_owned())
+        .collect())
+}
+
+fn run_git(root: &Path, args: &[String]) -> Result<Vec<u8>, Box<dyn Error>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "git command failed: git -C {} {}\n{}",
+            root.display(),
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+        .into());
+    }
+
+    Ok(output.stdout)
+}
+
+fn summarize_history(
+    target: &str,
+    commits: &[HistoryCommit],
+    max_files_per_commit: usize,
+) -> CochangeReport {
+    let mut focused = Vec::new();
+    let mut broad_commits_skipped = 0;
+
+    for commit in commits {
+        if commit.paths.len() > max_files_per_commit {
+            broad_commits_skipped += 1;
+        } else {
+            focused.push(commit);
+        }
+    }
+
+    let opportunities = focused.len();
+    let mut counts = BTreeMap::<String, usize>::new();
+
+    for commit in &focused {
+        for path in &commit.paths {
+            if path != target {
+                *counts.entry(path.clone()).or_default() += 1;
+            }
+        }
+    }
+
+    let mut companions: Vec<_> = counts
+        .into_iter()
+        .map(|(path, support)| {
+            let exemplars = focused
+                .iter()
+                .filter(|commit| commit.paths.contains(&path))
+                .take(MAX_EXAMPLE_COMMITS)
+                .map(|commit| short_sha(&commit.sha))
+                .collect();
+            let counterexamples = focused
+                .iter()
+                .filter(|commit| !commit.paths.contains(&path))
+                .take(MAX_EXAMPLE_COMMITS)
+                .map(|commit| short_sha(&commit.sha))
+                .collect();
+
+            CochangeCompanion {
+                path,
+                support,
+                opportunities,
+                exemplars,
+                counterexamples,
+            }
+        })
+        .collect();
+
+    companions.sort_by(|a, b| b.support.cmp(&a.support).then(a.path.cmp(&b.path)));
+    companions.truncate(MAX_REPORTED_COMPANIONS);
+
+    CochangeReport {
+        target: target.to_string(),
+        considered_commits: opportunities,
+        broad_commits_skipped,
+        companions,
+    }
+}
+
+fn support_percent(support: usize, opportunities: usize) -> f64 {
+    if opportunities == 0 {
+        0.0
+    } else {
+        support as f64 * 100.0 / opportunities as f64
+    }
+}
+
+fn short_sha(sha: &str) -> String {
+    sha.chars().take(8).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn commit(sha: &str, paths: &[&str]) -> HistoryCommit {
+        HistoryCommit {
+            sha: sha.to_string(),
+            paths: paths.iter().map(|path| (*path).to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn ranks_companions_and_keeps_counterexamples() {
+        let commits = vec![
+            commit("aaaaaaaa1111", &["src/main.rs", "src/a.rs", "src/b.rs"]),
+            commit("bbbbbbbb2222", &["src/main.rs", "src/a.rs"]),
+            commit("cccccccc3333", &["src/main.rs", "src/a.rs"]),
+            commit("dddddddd4444", &["src/main.rs", "src/b.rs"]),
+        ];
+
+        let report = summarize_history("src/main.rs", &commits, 10);
+
+        assert_eq!(report.considered_commits, 4);
+        assert_eq!(report.broad_commits_skipped, 0);
+        assert_eq!(report.companions[0].path, "src/a.rs");
+        assert_eq!(report.companions[0].support, 3);
+        assert_eq!(report.companions[0].opportunities, 4);
+        assert_eq!(
+            report.companions[0].counterexamples,
+            vec!["dddddddd".to_string()]
+        );
+        assert_eq!(report.companions[1].path, "src/b.rs");
+        assert_eq!(report.companions[1].support, 2);
+    }
+
+    #[test]
+    fn filters_broad_history_before_counting() {
+        let commits = vec![
+            commit("aaaaaaaa1111", &["src/main.rs", "src/a.rs"]),
+            commit(
+                "bbbbbbbb2222",
+                &["src/main.rs", "src/a.rs", "src/b.rs", "src/c.rs"],
+            ),
+        ];
+
+        let report = summarize_history("src/main.rs", &commits, 3);
+
+        assert_eq!(report.considered_commits, 1);
+        assert_eq!(report.broad_commits_skipped, 1);
+        assert_eq!(report.companions.len(), 1);
+        assert_eq!(report.companions[0].path, "src/a.rs");
+        assert_eq!(report.companions[0].support, 1);
+        assert_eq!(report.companions[0].opportunities, 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod cochange;
 mod diff;
 mod finding;
 mod report;
@@ -8,6 +9,10 @@ use std::error::Error;
 use std::path::PathBuf;
 use std::process;
 
+use cochange::{
+    analyze_cochange, build_cochange_analysis_report, print_cochange_report,
+    DEFAULT_HISTORY_LIMIT, DEFAULT_MAX_FILES_PER_COMMIT,
+};
 use diff::{build_diff_analysis_report, git_repo_root, print_diff_report};
 use report::build_test_module_analysis;
 use test_modules::{analyze_test_modules, print_test_module_report};
@@ -26,6 +31,27 @@ struct DiffArgs {
     base: Option<String>,
     path: Option<PathBuf>,
     format: OutputFormat,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct CochangeArgs {
+    target: Option<PathBuf>,
+    repo: Option<PathBuf>,
+    format: OutputFormat,
+    commits: usize,
+    max_files: usize,
+}
+
+impl Default for CochangeArgs {
+    fn default() -> Self {
+        Self {
+            target: None,
+            repo: None,
+            format: OutputFormat::Text,
+            commits: DEFAULT_HISTORY_LIMIT,
+            max_files: DEFAULT_MAX_FILES_PER_COMMIT,
+        }
+    }
 }
 
 fn main() {
@@ -47,6 +73,11 @@ fn run() -> Result<(), Box<dyn Error>> {
     if args.first().is_some_and(|arg| arg == "diff") {
         args.remove(0);
         return run_diff(args);
+    }
+
+    if args.first().is_some_and(|arg| arg == "cochange") {
+        args.remove(0);
+        return run_cochange(args);
     }
 
     if args.iter().any(|arg| arg == "-h" || arg == "--help") {
@@ -98,6 +129,40 @@ fn run_diff(args: Vec<String>) -> Result<(), Box<dyn Error>> {
         }
         OutputFormat::Json => {
             let analysis = build_diff_analysis_report(&root, base.as_deref(), &report)?;
+            println!("{}", serde_json::to_string_pretty(&analysis)?);
+        }
+    }
+
+    Ok(())
+}
+
+fn run_cochange(args: Vec<String>) -> Result<(), Box<dyn Error>> {
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_cochange_help();
+        return Ok(());
+    }
+
+    let CochangeArgs {
+        target,
+        repo,
+        format,
+        commits,
+        max_files,
+    } = parse_cochange_args(args)?;
+    let target = target.ok_or("`cochange` requires one repository-relative target path")?;
+    let requested_root = repo.unwrap_or(env::current_dir()?);
+    let requested_root = requested_root.canonicalize()?;
+    let root = git_repo_root(&requested_root)?;
+    let report = analyze_cochange(&root, &target, commits, max_files)?;
+
+    match format {
+        OutputFormat::Text => {
+            println!("cargo-cultist {VERSION}");
+            println!("repository: {}\n", root.display());
+            print_cochange_report(&report);
+        }
+        OutputFormat::Json => {
+            let analysis = build_cochange_analysis_report(&root, &report);
             println!("{}", serde_json::to_string_pretty(&analysis)?);
         }
     }
@@ -172,6 +237,56 @@ fn parse_diff_args(args: Vec<String>) -> Result<DiffArgs, Box<dyn Error>> {
     Ok(parsed)
 }
 
+fn parse_cochange_args(args: Vec<String>) -> Result<CochangeArgs, Box<dyn Error>> {
+    let mut parsed = CochangeArgs::default();
+    let mut args = args.into_iter();
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--repo" => {
+                if parsed.repo.is_some() {
+                    return Err("`--repo` may only be specified once".into());
+                }
+                parsed.repo = Some(PathBuf::from(
+                    args.next().ok_or("`--repo` requires a repository path")?,
+                ));
+            }
+            "--format" => {
+                parsed.format = parse_output_format(
+                    &args.next().ok_or("`--format` requires `text` or `json`")?,
+                )?;
+            }
+            "--commits" => {
+                let value = args.next().ok_or("`--commits` requires a positive integer")?;
+                parsed.commits = parse_positive_usize("--commits", &value)?;
+            }
+            "--max-files" => {
+                let value = args
+                    .next()
+                    .ok_or("`--max-files` requires a positive integer")?;
+                parsed.max_files = parse_positive_usize("--max-files", &value)?;
+            }
+            _ if arg.starts_with('-') => {
+                return Err(format!(
+                    "unknown cochange option `{arg}`; try `cargo cultist cochange --help`"
+                )
+                .into());
+            }
+            _ => {
+                if parsed.target.is_some() {
+                    return Err(
+                        "`cochange` expects one target path; try `cargo cultist cochange --help`"
+                            .into(),
+                    );
+                }
+                parsed.target = Some(PathBuf::from(arg));
+            }
+        }
+    }
+
+    Ok(parsed)
+}
+
 fn parse_output_format(value: &str) -> Result<OutputFormat, String> {
     match value {
         "text" => Ok(OutputFormat::Text),
@@ -182,12 +297,22 @@ fn parse_output_format(value: &str) -> Result<OutputFormat, String> {
     }
 }
 
+fn parse_positive_usize(option: &str, value: &str) -> Result<usize, Box<dyn Error>> {
+    let parsed: usize = value
+        .parse()
+        .map_err(|_| format!("`{option}` requires a positive integer"))?;
+    if parsed == 0 {
+        return Err(format!("`{option}` requires a positive integer").into());
+    }
+    Ok(parsed)
+}
+
 fn print_help() {
     println!(
         "cargo-cultist {VERSION}\n\
 Repository-aware analysis for Rust codebases.\n\n\
-USAGE:\n    cargo cultist [--format text|json] [PATH]\n    cargo cultist diff [--base REV] [--format text|json] [PATH]\n    cargo-cultist [--format text|json] [PATH]\n    cargo-cultist diff [--base REV] [--format text|json] [PATH]\n\n\
-COMMANDS:\n    diff    Inspect changed Rust code against repository precedent.\n\n\
+USAGE:\n    cargo cultist [--format text|json] [PATH]\n    cargo cultist diff [--base REV] [--format text|json] [PATH]\n    cargo cultist cochange [OPTIONS] TARGET\n    cargo-cultist [--format text|json] [PATH]\n    cargo-cultist diff [--base REV] [--format text|json] [PATH]\n    cargo-cultist cochange [OPTIONS] TARGET\n\n\
+COMMANDS:\n    diff        Inspect changed Rust code against repository precedent.\n    cochange    Explore historical path co-change precedent.\n\n\
 Without a command, cargo-cultist inspects repository-wide test-module naming\n\
 conventions without inventing a universal rule."
     );
@@ -201,6 +326,18 @@ By default, compares the working tree (including staged changes) against HEAD.\n
 With --base REV, compares changes from the merge base of REV and HEAD.\n\n\
 The first diff-aware check looks for added or renamed #[cfg(test)] modules and\n\
 compares their names with repository-wide and same-file precedent."
+    );
+}
+
+fn print_cochange_help() {
+    println!(
+        "cargo-cultist cochange\n\n\
+USAGE:\n    cargo cultist cochange [--repo PATH] [--commits N] [--max-files N] [--format text|json] TARGET\n\n\
+TARGET is a repository-relative path that currently exists.\n\
+The command reads local Git history only, ignores merge commits, and skips\n\
+commits touching more than --max-files paths before ranking companion paths.\n\n\
+Defaults: --commits {}, --max-files {}.",
+        DEFAULT_HISTORY_LIMIT, DEFAULT_MAX_FILES_PER_COMMIT
     );
 }
 
@@ -230,6 +367,38 @@ mod tests {
             parse_root_args(vec!["--format".to_string(), "json".to_string()]).unwrap();
         assert_eq!(format, OutputFormat::Json);
         assert_eq!(path, None);
+    }
+
+    #[test]
+    fn parses_cochange_target_and_limits() {
+        let parsed = parse_cochange_args(vec![
+            "--repo".to_string(),
+            "/repo".to_string(),
+            "--commits".to_string(),
+            "25".to_string(),
+            "--max-files".to_string(),
+            "12".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+            "src/main.rs".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(parsed.repo, Some(PathBuf::from("/repo")));
+        assert_eq!(parsed.target, Some(PathBuf::from("src/main.rs")));
+        assert_eq!(parsed.commits, 25);
+        assert_eq!(parsed.max_files, 12);
+        assert_eq!(parsed.format, OutputFormat::Json);
+    }
+
+    #[test]
+    fn rejects_zero_cochange_limits() {
+        assert!(parse_cochange_args(vec![
+            "--commits".to_string(),
+            "0".to_string(),
+            "src/main.rs".to_string(),
+        ])
+        .is_err());
     }
 
     #[test]


### PR DESCRIPTION
Superseded by #39 after parallel implementation discovery.

#39 carries the stronger first research explorer: revert filtering, commit dates/subjects, explicit exclusion receipts and limitations, README documentation, counterexample samples, and already-green CI.

Useful idea retained from this branch for later: once the raw explorer proves useful on external corpora, promote selected associations into the shared `AnalysisReport` / claim-provenance finding model rather than forcing every raw association to become a finding immediately.

Original experiment tracked #32.