### PR TITLE
research: dogfood live active-work heads-ups

### DIFF
--- a/.github/workflows/active-work-heads-up-research.yml
+++ b/.github/workflows/active-work-heads-up-research.yml
@@ -1,0 +1,134 @@
+name: Active work heads-up research
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  heads-up:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      CURRENT_PR: ${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Install stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Build active-work inventory
+        run: |
+          python - <<'PY'
+          import datetime
+          import json
+          import os
+          import subprocess
+          from pathlib import Path
+
+          repo = os.environ["GITHUB_REPOSITORY"]
+          current_number = int(os.environ["CURRENT_PR"])
+
+          def gh_json(args):
+              output = subprocess.check_output(["gh", *args], text=True)
+              return json.loads(output)
+
+          pages = gh_json([
+              "api", "--paginate", "--slurp",
+              f"repos/{repo}/pulls?state=open&per_page=100",
+          ])
+          prs = [pr for page in pages for pr in page]
+
+          def changed_paths(number):
+              file_pages = gh_json([
+                  "api", "--paginate", "--slurp",
+                  f"repos/{repo}/pulls/{number}/files?per_page=100",
+              ])
+              return sorted({item["filename"] for page in file_pages for item in page})
+
+          def item(pr):
+              return {
+                  "id": f"#{pr['number']}",
+                  "kind": "pull_request",
+                  "title": pr["title"],
+                  "url": pr["html_url"],
+                  "head_ref": pr["head"]["ref"],
+                  "head_sha": pr["head"]["sha"],
+                  "updated_at": pr["updated_at"],
+                  "draft": bool(pr.get("draft", False)),
+                  "changed_paths": changed_paths(pr["number"]),
+              }
+
+          current_pr = next((pr for pr in prs if pr["number"] == current_number), None)
+          if current_pr is None:
+              current_pr = gh_json(["api", f"repos/{repo}/pulls/{current_number}"])
+
+          inventory = {
+              "schema_version": 1,
+              "source": "github_pull_requests",
+              "observed_at": datetime.datetime.now(datetime.timezone.utc)
+                  .isoformat()
+                  .replace("+00:00", "Z"),
+              "current": item(current_pr),
+              "active_work": [item(pr) for pr in prs],
+          }
+          Path("/tmp/active-work-inventory.json").write_text(
+              json.dumps(inventory, indent=2) + "\n"
+          )
+          print(
+              f"inventory: {len(prs)} open PR(s), "
+              f"current #{current_number}, "
+              f"{len(inventory['current']['changed_paths'])} current path(s)"
+          )
+          PY
+
+      - name: Analyze active work
+        run: |
+          cargo run --quiet --example active_work_heads_up -- \
+            /tmp/active-work-inventory.json > /tmp/active-work-heads-up.json
+          python -m json.tool /tmp/active-work-heads-up.json >/dev/null
+
+      - name: Print advisory heads-ups
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path("/tmp/active-work-heads-up.json").read_text())
+          heads_up = report["heads_up"]
+          print(
+              f"examined: {report['candidates_examined']} active candidate(s); "
+              f"self excluded: {report['self_candidates_excluded']}"
+          )
+          if not heads_up:
+              print("No direct active-work path overlap worth surfacing.")
+          else:
+              print(f"HEADS UP: {len(heads_up)} active overlap(s)")
+              for item in heads_up:
+                  work = item["work"]
+                  print(
+                      f"  {work['id']} {work['title']} "
+                      f"[{work['head_sha'][:8]} updated {work['updated_at']}]"
+                  )
+                  for path in item["overlap_paths"]:
+                      print(f"    overlaps {path}")
+                  print("    No duplicate intent or incompatibility inferred.")
+          if report["omitted_heads_up"]:
+              print(f"omitted heads-ups: {report['omitted_heads_up']}")
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: active-work-heads-up-research
+          path: |
+            /tmp/active-work-inventory.json
+            /tmp/active-work-heads-up.json
+          if-no-files-found: error

--- a/.github/workflows/active-work-heads-up-research.yml
+++ b/.github/workflows/active-work-heads-up-research.yml
@@ -8,9 +8,15 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: active-work-heads-up-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   heads-up:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true
     env:
       GH_TOKEN: ${{ github.token }}
       CURRENT_PR: ${{ github.event.pull_request.number }}
@@ -125,64 +131,10 @@ jobs:
               print(f"omitted heads-ups: {report['omitted_heads_up']}")
           PY
 
-      - name: Exercise live pre-edit focus positive control
-        run: |
-          python - <<'PY'
-          import json
-          import subprocess
-          from pathlib import Path
-
-          inventory_path = Path("/tmp/active-work-inventory.json")
-          inventory = json.loads(inventory_path.read_text())
-          current = inventory["current"]
-          candidates = [
-              work
-              for work in inventory["active_work"]
-              if work["id"] != current["id"]
-              and work["head_sha"] != current["head_sha"]
-              and work["changed_paths"]
-          ]
-          candidates.sort(key=lambda work: int(work["id"].lstrip("#")))
-
-          output_path = Path("/tmp/active-work-focus-control.json")
-          if not candidates:
-              output_path.write_text(json.dumps({"skipped": True}, indent=2) + "\n")
-              print("focus control skipped: no non-self active work with changed paths")
-              raise SystemExit(0)
-
-          candidate = candidates[0]
-          focus = candidate["changed_paths"][0]
-          output = subprocess.check_output(
-              [
-                  "cargo", "run", "--quiet", "--example", "active_work_heads_up",
-                  "--", str(inventory_path), focus,
-              ],
-              text=True,
-          )
-          output_path.write_text(output)
-          report = json.loads(output)
-          matches = [
-              item
-              for item in report["heads_up"]
-              if item["work"]["id"] == candidate["id"]
-              and focus in item["focus_overlap_paths"]
-          ]
-          if not matches:
-              raise SystemExit(
-                  f"focus control failed: {candidate['id']} changes {focus!r} "
-                  "but focus-mode heads-up did not surface it"
-              )
-          print(
-              f"focus control: before touching {focus!r}, "
-              f"heads-up surfaced active {candidate['id']} at {candidate['head_sha'][:8]}"
-          )
-          PY
-
       - uses: actions/upload-artifact@v4
         with:
           name: active-work-heads-up-research
           path: |
             /tmp/active-work-inventory.json
             /tmp/active-work-heads-up.json
