### PR TITLE
Share Git-blob-keyed Rust facts across analyzers

### DIFF
--- a/examples/ci_test_selection_listing.rs
+++ b/examples/ci_test_selection_listing.rs
@@ -4,6 +4,9 @@ mod ci_test_filters;
 #[allow(dead_code)]
 #[path = "../src/finding.rs"]
 mod finding;
+#[allow(dead_code)]
+#[path = "../src/rust_facts.rs"]
+mod rust_facts;
 
 use std::env;
 use std::error::Error;

--- a/src/ci_test_filters.rs
+++ b/src/ci_test_filters.rs
@@ -8,13 +8,7 @@ use walkdir::WalkDir;
 use crate::finding::{AnalysisReport, Claim, ClaimKind, Evidence, Finding, Location};
 use crate::rust_facts::scan_rust_repository;
 
-const SKIPPED_RUST_DIRS: &[&str] = &[
-    ".git",
-    "target",
-    "node_modules",
-    ".venv",
-    "vendor",
-];
+const SKIPPED_RUST_DIRS: &[&str] = &[".git", "target", "node_modules", ".venv", "vendor"];
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ExplicitTest {

--- a/src/ci_test_filters.rs
+++ b/src/ci_test_filters.rs
@@ -3,12 +3,18 @@ use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use proc_macro2::Span;
-use syn::visit::{self, Visit};
-use syn::{Attribute, ItemFn, ItemMod};
-use walkdir::{DirEntry, WalkDir};
+use walkdir::WalkDir;
 
 use crate::finding::{AnalysisReport, Claim, ClaimKind, Evidence, Finding, Location};
+use crate::rust_facts::scan_rust_repository;
+
+const SKIPPED_RUST_DIRS: &[&str] = &[
+    ".git",
+    "target",
+    "node_modules",
+    ".venv",
+    "vendor",
+];
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ExplicitTest {
@@ -35,8 +41,15 @@ pub struct CiTestFilterReport {
 
 pub fn analyze_ci_test_filters(root: &Path) -> Result<CiTestFilterReport, Box<dyn Error>> {
     let mut report = CiTestFilterReport::default();
-    collect_explicit_tests(root, &mut report)?;
     collect_workflow_commands(root, &mut report)?;
+
+    // A repository with no supported selector has no CI-test finding to build,
+    // so avoid paying for a Rust inventory at all.
+    if report.commands.is_empty() {
+        return Ok(report);
+    }
+
+    collect_explicit_tests(root, &mut report)?;
 
     report
         .tests
@@ -56,6 +69,14 @@ pub fn build_ci_test_filter_analysis(root: &Path, report: &CiTestFilterReport) -
         "ci-test-filter-inventory",
         root.to_string_lossy().into_owned(),
     );
+
+    if report.commands.is_empty() {
+        analysis.claims.push(Claim::new(
+            ClaimKind::Proven,
+            "No supported literal `cargo test --lib FILTER` workflow commands were found.",
+        ));
+        return analysis;
+    }
 
     analysis.claims.push(Claim::new(
         ClaimKind::Proven,
@@ -165,32 +186,24 @@ fn collect_explicit_tests(
     root: &Path,
     report: &mut CiTestFilterReport,
 ) -> Result<(), Box<dyn Error>> {
-    for entry in WalkDir::new(root)
-        .into_iter()
-        .filter_entry(should_visit_rust)
-    {
-        let entry = entry?;
-        if !entry.file_type().is_file()
-            || entry.path().extension().and_then(|ext| ext.to_str()) != Some("rs")
-        {
+    let scan = scan_rust_repository(root, &BTreeSet::new(), SKIPPED_RUST_DIRS)?;
+
+    for file in scan.files {
+        if let Some(error) = file.facts.parse_error {
+            report.parse_failures.push((file.path, error));
             continue;
         }
 
-        let path = entry.path();
-        let source = fs::read_to_string(path)?;
-        match syn::parse_file(&source) {
-            Ok(file) => {
-                let mut visitor = ExplicitTestVisitor {
-                    path,
-                    tests: &mut report.tests,
-                    possible_module_fragments: &mut report.possible_module_fragments,
-                };
-                visitor.visit_file(&file);
-            }
-            Err(error) => report
-                .parse_failures
-                .push((path.to_path_buf(), error.to_string())),
+        for test in file.facts.explicit_tests {
+            report.tests.push(ExplicitTest {
+                name: test.name,
+                path: file.path.clone(),
+                line: test.line,
+            });
         }
+        report
+            .possible_module_fragments
+            .extend(file.facts.module_names);
     }
 
     Ok(())
@@ -340,50 +353,6 @@ fn is_yaml(path: &Path) -> bool {
     )
 }
 
-fn should_visit_rust(entry: &DirEntry) -> bool {
-    if !entry.file_type().is_dir() {
-        return true;
-    }
-
-    !matches!(
-        entry.file_name().to_str(),
-        Some(".git" | "target" | "node_modules" | ".venv" | "vendor")
-    )
-}
-
-struct ExplicitTestVisitor<'a> {
-    path: &'a Path,
-    tests: &'a mut Vec<ExplicitTest>,
-    possible_module_fragments: &'a mut BTreeSet<String>,
-}
-
-impl<'ast> Visit<'ast> for ExplicitTestVisitor<'_> {
-    fn visit_item_fn(&mut self, node: &'ast ItemFn) {
-        if has_test_attr(&node.attrs) {
-            self.tests.push(ExplicitTest {
-                name: node.sig.ident.to_string(),
-                path: self.path.to_path_buf(),
-                line: span_line(node.sig.ident.span()),
-            });
-        }
-        visit::visit_item_fn(self, node);
-    }
-
-    fn visit_item_mod(&mut self, node: &'ast ItemMod) {
-        self.possible_module_fragments
-            .insert(node.ident.to_string());
-        visit::visit_item_mod(self, node);
-    }
-}
-
-fn has_test_attr(attrs: &[Attribute]) -> bool {
-    attrs.iter().any(|attr| attr.path().is_ident("test"))
-}
-
-fn span_line(span: Span) -> usize {
-    span.start().line
-}
-
 fn relative_path(root: &Path, path: &Path) -> String {
     path.strip_prefix(root)
         .unwrap_or(path)
@@ -393,7 +362,20 @@ fn relative_path(root: &Path, path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     use super::*;
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "cargo-cultist-{name}-{}-{nanos}",
+            std::process::id()
+        ))
+    }
 
     #[test]
     fn recognizes_narrow_filtered_lib_commands() {
@@ -487,5 +469,19 @@ mod tests {
         assert!(has_possible_explicit_match(&report, "works"));
         assert!(!has_possible_explicit_match(&report, "src"));
         assert!(!has_possible_explicit_match(&report, "missing"));
+    }
+
+    #[test]
+    fn no_supported_workflow_skips_rust_inventory() {
+        let root = unique_temp_dir("ci-tests-no-command");
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/lib.rs"), [0xff, 0xfe, 0xfd]).unwrap();
+
+        let report = analyze_ci_test_filters(&root).unwrap();
+
+        assert!(report.commands.is_empty());
+        assert!(report.tests.is_empty());
+        assert!(report.parse_failures.is_empty());
+        fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod finding;
 mod history;
 mod render;
 mod report;
+mod rust_facts;
 mod test_modules;
 
 use std::env;

--- a/src/rust_facts.rs
+++ b/src/rust_facts.rs
@@ -227,8 +227,7 @@ fn git_rust_inputs(
         }
         let path = root.join(&relative);
         if excluded_paths.contains(&path)
-            || !fs::symlink_metadata(&path)
-                .is_ok_and(|metadata| metadata.file_type().is_file())
+            || !fs::symlink_metadata(&path).is_ok_and(|metadata| metadata.file_type().is_file())
         {
             continue;
         }
@@ -246,7 +245,11 @@ fn git_rust_inputs(
 }
 
 fn git_output(root: &Path, args: &[&str]) -> Result<Vec<u8>, Box<dyn Error>> {
-    let output = Command::new("git").arg("-C").arg(root).args(args).output()?;
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()?;
     if !output.status.success() {
         return Err(format!(
             "git {} failed: {}",
@@ -268,7 +271,10 @@ fn parse_nul_paths(output: &[u8]) -> Option<Vec<PathBuf>> {
 
 fn parse_index_ids(output: &[u8]) -> Option<BTreeMap<PathBuf, String>> {
     let mut ids = BTreeMap::new();
-    for record in output.split(|byte| *byte == 0).filter(|record| !record.is_empty()) {
+    for record in output
+        .split(|byte| *byte == 0)
+        .filter(|record| !record.is_empty())
+    {
         let record = std::str::from_utf8(record).ok()?;
         let (metadata, path) = record.split_once('\t')?;
         let mut fields = metadata.split_whitespace();
@@ -299,7 +305,11 @@ fn parse_dirty_paths(output: &[u8]) -> Option<BTreeSet<PathBuf>> {
         let status = &record[..2];
         dirty.insert(PathBuf::from(&record[3..]));
 
-        if status.as_bytes().iter().any(|byte| matches!(byte, b'R' | b'C')) {
+        if status
+            .as_bytes()
+            .iter()
+            .any(|byte| matches!(byte, b'R' | b'C'))
+        {
             index += 1;
             let other = std::str::from_utf8(*records.get(index)?).ok()?;
             dirty.insert(PathBuf::from(other));
@@ -378,10 +388,9 @@ impl FactCache {
             return;
         };
 
-        let temporary = self.root.join(format!(
-            ".{content_id}.{}.tmp",
-            std::process::id()
-        ));
+        let temporary = self
+            .root
+            .join(format!(".{content_id}.{}.tmp", std::process::id()));
         if fs::write(&temporary, bytes).is_ok() {
             let _ = fs::rename(&temporary, &path);
         }
@@ -569,8 +578,7 @@ mod tests {
 
         run_git(&root, &["mv", "src/lib.rs", "src/renamed.rs"]);
         run_git(&root, &["commit", "-q", "-m", "rename"]);
-        let renamed_inputs =
-            rust_inputs(&root, &BTreeSet::new(), &[".git", "target"]).unwrap();
+        let renamed_inputs = rust_inputs(&root, &BTreeSet::new(), &[".git", "target"]).unwrap();
         let renamed = scan_inputs(&renamed_inputs, Some(&cache)).unwrap();
         assert_eq!(renamed.parsed_files, 0);
         assert_eq!(renamed.cache_hits, 1);

--- a/src/rust_facts.rs
+++ b/src/rust_facts.rs
@@ -1,0 +1,629 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use proc_macro2::Span;
+use serde::{Deserialize, Serialize};
+use syn::parse::Parser;
+use syn::punctuated::Punctuated;
+use syn::visit::{self, Visit};
+use syn::{Attribute, ItemFn, ItemMod, Meta, Token};
+use walkdir::{DirEntry, WalkDir};
+
+const CACHE_SCHEMA_VERSION: u32 = 1;
+const CACHE_NAMESPACE: &str = "rust-syntax-v1";
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NamedRustFact {
+    pub name: String,
+    pub line: usize,
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RustFileFacts {
+    pub test_modules: Vec<NamedRustFact>,
+    pub explicit_tests: Vec<NamedRustFact>,
+    pub module_names: Vec<String>,
+    pub parse_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RustFactFile {
+    pub path: PathBuf,
+    pub facts: RustFileFacts,
+}
+
+#[derive(Debug, Default)]
+pub struct RustFactScan {
+    pub files: Vec<RustFactFile>,
+    pub cache_hits: usize,
+    pub parsed_files: usize,
+}
+
+#[derive(Debug, Clone)]
+struct RustInput {
+    path: PathBuf,
+    content_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct FactCache {
+    root: PathBuf,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CacheEnvelope {
+    schema_version: u32,
+    facts: RustFileFacts,
+}
+
+pub fn scan_rust_repository(
+    root: &Path,
+    excluded_paths: &BTreeSet<PathBuf>,
+    skipped_dirs: &[&str],
+) -> Result<RustFactScan, Box<dyn Error>> {
+    let inputs = rust_inputs(root, excluded_paths, skipped_dirs)?;
+    let cache = FactCache::from_environment();
+    scan_inputs(&inputs, cache.as_ref())
+}
+
+pub fn scan_rust_paths(paths: &[PathBuf]) -> Result<RustFactScan, Box<dyn Error>> {
+    let inputs: Vec<_> = paths
+        .iter()
+        .filter(|path| {
+            path.extension().and_then(|ext| ext.to_str()) == Some("rs") && path.is_file()
+        })
+        .map(|path| RustInput {
+            path: path.clone(),
+            content_id: None,
+        })
+        .collect();
+    scan_inputs(&inputs, None)
+}
+
+fn scan_inputs(
+    inputs: &[RustInput],
+    cache: Option<&FactCache>,
+) -> Result<RustFactScan, Box<dyn Error>> {
+    let mut scan = RustFactScan::default();
+
+    for input in inputs {
+        let cached = input
+            .content_id
+            .as_deref()
+            .and_then(|content_id| cache.and_then(|cache| cache.load(content_id)));
+
+        let facts = if let Some(facts) = cached {
+            scan.cache_hits += 1;
+            facts
+        } else {
+            scan.parsed_files += 1;
+            let facts = extract_rust_file(&input.path)?;
+            if let (Some(cache), Some(content_id)) = (cache, input.content_id.as_deref()) {
+                cache.store(content_id, &facts);
+            }
+            facts
+        };
+
+        scan.files.push(RustFactFile {
+            path: input.path.clone(),
+            facts,
+        });
+    }
+
+    scan.files.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(scan)
+}
+
+fn extract_rust_file(path: &Path) -> Result<RustFileFacts, Box<dyn Error>> {
+    let source = fs::read_to_string(path)?;
+    Ok(extract_rust_source(&source))
+}
+
+fn extract_rust_source(source: &str) -> RustFileFacts {
+    let file = match syn::parse_file(source) {
+        Ok(file) => file,
+        Err(error) => {
+            return RustFileFacts {
+                parse_error: Some(error.to_string()),
+                ..RustFileFacts::default()
+            };
+        }
+    };
+
+    let mut facts = RustFileFacts::default();
+    let mut visitor = RustFactVisitor { facts: &mut facts };
+    visitor.visit_file(&file);
+    facts
+}
+
+fn rust_inputs(
+    root: &Path,
+    excluded_paths: &BTreeSet<PathBuf>,
+    skipped_dirs: &[&str],
+) -> Result<Vec<RustInput>, Box<dyn Error>> {
+    if let Some(inputs) = git_rust_inputs(root, excluded_paths, skipped_dirs)? {
+        return Ok(inputs);
+    }
+
+    let mut inputs = Vec::new();
+    for entry in WalkDir::new(root)
+        .into_iter()
+        .filter_entry(|entry| should_visit(entry, skipped_dirs))
+    {
+        let entry = entry?;
+        if !entry.file_type().is_file()
+            || entry.path().extension().and_then(|ext| ext.to_str()) != Some("rs")
+            || excluded_paths.contains(entry.path())
+        {
+            continue;
+        }
+        inputs.push(RustInput {
+            path: entry.path().to_path_buf(),
+            content_id: None,
+        });
+    }
+    inputs.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(inputs)
+}
+
+fn git_rust_inputs(
+    root: &Path,
+    excluded_paths: &BTreeSet<PathBuf>,
+    skipped_dirs: &[&str],
+) -> Result<Option<Vec<RustInput>>, Box<dyn Error>> {
+    let probe = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()?;
+    if !probe.status.success() || probe.stdout != b"true\n" {
+        return Ok(None);
+    }
+
+    let inventory = git_output(
+        root,
+        &[
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+            "*.rs",
+        ],
+    )?;
+    let Some(paths) = parse_nul_paths(&inventory) else {
+        return Ok(None);
+    };
+
+    let staged = git_output(root, &["ls-files", "-s", "-z", "--", "*.rs"])?;
+    let Some(index_ids) = parse_index_ids(&staged) else {
+        return Ok(None);
+    };
+
+    let status = git_output(
+        root,
+        &[
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+            "--",
+            "*.rs",
+        ],
+    )?;
+    let Some(dirty_paths) = parse_dirty_paths(&status) else {
+        return Ok(None);
+    };
+
+    let mut inputs = Vec::new();
+    for relative in paths {
+        if path_has_skipped_dir(&relative, skipped_dirs) {
+            continue;
+        }
+        let path = root.join(&relative);
+        if excluded_paths.contains(&path)
+            || !fs::symlink_metadata(&path)
+                .is_ok_and(|metadata| metadata.file_type().is_file())
+        {
+            continue;
+        }
+
+        let content_id = if dirty_paths.contains(&relative) {
+            None
+        } else {
+            index_ids.get(&relative).cloned()
+        };
+        inputs.push(RustInput { path, content_id });
+    }
+
+    inputs.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(Some(inputs))
+}
+
+fn git_output(root: &Path, args: &[&str]) -> Result<Vec<u8>, Box<dyn Error>> {
+    let output = Command::new("git").arg("-C").arg(root).args(args).output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "git {} failed: {}",
+            args.first().copied().unwrap_or("command"),
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+    Ok(output.stdout)
+}
+
+fn parse_nul_paths(output: &[u8]) -> Option<Vec<PathBuf>> {
+    output
+        .split(|byte| *byte == 0)
+        .filter(|record| !record.is_empty())
+        .map(|record| std::str::from_utf8(record).ok().map(PathBuf::from))
+        .collect()
+}
+
+fn parse_index_ids(output: &[u8]) -> Option<BTreeMap<PathBuf, String>> {
+    let mut ids = BTreeMap::new();
+    for record in output.split(|byte| *byte == 0).filter(|record| !record.is_empty()) {
+        let record = std::str::from_utf8(record).ok()?;
+        let (metadata, path) = record.split_once('\t')?;
+        let mut fields = metadata.split_whitespace();
+        let _mode = fields.next()?;
+        let object_id = fields.next()?;
+        let stage = fields.next()?;
+        if stage == "0" && valid_content_id(object_id) {
+            ids.insert(PathBuf::from(path), object_id.to_string());
+        }
+    }
+    Some(ids)
+}
+
+fn parse_dirty_paths(output: &[u8]) -> Option<BTreeSet<PathBuf>> {
+    let records: Vec<_> = output
+        .split(|byte| *byte == 0)
+        .filter(|record| !record.is_empty())
+        .collect();
+    let mut dirty = BTreeSet::new();
+    let mut index = 0;
+
+    while index < records.len() {
+        let record = std::str::from_utf8(records[index]).ok()?;
+        let bytes = record.as_bytes();
+        if bytes.len() < 4 || bytes[2] != b' ' {
+            return None;
+        }
+        let status = &record[..2];
+        dirty.insert(PathBuf::from(&record[3..]));
+
+        if status.as_bytes().iter().any(|byte| matches!(byte, b'R' | b'C')) {
+            index += 1;
+            let other = std::str::from_utf8(*records.get(index)?).ok()?;
+            dirty.insert(PathBuf::from(other));
+        }
+        index += 1;
+    }
+
+    Some(dirty)
+}
+
+fn valid_content_id(value: &str) -> bool {
+    (32..=128).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn should_visit(entry: &DirEntry, skipped_dirs: &[&str]) -> bool {
+    if !entry.file_type().is_dir() {
+        return true;
+    }
+    !entry
+        .file_name()
+        .to_str()
+        .is_some_and(|name| skipped_dirs.contains(&name))
+}
+
+fn path_has_skipped_dir(path: &Path, skipped_dirs: &[&str]) -> bool {
+    path.components().any(|component| match component {
+        Component::Normal(name) => name
+            .to_str()
+            .is_some_and(|name| skipped_dirs.contains(&name)),
+        _ => false,
+    })
+}
+
+impl FactCache {
+    fn from_environment() -> Option<Self> {
+        if env::var_os("CARGO_CULTIST_CACHE").is_some_and(|value| value == "0") {
+            return None;
+        }
+
+        if let Some(path) = env::var_os("CARGO_CULTIST_CACHE_DIR") {
+            return Some(Self {
+                root: PathBuf::from(path).join(CACHE_NAMESPACE),
+            });
+        }
+
+        let base = platform_cache_dir()?;
+        Some(Self {
+            root: base.join("cargo-cultist").join(CACHE_NAMESPACE),
+        })
+    }
+
+    fn load(&self, content_id: &str) -> Option<RustFileFacts> {
+        let path = self.path_for(content_id)?;
+        let bytes = fs::read(&path).ok()?;
+        let envelope: CacheEnvelope = match serde_json::from_slice(&bytes) {
+            Ok(envelope) => envelope,
+            Err(_) => {
+                let _ = fs::remove_file(path);
+                return None;
+            }
+        };
+        (envelope.schema_version == CACHE_SCHEMA_VERSION).then_some(envelope.facts)
+    }
+
+    fn store(&self, content_id: &str, facts: &RustFileFacts) {
+        let Some(path) = self.path_for(content_id) else {
+            return;
+        };
+        if path.exists() || fs::create_dir_all(&self.root).is_err() {
+            return;
+        }
+        let Ok(bytes) = serde_json::to_vec(&CacheEnvelope {
+            schema_version: CACHE_SCHEMA_VERSION,
+            facts: facts.clone(),
+        }) else {
+            return;
+        };
+
+        let temporary = self.root.join(format!(
+            ".{content_id}.{}.tmp",
+            std::process::id()
+        ));
+        if fs::write(&temporary, bytes).is_ok() {
+            let _ = fs::rename(&temporary, &path);
+        }
+        let _ = fs::remove_file(temporary);
+    }
+
+    fn path_for(&self, content_id: &str) -> Option<PathBuf> {
+        valid_content_id(content_id).then(|| self.root.join(format!("{content_id}.json")))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn platform_cache_dir() -> Option<PathBuf> {
+    env::var_os("LOCALAPPDATA").map(PathBuf::from)
+}
+
+#[cfg(target_os = "macos")]
+fn platform_cache_dir() -> Option<PathBuf> {
+    env::var_os("HOME").map(|home| PathBuf::from(home).join("Library/Caches"))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn platform_cache_dir() -> Option<PathBuf> {
+    env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".cache")))
+}
+
+#[cfg(not(any(unix, target_os = "windows")))]
+fn platform_cache_dir() -> Option<PathBuf> {
+    None
+}
+
+struct RustFactVisitor<'a> {
+    facts: &'a mut RustFileFacts,
+}
+
+impl<'ast> Visit<'ast> for RustFactVisitor<'_> {
+    fn visit_item_fn(&mut self, node: &'ast ItemFn) {
+        if has_test_attr(&node.attrs) {
+            self.facts.explicit_tests.push(NamedRustFact {
+                name: node.sig.ident.to_string(),
+                line: span_line(node.sig.ident.span()),
+            });
+        }
+        visit::visit_item_fn(self, node);
+    }
+
+    fn visit_item_mod(&mut self, node: &'ast ItemMod) {
+        self.facts.module_names.push(node.ident.to_string());
+        if is_test_module(&node.attrs) {
+            self.facts.test_modules.push(NamedRustFact {
+                name: node.ident.to_string(),
+                line: span_line(node.ident.span()),
+            });
+        }
+        visit::visit_item_mod(self, node);
+    }
+}
+
+fn span_line(span: Span) -> usize {
+    span.start().line
+}
+
+fn has_test_attr(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| attr.path().is_ident("test"))
+}
+
+fn is_test_module(attrs: &[Attribute]) -> bool {
+    attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("cfg"))
+        .any(|attr| match &attr.meta {
+            Meta::List(list) => parse_meta_list(list.tokens.clone())
+                .is_some_and(|metas| metas.iter().any(|meta| meta_mentions_test(meta, false))),
+            _ => false,
+        })
+}
+
+fn parse_meta_list(tokens: proc_macro2::TokenStream) -> Option<Punctuated<Meta, Token![,]>> {
+    Punctuated::<Meta, Token![,]>::parse_terminated
+        .parse2(tokens)
+        .ok()
+}
+
+fn meta_mentions_test(meta: &Meta, negated: bool) -> bool {
+    match meta {
+        Meta::Path(path) => path.is_ident("test") && !negated,
+        Meta::List(list) => {
+            let nested_negated = if list.path.is_ident("not") {
+                !negated
+            } else {
+                negated
+            };
+            parse_meta_list(list.tokens.clone()).is_some_and(|metas| {
+                metas
+                    .iter()
+                    .any(|meta| meta_mentions_test(meta, nested_negated))
+            })
+        }
+        Meta::NameValue(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        env::temp_dir().join(format!(
+            "cargo-cultist-{name}-{}-{nanos}",
+            std::process::id()
+        ))
+    }
+
+    fn run_git(root: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(args)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git command failed: git {args:?}");
+    }
+
+    fn init_repo(name: &str) -> PathBuf {
+        let root = unique_temp_dir(name);
+        fs::create_dir_all(root.join("src")).unwrap();
+        run_git(&root, &["init", "-q"]);
+        run_git(&root, &["config", "user.email", "cultist@example.invalid"]);
+        run_git(&root, &["config", "user.name", "Cargo Cultist Tests"]);
+        root
+    }
+
+    #[test]
+    fn extracts_shared_syntax_facts_in_one_parse() {
+        let facts = extract_rust_source(
+            r#"
+            mod support {}
+            #[cfg(test)]
+            mod tests {
+                #[test]
+                fn works() {}
+            }
+            "#,
+        );
+
+        assert_eq!(facts.test_modules.len(), 1);
+        assert_eq!(facts.test_modules[0].name, "tests");
+        assert_eq!(facts.explicit_tests.len(), 1);
+        assert_eq!(facts.explicit_tests[0].name, "works");
+        assert!(facts.module_names.contains(&"support".to_string()));
+        assert!(facts.module_names.contains(&"tests".to_string()));
+        assert_eq!(facts.parse_error, None);
+    }
+
+    #[test]
+    fn clean_git_blob_hits_cache_and_reuses_across_rename() {
+        let root = init_repo("rust-fact-cache");
+        let cache = FactCache {
+            root: root.join("cache"),
+        };
+        fs::write(
+            root.join("src/lib.rs"),
+            "#[cfg(test)]\nmod tests { #[test] fn works() {} }\n",
+        )
+        .unwrap();
+        run_git(&root, &["add", "."]);
+        run_git(&root, &["commit", "-q", "-m", "baseline"]);
+
+        let inputs = rust_inputs(&root, &BTreeSet::new(), &[".git", "target"]).unwrap();
+        let first = scan_inputs(&inputs, Some(&cache)).unwrap();
+        assert_eq!(first.parsed_files, 1);
+        assert_eq!(first.cache_hits, 0);
+
+        let second = scan_inputs(&inputs, Some(&cache)).unwrap();
+        assert_eq!(second.parsed_files, 0);
+        assert_eq!(second.cache_hits, 1);
+
+        run_git(&root, &["mv", "src/lib.rs", "src/renamed.rs"]);
+        run_git(&root, &["commit", "-q", "-m", "rename"]);
+        let renamed_inputs =
+            rust_inputs(&root, &BTreeSet::new(), &[".git", "target"]).unwrap();
+        let renamed = scan_inputs(&renamed_inputs, Some(&cache)).unwrap();
+        assert_eq!(renamed.parsed_files, 0);
+        assert_eq!(renamed.cache_hits, 1);
+        assert!(renamed.files[0].path.ends_with("src/renamed.rs"));
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn dirty_git_file_bypasses_clean_blob_cache() {
+        let root = init_repo("rust-fact-dirty");
+        let cache = FactCache {
+            root: root.join("cache"),
+        };
+        let source = root.join("src/lib.rs");
+        fs::write(&source, "#[cfg(test)]\nmod tests {}\n").unwrap();
+        run_git(&root, &["add", "."]);
+        run_git(&root, &["commit", "-q", "-m", "baseline"]);
+
+        let inputs = rust_inputs(&root, &BTreeSet::new(), &[".git", "target"]).unwrap();
+        let _ = scan_inputs(&inputs, Some(&cache)).unwrap();
+
+        fs::write(&source, "#[cfg(test)]\nmod changed_tests {}\n").unwrap();
+        let dirty_inputs = rust_inputs(&root, &BTreeSet::new(), &[".git", "target"]).unwrap();
+        let dirty = scan_inputs(&dirty_inputs, Some(&cache)).unwrap();
+        assert_eq!(dirty.cache_hits, 0);
+        assert_eq!(dirty.parsed_files, 1);
+        assert_eq!(dirty.files[0].facts.test_modules[0].name, "changed_tests");
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn corrupt_cache_entry_recomputes() {
+        let root = init_repo("rust-fact-corrupt-cache");
+        let cache = FactCache {
+            root: root.join("cache"),
+        };
+        fs::write(root.join("src/lib.rs"), "#[cfg(test)]\nmod tests {}\n").unwrap();
+        run_git(&root, &["add", "."]);
+        run_git(&root, &["commit", "-q", "-m", "baseline"]);
+
+        let inputs = rust_inputs(&root, &BTreeSet::new(), &[".git", "target"]).unwrap();
+        let first = scan_inputs(&inputs, Some(&cache)).unwrap();
+        assert_eq!(first.parsed_files, 1);
+        let content_id = inputs[0].content_id.as_deref().unwrap();
+        let cache_path = cache.path_for(content_id).unwrap();
+        fs::write(cache_path, "broken json").unwrap();
+
+        let second = scan_inputs(&inputs, Some(&cache)).unwrap();
+        assert_eq!(second.cache_hits, 0);
+        assert_eq!(second.parsed_files, 1);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/rust_facts.rs
+++ b/src/rust_facts.rs
@@ -311,7 +311,7 @@ fn parse_dirty_paths(output: &[u8]) -> Option<BTreeSet<PathBuf>> {
             .any(|byte| matches!(byte, b'R' | b'C'))
         {
             index += 1;
-            let other = std::str::from_utf8(*records.get(index)?).ok()?;
+            let other = std::str::from_utf8(records.get(index)?).ok()?;
             dirty.insert(PathBuf::from(other));
         }
         index += 1;

--- a/src/test_modules.rs
+++ b/src/test_modules.rs
@@ -1,14 +1,10 @@
 use std::collections::BTreeSet;
 use std::error::Error;
-use std::fs;
 use std::path::{Path, PathBuf};
 
-use proc_macro2::Span;
-use syn::parse::Parser;
-use syn::punctuated::Punctuated;
-use syn::visit::{self, Visit};
-use syn::{Attribute, ItemMod, Meta, Token};
-use walkdir::{DirEntry, WalkDir};
+use crate::rust_facts::{RustFactScan, scan_rust_paths, scan_rust_repository};
+
+const SKIPPED_DIRS: &[&str] = &[".git", "target", "node_modules"];
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TestModuleOccurrence {
@@ -39,56 +35,34 @@ pub fn analyze_test_modules_excluding(
     root: &Path,
     excluded_paths: &BTreeSet<PathBuf>,
 ) -> Result<TestModuleReport, Box<dyn Error>> {
-    let mut report = TestModuleReport::default();
-
-    for entry in WalkDir::new(root).into_iter().filter_entry(should_visit) {
-        let entry = entry?;
-        if !entry.file_type().is_file()
-            || entry.path().extension().and_then(|ext| ext.to_str()) != Some("rs")
-            || excluded_paths.contains(entry.path())
-        {
-            continue;
-        }
-
-        analyze_test_module_file(entry.path(), &mut report)?;
-    }
-
-    sort_report(&mut report);
-    Ok(report)
+    let scan = scan_rust_repository(root, excluded_paths, SKIPPED_DIRS)?;
+    Ok(test_module_report(scan))
 }
 
 pub fn analyze_test_module_files(paths: &[PathBuf]) -> Result<TestModuleReport, Box<dyn Error>> {
+    Ok(test_module_report(scan_rust_paths(paths)?))
+}
+
+fn test_module_report(scan: RustFactScan) -> TestModuleReport {
     let mut report = TestModuleReport::default();
 
-    for path in paths {
-        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") || !path.is_file() {
+    for file in scan.files {
+        if let Some(error) = file.facts.parse_error {
+            report.parse_failures.push((file.path, error));
             continue;
         }
-        analyze_test_module_file(path, &mut report)?;
+
+        for occurrence in file.facts.test_modules {
+            report.occurrences.push(TestModuleOccurrence {
+                name: occurrence.name,
+                path: file.path.clone(),
+                line: occurrence.line,
+            });
+        }
     }
 
     sort_report(&mut report);
-    Ok(report)
-}
-
-fn analyze_test_module_file(
-    path: &Path,
-    report: &mut TestModuleReport,
-) -> Result<(), Box<dyn Error>> {
-    let source = fs::read_to_string(path)?;
-    match syn::parse_file(&source) {
-        Ok(file) => {
-            let mut visitor = TestModuleVisitor {
-                path,
-                occurrences: &mut report.occurrences,
-            };
-            visitor.visit_file(&file);
-        }
-        Err(error) => report
-            .parse_failures
-            .push((path.to_path_buf(), error.to_string())),
-    }
-    Ok(())
+    report
 }
 
 fn sort_report(report: &mut TestModuleReport) {
@@ -98,96 +72,12 @@ fn sort_report(report: &mut TestModuleReport) {
     report.parse_failures.sort_by(|a, b| a.0.cmp(&b.0));
 }
 
-fn should_visit(entry: &DirEntry) -> bool {
-    if !entry.file_type().is_dir() {
-        return true;
-    }
-
-    !matches!(
-        entry.file_name().to_str(),
-        Some(".git" | "target" | "node_modules")
-    )
-}
-
-struct TestModuleVisitor<'a> {
-    path: &'a Path,
-    occurrences: &'a mut Vec<TestModuleOccurrence>,
-}
-
-impl<'ast> Visit<'ast> for TestModuleVisitor<'_> {
-    fn visit_item_mod(&mut self, node: &'ast ItemMod) {
-        if is_test_module(&node.attrs) {
-            self.occurrences.push(TestModuleOccurrence {
-                name: node.ident.to_string(),
-                path: self.path.to_path_buf(),
-                line: span_line(node.ident.span()),
-            });
-        }
-
-        visit::visit_item_mod(self, node);
-    }
-}
-
-fn span_line(span: Span) -> usize {
-    span.start().line
-}
-
-fn is_test_module(attrs: &[Attribute]) -> bool {
-    attrs
-        .iter()
-        .filter(|attr| attr.path().is_ident("cfg"))
-        .any(|attr| match &attr.meta {
-            Meta::List(list) => parse_meta_list(list.tokens.clone())
-                .is_some_and(|metas| metas.iter().any(|meta| meta_mentions_test(meta, false))),
-            _ => false,
-        })
-}
-
-fn parse_meta_list(tokens: proc_macro2::TokenStream) -> Option<Punctuated<Meta, Token![,]>> {
-    Punctuated::<Meta, Token![,]>::parse_terminated
-        .parse2(tokens)
-        .ok()
-}
-
-fn meta_mentions_test(meta: &Meta, negated: bool) -> bool {
-    match meta {
-        Meta::Path(path) => path.is_ident("test") && !negated,
-        Meta::List(list) => {
-            let nested_negated = if list.path.is_ident("not") {
-                !negated
-            } else {
-                negated
-            };
-            parse_meta_list(list.tokens.clone()).is_some_and(|metas| {
-                metas
-                    .iter()
-                    .any(|meta| meta_mentions_test(meta, nested_negated))
-            })
-        }
-        Meta::NameValue(_) => false,
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;
-
-    fn names(source: &str) -> Vec<String> {
-        let file = syn::parse_file(source).unwrap();
-        let path = Path::new("fixture.rs");
-        let mut occurrences = Vec::new();
-        let mut visitor = TestModuleVisitor {
-            path,
-            occurrences: &mut occurrences,
-        };
-        visitor.visit_file(&file);
-        occurrences
-            .into_iter()
-            .map(|occurrence| occurrence.name)
-            .collect()
-    }
 
     fn unique_temp_dir(name: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -198,6 +88,20 @@ mod tests {
             "cargo-cultist-{name}-{}-{nanos}",
             std::process::id()
         ))
+    }
+
+    fn names(source: &str) -> Vec<String> {
+        let root = unique_temp_dir("test-module-names");
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("fixture.rs");
+        std::fs::write(&path, source).unwrap();
+        let report = analyze_test_module_files(&[path]).unwrap();
+        std::fs::remove_dir_all(root).unwrap();
+        report
+            .occurrences
+            .into_iter()
+            .map(|occurrence| occurrence.name)
+            .collect()
     }
 
     #[test]


### PR DESCRIPTION
## What

Introduce the first persistent Rust fact cache and make the two syntax analyzers consume the same extraction format.

### Shared fact extraction

A single `syn` visit now extracts reusable content-local facts:

- test-gated module declarations;
- explicit `#[test]` functions;
- declared module names;
- parse failure state.

The test-module analyzer and `ci-tests` derive their reports from that same fact record instead of maintaining independent whole-file AST walks.

### Git content identity

For Git repositories, the scanner uses Git's file inventory and clean tracked blob identity:

- tracked + relevant untracked Rust files come from Git-aware inventory;
- clean tracked files use their index/blob OID as the cache key;
- dirty or untracked files bypass persistent reuse and are parsed from the working tree;
- ignored untracked files stay out of the inventory;
- path/scope stays outside the cached fact, so the same blob can be reused after a clean rename or across matching branches.

The cache lives in the user cache directory by default, can be redirected with `CARGO_CULTIST_CACHE_DIR`, and can be disabled with `CARGO_CULTIST_CACHE=0`. Corrupt entries degrade to recomputation.

### Demand-driven `ci-tests`

`ci-tests` discovers supported workflow selectors before requesting Rust facts. If no supported selector exists, it exits without opening Rust source.

## Regression coverage

- one parse extracts facts needed by both current analyzers;
- first clean scan parses a blob, second scan hits the cache;
- clean rename reuses the same blob facts under the new path;
- dirty working-tree edit bypasses the clean blob cache;
- corrupt cache entry recomputes;
- `ci-tests` with no supported workflow succeeds even when unrelated Rust source is invalid UTF-8, proving the Rust inventory was skipped;
- existing test-module and CI selector semantics remain covered by their original tests.

## Scope

This is the first #44/#45 slice. Dirty/untracked content hashing, scoped aggregate snapshots (#50), bounded parallel extraction, and performance counters (#48) remain follow-ups. Cache reuse stays conservative when Git state cannot be parsed cleanly.

Progresses #44
Progresses #45
Related: #13 #48 #49 #50