### PR TITLE
feat: add direct preflight collision analysis

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod diff;
 mod finding;
 mod generated_diff;
 mod history;
+mod preflight;
 mod render;
 mod report;
 mod rust_facts;
@@ -19,6 +20,7 @@ use finding::AnalysisReport;
 use history::{
     DEFAULT_MAX_COMMITS, HistoryOptions, analyze_historical_companions, print_history_report,
 };
+use preflight::build_preflight_analysis_report;
 use render::render_analysis_report;
 use report::build_test_module_analysis;
 use test_modules::analyze_test_modules;
@@ -35,6 +37,13 @@ enum OutputFormat {
 #[derive(Debug, Default, Eq, PartialEq)]
 struct DiffArgs {
     base: Option<String>,
+    path: Option<PathBuf>,
+    format: OutputFormat,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct PreflightArgs {
+    against: String,
     path: Option<PathBuf>,
     format: OutputFormat,
 }
@@ -65,6 +74,11 @@ fn run() -> Result<(), Box<dyn Error>> {
     if args.first().is_some_and(|arg| arg == "diff") {
         args.remove(0);
         return run_diff(args);
+    }
+
+    if args.first().is_some_and(|arg| arg == "preflight") {
+        args.remove(0);
+        return run_preflight(args);
     }
 
     if args.first().is_some_and(|arg| arg == "history") {
@@ -105,6 +119,37 @@ fn run_diff(args: Vec<String>) -> Result<(), Box<dyn Error>> {
     let requested_root = requested_root.canonicalize()?;
     let root = git_repo_root(&requested_root)?;
     let analysis = build_diff_analysis_report(&root, base.as_deref())?;
+    emit_analysis(&analysis, format)
+}
+
+fn run_preflight(args: Vec<String>) -> Result<(), Box<dyn Error>> {
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_preflight_help();
+        return Ok(());
+    }
+
+    let PreflightArgs {
+        against,
+        path,
+        format,
+    } = parse_preflight_args(args)?;
+
+    let requested = path.unwrap_or(env::current_dir()?);
+    let requested = requested.canonicalize()?;
+    let probe = if requested.is_file() {
+        requested
+            .parent()
+            .ok_or("could not determine the preflight path's parent directory")?
+    } else {
+        requested.as_path()
+    };
+    let root = git_repo_root(probe)?;
+    let relative = requested
+        .strip_prefix(&root)
+        .map_err(|_| "preflight path is outside the resolved Git repository")?;
+    let scope = (!relative.as_os_str().is_empty()).then(|| relative.to_path_buf());
+
+    let analysis = build_preflight_analysis_report(&root, &against, scope.as_deref())?;
     emit_analysis(&analysis, format)
 }
 
@@ -262,6 +307,50 @@ fn parse_diff_args(args: Vec<String>) -> Result<DiffArgs, Box<dyn Error>> {
     Ok(parsed)
 }
 
+fn parse_preflight_args(args: Vec<String>) -> Result<PreflightArgs, Box<dyn Error>> {
+    let mut against = None;
+    let mut path = None;
+    let mut format = OutputFormat::Text;
+    let mut args = args.into_iter();
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--against" => {
+                if against.is_some() {
+                    return Err("`--against` may only be specified once".into());
+                }
+                against = Some(args.next().ok_or("`--against` requires a Git revision")?);
+            }
+            "--format" => {
+                format = parse_output_format(
+                    &args.next().ok_or("`--format` requires `text` or `json`")?,
+                )?;
+            }
+            _ if arg.starts_with('-') => {
+                return Err(format!(
+                    "unknown preflight option `{arg}`; try `cargo cultist preflight --help`"
+                )
+                .into());
+            }
+            _ => {
+                if path.is_some() {
+                    return Err(
+                        "expected at most one path argument; try `cargo cultist preflight --help`"
+                            .into(),
+                    );
+                }
+                path = Some(PathBuf::from(arg));
+            }
+        }
+    }
+
+    Ok(PreflightArgs {
+        against: against.ok_or("preflight requires `--against REV`")?,
+        path,
+        format,
+    })
+}
+
 fn parse_history_args(args: Vec<String>) -> Result<HistoryArgs, Box<dyn Error>> {
     let mut path = None;
     let mut max_commits = DEFAULT_MAX_COMMITS;
@@ -325,8 +414,8 @@ fn print_help() {
     println!(
         "cargo-cultist {VERSION}\n\
 Repository-aware analysis for Rust codebases.\n\n\
-USAGE:\n    cargo cultist [--format text|json] [PATH]\n    cargo cultist diff [--base REV] [--format text|json] [PATH]\n    cargo cultist history [--max-commits N] [--format text|json] FILE\n    cargo cultist ci-tests [--format text|json] [PATH]\n    cargo-cultist [--format text|json] [PATH]\n    cargo-cultist diff [--base REV] [--format text|json] [PATH]\n    cargo-cultist history [--max-commits N] [--format text|json] FILE\n    cargo-cultist ci-tests [--format text|json] [PATH]\n\n\
-COMMANDS:\n    diff       Inspect changed Rust code against repository precedent.\n    history    Explore which paths historically change with one file.\n    ci-tests   Compare supported CI test filters with explicit test-name evidence.\n\n\
+USAGE:\n    cargo cultist [--format text|json] [PATH]\n    cargo cultist diff [--base REV] [--format text|json] [PATH]\n    cargo cultist preflight --against REV [--format text|json] [PATH]\n    cargo cultist history [--max-commits N] [--format text|json] FILE\n    cargo cultist ci-tests [--format text|json] [PATH]\n    cargo-cultist [--format text|json] [PATH]\n    cargo-cultist diff [--base REV] [--format text|json] [PATH]\n    cargo-cultist preflight --against REV [--format text|json] [PATH]\n    cargo-cultist history [--max-commits N] [--format text|json] FILE\n    cargo-cultist ci-tests [--format text|json] [PATH]\n\n\
+COMMANDS:\n    diff       Inspect changed Rust code against repository precedent.\n    preflight  Compare concurrent change sets for collision evidence.\n    history    Explore which paths historically change with one file.\n    ci-tests   Compare supported CI test filters with explicit test-name evidence.\n\n\
 Without a command, cargo-cultist inspects repository-wide test-module naming\n\
 conventions without inventing a universal rule."
     );
@@ -340,6 +429,18 @@ By default, compares the working tree (including staged changes) against HEAD.\n
 With --base REV, compares changes from the merge base of REV and HEAD.\n\n\
 The first diff-aware check looks for added or renamed #[cfg(test)] modules and\n\
 compares their names with repository-wide and same-file precedent."
+    );
+}
+
+fn print_preflight_help() {
+    println!(
+        "cargo-cultist preflight\n\n\
+USAGE:\n    cargo cultist preflight --against REV [--format text|json] [PATH]\n\n\
+Compares current work with REV from their merge base and reports direct path\n\
+overlap as PROVEN collision evidence. Current work includes committed branch\n\
+changes plus staged and unstaged tracked changes.\n\n\
+Different paths remain semantically UNKNOWN in this first slice; future\n\
+enrichments can add generated, historical, policy, and behavioral evidence."
     );
 }
 
