### PR TITLE
Make diff analysis changed-first

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -4,32 +4,59 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::finding::{AnalysisReport, Claim, ClaimKind, Evidence, Finding, Location};
-use crate::test_modules::{TestModuleOccurrence, TestModuleReport};
+use crate::test_modules::{
+    TestModuleOccurrence, TestModuleReport, analyze_test_module_files,
+    analyze_test_modules_excluding,
+};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct LineRange {
+    start: usize,
+    end: usize,
+}
 
 #[derive(Debug, Default, Eq, PartialEq)]
 struct ChangedLines {
-    by_path: BTreeMap<PathBuf, BTreeSet<usize>>,
+    by_path: BTreeMap<PathBuf, Vec<LineRange>>,
 }
 
 impl ChangedLines {
     fn insert(&mut self, path: &Path, line: usize) {
-        self.by_path
-            .entry(path.to_path_buf())
-            .or_default()
-            .insert(line);
+        let ranges = self.by_path.entry(path.to_path_buf()).or_default();
+        if let Some(last) = ranges.last_mut()
+            && line <= last.end.saturating_add(1)
+        {
+            last.end = last.end.max(line);
+            return;
+        }
+        ranges.push(LineRange {
+            start: line,
+            end: line,
+        });
     }
 
     fn contains(&self, path: &Path, line: usize) -> bool {
-        self.by_path
-            .get(path)
-            .is_some_and(|lines| lines.contains(&line))
+        self.by_path.get(path).is_some_and(|ranges| {
+            ranges
+                .iter()
+                .any(|range| range.start <= line && line <= range.end)
+        })
     }
 
-    fn rust_file_count(&self) -> usize {
+    fn rust_paths(&self) -> impl Iterator<Item = &Path> {
         self.by_path
             .keys()
             .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("rs"))
-            .count()
+            .map(PathBuf::as_path)
+    }
+
+    fn rust_file_count(&self) -> usize {
+        self.rust_paths().count()
+    }
+
+    #[cfg(test)]
+    fn range_count(&self, path: &Path) -> usize {
+        self.by_path.get(path).map_or(0, Vec::len)
     }
 }
 