-            /tmp/active-work-focus-control.json
           if-no-files-found: error

--- a/.github/workflows/active-work-heads-up-research.yml
+++ b/.github/workflows/active-work-heads-up-research.yml
@@ -125,10 +125,64 @@ jobs:
               print(f"omitted heads-ups: {report['omitted_heads_up']}")
           PY
 
+      - name: Exercise live pre-edit focus positive control
+        run: |
+          python - <<'PY'
+          import json
+          import subprocess
+          from pathlib import Path
+
+          inventory_path = Path("/tmp/active-work-inventory.json")
+          inventory = json.loads(inventory_path.read_text())
+          current = inventory["current"]
+          candidates = [
+              work
+              for work in inventory["active_work"]
+              if work["id"] != current["id"]
+              and work["head_sha"] != current["head_sha"]
+              and work["changed_paths"]
+          ]
+          candidates.sort(key=lambda work: int(work["id"].lstrip("#")))
+
+          output_path = Path("/tmp/active-work-focus-control.json")
+          if not candidates:
+              output_path.write_text(json.dumps({"skipped": True}, indent=2) + "\n")
+              print("focus control skipped: no non-self active work with changed paths")
+              raise SystemExit(0)
+
+          candidate = candidates[0]
+          focus = candidate["changed_paths"][0]
+          output = subprocess.check_output(
+              [
+                  "cargo", "run", "--quiet", "--example", "active_work_heads_up",
+                  "--", str(inventory_path), focus,
+              ],
+              text=True,
+          )
+          output_path.write_text(output)
+          report = json.loads(output)
+          matches = [
+              item
+              for item in report["heads_up"]
+              if item["work"]["id"] == candidate["id"]
+              and focus in item["focus_overlap_paths"]
+          ]
+          if not matches:
+              raise SystemExit(
+                  f"focus control failed: {candidate['id']} changes {focus!r} "
+                  "but focus-mode heads-up did not surface it"
+              )
+          print(
+              f"focus control: before touching {focus!r}, "
+              f"heads-up surfaced active {candidate['id']} at {candidate['head_sha'][:8]}"
+          )
+          PY
+
       - uses: actions/upload-artifact@v4
         with:
           name: active-work-heads-up-research
           path: |
             /tmp/active-work-inventory.json
             /tmp/active-work-heads-up.json
+            /tmp/active-work-focus-control.json
           if-no-files-found: error

