### PR TITLE
dogfood: repair generated-root provenance (#80)

### DIFF
--- a/.github/workflows/dogfood-80-context.yml
+++ b/.github/workflows/dogfood-80-context.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - dogfood/80-proven-root
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/dogfood-80-context.yml
+++ b/.github/workflows/dogfood-80-context.yml
@@ -1,0 +1,53 @@
+name: Dogfood #80 pre-edit context
+
+on:
+  push:
+    branches:
+      - dogfood/80-proven-root
+
+permissions:
+  contents: read
+
+jobs:
+  brief:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - name: Generate pre-edit packet
+        run: |
+          cargo run --quiet --example agent_context_packet -- src/generated_diff.rs > /tmp/generated-diff-context.json
+          python -m json.tool /tmp/generated-diff-context.json >/dev/null
+      - name: Print selected evidence
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          p = json.loads(Path('/tmp/generated-diff-context.json').read_text())
+          print('target:', p['target']['path'])
+          print('serialized_bytes:', p['serialized_bytes'])
+          print('guidance:', [g['path'] for g in p['guidance']])
+          print('recent_history:')
+          for c in p['recent_history']:
+              print(' ', c['sha'][:8], c['subject'])
+          print('companions:')
+          for c in p['historical_companions']:
+              print(' ', c['support'], '/', c['opportunities'], c['path'])
+          print('unknowns:')
+          for u in p['unknowns']:
+              print(' ', u)
+          print('truncation:')
+          for t in p['truncation']:
+              print(' ', t)
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dogfood-80-pre-edit-context
+          path: /tmp/generated-diff-context.json
+          if-no-files-found: error


### PR DESCRIPTION
Dogfood carrier for the #74 before/during/after workflow on issue #80.

## Before-code result

The temporary local `agent_context_packet` run for `src/generated_diff.rs` succeeded and produced a 3,717-byte packet. It selected:

```text
recent history
  d15bcdea  Contain generated companion findings pending provenance repair
  c59f6e4b  feat: detect missing generated companions in diffs

historical companions
  research/generated-companion-product-replay.md  1/2
  src/diff.rs                                      1/2
  src/main.rs                                      1/2
```

No applicable local guidance was found. The packet explicitly reported remote PR/issue/review rationale as unavailable.

Following the selected product replay recovered the relevant design decision: preserve the held-out product behavior, then consolidate the repeated generator/history adapter separately so evidence semantics cannot drift.

## Coordination result

While moving from investigation to implementation, PR #90 opened on `fix/80-canonical-generator-ownership` with the same repair direction. This carrier is therefore intentionally closed rather than duplicating the implementation.

The episode exposed a useful missing pre-edit evidence class: optional remote `active_work` (branches/PRs/issues touching the same target or repair). That result is recorded on #74.

## Disposition

Superseded by PR #90 for the actual #80 implementation. This branch was useful as the dogfood measurement carrier; its temporary workflow is not product work and should not merge.