### PR TITLE
research: prototype repo-local decision memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,61 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
       - name: Test
         run: cargo test
+      - name: Exercise decision-memory research resolver
+        run: |
+          set -euo pipefail
+
+          cargo run --quiet --example decision_memory -- \
+            research/decision-memory src/history.rs \
+            > /tmp/cultist-decision-history.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path('/tmp/cultist-decision-history.json').read_text())
+          assert report['analysis'] == 'decision_memory', report
+          assert report['target'] == 'src/history.rs', report
+          assert len(report['decisions']) == 1, report
+          decision = report['decisions'][0]
+          assert decision['record']['id'] == 'history-cochange-remains-association-v1', decision
+          assert decision['record']['scope']['path_prefix'] == 'src/history.rs', decision
+          assert [item['reference'] for item in decision['record']['authority']] == [
+              '#34', '#39', '#19'
+          ], decision
+          PY
+
+          cargo run --quiet --example decision_memory -- \
+            research/decision-memory src/main.rs \
+            > /tmp/cultist-decision-unrelated.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path('/tmp/cultist-decision-unrelated.json').read_text())
+          assert report['target'] == 'src/main.rs', report
+          assert report['decisions'] == [], report
+          PY
+
+          bad_records="$(mktemp -d -p . decision-memory-invalid.XXXXXX)"
+          cat > "$bad_records/unsupported.json" <<'EOF'
+          {
+            "schema_version": 99,
+            "id": "unsupported",
+            "kind": "test",
+            "scope": {"path_prefix": "src/history.rs"},
+            "reason": "invalid fixture",
+            "authority": [{"kind": "issue", "reference": "#75"}]
+          }
+          EOF
+          if cargo run --quiet --example decision_memory -- \
+              "$bad_records" src/history.rs \
+              > /tmp/cultist-decision-invalid.out \
+              2> /tmp/cultist-decision-invalid.err; then
+            echo "unsupported decision schema unexpectedly succeeded" >&2
+            exit 1
+          fi
+          grep -q 'unsupported decision schema 99' /tmp/cultist-decision-invalid.err
+          rm -rf "$bad_records"
       - name: Dogfood repository scan
         run: cargo run -- .
       - name: Dogfood repository JSON