--- a/examples/active_work_heads_up.rs
+++ b/examples/active_work_heads_up.rs
@@ -310,8 +310,7 @@ mod tests {
 
     #[test]
     fn rejects_paths_that_escape_repository() {
-        let error =
-            analyze(inventory(work("#1", "aaa", &["../outside"]), Vec::new())).unwrap_err();
+        let error = analyze(inventory(work("#1", "aaa", &["../outside"]), Vec::new())).unwrap_err();
 
         assert!(error.contains("may not escape"));
     }

--- a/examples/active_work_heads_up.rs
+++ b/examples/active_work_heads_up.rs
@@ -7,8 +7,7 @@ use serde::{Deserialize, Serialize};
 
 const SCHEMA_VERSION: u32 = 1;
 const MAX_HEADS_UP: usize = 12;
-const USAGE: &str =
-    "usage: cargo run --example active_work_heads_up -- ACTIVE_WORK_INVENTORY.json [FOCUS_PATH ...]";
+const USAGE: &str = "usage: cargo run --example active_work_heads_up -- ACTIVE_WORK_INVENTORY.json [FOCUS_PATH ...]";
 
 #[derive(Debug, Clone, Deserialize)]
 struct ActiveWorkInventory {

--- a/examples/active_work_heads_up.rs
+++ b/examples/active_work_heads_up.rs
@@ -1,0 +1,321 @@
+use std::collections::BTreeSet;
+use std::env;
+use std::error::Error;
+use std::fs;
+
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_VERSION: u32 = 1;
+const MAX_HEADS_UP: usize = 12;
+
+#[derive(Debug, Clone, Deserialize)]
+struct ActiveWorkInventory {
+    schema_version: u32,
+    source: String,
+    observed_at: String,
+    current: WorkItem,
+    active_work: Vec<WorkItem>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct WorkItem {
+    id: String,
+    kind: String,
+    title: String,
+    url: String,
+    head_ref: String,
+    head_sha: String,
+    updated_at: String,
+    draft: bool,
+    changed_paths: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct HeadsUpReport {
+    schema_version: u32,
+    analysis: &'static str,
+    source: String,
+    observed_at: String,
+    current: WorkIdentity,
+    candidates_examined: usize,
+    self_candidates_excluded: usize,
+    heads_up: Vec<HeadsUp>,
+    omitted_heads_up: usize,
+    unknowns: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct WorkIdentity {
+    id: String,
+    kind: String,
+    title: String,
+    url: String,
+    head_ref: String,
+    head_sha: String,
+    updated_at: String,
+    draft: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct HeadsUp {
+    kind: &'static str,
+    claim_kind: &'static str,
+    work: WorkIdentity,
+    overlap_paths: Vec<String>,
+    message: String,
+    question: &'static str,
+    unknowns: Vec<&'static str>,
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("active-work-heads-up: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let path = env::args()
+        .nth(1)
+        .ok_or("usage: cargo run --example active_work_heads_up -- ACTIVE_WORK_INVENTORY.json")?;
+    if env::args().nth(2).is_some() {
+        return Err(
+            "usage: cargo run --example active_work_heads_up -- ACTIVE_WORK_INVENTORY.json".into(),
+        );
+    }
+
+    let inventory: ActiveWorkInventory = serde_json::from_slice(&fs::read(path)?)?;
+    let report = analyze(inventory).map_err(|error| format!("invalid inventory: {error}"))?;
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    Ok(())
+}
+
+fn analyze(mut inventory: ActiveWorkInventory) -> Result<HeadsUpReport, String> {
+    if inventory.schema_version != SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported schema {}; expected {SCHEMA_VERSION}",
+            inventory.schema_version
+        ));
+    }
+    if inventory.source.trim().is_empty() {
+        return Err("source must not be empty".to_string());
+    }
+    if inventory.observed_at.trim().is_empty() {
+        return Err("observed_at must not be empty".to_string());
+    }
+
+    normalize_work(&mut inventory.current)?;
+    for work in &mut inventory.active_work {
+        normalize_work(work)?;
+    }
+
+    let current_paths: BTreeSet<_> = inventory.current.changed_paths.iter().cloned().collect();
+    let mut heads_up = Vec::new();
+    let mut candidates_examined = 0;
+    let mut self_candidates_excluded = 0;
+
+    for work in inventory.active_work {
+        if same_work(&inventory.current, &work) {
+            self_candidates_excluded += 1;
+            continue;
+        }
+        candidates_examined += 1;
+
+        let work_paths: BTreeSet<_> = work.changed_paths.iter().cloned().collect();
+        let overlap_paths = current_paths
+            .intersection(&work_paths)
+            .cloned()
+            .collect::<Vec<_>>();
+        if overlap_paths.is_empty() {
+            continue;
+        }
+
+        heads_up.push(HeadsUp {
+            kind: "active-direct-path-overlap",
+            claim_kind: "proven",
+            message: format!(
+                "Active work `{}` overlaps {} current path(s).",
+                work.id,
+                overlap_paths.len()
+            ),
+            work: identity(&work),
+            overlap_paths,
+            question: "Is there anything worth reconciling before continuing?",
+            unknowns: vec![
+                "Path overlap does not establish duplicate intent, ownership, incompatibility, or required coordination.",
+                "Freshness metadata is reported as observed; this analyzer does not infer whether the other work is still actively executing.",
+            ],
+        });
+    }
+
+    heads_up.sort_by(|left, right| {
+        right
+            .overlap_paths
+            .len()
+            .cmp(&left.overlap_paths.len())
+            .then_with(|| left.work.id.cmp(&right.work.id))
+    });
+    let omitted_heads_up = heads_up.len().saturating_sub(MAX_HEADS_UP);
+    heads_up.truncate(MAX_HEADS_UP);
+
+    Ok(HeadsUpReport {
+        schema_version: SCHEMA_VERSION,
+        analysis: "active_work_heads_up",
+        source: inventory.source,
+        observed_at: inventory.observed_at,
+        current: identity(&inventory.current),
+        candidates_examined,
+        self_candidates_excluded,
+        heads_up,
+        omitted_heads_up,
+        unknowns: vec![
+            "No direct path overlap is not evidence that active work is semantically independent.",
+            "This first experiment does not compare issue references, symbols, generated relationships, historical companions, policy, or behavior.",
+            "Remote inventory completeness and freshness are properties of the supplying adapter and remain separate from overlap analysis.",
+        ],
+    })
+}
+
+fn same_work(current: &WorkItem, other: &WorkItem) -> bool {
+    current.id == other.id || current.head_sha == other.head_sha
+}
+
+fn identity(work: &WorkItem) -> WorkIdentity {
+    WorkIdentity {
+        id: work.id.clone(),
+        kind: work.kind.clone(),
+        title: work.title.clone(),
+        url: work.url.clone(),
+        head_ref: work.head_ref.clone(),
+        head_sha: work.head_sha.clone(),
+        updated_at: work.updated_at.clone(),
+        draft: work.draft,
+    }
+}
+
+fn normalize_work(work: &mut WorkItem) -> Result<(), String> {
+    for (field, value) in [
+        ("id", work.id.as_str()),
+        ("kind", work.kind.as_str()),
+        ("title", work.title.as_str()),
+        ("url", work.url.as_str()),
+        ("head_ref", work.head_ref.as_str()),
+        ("head_sha", work.head_sha.as_str()),
+        ("updated_at", work.updated_at.as_str()),
+    ] {
+        if value.trim().is_empty() {
+            return Err(format!("work item {field} must not be empty"));
+        }
+    }
+
+    let mut paths = BTreeSet::new();
+    for path in &work.changed_paths {
+        paths.insert(normalize_repo_path(path)?);
+    }
+    work.changed_paths = paths.into_iter().collect();
+    Ok(())
+}
+
+fn normalize_repo_path(raw: &str) -> Result<String, String> {
+    let mut path = raw.trim().replace('\\', "/");
+    while let Some(stripped) = path.strip_prefix("./") {
+        path = stripped.to_string();
+    }
+
+    if path.is_empty() || path.starts_with('/') {
+        return Err(format!("path must be repository-relative: {raw:?}"));
+    }
+    if path.split('/').any(|component| component == "..") {
+        return Err(format!("path may not escape the repository: {raw:?}"));
+    }
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn work(id: &str, sha: &str, paths: &[&str]) -> WorkItem {
+        WorkItem {
+            id: id.to_string(),
+            kind: "pull_request".to_string(),
+            title: format!("Work {id}"),
+            url: format!("https://example.invalid/{id}"),
+            head_ref: format!("branch-{id}"),
+            head_sha: sha.to_string(),
+            updated_at: "2026-08-19T00:00:00Z".to_string(),
+            draft: true,
+            changed_paths: paths.iter().map(|path| (*path).to_string()).collect(),
+        }
+    }
+
+    fn inventory(current: WorkItem, active_work: Vec<WorkItem>) -> ActiveWorkInventory {
+        ActiveWorkInventory {
+            schema_version: SCHEMA_VERSION,
+            source: "fixture".to_string(),
+            observed_at: "2026-08-19T00:01:00Z".to_string(),
+            current,
+            active_work,
+        }
+    }
+
+    #[test]
+    fn emits_direct_overlap_only() {
+        let report = analyze(inventory(
+            work("#1", "aaa", &["src/a.rs", "src/b.rs"]),
+            vec![
+                work("#2", "bbb", &["src/b.rs", "src/c.rs"]),
+                work("#3", "ccc", &["docs/readme.md"]),
+            ],
+        ))
+        .unwrap();
+
+        assert_eq!(report.candidates_examined, 2);
+        assert_eq!(report.heads_up.len(), 1);
+        assert_eq!(report.heads_up[0].work.id, "#2");
+        assert_eq!(report.heads_up[0].overlap_paths, vec!["src/b.rs"]);
+    }
+
+    #[test]
+    fn stays_quiet_for_disjoint_active_work() {
+        let report = analyze(inventory(
+            work("#1", "aaa", &["src/a.rs"]),
+            vec![work("#2", "bbb", &["src/b.rs"])],
+        ))
+        .unwrap();
+
+        assert!(report.heads_up.is_empty());
+    }
+
+    #[test]
+    fn excludes_current_work_from_remote_inventory() {
+        let current = work("#1", "aaa", &["src/a.rs"]);
+        let report = analyze(inventory(current.clone(), vec![current])).unwrap();
+
+        assert_eq!(report.self_candidates_excluded, 1);
+        assert_eq!(report.candidates_examined, 0);
+        assert!(report.heads_up.is_empty());
+    }
+
+    #[test]
+    fn normalizes_and_deduplicates_repository_paths() {
+        let report = analyze(inventory(
+            work("#1", "aaa", &["./src/a.rs", "src/a.rs"]),
+            vec![work("#2", "bbb", &["src\\a.rs"])],
+        ))
+        .unwrap();
+
+        assert_eq!(report.heads_up[0].overlap_paths, vec!["src/a.rs"]);
+    }
+
+    #[test]
+    fn rejects_paths_that_escape_repository() {
+        let error = analyze(inventory(
+            work("#1", "aaa", &["../outside"]),
+            Vec::new(),
+        ))
+        .unwrap_err();
+
+        assert!(error.contains("may not escape"));
+    }
+}

--- a/examples/active_work_heads_up.rs
+++ b/examples/active_work_heads_up.rs
@@ -310,11 +310,8 @@ mod tests {
 
     #[test]
     fn rejects_paths_that_escape_repository() {
-        let error = analyze(inventory(
-            work("#1", "aaa", &["../outside"]),
-            Vec::new(),
-        ))
-        .unwrap_err();
+        let error =
+            analyze(inventory(work("#1", "aaa", &["../outside"]), Vec::new())).unwrap_err();
 
         assert!(error.contains("may not escape"));
     }

--- a/examples/active_work_heads_up.rs
+++ b/examples/active_work_heads_up.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 
 const SCHEMA_VERSION: u32 = 1;
 const MAX_HEADS_UP: usize = 12;
+const USAGE: &str =
+    "usage: cargo run --example active_work_heads_up -- ACTIVE_WORK_INVENTORY.json [FOCUS_PATH ...]";
 
 #[derive(Debug, Clone, Deserialize)]
 struct ActiveWorkInventory {
@@ -37,6 +39,8 @@ struct HeadsUpReport {
     source: String,
     observed_at: String,
     current: WorkIdentity,
+    current_changed_path_count: usize,
+    focus_paths: Vec<String>,
     candidates_examined: usize,
     self_candidates_excluded: usize,
     heads_up: Vec<HeadsUp>,
@@ -62,6 +66,8 @@ struct HeadsUp {
     claim_kind: &'static str,
     work: WorkIdentity,
     overlap_paths: Vec<String>,
+    changed_overlap_paths: Vec<String>,
+    focus_overlap_paths: Vec<String>,
     message: String,
     question: &'static str,
     unknowns: Vec<&'static str>,
@@ -75,22 +81,21 @@ fn main() {
 }
 
 fn run() -> Result<(), Box<dyn Error>> {
-    let path = env::args()
-        .nth(1)
-        .ok_or("usage: cargo run --example active_work_heads_up -- ACTIVE_WORK_INVENTORY.json")?;
-    if env::args().nth(2).is_some() {
-        return Err(
-            "usage: cargo run --example active_work_heads_up -- ACTIVE_WORK_INVENTORY.json".into(),
-        );
-    }
+    let mut args = env::args().skip(1);
+    let path = args.next().ok_or(USAGE)?;
+    let focus_paths = args.collect::<Vec<_>>();
 
     let inventory: ActiveWorkInventory = serde_json::from_slice(&fs::read(path)?)?;
-    let report = analyze(inventory).map_err(|error| format!("invalid inventory: {error}"))?;
+    let report = analyze(inventory, &focus_paths)
+        .map_err(|error| format!("invalid inventory or focus path: {error}"))?;
     println!("{}", serde_json::to_string_pretty(&report)?);
     Ok(())
 }
 
-fn analyze(mut inventory: ActiveWorkInventory) -> Result<HeadsUpReport, String> {
+fn analyze(
+    mut inventory: ActiveWorkInventory,
+    raw_focus_paths: &[String],
+) -> Result<HeadsUpReport, String> {
     if inventory.schema_version != SCHEMA_VERSION {
         return Err(format!(
             "unsupported schema {}; expected {SCHEMA_VERSION}",
@@ -109,7 +114,13 @@ fn analyze(mut inventory: ActiveWorkInventory) -> Result<HeadsUpReport, String> 
         normalize_work(work)?;
     }
 
-    let current_paths: BTreeSet<_> = inventory.current.changed_paths.iter().cloned().collect();
+    let changed_paths: BTreeSet<_> = inventory.current.changed_paths.iter().cloned().collect();
+    let focus_paths = normalize_paths(raw_focus_paths)?;
+    let effective_paths = changed_paths
+        .union(&focus_paths)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
     let mut heads_up = Vec::new();
     let mut candidates_examined = 0;
     let mut self_candidates_excluded = 0;
@@ -122,24 +133,34 @@ fn analyze(mut inventory: ActiveWorkInventory) -> Result<HeadsUpReport, String> 
         candidates_examined += 1;
 
         let work_paths: BTreeSet<_> = work.changed_paths.iter().cloned().collect();
-        let overlap_paths = current_paths
+        let overlap_paths = effective_paths
             .intersection(&work_paths)
             .cloned()
             .collect::<Vec<_>>();
         if overlap_paths.is_empty() {
             continue;
         }
+        let changed_overlap_paths = changed_paths
+            .intersection(&work_paths)
+            .cloned()
+            .collect::<Vec<_>>();
+        let focus_overlap_paths = focus_paths
+            .intersection(&work_paths)
+            .cloned()
+            .collect::<Vec<_>>();
 
         heads_up.push(HeadsUp {
             kind: "active-direct-path-overlap",
             claim_kind: "proven",
             message: format!(
-                "Active work `{}` overlaps {} current path(s).",
+                "Active work `{}` overlaps {} current or intended path(s).",
                 work.id,
                 overlap_paths.len()
             ),
             work: identity(&work),
             overlap_paths,
+            changed_overlap_paths,
+            focus_overlap_paths,
             question: "Is there anything worth reconciling before continuing?",
             unknowns: vec![
                 "Path overlap does not establish duplicate intent, ownership, incompatibility, or required coordination.",
@@ -164,12 +185,15 @@ fn analyze(mut inventory: ActiveWorkInventory) -> Result<HeadsUpReport, String> 
         source: inventory.source,
         observed_at: inventory.observed_at,
         current: identity(&inventory.current),
+        current_changed_path_count: changed_paths.len(),
+        focus_paths: focus_paths.into_iter().collect(),
         candidates_examined,
         self_candidates_excluded,
         heads_up,
         omitted_heads_up,
         unknowns: vec![
             "No direct path overlap is not evidence that active work is semantically independent.",
+            "Focus paths represent caller-supplied intent; they do not prove the current work will modify those paths.",
             "This first experiment does not compare issue references, symbols, generated relationships, historical companions, policy, or behavior.",
             "Remote inventory completeness and freshness are properties of the supplying adapter and remain separate from overlap analysis.",
         ],
@@ -208,12 +232,15 @@ fn normalize_work(work: &mut WorkItem) -> Result<(), String> {
         }
     }
 
-    let mut paths = BTreeSet::new();
-    for path in &work.changed_paths {
-        paths.insert(normalize_repo_path(path)?);
-    }
-    work.changed_paths = paths.into_iter().collect();
+    work.changed_paths = normalize_paths(&work.changed_paths)?.into_iter().collect();
     Ok(())
+}
+
+fn normalize_paths(raw_paths: &[String]) -> Result<BTreeSet<String>, String> {
+    raw_paths
+        .iter()
+        .map(|path| normalize_repo_path(path))
+        .collect()
 }
 
 fn normalize_repo_path(raw: &str) -> Result<String, String> {
@@ -259,29 +286,62 @@ mod tests {
         }
     }
 
+    fn focus(paths: &[&str]) -> Vec<String> {
+        paths.iter().map(|path| (*path).to_string()).collect()
+    }
+
     #[test]
     fn emits_direct_overlap_only() {
-        let report = analyze(inventory(
-            work("#1", "aaa", &["src/a.rs", "src/b.rs"]),
-            vec![
-                work("#2", "bbb", &["src/b.rs", "src/c.rs"]),
-                work("#3", "ccc", &["docs/readme.md"]),
-            ],
-        ))
+        let report = analyze(
+            inventory(
+                work("#1", "aaa", &["src/a.rs", "src/b.rs"]),
+                vec![
+                    work("#2", "bbb", &["src/b.rs", "src/c.rs"]),
+                    work("#3", "ccc", &["docs/readme.md"]),
+                ],
+            ),
+            &[],
+        )
         .unwrap();
 
         assert_eq!(report.candidates_examined, 2);
         assert_eq!(report.heads_up.len(), 1);
         assert_eq!(report.heads_up[0].work.id, "#2");
         assert_eq!(report.heads_up[0].overlap_paths, vec!["src/b.rs"]);
+        assert_eq!(report.heads_up[0].changed_overlap_paths, vec!["src/b.rs"]);
+        assert!(report.heads_up[0].focus_overlap_paths.is_empty());
+    }
+
+    #[test]
+    fn surfaces_focus_path_before_current_diff_changes() {
+        let report = analyze(
+            inventory(
+                work("#1", "aaa", &[]),
+                vec![work("#2", "bbb", &["src/parser.rs"])],
+            ),
+            &focus(&["src/parser.rs"]),
+        )
+        .unwrap();
+
+        assert_eq!(report.current_changed_path_count, 0);
+        assert_eq!(report.focus_paths, vec!["src/parser.rs"]);
+        assert_eq!(report.heads_up.len(), 1);
+        assert!(report.heads_up[0].changed_overlap_paths.is_empty());
+        assert_eq!(
+            report.heads_up[0].focus_overlap_paths,
+            vec!["src/parser.rs"]
+        );
     }
 
     #[test]
     fn stays_quiet_for_disjoint_active_work() {
-        let report = analyze(inventory(
-            work("#1", "aaa", &["src/a.rs"]),
-            vec![work("#2", "bbb", &["src/b.rs"])],
-        ))
+        let report = analyze(
+            inventory(
+                work("#1", "aaa", &["src/a.rs"]),
+                vec![work("#2", "bbb", &["src/b.rs"])],
+            ),
+            &[],
+        )
         .unwrap();
 
         assert!(report.heads_up.is_empty());
@@ -290,7 +350,7 @@ mod tests {
     #[test]
     fn excludes_current_work_from_remote_inventory() {
         let current = work("#1", "aaa", &["src/a.rs"]);
-        let report = analyze(inventory(current.clone(), vec![current])).unwrap();
+        let report = analyze(inventory(current.clone(), vec![current]), &[]).unwrap();
 
         assert_eq!(report.self_candidates_excluded, 1);
         assert_eq!(report.candidates_examined, 0);
@@ -299,10 +359,13 @@ mod tests {
 
     #[test]
     fn normalizes_and_deduplicates_repository_paths() {
-        let report = analyze(inventory(
-            work("#1", "aaa", &["./src/a.rs", "src/a.rs"]),
-            vec![work("#2", "bbb", &["src\\a.rs"])],
-        ))
+        let report = analyze(
+            inventory(
+                work("#1", "aaa", &["./src/a.rs", "src/a.rs"]),
+                vec![work("#2", "bbb", &["src\\a.rs"])],
+            ),
+            &[],
+        )
         .unwrap();
 
         assert_eq!(report.heads_up[0].overlap_paths, vec!["src/a.rs"]);
@@ -310,7 +373,11 @@ mod tests {
 
     #[test]
     fn rejects_paths_that_escape_repository() {
-        let error = analyze(inventory(work("#1", "aaa", &["../outside"]), Vec::new())).unwrap_err();
+        let error = analyze(
+            inventory(work("#1", "aaa", &["../outside"]), Vec::new()),
+            &[],
+        )
+        .unwrap_err();
 
         assert!(error.contains("may not escape"));
     }

--- a/research/active-work-heads-up.md
+++ b/research/active-work-heads-up.md
@@ -1,0 +1,127 @@
+# Active-work heads-up research
+
+Date: 2026-08-19
+
+## Question
+
+Can Cargo Cultist cheaply surface live concurrent work that a coding agent would reasonably want to know about, without becoming a scheduler, lock manager, or GitHub-dependent core?
+
+The first experiment asks only:
+
+> Does another currently open work item modify an exact repository path that this work item also modifies?
+
+That is intentionally smaller than semantic conflict detection. The goal is to dogfood the interruption policy before broadening the evidence model.
+
+## Adapter boundary
+
+Remote project state and local evidence analysis stay separate:
+
+```text
+GitHub / orchestrator / other provider
+  -> active-work inventory JSON
+
+Cargo Cultist research analyzer
+  -> validate + normalize inventory
+  -> exact path intersection
+  -> advisory heads-ups
+```
+
+The core analyzer does not call GitHub and does not need credentials or network access.
+
+The current GitHub Actions research adapter records, for each open PR:
+
+- PR identity, title, and URL;
+- exact head ref and head SHA;
+- GitHub `updated_at` freshness receipt;
+- draft state;
+- complete changed-path inventory retrieved through paginated PR-files API calls.
+
+The supplying adapter's completeness and freshness remain separate evidence from the overlap result.
+
+## First evidence contract
+
+Exact repository-path overlap is `PROVEN` relative to the supplied inventory:
+
+```text
+current changed paths ∩ active work changed paths != empty
+```
+
+The analyzer does **not** infer:
+
+- duplicate intent;
+- ownership;
+- incompatibility;
+- required coordination;
+- whether the other worker is still actively executing;
+- semantic independence when paths do not overlap.
+
+A heads-up asks only:
+
+> Is there anything worth reconciling before continuing?
+
+## Quietness contract
+
+No overlap means no heads-up entry.
+
+The machine report still preserves explicit `UNKNOWN` boundaries, but the workflow's normal human-facing line is simply:
+
+```text
+No direct active-work path overlap worth surfacing.
+```
+
+The first experiment caps returned heads-ups and reports omissions so a busy repository cannot silently turn into an unbounded context dump.
+
+## Why start with PR paths instead of `preflight --against` every branch?
+
+PR comparison and arbitrary-ref comparison are related but not identical evidence problems.
+
+`cargo cultist preflight --against REF` compares two Git change sets from their common merge base. That is the right deterministic local primitive for two refs whose relationship is the question.
+
+For live PR awareness, GitHub already exposes each PR's own changed-path set relative to its configured base. Using that metadata avoids accidentally treating unrelated base-branch movement as one worker's change when two PR heads have different freshness or ancestry.
+
+The remote adapter therefore supplies PR-relative changed paths directly. Future adapters can supply equivalent work-item change sets from other systems.
+
+## First dogfood workflow
+
+Draft PRs carrying `.github/workflows/active-work-heads-up-research.yml`:
+
+1. query all currently open PRs;
+2. fetch paginated changed paths for every PR;
+3. build a schema-versioned inventory snapshot;
+4. run `examples/active_work_heads_up.rs` locally over that snapshot;
+5. print only direct overlap heads-ups;
+6. upload the raw inventory and report as a research receipt;
+7. never fail merely because a heads-up exists.
+
+## Evaluation labels
+
+For each surfaced interruption, record one of:
+
+```text
+useful
+irrelevant
+missing stronger evidence
+misleading
+```
+
+Useful future enrichments should be added one evidence class at a time with negative controls:
+
+- exact issue / explicit intent references;
+- symbol overlap;
+- historical companions + counterexamples;
+- generated ownership relationships;
+- explicit policy/oracle overlap;
+- decisions / known exceptions;
+- head freshness changes that invalidate earlier evidence.
+
+Do not collapse these into one hidden conflict score.
+
+## Success criterion
+
+This experiment earns product promotion if repeated real work shows that its heads-ups change investigation or coordination behavior usefully while quiet runs remain common.
+
+The desired product property is:
+
+> Increase worker awareness without reducing worker autonomy.
+
+Refs #96, #62, #74, #41.

--- a/research/active-work-heads-up.md
+++ b/research/active-work-heads-up.md
@@ -8,7 +8,7 @@ Can Cargo Cultist cheaply surface live concurrent work that a coding agent would
 
 The first experiment asks only:
 
-> Does another currently open work item modify an exact repository path that this work item also modifies?
+> Does another currently open work item modify an exact repository path that this work item already modifies or explicitly intends to inspect/change?
 
 That is intentionally smaller than semantic conflict detection. The goal is to dogfood the interruption policy before broadening the evidence model.
 
@@ -38,12 +38,36 @@ The current GitHub Actions research adapter records, for each open PR:
 
 The supplying adapter's completeness and freshness remain separate evidence from the overlap result.
 
-## First evidence contract
+## Current and intended paths remain distinct
 
-Exact repository-path overlap is `PROVEN` relative to the supplied inventory:
+The analyzer accepts two path sources:
 
 ```text
-current changed paths ∩ active work changed paths != empty
+current.changed_paths
+  -> provider-observed paths already changed by this work item
+
+FOCUS_PATH arguments
+  -> caller-supplied intended targets before the first edit
+```
+
+The report retains `changed_overlap_paths` and `focus_overlap_paths` separately. A focus path is intent evidence supplied by the caller; it does not prove that the current work will eventually modify that path.
+
+This distinction lets the same analyzer serve both:
+
+```text
+BEFORE
+  I am about to touch src/foo.rs. Is active work already there?
+
+DURING
+  My diff now touches src/foo.rs. Is active work already there?
+```
+
+## First evidence contract
+
+Exact repository-path overlap is `PROVEN` relative to the supplied inventory and focus set:
+
+```text
+(current changed paths ∪ focus paths) ∩ active work changed paths != empty
 ```
 
 The analyzer does **not** infer:
@@ -71,7 +95,7 @@ No direct active-work path overlap worth surfacing.
 
 The first experiment caps returned heads-ups and reports omissions so a busy repository cannot silently turn into an unbounded context dump.
 
-## Why start with PR paths instead of `preflight --against` every branch?
+## Why PR-relative paths instead of `preflight --against` every PR head?
 
 PR comparison and arbitrary-ref comparison are related but not identical evidence problems.
 
@@ -81,21 +105,97 @@ For live PR awareness, GitHub already exposes each PR's own changed-path set rel
 
 The remote adapter therefore supplies PR-relative changed paths directly. Future adapters can supply equivalent work-item change sets from other systems.
 
-## First dogfood workflow
+## Executed dogfood
 
-Draft PRs carrying `.github/workflows/active-work-heads-up-research.yml`:
+### Organic quiet negative
 
-1. query all currently open PRs;
-2. fetch paginated changed paths for every PR;
-3. build a schema-versioned inventory snapshot;
-4. run `examples/active_work_heads_up.rs` locally over that snapshot;
-5. print only direct overlap heads-ups;
-6. upload the raw inventory and report as a research receipt;
-7. never fail merely because a heads-up exists.
+Workflow run:
+
+```text
+run:      32230058489
+job:      95997754356
+artifact: 9356901801
+sha256:   9d218b3d2e534ac52ace2361d4088bd5d38927eaaaa86609dcd8e7f2cf31a34f
+```
+
+At observation time, #98 and #95 were both open. The adapter reported:
+
+```text
+inventory: 2 open PR(s), current #98, 3 current path(s)
+examined: 1 active candidate(s); self excluded: 1
+No direct active-work path overlap worth surfacing.
+```
+
+This is a useful negative control: another active work item existed, but its changed paths were disjoint from #98, so the analyzer did not manufacture a coordination warning.
+
+### Live pre-edit focus positive
+
+Workflow run:
+
+```text
+run:      32230448378
+job:      95998910861
+artifact: 9357034687
+sha256:   a3fc0d5df95c7a0f22484b7bf3b296a57759d642a6fa9db7493b303c3767a6d7
+```
+
+The ordinary advisory stream in that run stayed quiet. A separately labeled positive control then used real active #95 metadata.
+
+#95 changed:
+
+```text
+.github/workflows/decision-memory-accepted-ref-research.yml
+research/decision-memory/current-only-authority-fixture.json
+```
+
+Before the current lane touched the first path, focus mode reported:
+
+```text
+focus control: before touching '.github/workflows/decision-memory-accepted-ref-research.yml',
+heads-up surfaced active #95 at 7fbfd6ca
+```
+
+This proves the pre-edit question against a real active work item without fabricating an overlapping PR.
+
+The positive control was then removed from the normal workflow after capture so routine dogfood measures natural signal rather than forced positives.
+
+### Exact-head repository CI
+
+Head:
+
+```text
+3173e650695e86eeb3e82f078504ed78dff10ed8
+```
+
+CI run `32230688380` passed:
+
+- rustfmt;
+- Clippy with warnings denied;
+- full tests;
+- repository text + JSON dogfood;
+- history text + JSON dogfood;
+- CI-test inventory and fixtures;
+- PR diff text + JSON dogfood.
+
+The active-work workflow on the same head also completed successfully.
+
+## Normal dogfood activation
+
+The research workflow is designed to run on PR open/synchronize/reopen/ready-for-review events.
+
+It is intentionally advisory:
+
+- a heads-up never fails the job;
+- the job uses read-only GitHub permissions;
+- old runs for the same PR are cancelled when a new head appears;
+- the research job is marked `continue-on-error` so adapter/probe failure cannot block ordinary development;
+- only the raw inventory and natural advisory report are retained after the positive-control receipt.
+
+This makes it cheap enough to leave enabled while signal quality is measured.
 
 ## Evaluation labels
 
-For each surfaced interruption, record one of:
+For each naturally surfaced interruption, record one of:
 
 ```text
 useful
@@ -116,6 +216,8 @@ Useful future enrichments should be added one evidence class at a time with nega
 
 Do not collapse these into one hidden conflict score.
 
+Issue #99 now owns a real agent-heavy corpus for explicit coordination/intent relationships such as `depends on`, `blocks`, `supersedes`, and evidence-coordinate sequencing. Those relationships should remain a separate evidence layer from direct path overlap.
+
 ## Success criterion
 
 This experiment earns product promotion if repeated real work shows that its heads-ups change investigation or coordination behavior usefully while quiet runs remain common.
@@ -124,4 +226,4 @@ The desired product property is:
 
 > Increase worker awareness without reducing worker autonomy.
 
-Refs #96, #62, #74, #41.
+Refs #96, #99, #62, #74, #41.


### PR DESCRIPTION
Research follow-up to #96 / #62 / #74.

## Question

Can Cargo Cultist surface live concurrent work cheaply enough to sit in an agent edit loop without becoming a scheduler or making the core depend on GitHub?

## Experiment

Adds a deliberately narrow split architecture:

```text
remote adapter
  -> schema-versioned active-work inventory

examples/active_work_heads_up.rs
  -> validate + normalize
  -> exact path intersection only
  -> advisory heads-ups
```

The first GitHub Actions adapter inventories all open PRs with exact head SHA, update time, draft state, and paginated changed paths. The Rust analyzer receives only the JSON snapshot; it has no GitHub/network dependency.

The analyzer can also receive caller-supplied **focus paths**. These represent intended targets before the first edit and remain explicitly distinct from paths already changed by the current work.

## Signal contract

Only exact changed/focus-path overlap produces a heads-up. That is `PROVEN` relative to the supplied inventory and caller-supplied focus.

The analyzer explicitly does **not** infer duplicate intent, ownership, incompatibility, required coordination, active execution, or semantic independence for disjoint paths.

Findings never fail the workflow. A quiet run prints only:

```text
No direct active-work path overlap worth surfacing.
```

## Executed live dogfood

### Organic quiet negative

Run `32230058489`, job `95997754356` queried the actual open PR inventory while #98 and #95 were open:

```text
inventory: 2 open PR(s), current #98, 3 current path(s)
examined: 1 active candidate(s); self excluded: 1
No direct active-work path overlap worth surfacing.
```

This is the desired negative behavior: another worker existed, but no direct path overlap existed, so Cargo Cultist did not manufacture a coordination warning.

Artifact `9356901801`, digest:

```text
sha256:9d218b3d2e534ac52ace2361d4088bd5d38927eaaaa86609dcd8e7f2cf31a34f
```

### Live pre-edit focus positive

Run `32230448378`, job `95998910861` kept the normal advisory stream quiet, then ran a separately labeled positive control using real active PR metadata.

#95 was actively changing:

```text
.github/workflows/decision-memory-accepted-ref-research.yml
research/decision-memory/current-only-authority-fixture.json
```

Before the current lane touched the first path, focus mode reported:

```text
focus control: before touching '.github/workflows/decision-memory-accepted-ref-research.yml',
heads-up surfaced active #95 at 7fbfd6ca
```

Artifact `9357034687`, digest:

```text
sha256:a3fc0d5df95c7a0f22484b7bf3b296a57759d642a6fa9db7493b303c3767a6d7
```

So the first live matrix is:

```text
another active PR exists + disjoint current paths
  -> quiet

caller says "I am about to touch this real path"
+ active PR changes that exact path
  -> heads up with PR/head/freshness evidence
```

The positive control is deliberately separate from the organic advisory stream so capability testing does not contaminate signal-quality evaluation.

## Architecture result

`cargo cultist preflight --against REF` and active-PR awareness should remain related but distinct evidence adapters:

- `preflight --against REF` is the local arbitrary-ref primitive and compares two Git change sets from a common merge base;
- active PR inventory should use each work item's own provider-reported changed paths and exact freshness metadata.

Blindly comparing unrelated PR heads from one common merge base can attribute base-branch movement to the wrong worker.

## Dogfood policy

Each naturally surfaced interruption should be judged as:

```text
useful
irrelevant
missing stronger evidence
misleading
```

before adding semantic enrichments.

## Boundary

This is research instrumentation, not a final public `heads-up` command. The already-merged `preflight --against REF` remains the local arbitrary-ref collision primitive. This experiment tests optional live work-item metadata as a separate evidence source.

Refs #96, #62, #74, #41.