@@ -386,6 +487,27 @@ mod tests {
         assert_eq!(parsed.base.as_deref(), Some("origin/main"));
         assert_eq!(parsed.path, Some(PathBuf::from(".")));
         assert_eq!(parsed.format, OutputFormat::Json);
+    }
+
+    #[test]
+    fn parses_preflight_against_path_and_format() {
+        let parsed = parse_preflight_args(vec![
+            "--against".to_string(),
+            "other-agent".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+            "src".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(parsed.against, "other-agent");
+        assert_eq!(parsed.path, Some(PathBuf::from("src")));
+        assert_eq!(parsed.format, OutputFormat::Json);
+    }
+
+    #[test]
+    fn rejects_preflight_without_against() {
+        assert!(parse_preflight_args(vec![]).is_err());
     }
 
     #[test]

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -1,0 +1,260 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::finding::{AnalysisReport, Claim, ClaimKind, Evidence, Finding, Location};
+
+pub fn build_preflight_analysis_report(
+    root: &Path,
+    against: &str,
+    scope: Option<&Path>,
+) -> Result<AnalysisReport, Box<dyn Error>> {
+    let anchor = merge_base(root, against)?;
+    let current_paths = changed_paths(root, &anchor, None, scope)?;
+    let other_paths = changed_paths(root, &anchor, Some(against), scope)?;
+
+    let mut analysis = AnalysisReport::new("preflight-collisions", root.to_string_lossy().into_owned());
+    analysis.claims.push(Claim::new(
+        ClaimKind::Derived,
+        format!(
+            "Preflight compares current work and `{against}` from merge base `{anchor}`."
+        ),
+    ));
+    analysis.claims.push(Claim::new(
+        ClaimKind::Proven,
+        format!(
+            "Current work modifies {} path(s); `{against}` modifies {} path(s) in the selected scope.",
+            current_paths.len(),
+            other_paths.len()
+        ),
+    ));
+
+    for path in current_paths.intersection(&other_paths) {
+        let display = path.to_string_lossy().into_owned();
+        analysis.findings.push(
+            Finding::new("preflight-direct-path-overlap", "Concurrent path overlap")
+                .at(Location::new(display.clone(), None))
+                .with_claim(
+                    Claim::new(
+                        ClaimKind::Proven,
+                        format!("Both current work and `{against}` modify `{display}`."),
+                    )
+                    .with_evidence(Evidence::at(
+                        format!("Current work changes `{display}` from merge base `{anchor}`."),
+                        Location::new(display.clone(), None),
+                    ))
+                    .with_evidence(Evidence::at(
+                        format!("`{against}` changes `{display}` from the same merge base."),
+                        Location::new(display.clone(), None),
+                    )),
+                )
+                .with_question(
+                    "Should ownership, ordering, or intent be coordinated before these changes proceed independently?",
+                ),
+        );
+    }
+
+    if analysis.findings.is_empty() {
+        analysis.claims.push(Claim::new(
+            ClaimKind::Proven,
+            "The two change sets have no direct repository-path overlap in the selected scope.",
+        ));
+    }
+
+    analysis.claims.push(Claim::new(
+        ClaimKind::Unknown,
+        "Direct path comparison does not determine whether different paths participate in the same generated, historical, policy, or behavioral relationship.",
+    ));
+
+    Ok(analysis)
+}
+
+fn changed_paths(
+    root: &Path,
+    anchor: &str,
+    target: Option<&str>,
+    scope: Option<&Path>,
+) -> Result<BTreeSet<PathBuf>, Box<dyn Error>> {
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(root)
+        .args([
+            "-c",
+            "core.quotepath=false",
+            "diff",
+            "--name-only",
+            "--no-renames",
+            "-z",
+            anchor,
+        ]);
+
+    if let Some(target) = target {
+        command.arg(target);
+    }
+
+    command.arg("--");
+    if let Some(scope) = scope {
+        command.arg(scope);
+    }
+
+    let output = command.output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git diff failed while building preflight evidence: {stderr}").into());
+    }
+
+    let mut paths = BTreeSet::new();
+    for raw in output.stdout.split(|byte| *byte == 0) {
+        if raw.is_empty() {
+            continue;
+        }
+        let path = std::str::from_utf8(raw)?;
+        paths.insert(PathBuf::from(path));
+    }
+    Ok(paths)
+}
+
+fn merge_base(root: &Path, against: &str) -> Result<String, Box<dyn Error>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["merge-base", against, "HEAD"])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(
+            format!("could not find merge base for `{against}` and HEAD: {stderr}").into(),
+        );
+    }
+
+    Ok(String::from_utf8(output.stdout)?.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "cargo-cultist-preflight-{name}-{}-{nanos}",
+            std::process::id()
+        ))
+    }
+
+    fn run_git(root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git command failed: git {args:?}\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo(name: &str) -> PathBuf {
+        let root = unique_temp_dir(name);
+        fs::create_dir_all(&root).unwrap();
+        run_git(&root, &["init", "-q", "-b", "main"]);
+        run_git(&root, &["config", "user.email", "cultist@example.invalid"]);
+        run_git(&root, &["config", "user.name", "Cargo Cultist Tests"]);
+        fs::write(root.join("shared.txt"), "baseline\n").unwrap();
+        fs::write(root.join("current.txt"), "baseline\n").unwrap();
+        fs::write(root.join("other.txt"), "baseline\n").unwrap();
+        run_git(&root, &["add", "."]);
+        run_git(&root, &["commit", "-q", "-m", "baseline"]);
+        root
+    }
+
+    fn make_other_branch(root: &Path, path: &str, contents: &str) {
+        run_git(root, &["switch", "-q", "-c", "other"]);
+        fs::write(root.join(path), contents).unwrap();
+        run_git(root, &["add", path]);
+        run_git(root, &["commit", "-q", "-m", "other change"]);
+        run_git(root, &["switch", "-q", "main"]);
+    }
+
+    #[test]
+    fn reports_direct_path_overlap() {
+        let root = init_repo("direct-overlap");
+        make_other_branch(&root, "shared.txt", "other\n");
+        fs::write(root.join("shared.txt"), "current\n").unwrap();
+
+        let analysis = build_preflight_analysis_report(&root, "other", None).unwrap();
+
+        assert_eq!(analysis.findings.len(), 1);
+        assert_eq!(analysis.findings[0].kind, "preflight-direct-path-overlap");
+        assert_eq!(
+            analysis.findings[0].location.as_ref().unwrap().path,
+            "shared.txt"
+        );
+        assert_eq!(analysis.findings[0].claims[0].kind, ClaimKind::Proven);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn disjoint_paths_remain_explicitly_unknown_semantically() {
+        let root = init_repo("disjoint");
+        make_other_branch(&root, "other.txt", "other\n");
+        fs::write(root.join("current.txt"), "current\n").unwrap();
+
+        let analysis = build_preflight_analysis_report(&root, "other", None).unwrap();
+
+        assert!(analysis.findings.is_empty());
+        assert!(analysis.claims.iter().any(|claim| {
+            claim.kind == ClaimKind::Proven && claim.message.contains("no direct repository-path overlap")
+        }));
+        assert!(analysis.claims.iter().any(|claim| claim.kind == ClaimKind::Unknown));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn includes_staged_and_unstaged_current_changes() {
+        let root = init_repo("staged-and-unstaged");
+        make_other_branch(&root, "shared.txt", "other shared\n");
+
+        fs::write(root.join("shared.txt"), "staged shared\n").unwrap();
+        run_git(&root, &["add", "shared.txt"]);
+        fs::write(root.join("current.txt"), "unstaged current\n").unwrap();
+
+        let analysis = build_preflight_analysis_report(&root, "other", None).unwrap();
+
+        assert_eq!(analysis.findings.len(), 1);
+        assert!(analysis.claims.iter().any(|claim| {
+            claim.kind == ClaimKind::Proven && claim.message.contains("Current work modifies 2 path(s)")
+        }));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn branch_commits_on_current_side_are_measured_from_merge_base() {
+        let root = init_repo("merge-base");
+        make_other_branch(&root, "shared.txt", "other\n");
+
+        fs::write(root.join("shared.txt"), "current committed\n").unwrap();
+        run_git(&root, &["add", "shared.txt"]);
+        run_git(&root, &["commit", "-q", "-m", "current change"]);
+
+        let analysis = build_preflight_analysis_report(&root, "other", None).unwrap();
+
+        assert_eq!(analysis.findings.len(), 1);
+        assert_eq!(
+            analysis.findings[0].location.as_ref().unwrap().path,
+            "shared.txt"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -14,12 +14,11 @@ pub fn build_preflight_analysis_report(
     let current_paths = changed_paths(root, &anchor, None, scope)?;
     let other_paths = changed_paths(root, &anchor, Some(against), scope)?;
 
-    let mut analysis = AnalysisReport::new("preflight-collisions", root.to_string_lossy().into_owned());
+    let mut analysis =
+        AnalysisReport::new("preflight-collisions", root.to_string_lossy().into_owned());
     analysis.claims.push(Claim::new(
         ClaimKind::Derived,
-        format!(
-            "Preflight compares current work and `{against}` from merge base `{anchor}`."
-        ),
+        format!("Preflight compares current work and `{against}` from merge base `{anchor}`."),
     ));
     analysis.claims.push(Claim::new(
         ClaimKind::Proven,
@@ -77,18 +76,15 @@ fn changed_paths(
     scope: Option<&Path>,
 ) -> Result<BTreeSet<PathBuf>, Box<dyn Error>> {
     let mut command = Command::new("git");
-    command
-        .arg("-C")
-        .arg(root)
-        .args([
-            "-c",
-            "core.quotepath=false",
-            "diff",
-            "--name-only",
-            "--no-renames",
-            "-z",
-            anchor,
-        ]);
+    command.arg("-C").arg(root).args([
+        "-c",
+        "core.quotepath=false",
+        "diff",
+        "--name-only",
+        "--no-renames",
+        "-z",
+        anchor,
+    ]);
 
     if let Some(target) = target {
         command.arg(target);
@@ -125,9 +121,7 @@ fn merge_base(root: &Path, against: &str) -> Result<String, Box<dyn Error>> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(
-            format!("could not find merge base for `{against}` and HEAD: {stderr}").into(),
-        );
+        return Err(format!("could not find merge base for `{against}` and HEAD: {stderr}").into());
     }
 
     Ok(String::from_utf8(output.stdout)?.trim().to_string())
@@ -215,9 +209,15 @@ mod tests {
 
         assert!(analysis.findings.is_empty());
         assert!(analysis.claims.iter().any(|claim| {
-            claim.kind == ClaimKind::Proven && claim.message.contains("no direct repository-path overlap")
+            claim.kind == ClaimKind::Proven
+                && claim.message.contains("no direct repository-path overlap")
         }));
-        assert!(analysis.claims.iter().any(|claim| claim.kind == ClaimKind::Unknown));
+        assert!(
+            analysis
+                .claims
+                .iter()
+                .any(|claim| claim.kind == ClaimKind::Unknown)
+        );
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -234,7 +234,8 @@ mod tests {
 
         assert_eq!(analysis.findings.len(), 1);
         assert!(analysis.claims.iter().any(|claim| {
-            claim.kind == ClaimKind::Proven && claim.message.contains("Current work modifies 2 path(s)")
+            claim.kind == ClaimKind::Proven
+                && claim.message.contains("Current work modifies 2 path(s)")
         }));
         fs::remove_dir_all(root).unwrap();
     }


### PR DESCRIPTION
Starts #96 with the deterministic baseline only.

## What

- add `cargo cultist preflight --against REV [PATH]`
- compare current work and `REV` from their merge base
- include committed current-branch changes plus staged/unstaged tracked work
- emit direct shared-path overlap as `PROVEN`
- emit explicit `UNKNOWN` for deeper generated/history/policy/behavioral relationships
- render through the existing shared text/JSON finding model
- add temporary-repository tests for overlap, disjoint paths, staged+unstaged changes, and merge-base semantics

## Boundary

This PR intentionally stops at direct path overlap. Historical companions, generated ownership, policy relationships, and active-PR discovery remain independent follow-ups with their own evidence gates and negative controls.

Refs #96.