@@ -52,11 +79,9 @@ pub fn git_repo_root(path: &Path) -> Result<PathBuf, Box<dyn Error>> {
 pub fn build_diff_analysis_report(
     root: &Path,
     base: Option<&str>,
-    report: &TestModuleReport,
 ) -> Result<AnalysisReport, Box<dyn Error>> {
     let patch = git_diff(root, base)?;
     let changed = parse_changed_lines(&patch);
-    let changed_modules = changed_test_modules(root, report, &changed);
 
     let mut analysis = AnalysisReport::new("diff-precedent", root.to_string_lossy().into_owned());
     analysis.claims.push(Claim::new(
@@ -73,13 +98,46 @@ pub fn build_diff_analysis_report(
         },
     ));
 
-    if changed_modules.is_empty() {
+    let changed_rust_paths: Vec<_> = changed
+        .rust_paths()
+        .map(|path| root.join(path))
+        .collect();
+    if changed_rust_paths.is_empty() {
         analysis.claims.push(Claim::new(
             ClaimKind::Observed,
             "No added or renamed test-gated module declarations were found in the diff.",
         ));
         return Ok(analysis);
     }
+
+    // Parse only changed Rust files first. Most diffs can stop here without
+    // walking or parsing the rest of the repository.
+    let changed_report = analyze_test_module_files(&changed_rust_paths)?;
+    if changed_test_modules(root, &changed_report, &changed).is_empty() {
+        analysis.claims.push(Claim::new(
+            ClaimKind::Observed,
+            "No added or renamed test-gated module declarations were found in the diff.",
+        ));
+        return Ok(analysis);
+    }
+
+    // A relevant declaration needs repository precedent. Reuse the changed
+    // files we already parsed and scan only the remaining Rust files.
+    let excluded_paths: BTreeSet<_> = changed_rust_paths.into_iter().collect();
+    let mut report = analyze_test_modules_excluding(root, &excluded_paths)?;
+    report.extend(changed_report);
+
+    add_diff_findings(root, &report, &changed, &mut analysis);
+    Ok(analysis)
+}
+
+fn add_diff_findings(
+    root: &Path,
+    report: &TestModuleReport,
+    changed: &ChangedLines,
+    analysis: &mut AnalysisReport,
+) {
+    let changed_modules = changed_test_modules(root, report, changed);
 
     for occurrence in changed_modules {
         let local_names = same_file_names(report, occurrence);
@@ -197,8 +255,6 @@ pub fn build_diff_analysis_report(
             "The changed test-module names match existing repository precedent.",
         ));
     }
-
-    Ok(analysis)
 }
 
 fn git_diff(root: &Path, base: Option<&str>) -> Result<String, Box<dyn Error>> {
@@ -221,6 +277,7 @@ fn git_diff(root: &Path, base: Option<&str>) -> Result<String, Box<dyn Error>> {
         ])
         .arg(anchor)
         .arg("--")
+        .arg("*.rs")
         .output()?;
 
     if !output.status.success() {
@@ -384,7 +441,45 @@ fn relative_path<'a>(root: &'a Path, path: &'a Path) -> &'a Path {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     use super::*;
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "cargo-cultist-{name}-{}-{nanos}",
+            std::process::id()
+        ))
+    }
+
+    fn run_git(root: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(args)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git command failed: git {args:?}");
+    }
+
+    fn init_repo(name: &str) -> PathBuf {
+        let root = unique_temp_dir(name);
+        fs::create_dir_all(&root).unwrap();
+        run_git(&root, &["init", "-q"]);
+        run_git(&root, &["config", "user.email", "cultist@example.invalid"]);
+        run_git(&root, &["config", "user.name", "Cargo Cultist Tests"]);
+        fs::write(root.join("README.md"), "baseline\n").unwrap();
+        fs::write(root.join("changed.rs"), "fn baseline() {}\n").unwrap();
+        fs::write(root.join("unrelated.rs"), [0xff, 0xfe, 0xfd]).unwrap();
+        run_git(&root, &["add", "."]);
+        run_git(&root, &["commit", "-q", "-m", "baseline"]);
+        root
+    }
 
     #[test]
     fn detects_scope_tension_only_with_clear_precedent() {
@@ -446,6 +541,26 @@ mod tests {
         assert!(changed.contains(Path::new("src/a.rs"), 12));
         assert!(changed.contains(Path::new("src/a.rs"), 32));
         assert!(!changed.contains(Path::new("src/a.rs"), 31));
+        assert_eq!(changed.range_count(Path::new("src/a.rs")), 2);
+    }
+
+    #[test]
+    fn compacts_contiguous_added_lines_into_one_range() {
+        let patch = r#"diff --git src/a.rs src/a.rs
+--- src/a.rs
++++ src/a.rs
+@@ -10,0 +11,4 @@
++one
++two
++three
++four
+"#;
+
+        let changed = parse_changed_lines(patch);
+        assert_eq!(changed.range_count(Path::new("src/a.rs")), 1);
+        assert!(changed.contains(Path::new("src/a.rs"), 11));
+        assert!(changed.contains(Path::new("src/a.rs"), 14));
+        assert!(!changed.contains(Path::new("src/a.rs"), 15));
     }
 
     #[test]
@@ -472,5 +587,33 @@ mod tests {
         let selected = changed_test_modules(root, &report, &changed);
         assert_eq!(selected.len(), 1);
         assert_eq!(selected[0].name, "special_tests");
+    }
+
+    #[test]
+    fn docs_only_diff_skips_repository_rust_scan() {
+        let root = init_repo("docs-only-diff");
+        fs::write(root.join("README.md"), "changed docs\n").unwrap();
+
+        let analysis = build_diff_analysis_report(&root, None).unwrap();
+
+        assert!(analysis.findings.is_empty());
+        assert!(analysis.claims.iter().any(|claim| claim
+            .message
+            .contains("No added or renamed test-gated module declarations")));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn irrelevant_rust_diff_skips_unrelated_repository_rust_scan() {
+        let root = init_repo("irrelevant-rust-diff");
+        fs::write(root.join("changed.rs"), "fn changed() { println!(\"hi\"); }\n").unwrap();
+
+        let analysis = build_diff_analysis_report(&root, None).unwrap();
+
+        assert!(analysis.findings.is_empty());
+        assert!(analysis.claims.iter().any(|claim| claim
+            .message
+            .contains("No added or renamed test-gated module declarations")));
+        fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -98,10 +98,7 @@ pub fn build_diff_analysis_report(
         },
     ));
 
-    let changed_rust_paths: Vec<_> = changed
-        .rust_paths()
-        .map(|path| root.join(path))
-        .collect();
+    let changed_rust_paths: Vec<_> = changed.rust_paths().map(|path| root.join(path)).collect();
     if changed_rust_paths.is_empty() {
         analysis.claims.push(Claim::new(
             ClaimKind::Observed,
@@ -597,23 +594,31 @@ mod tests {
         let analysis = build_diff_analysis_report(&root, None).unwrap();
 
         assert!(analysis.findings.is_empty());
-        assert!(analysis.claims.iter().any(|claim| claim
-            .message
-            .contains("No added or renamed test-gated module declarations")));
+        assert!(analysis.claims.iter().any(|claim| {
+            claim
+                .message
+                .contains("No added or renamed test-gated module declarations")
+        }));
         fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
     fn irrelevant_rust_diff_skips_unrelated_repository_rust_scan() {
         let root = init_repo("irrelevant-rust-diff");
-        fs::write(root.join("changed.rs"), "fn changed() { println!(\"hi\"); }\n").unwrap();
+        fs::write(
+            root.join("changed.rs"),
+            "fn changed() { println!(\"hi\"); }\n",
+        )
+        .unwrap();
 
         let analysis = build_diff_analysis_report(&root, None).unwrap();
 
         assert!(analysis.findings.is_empty());
-        assert!(analysis.claims.iter().any(|claim| claim
-            .message
-            .contains("No added or renamed test-gated module declarations")));
+        assert!(analysis.claims.iter().any(|claim| {
+            claim
+                .message
+                .contains("No added or renamed test-gated module declarations")
+        }));
         fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,8 +95,7 @@ fn run_diff(args: Vec<String>) -> Result<(), Box<dyn Error>> {
     let requested_root = path.unwrap_or(env::current_dir()?);
     let requested_root = requested_root.canonicalize()?;
     let root = git_repo_root(&requested_root)?;
-    let report = analyze_test_modules(&root)?;
-    let analysis = build_diff_analysis_report(&root, base.as_deref(), &report)?;
+    let analysis = build_diff_analysis_report(&root, base.as_deref())?;
     emit_analysis(&analysis, format)
 }
 

--- a/src/test_modules.rs
+++ b/src/test_modules.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -22,39 +23,79 @@ pub struct TestModuleReport {
     pub parse_failures: Vec<(PathBuf, String)>,
 }
 
+impl TestModuleReport {
+    pub fn extend(&mut self, other: Self) {
+        self.occurrences.extend(other.occurrences);
+        self.parse_failures.extend(other.parse_failures);
+        sort_report(self);
+    }
+}
+
 pub fn analyze_test_modules(root: &Path) -> Result<TestModuleReport, Box<dyn Error>> {
+    analyze_test_modules_excluding(root, &BTreeSet::new())
+}
+
+pub fn analyze_test_modules_excluding(
+    root: &Path,
+    excluded_paths: &BTreeSet<PathBuf>,
+) -> Result<TestModuleReport, Box<dyn Error>> {
     let mut report = TestModuleReport::default();
 
     for entry in WalkDir::new(root).into_iter().filter_entry(should_visit) {
         let entry = entry?;
         if !entry.file_type().is_file()
             || entry.path().extension().and_then(|ext| ext.to_str()) != Some("rs")
+            || excluded_paths.contains(entry.path())
         {
             continue;
         }
 
-        let path = entry.path();
-        let source = fs::read_to_string(path)?;
-        match syn::parse_file(&source) {
-            Ok(file) => {
-                let mut visitor = TestModuleVisitor {
-                    path,
-                    occurrences: &mut report.occurrences,
-                };
-                visitor.visit_file(&file);
-            }
-            Err(error) => report
-                .parse_failures
-                .push((path.to_path_buf(), error.to_string())),
-        }
+        analyze_test_module_file(entry.path(), &mut report)?;
     }
 
+    sort_report(&mut report);
+    Ok(report)
+}
+
+pub fn analyze_test_module_files(paths: &[PathBuf]) -> Result<TestModuleReport, Box<dyn Error>> {
+    let mut report = TestModuleReport::default();
+
+    for path in paths {
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") || !path.is_file() {
+            continue;
+        }
+        analyze_test_module_file(path, &mut report)?;
+    }
+
+    sort_report(&mut report);
+    Ok(report)
+}
+
+fn analyze_test_module_file(
+    path: &Path,
+    report: &mut TestModuleReport,
+) -> Result<(), Box<dyn Error>> {
+    let source = fs::read_to_string(path)?;
+    match syn::parse_file(&source) {
+        Ok(file) => {
+            let mut visitor = TestModuleVisitor {
+                path,
+                occurrences: &mut report.occurrences,
+            };
+            visitor.visit_file(&file);
+        }
+        Err(error) => report
+            .parse_failures
+            .push((path.to_path_buf(), error.to_string())),
+    }
+    Ok(())
+}
+
+fn sort_report(report: &mut TestModuleReport) {
     report
         .occurrences
         .sort_by(|a, b| a.path.cmp(&b.path).then(a.line.cmp(&b.line)));
     report.parse_failures.sort_by(|a, b| a.0.cmp(&b.0));
-
-    Ok(report)
 }
 
 fn should_visit(entry: &DirEntry) -> bool {
@@ -129,6 +170,8 @@ fn meta_mentions_test(meta: &Meta, negated: bool) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     use super::*;
 
     fn names(source: &str) -> Vec<String> {
@@ -144,6 +187,17 @@ mod tests {
             .into_iter()
             .map(|occurrence| occurrence.name)
             .collect()
+    }
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "cargo-cultist-{name}-{}-{nanos}",
+            std::process::id()
+        ))
     }
 
     #[test]
@@ -166,5 +220,23 @@ mod tests {
     fn ignores_ordinary_and_not_test_modules() {
         assert!(names("mod production {}").is_empty());
         assert!(names("#[cfg(not(test))] mod production {}").is_empty());
+    }
+
+    #[test]
+    fn targeted_scan_reads_only_requested_files() {
+        let root = unique_temp_dir("targeted-scan");
+        fs::create_dir_all(&root).unwrap();
+        let selected = root.join("selected.rs");
+        let ignored = root.join("ignored.rs");
+        fs::write(&selected, "#[cfg(test)]\nmod selected_tests {}\n").unwrap();
+        fs::write(&ignored, "this is deliberately invalid Rust {{{").unwrap();
+
+        let report = analyze_test_module_files(std::slice::from_ref(&selected)).unwrap();
+
+        assert_eq!(report.occurrences.len(), 1);
+        assert_eq!(report.occurrences[0].name, "selected_tests");
+        assert!(report.parse_failures.is_empty());
+
+        fs::remove_dir_all(root).unwrap();
     }
 }


### PR DESCRIPTION
## What

Make the current diff analyzer pay repository-wide parsing cost only after the diff proves it has a relevant changed test-module declaration.

The execution path is now:

1. resolve the diff, path-limited to Rust files;
2. retain added-line membership as compact ranges;
3. parse only changed Rust files;
4. return immediately when none of their changed lines contain a test-gated module declaration;
5. only then scan the rest of the repository for precedent, reusing the changed-file parse results.

The repository-wide command keeps the same full scan behavior.

## Regression coverage

Two end-to-end tests put an invalid-UTF-8 Rust file elsewhere in a temporary Git repository:

- a docs-only diff must succeed without touching repository Rust source;
- an unrelated Rust diff must parse only the changed Rust file and succeed without touching the unrelated source.

That makes the changed-first property observable in tests.

The diff representation also coalesces contiguous added lines into ranges instead of storing one `BTreeSet` node per added line. Streaming the Git patch remains follow-up work in #51.

## Why

This is the first execution-model change from the performance program: cheap and irrelevant review paths should do work proportional to the diff, while repository-wide precedent is fetched only for candidate findings.

Closes #43
Progresses #51
Related: #49 #48 #45