--- a/examples/decision_memory.rs
+++ b/examples/decision_memory.rs
@@ -72,7 +72,11 @@ fn run() -> Result<(), Box<dyn Error>> {
 
     let requested_target = absolute_from(&cwd, Path::new(&target_arg)).canonicalize()?;
     if !requested_target.is_file() {
-        return Err(format!("target must be an existing file: {}", requested_target.display()).into());
+        return Err(format!(
+            "target must be an existing file: {}",
+            requested_target.display()
+        )
+        .into());
     }
 
     let root = git_repo_root(
@@ -144,9 +148,8 @@ fn resolve_decisions(
     let mut resolved = Vec::new();
     for path in files {
         let bytes = fs::read(&path)?;
-        let record: DecisionRecord = serde_json::from_slice(&bytes).map_err(|error| {
-            format!("invalid decision record {}: {error}", path.display())
-        })?;
+        let record: DecisionRecord = serde_json::from_slice(&bytes)
+            .map_err(|error| format!("invalid decision record {}: {error}", path.display()))?;
         validate_record(&record, &path)?;
 
         let scope = Path::new(&record.scope.path_prefix);
@@ -211,7 +214,11 @@ fn validate_record(record: &DecisionRecord, path: &Path) -> Result<(), Box<dyn E
         .iter()
         .any(|item| item.kind.trim().is_empty() || item.reference.trim().is_empty())
     {
-        return Err(format!("decision authority contains an empty field in {}", path.display()).into());
+        return Err(format!(
+            "decision authority contains an empty field in {}",
+            path.display()
+        )
+        .into());
     }
     Ok(())
 }

--- a/examples/decision_memory.rs
+++ b/examples/decision_memory.rs
@@ -1,0 +1,234 @@
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+struct DecisionScope {
+    path_prefix: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+struct DecisionAuthority {
+    kind: String,
+    reference: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+struct DecisionRecord {
+    schema_version: u32,
+    id: String,
+    kind: String,
+    scope: DecisionScope,
+    reason: String,
+    authority: Vec<DecisionAuthority>,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct ResolvedDecision {
+    source_file: String,
+    record: DecisionRecord,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct DecisionMemoryReport {
+    schema_version: u32,
+    analysis: &'static str,
+    repository: String,
+    target: String,
+    records_directory: String,
+    decisions: Vec<ResolvedDecision>,
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("decision-memory: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut args = env::args().skip(1);
+    let records_arg = args
+        .next()
+        .ok_or("usage: cargo run --example decision_memory -- RECORDS_DIR TARGET")?;
+    let target_arg = args
+        .next()
+        .ok_or("usage: cargo run --example decision_memory -- RECORDS_DIR TARGET")?;
+    if args.next().is_some() {
+        return Err("expected exactly RECORDS_DIR and TARGET".into());
+    }
+
+    let cwd = env::current_dir()?;
+    let records = absolute_from(&cwd, Path::new(&records_arg)).canonicalize()?;
+    if !records.is_dir() {
+        return Err(format!("records directory does not exist: {}", records.display()).into());
+    }
+
+    let requested_target = absolute_from(&cwd, Path::new(&target_arg)).canonicalize()?;
+    if !requested_target.is_file() {
+        return Err(format!("target must be an existing file: {}", requested_target.display()).into());
+    }
+
+    let root = git_repo_root(
+        requested_target
+            .parent()
+            .ok_or("could not determine target parent directory")?,
+    )?;
+    let target = requested_target
+        .strip_prefix(&root)
+        .map_err(|_| "target is outside the resolved Git repository")?
+        .to_path_buf();
+
+    let records_relative = records
+        .strip_prefix(&root)
+        .map_err(|_| "records directory is outside the resolved Git repository")?;
+
+    let decisions = resolve_decisions(&root, &records, &target)?;
+    let report = DecisionMemoryReport {
+        schema_version: SCHEMA_VERSION,
+        analysis: "decision_memory",
+        repository: root.display().to_string(),
+        target: target.display().to_string(),
+        records_directory: records_relative.display().to_string(),
+        decisions,
+    };
+
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    Ok(())
+}
+
+fn absolute_from(cwd: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn git_repo_root(path: &Path) -> Result<PathBuf, Box<dyn Error>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "{} is not inside a Git repository: {stderr}",
+            path.display()
+        )
+        .into());
+    }
+
+    Ok(PathBuf::from(String::from_utf8(output.stdout)?.trim()).canonicalize()?)
+}
+
+fn resolve_decisions(
+    root: &Path,
+    records: &Path,
+    target: &Path,
+) -> Result<Vec<ResolvedDecision>, Box<dyn Error>> {
+    let mut files = fs::read_dir(records)?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<Result<Vec<_>, _>>()?;
+    files.retain(|path| path.extension().and_then(|value| value.to_str()) == Some("json"));
+    files.sort();
+
+    let mut resolved = Vec::new();
+    for path in files {
+        let bytes = fs::read(&path)?;
+        let record: DecisionRecord = serde_json::from_slice(&bytes).map_err(|error| {
+            format!("invalid decision record {}: {error}", path.display())
+        })?;
+        validate_record(&record, &path)?;
+
+        let scope = Path::new(&record.scope.path_prefix);
+        if scope.is_absolute() {
+            return Err(format!(
+                "decision record {} uses an absolute scope; scopes must be repository-relative",
+                path.display()
+            )
+            .into());
+        }
+
+        if target.starts_with(scope) {
+            let source_file = path
+                .strip_prefix(root)
+                .map_err(|_| "decision record is outside the resolved Git repository")?
+                .display()
+                .to_string();
+            resolved.push(ResolvedDecision {
+                source_file,
+                record,
+            });
+        }
+    }
+
+    resolved.sort_by(|left, right| {
+        left.record
+            .scope
+            .path_prefix
+            .cmp(&right.record.scope.path_prefix)
+            .then_with(|| left.record.id.cmp(&right.record.id))
+    });
+    Ok(resolved)
+}
+
+fn validate_record(record: &DecisionRecord, path: &Path) -> Result<(), Box<dyn Error>> {
+    if record.schema_version != SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported decision schema {} in {}; expected {}",
+            record.schema_version,
+            path.display(),
+            SCHEMA_VERSION
+        )
+        .into());
+    }
+    if record.id.trim().is_empty() {
+        return Err(format!("decision id is empty in {}", path.display()).into());
+    }
+    if record.kind.trim().is_empty() {
+        return Err(format!("decision kind is empty in {}", path.display()).into());
+    }
+    if record.scope.path_prefix.trim().is_empty() {
+        return Err(format!("decision scope is empty in {}", path.display()).into());
+    }
+    if record.reason.trim().is_empty() {
+        return Err(format!("decision reason is empty in {}", path.display()).into());
+    }
+    if record.authority.is_empty() {
+        return Err(format!("decision authority is empty in {}", path.display()).into());
+    }
+    if record
+        .authority
+        .iter()
+        .any(|item| item.kind.trim().is_empty() || item.reference.trim().is_empty())
+    {
+        return Err(format!("decision authority contains an empty field in {}", path.display()).into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn component_scope_does_not_match_string_prefix_neighbor() {
+        let scope = Path::new("src/history.rs");
+        assert!(Path::new("src/history.rs").starts_with(scope));
+        assert!(!Path::new("src/history.rs.bak").starts_with(scope));
+    }
+
+    #[test]
+    fn directory_scope_matches_descendants() {
+        assert!(Path::new("src/history/tests.rs").starts_with(Path::new("src/history")));
+    }
+}

--- a/research/decision-memory.md
+++ b/research/decision-memory.md
@@ -1,0 +1,296 @@
+# Decision memory: closing the after -> future-before loop
+
+Date: 2026-08-19
+
+Status: research slice for #75, composed from #10, #18, #62, and #74. The record format and location in this branch are explicitly provisional.
+
+## Question
+
+Can one reviewed repository decision become deterministic project memory that a later agent can recover for the exact target it applies to?
+
+The lifecycle is:
+
+```text
+repository question / finding
+-> human-reviewed decision
+-> rationale stored in version control
+-> later agent targets related code
+-> decision resolver returns the applicable rationale + authority references
+```
+
+The key product property is continuity. Cargo Cultist should not need a second private memory database for the after-code lesson to become before-code context.
+
+## Why this is separate from suppression
+
+A decision record is evidence first.
+
+It may explain why a finding is intentional, but merely resolving a record must not automatically:
+
+- suppress a future finding;
+- prove that the decision still applies;
+- widen the decision to neighboring code;
+- turn one maintainer choice into repository-wide policy.
+
+Those are later explicit operations with their own evidence and authority.
+
+## Research storage
+
+This branch uses:
+
+```text
+research/decision-memory/*.json
+```
+
+That location is intentionally research-only. It proves record semantics without claiming a final `.cargo-cultist` layout or committing #10 to JSON rather than TOML/another reviewed format.
+
+One record per file has useful properties worth testing:
+
+- independent Git history for each decision;
+- reduced merge contention for parallel agents;
+- simple stable identity;
+- easy code review and deletion;
+- no need to rewrite a monolithic registry for every new rationale.
+
+## v0 record
+
+The first record captures an existing Cargo Cultist decision already present in #34, PR #39, and #19:
+
+```json
+{
+  "schema_version": 1,
+  "id": "history-cochange-remains-association-v1",
+  "kind": "historical-companion-policy",
+  "scope": {
+    "path_prefix": "src/history.rs"
+  },
+  "reason": "Raw historical co-change support is association evidence. Frequency alone does not establish that a companion is required for a future change, so examples, counterexamples, cohort exclusions, and stronger evidence layers remain visible before promotion.",
+  "authority": [
+    {"kind": "issue", "reference": "#34"},
+    {"kind": "pull_request", "reference": "#39"},
+    {"kind": "roadmap", "reference": "#19"}
+  ]
+}
+```
+
+This is useful as a self-dogfood decision because it directly protects Cargo Cultist from cargo-culting its own historical percentages.
+
+## Resolver
+
+`examples/decision_memory.rs` is a standalone read-only probe:
+
+```text
+cargo run --example decision_memory -- RECORDS_DIR TARGET
+```
+
+It:
+
+1. resolves the target inside the current Git repository;
+2. reads sorted JSON decision files from the explicitly supplied research directory;
+3. validates schema and required fields;
+4. treats absolute scopes as invalid;
+5. matches `path_prefix` using path-component semantics rather than string prefixing;
+6. returns source file, full decision record, rationale, and authority references;
+7. fails closed on malformed or unsupported records.
+
+It does not modify the repository or suppress analyzer output.
+
+## First discriminator
+
+For:
+
+```text
+TARGET=src/history.rs
+```
+
+expected:
+
+```text
+1 applicable decision
+id = history-cochange-remains-association-v1
+```
+
+For:
+
+```text
+TARGET=src/main.rs
+```
+
+expected:
+
+```text
+0 applicable decisions
+```
+
+For a record with:
+
+```json
+{"schema_version": 99, ...}
+```
+
+expected:
+
+```text
+hard refusal: unsupported decision schema
+```
+
+CI executes all three cases.
+
+## Authority model
+
+This prototype deliberately separates **record content** from **record authority**.
+
+A file on an unmerged agent branch is only a proposal. It becomes accepted repository memory through the ordinary repository authority path: review/merge or another explicit maintainer action.
+
+That means an agent can draft:
+
+```text
+reason + scope + evidence references
+```
+
+without silently teaching the project anything.
+
+The Git event that accepts the record is part of its provenance.
+
+A later product implementation should consider exposing that acceptance identity directly rather than relying only on the record's self-declared authority list.
+
+## Why authority references remain plural
+
+The first fixture cites #34, #39, and #19 separately because they provide different evidence:
+
+- #34 owns the raw history experiment contract;
+- #39 is the implementation/replay carrier;
+- #19 records the broader project rule that raw evidence remains exploratory until promoted.
+
+Collapsing those into one prose summary would lose useful ancestry.
+
+## Scope semantics
+
+The current `path_prefix` model is intentionally narrow.
+
+Path-component matching means:
+
+```text
+scope: src/history.rs
+```
+
+matches:
+
+```text
+src/history.rs
+```
+
+and does not match:
+
+```text
+src/history.rs.bak
+```
+
+A directory scope such as:
+
+```text
+src/history
+```
+
+can match descendants.
+
+Future questions include:
+
+- item/function scopes;
+- finding-family scopes;
+- package/workspace scopes;
+- glob semantics;
+- rename/refactor migration;
+- expiry/conditions.
+
+Do not add them until real decisions require them.
+
+## Feeding #62 `brief`
+
+The important composition is straightforward:
+
+```text
+brief TARGET
+-> resolve applicable decision records
+-> emit them as explicit project-memory evidence
+-> keep observed history/precedent separate
+```
+
+Possible future packet section:
+
+```json
+{
+  "decisions": [
+    {
+      "claim_kind": "proven",
+      "record_id": "history-cochange-remains-association-v1",
+      "scope": "src/history.rs",
+      "reason": "...",
+      "authority": ["#34", "#39", "#19"],
+      "source_file": "..."
+    }
+  ]
+}
+```
+
+`PROVEN` here would mean the reviewed record exists and applies by deterministic scope. It would not mean every assertion inside the rationale is formally proved.
+
+That distinction should remain visible.
+
+## Feeding the during-code phase
+
+`diff` can use the same resolver to say:
+
+```text
+KNOWN DECISION
+  This changed target has an applicable repository decision.
+  Reason: raw co-change remains association evidence.
+```
+
+If the live change contradicts the decision, Cultist should surface tension rather than silently suppressing either side.
+
+## Feeding #11 promotion
+
+Repeated decisions may later justify a deterministic rule, but the record itself should preserve the intermediate history:
+
+```text
+finding
+-> reviewed decision record
+-> repeated reviewed decisions
+-> explicit promotion event
+-> lint / CI rule
+```
+
+The promoted rule should link back to the decision records/counterexamples that earned it.
+
+## Agent lifecycle consequence
+
+This is the missing closure in #74:
+
+```text
+BEFORE
+  brief retrieves earned memory
+
+DURING
+  diff checks the live change against that memory
+
+AFTER
+  reviewed decision stores a newly earned lesson
+
+NEXT TIME
+  brief retrieves it automatically
+```
+
+An agent can therefore enter with no original chat transcript, work from repository evidence, and leave behind reviewable memory for its successor.
+
+## Promotion gates
+
+Keep this as research until:
+
+1. at least two independent decision types need the same core fields;
+2. scope semantics survive a real refactor/rename case;
+3. brief/diff consume decisions without turning them into implicit suppressions;
+4. accepted-vs-proposed authority can be represented cleanly;
+5. invalid records fail closed with useful source identity;
+6. one longitudinal agent replay shows agent B recovering a decision left by agent A.
+
+If the record format fails these tests, replace it rather than preserving compatibility with a research fixture.

--- a/research/decision-memory/history-cochange-remains-association.json
+++ b/research/decision-memory/history-cochange-remains-association.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "id": "history-cochange-remains-association-v1",
+  "kind": "historical-companion-policy",
+  "scope": {
+    "path_prefix": "src/history.rs"
+  },
+  "reason": "Raw historical co-change support is association evidence. Frequency alone does not establish that a companion is required for a future change, so examples, counterexamples, cohort exclusions, and stronger evidence layers remain visible before promotion.",
+  "authority": [
+    {
+      "kind": "issue",
+      "reference": "#34"
+    },
+    {
+      "kind": "pull_request",
+      "reference": "#39"
+    },
+    {
+      "kind": "roadmap",
+      "reference": "#19"
+    }
+  ]
+}


### PR DESCRIPTION
Superseded by #91.

The original proof established the minimal reviewed-decision -> repo-local record -> later target lookup loop, but its branch predates current `main` and permanently modified generic CI for a provisional research format.

#91 rebuilds the proof from current main with the same self-dogfood rationale plus stricter record provenance:

- canonical repository-relative scope syntax;
- duplicate decision-ID rejection;
- symlinked record rejection;
- temporary research workflow instead of a permanent generic-CI step.

The record format remains research-only.