### PR TITLE
docs: rebrand project as Cultist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# Agent guidance
+
+Cultist is built by dogfooding the same repository-reasoning ideas it is trying to make useful for other projects.
+
+While working here, do the requested task first. At the same time, pay attention to evidence that the work itself exposes about how Cultist could improve.
+
+## Feed useful friction back into the project
+
+If the task reveals something that made the work harder, less reliable, more repetitive, or easier to misunderstand, ask whether Cultist could have surfaced that fact earlier or preserved the lesson for the next worker.
+
+Useful signals include:
+
+- two workers or branches independently doing overlapping work;
+- a repository fact, convention, generated relationship, or policy that was important but easy to miss;
+- a false assumption that later evidence disproves;
+- a stale or wrong evidence coordinate;
+- a historical reason that had to be reconstructed manually;
+- a useful counterexample that weakens an existing heuristic;
+- an analyzer finding that was noisy, overconfident, incomplete, or missing an important `UNKNOWN`;
+- repeated investigation that could become a deterministic probe;
+- a reviewed lesson that future agents would benefit from seeing before making the same edit.
+
+Do not turn every inconvenience into a feature. Preserve the distinction between:
+
+- an observation from this task;
+- a plausible reusable pattern;
+- a tested discriminator with counterexamples;
+- a product behavior that has earned promotion.
+
+## Prefer evidence over retrospective stories
+
+When proposing a Cultist improvement from dogfood:
+
+1. identify the exact task, change, file, issue, PR, commit, or repository evidence that exposed it;
+2. state what is **PROVEN**, **DERIVED**, **OBSERVED**, **INFERRED**, or **UNKNOWN**;
+3. search for a counterexample or negative control before generalizing;
+4. keep chronology separate from causality unless an explicit relationship establishes it;
+5. prefer a small deterministic probe or evidence packet before a broad heuristic;
+6. preserve failed experiments and weakened hypotheses when they teach a boundary.
+
+A successful task can still expose a product problem. A failed task can still produce useful evidence. Neither automatically proves a general rule.
+
+## Close the loop when it is useful
+
+When the evidence is strong enough and the task scope permits it, incorporate the lesson into Cultist through the smallest appropriate durable surface:
+
+- improve an existing analyzer or evidence contract;
+- add a focused regression or negative control;
+- record a research receipt;
+- update a relevant roadmap/research issue;
+- preserve reviewed rationale for future context/decision memory;
+- open a focused follow-up issue when the lesson is real but outside the current task.
+
+Avoid unrelated implementation expansion merely because an idea occurred during the task. If the lesson belongs elsewhere, leave an exact handoff with its evidence instead of silently widening scope.
+
+## Agent-facing product test
+
+A recurring question for work in this repository is:
+
+> What did this task force the worker to discover manually that Cultist could have surfaced, bounded, or preserved for the next worker?
+
+If the answer is meaningful, treat the task as dogfood evidence and carry the lesson forward with provenance.
+
+The goal is a repository that becomes easier to work in because prior workers leave behind earned, inspectable knowledge—not because later workers inherit their conversations or trust their conclusions blindly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
+# Rust distribution name retained so `cargo cultist ...` continues to work.
 name = "cargo-cultist"
 version = "0.1.0"
 edition = "2024"
-description = "Repository-aware analysis for Rust codebases"
-repository = "https://github.com/teamleaderleo/cargo-cultist"
+description = "Repository-aware evidence and analysis with Rust-focused adapters"
+repository = "https://github.com/teamleaderleo/cultist"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# cargo-cultist
+# Cultist
 
 **Find out why before you copy it.**
 
-`cargo-cultist` is an experiment in repository-aware analysis for Rust codebases.
+Cultist is an experiment in repository-aware analysis: gather facts about what a repository actually does, recover relevant precedent and history, search for counterexamples, and raise useful questions without pretending every observation is an error.
 
 > Status: very early prototype. The public analyzer commands are deterministic, local, and read-only.
 
+The current implementation is distributed as the Rust package and Cargo subcommand `cargo-cultist`. Rust-specific analyzers are the first semantic adapter, not the product boundary. Repository-level primitives such as Git history and direct concurrent-change preflight are language-agnostic.
+
 See [ROADMAP.md](ROADMAP.md) for the project thesis, design principles, and active research directions. The umbrella tracking issue is #19.
 
-Traditional linters are strongest when a rule is already known. `cargo-cultist` starts one step earlier: it gathers facts about what a repository actually does, identifies deviations or unexplained relationships, searches for counterexamples, and raises questions without pretending every observation is an error.
+Traditional linters are strongest when a rule is already known. Cultist starts one step earlier: it gathers repository evidence, identifies deviations or unexplained relationships, and preserves uncertainty when the evidence is not strong enough to recover intent.
 
 The core evidence model distinguishes:
 
@@ -24,7 +26,7 @@ Human-readable and JSON output are rendered from the same provenance-bearing fin
 
 ### Repository test-module conventions
 
-The default command inspects `#[cfg(test)]` modules and reports the names a repository actually uses. It calls out one-off names and files that mix multiple test-module names without turning the majority spelling into a universal rule.
+The default Rust analyzer inspects `#[cfg(test)]` modules and reports the names a repository actually uses. It calls out one-off names and files that mix multiple test-module names without turning the majority spelling into a universal rule.
 
 ```bash
 cargo cultist
@@ -43,9 +45,20 @@ cargo cultist diff --base origin/main
 cargo cultist diff --base origin/main --format json
 ```
 
-With `--base REV`, Cargo Cultist finds the merge base between `REV` and `HEAD`, then analyzes the current working tree from that point so branch/PR semantics still include local staged or unstaged work.
+With `--base REV`, Cultist finds the merge base between `REV` and `HEAD`, then analyzes the current working tree from that point so branch/PR semantics still include local staged or unstaged work.
 
 When repository-wide and file-local precedent disagree, the analyzer surfaces **precedent tension** instead of silently choosing a winner. Changed-file parse failures remain explicit uncertainty instead of being converted into an observed absence claim.
+
+### Concurrent-change preflight
+
+`cargo cultist preflight` compares the current change set with another ref from their merge base and reports direct repository-path overlap as `PROVEN` collision evidence.
+
+```bash
+cargo cultist preflight --against other-agent
+cargo cultist preflight --against origin/main --format json
+```
+
+The first slice is deliberately language-agnostic: it uses Git path changes and does not parse Rust. When two changes touch different paths, Cultist says that deeper generated, historical, policy, or behavioral relationships remain `UNKNOWN` instead of claiming independence.
 
 ### Historical companions
 
@@ -97,7 +110,7 @@ UNKNOWN
 
 Unsupported shell forms, ambiguous package/integration/bin targets, unknown flags, and parse failures are skipped or surfaced conservatively instead of guessed through.
 
-This check has a retained real-world witness: a pinned Tantivy workflow stayed green while `cargo test --lib test_rollback` selected zero tests, and Cargo Cultist identified that exact selector/location. The full acceptance receipt lives in `research/ci-test-filter-replay.md`.
+This check has a retained real-world witness: a pinned Tantivy workflow stayed green while `cargo test --lib test_rollback` selected zero tests, and Cultist identified that exact selector/location. The full acceptance receipt lives in `research/ci-test-filter-replay.md`.
 
 ## Research layer
 
@@ -109,7 +122,8 @@ Current research includes:
 - explicit generated-file and Rust generator-ownership evidence;
 - execution-aware libtest `--list` verification of CI selectors;
 - agentic-history corpora from Stensibly and SmolRunner;
-- bounded repository-evidence packets for coding agents.
+- bounded repository-evidence packets for coding agents;
+- repo-local decision memory and concurrent-change coordination evidence.
 
 Some research examples intentionally execute repository tooling. In particular, Cargo/libtest listing can compile code and run build scripts. Those experiments carry an explicit effect boundary and are not silently invoked by the ordinary analyzer commands.
 
@@ -126,14 +140,15 @@ hypothesis
 
 A successful experiment does not automatically become a lint or public feature.
 
-## Usage
+## Current Rust distribution
 
 From this repository while developing:
 
 ```bash
 cargo run -- /path/to/a/rust/repository
 cargo run -- diff --base origin/main /path/to/a/rust/repository
-cargo run -- history /path/to/a/rust/repository/src/file.rs
+cargo run -- preflight --against other-agent /path/to/a/repository
+cargo run -- history /path/to/a/repository/src/file.rs
 cargo run -- ci-tests /path/to/a/rust/repository
 ```
 
@@ -141,25 +156,29 @@ After installing locally:
 
 ```bash
 cargo install --path .
-cd /path/to/a/rust/repository
+cd /path/to/a/repository
 cargo cultist
 cargo cultist diff
+cargo cultist preflight --against origin/main
 cargo cultist history src/file.rs
 cargo cultist ci-tests
 ```
 
-The binary can also be invoked directly:
+The current Rust binary can also be invoked directly:
 
 ```bash
 cargo-cultist .
 cargo-cultist diff --base origin/main .
+cargo-cultist preflight --against origin/main .
 cargo-cultist history src/file.rs
 cargo-cultist ci-tests .
 ```
 
+The product/protocol name is **Cultist**. `cargo-cultist` is the Rust distribution name retained so `cargo cultist ...` works naturally.
+
 ## Dogfooding
 
-CI runs formatting, Clippy, and tests, then dogfoods the public analyzers and their JSON output against Cargo Cultist itself. Pull-request and push CI run diff analysis against the relevant base/current change.
+CI runs formatting, Clippy, and tests, then dogfoods the public analyzers and their JSON output against Cultist itself. Pull-request and push CI run diff analysis against the relevant base/current change.
 
 The tool is expected to inspect its own changes without special treatment. Disposable fixtures and pinned external replays are used when a detector needs a stronger discriminator; temporary network-heavy research workflows are retired after their evidence is recorded.
 
@@ -173,6 +192,8 @@ Near-term work is increasingly about composing independent evidence instead of a
 - helper/dependency intent and locally expanded idioms;
 - explicit repository-guidance freshness and instruction lifecycle;
 - bounded agent context packets that optimize selected evidence per byte instead of context volume;
+- concurrent-work preflight using independently earned repository relationships;
+- language-neutral evidence contracts with language-specific semantic adapters;
 - promotion of repeated, well-understood human consensus into deterministic policy.
 
 Optional model-assisted explanation can sit on top of bounded evidence later. The deterministic finding must remain useful without a model.

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 **Find out why before you copy it.**
 
-Cultist is an experiment in repository-aware analysis: gather facts about what a repository actually does, recover relevant precedent and history, search for counterexamples, and raise useful questions without pretending every observation is an error.
+Cultist is an experiment in repository-aware analysis: gather deterministic facts, preserve provenance and counterexamples, and ask useful questions before inventing project rules.
 
-> Status: very early prototype. The public analyzer commands are deterministic, local, and read-only.
+> Status: very early prototype. The current public analyzer implementation is a Rust distribution named `cargo-cultist`; its public commands are deterministic, local, and read-only.
 
-The current implementation is distributed as the Rust package and Cargo subcommand `cargo-cultist`. Rust-specific analyzers are the first semantic adapter, not the product boundary. Repository-level primitives such as Git history and direct concurrent-change preflight are language-agnostic.
+Rust is the first semantic adapter, not the product boundary. Some useful Cultist primitives are already repository-generic — Git history, decision memory, evidence provenance, and direct concurrent-change preflight — while Rust-specific analyzers currently provide the deepest source-level evidence.
 
-See [ROADMAP.md](ROADMAP.md) for the project thesis, design principles, and active research directions. The umbrella tracking issue is #19.
+See [ROADMAP.md](ROADMAP.md) for the project thesis, design principles, and active research directions. The umbrella tracking issue is #19. Agents working on Cultist should also follow [AGENTS.md](AGENTS.md), which treats implementation friction, false assumptions, counterexamples, and duplicated work as dogfood evidence worth feeding back into the project when the evidence earns it.
 
-Traditional linters are strongest when a rule is already known. Cultist starts one step earlier: it gathers repository evidence, identifies deviations or unexplained relationships, and preserves uncertainty when the evidence is not strong enough to recover intent.
+Traditional linters are strongest when a rule is already known. Cultist starts one step earlier: it gathers facts about what a repository actually does, identifies deviations or unexplained relationships, searches for counterexamples, and raises questions without pretending every observation is an error.
 
 The core evidence model distinguishes:
 
@@ -24,9 +24,11 @@ Human-readable and JSON output are rendered from the same provenance-bearing fin
 
 ## Current commands
 
+The current Rust distribution is installed/invoked as `cargo-cultist` / `cargo cultist`. That launcher name does not imply every Cultist analyzer is Cargo-specific.
+
 ### Repository test-module conventions
 
-The default Rust analyzer inspects `#[cfg(test)]` modules and reports the names a repository actually uses. It calls out one-off names and files that mix multiple test-module names without turning the majority spelling into a universal rule.
+The default command inspects Rust `#[cfg(test)]` modules and reports the names a repository actually uses. It calls out one-off names and files that mix multiple test-module names without turning the majority spelling into a universal rule.
 
 ```bash
 cargo cultist
@@ -37,7 +39,7 @@ The interesting primitive is a **finding**, not a lint error: repository statist
 
 ### Diff-aware precedent
 
-`cargo cultist diff` looks at test-module declarations added or renamed by the current change and compares them with existing repository-wide and file-local precedent.
+`cargo cultist diff` currently applies Rust-aware change analysis, including test-module precedent and generated-companion evidence where the required provenance gates are satisfied.
 
 ```bash
 cargo cultist diff
@@ -51,14 +53,14 @@ When repository-wide and file-local precedent disagree, the analyzer surfaces **
 
 ### Concurrent-change preflight
 
-`cargo cultist preflight` compares the current change set with another ref from their merge base and reports direct repository-path overlap as `PROVEN` collision evidence.
+`cargo cultist preflight` compares two concurrent Git change sets from their merge base and reports direct path overlap as `PROVEN` collision evidence.
 
 ```bash
 cargo cultist preflight --against other-agent
 cargo cultist preflight --against origin/main --format json
 ```
 
-The first slice is deliberately language-agnostic: it uses Git path changes and does not parse Rust. When two changes touch different paths, Cultist says that deeper generated, historical, policy, or behavioral relationships remain `UNKNOWN` instead of claiming independence.
+The first slice is deliberately repository-generic: it does not parse Rust to establish direct path overlap. Different paths remain semantically `UNKNOWN` until independent evidence can establish a generated, historical, policy, or behavioral relationship.
 
 ### Historical companions
 
@@ -123,7 +125,8 @@ Current research includes:
 - execution-aware libtest `--list` verification of CI selectors;
 - agentic-history corpora from Stensibly and SmolRunner;
 - bounded repository-evidence packets for coding agents;
-- repo-local decision memory and concurrent-change coordination evidence.
+- repository-local decision memory;
+- concurrent-change coordination evidence.
 
 Some research examples intentionally execute repository tooling. In particular, Cargo/libtest listing can compile code and run build scripts. Those experiments carry an explicit effect boundary and are not silently invoked by the ordinary analyzer commands.
 
@@ -140,14 +143,14 @@ hypothesis
 
 A successful experiment does not automatically become a lint or public feature.
 
-## Current Rust distribution
+## Usage
 
-From this repository while developing:
+From this repository while developing the current Rust distribution:
 
 ```bash
 cargo run -- /path/to/a/rust/repository
 cargo run -- diff --base origin/main /path/to/a/rust/repository
-cargo run -- preflight --against other-agent /path/to/a/repository
+cargo run -- preflight --against some-ref /path/to/a/repository
 cargo run -- history /path/to/a/repository/src/file.rs
 cargo run -- ci-tests /path/to/a/rust/repository
 ```
@@ -156,10 +159,10 @@ After installing locally:
 
 ```bash
 cargo install --path .
-cd /path/to/a/repository
+cargo cultist preflight --against other-ref /path/to/a/repository
+cd /path/to/a/rust/repository
 cargo cultist
 cargo cultist diff
-cargo cultist preflight --against origin/main
 cargo cultist history src/file.rs
 cargo cultist ci-tests
 ```
@@ -169,18 +172,20 @@ The current Rust binary can also be invoked directly:
 ```bash
 cargo-cultist .
 cargo-cultist diff --base origin/main .
-cargo-cultist preflight --against origin/main .
+cargo-cultist preflight --against other-ref .
 cargo-cultist history src/file.rs
 cargo-cultist ci-tests .
 ```
 
-The product/protocol name is **Cultist**. `cargo-cultist` is the Rust distribution name retained so `cargo cultist ...` works naturally.
+Future distribution wrappers or language adapters should consume the same stable machine-readable evidence model instead of requiring the rest of the ecosystem to embed the Rust crate.
 
 ## Dogfooding
 
 CI runs formatting, Clippy, and tests, then dogfoods the public analyzers and their JSON output against Cultist itself. Pull-request and push CI run diff analysis against the relevant base/current change.
 
 The tool is expected to inspect its own changes without special treatment. Disposable fixtures and pinned external replays are used when a detector needs a stronger discriminator; temporary network-heavy research workflows are retired after their evidence is recorded.
+
+Dogfood is also product input. When work exposes duplicate effort, a missed repository fact, stale evidence, a false assumption, a useful counterexample, or a repeated manual investigation, treat that as a candidate Cultist lesson. Preserve the exact evidence, test the generalization, and feed it back through the smallest appropriate analyzer, regression, research receipt, decision record, or focused follow-up. Do not turn ordinary inconvenience into a universal rule.
 
 ## Active research directions
 
@@ -192,9 +197,9 @@ Near-term work is increasingly about composing independent evidence instead of a
 - helper/dependency intent and locally expanded idioms;
 - explicit repository-guidance freshness and instruction lifecycle;
 - bounded agent context packets that optimize selected evidence per byte instead of context volume;
-- concurrent-work preflight using independently earned repository relationships;
-- language-neutral evidence contracts with language-specific semantic adapters;
-- promotion of repeated, well-understood human consensus into deterministic policy.
+- active-change coordination and semantic preflight;
+- promotion of repeated, well-understood human consensus into deterministic policy;
+- additional language adapters only where real corpus evidence earns them.
 
 Optional model-assisted explanation can sit on top of bounded evidence later. The deterministic finding must remain useful without a model.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,11 +1,13 @@
 # Roadmap
 
-`cargo-cultist` explores repository reasoning between two familiar extremes:
+Cultist explores repository reasoning between two familiar extremes:
 
 - deterministic tools that enforce rules we already know; and
 - unconstrained AI review that is asked to infer everything from a codebase.
 
 The project goal is to make the middle useful.
+
+Rust is the first semantic adapter, not the product boundary. Repository-generic evidence such as Git history, concurrent-change overlap, decision memory, and explicit project guidance should remain useful across languages. Language-specific analyzers should add stronger claims only where their adapters can justify them.
 
 ## Core loop
 
@@ -30,7 +32,7 @@ Repository statistics are evidence, not policy. If a repository uses `unit_tests
 
 ### Keep scope visible
 
-Precedent can differ at the same time across a file, crate, repository, and recent history. When those scopes disagree, Cultist should show the tension instead of hiding it in one score.
+Precedent can differ at the same time across a file, module/package/crate, repository, and recent history. When those scopes disagree, Cultist should show the tension instead of hiding it in one score.
 
 Tracking issue: #3.
 
@@ -62,6 +64,12 @@ Model-assisted explanations may eventually help interpret evidence, but the tool
 
 Tracking issue: #17.
 
+### Keep language adapters honest
+
+A language adapter can strengthen repository evidence with syntax or semantic facts, but it must not silently turn adapter coverage into a universal repository claim. Generic Git/project evidence and language-specific evidence should remain separately attributable.
+
+Tracking issue: #14.
+
 ### Teach the project why
 
 When humans decide an exception is intentional, the reason should be preservable in version control so future analysis can distinguish a known exception from forgotten folklore.
@@ -78,7 +86,7 @@ Tracking issue: #11.
 
 ### 1. Precedent engine
 
-The first implementation already compares changed test-module declarations with repository-wide and same-file precedent. The next step is to make precedent richer without pretending popularity is correctness.
+The first Rust implementation already compares changed test-module declarations with repository-wide and same-file precedent. The next step is to make precedent richer without pretending popularity is correctness.
 
 - #3 — scope-aware precedent and precedent tension
 - #4 — temporal precedent and convention drift
@@ -105,15 +113,26 @@ Questions become more valuable when their human answers can persist and eventual
 - #11 — lint incubation and promotion
 - #15 — claim provenance model
 
-### 4. Engine, interfaces, and evaluation
+### 4. Engine, adapters, interfaces, and evaluation
 
-The underlying engine should support more analyzers without turning into a pile of ad hoc scans or opaque scores.
+The underlying engine should support more analyzers and languages without turning into a pile of ad hoc scans or opaque scores.
 
 - #13 — local evidence index
-- #14 — progressive semantic adapters
+- #14 — progressive semantic/language adapters
 - #16 — dogfood corpus and precision-focused evaluation
 - #17 — optional bounded LLM explanations
 - #22 — stable machine-readable findings / JSON
+
+### 5. Concurrent work and agent context
+
+Cultist should help changes see relevant work around them before integration cost accumulates.
+
+- #62 — bounded agent context packets
+- #74 — `brief -> diff -> teach` agent edit lifecycle
+- #96 — concurrent-change preflight
+- #99 — real agent-heavy coordination corpus
+
+The first preflight slice is intentionally generic Git evidence: direct path overlap is `PROVEN`; deeper generated, historical, policy, or behavioral relationships remain separately earned evidence.
 
 ## Near-term sequence
 
@@ -126,13 +145,17 @@ A useful order for the next few experiments is:
 5. **Temporal precedent** (#4)
 6. **Helper/dependency precedent** (#20, #21)
 7. **History and exception archaeology** (#8, #9, #12)
+8. **Agent context + concurrent-work evidence** (#62, #74, #96, #99)
+9. **Additional language adapters** only where held-out cases justify them
 
 This is not a commitment to build everything in order. Small experiments that falsify an idea are valuable. The project should prefer evidence that a feature is useful over completing a grand architecture.
 
 ## Canonical dogfood case
 
-Cloud Hypervisor PR #8734 is currently the clearest example of the intended behavior.
+Cloud Hypervisor PR #8734 is currently the clearest example of the intended precedent behavior.
 
 The repository-wide evidence favored `unit_tests`, while the changed `vfio.rs` file already contained `tests`. Cultist surfaced both facts and asked which scope should govern the change. During that dogfood run, the tool also exposed a bug in its own diff semantics, leading to a merge-base-aware fix.
+
+The newer concurrent-work dogfood adds a second standard: Cultist should surface direct overlap between parallel changes without claiming that disjoint paths are independent.
 
 That is the standard to aim for: the tool should be willing to find ambiguity in the repository, ambiguity in its own conclusions, and bugs in itself.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Cultist explores repository reasoning between two familiar extremes:
 
 The project goal is to make the middle useful.
 
-Rust is the first semantic adapter, not the product boundary. Repository-generic evidence such as Git history, concurrent-change overlap, decision memory, and explicit project guidance should remain useful across languages. Language-specific analyzers should add stronger claims only where their adapters can justify them.
+Rust currently provides the deepest semantic adapter and the `cargo-cultist` distribution, but Cultist's evidence model is repository-oriented. Git history, provenance, decision memory, and concurrent-change coordination can apply independently of source language; language-specific adapters should add claims only where their evidence justifies them.
 
 ## Core loop
 
@@ -22,6 +22,18 @@ deterministic facts
   -> promote stable consensus into deterministic policy
 ```
 
+There is a second loop for Cultist's own development:
+
+```text
+agent/human works on Cultist
+  -> task exposes friction, a false assumption, duplication, missing context, or a counterexample
+  -> preserve exact evidence
+  -> ask whether Cultist could have surfaced or retained it earlier
+  -> test the generalization against negative controls
+  -> improve analyzer / evidence contract / regression / decision memory when earned
+  -> future worker starts with a better repository
+```
+
 The primitive is a **finding**, not an error. A good finding says what the repository evidence shows, what it does not establish, and why a human may want to look.
 
 ## Principles
@@ -32,7 +44,7 @@ Repository statistics are evidence, not policy. If a repository uses `unit_tests
 
 ### Keep scope visible
 
-Precedent can differ at the same time across a file, module/package/crate, repository, and recent history. When those scopes disagree, Cultist should show the tension instead of hiding it in one score.
+Precedent can differ at the same time across a file, package/crate, repository, and recent history. When those scopes disagree, Cultist should show the tension instead of hiding it in one score.
 
 Tracking issue: #3.
 
@@ -64,17 +76,19 @@ Model-assisted explanations may eventually help interpret evidence, but the tool
 
 Tracking issue: #17.
 
-### Keep language adapters honest
-
-A language adapter can strengthen repository evidence with syntax or semantic facts, but it must not silently turn adapter coverage into a universal repository claim. Generic Git/project evidence and language-specific evidence should remain separately attributable.
-
-Tracking issue: #14.
-
 ### Teach the project why
 
 When humans decide an exception is intentional, the reason should be preservable in version control so future analysis can distinguish a known exception from forgotten folklore.
 
 Tracking issue: #10.
+
+### Learn from the work itself
+
+Cultist development is part of the evaluation corpus. If implementing or reviewing a change forces a worker to manually discover an important repository fact, coordinate duplicate work late, recover lost rationale, correct a stale assumption, or weaken a heuristic after finding a counterexample, treat that episode as candidate product evidence.
+
+Do not automatically widen the current task. Record the exact evidence and use the smallest appropriate durable surface: a regression, research receipt, decision record, roadmap note, or focused follow-up. Generalize only after a discriminator and negative control justify it.
+
+Repository agent guidance: `AGENTS.md`.
 
 ### Promote mature questions into rules
 
@@ -86,7 +100,7 @@ Tracking issue: #11.
 
 ### 1. Precedent engine
 
-The first Rust implementation already compares changed test-module declarations with repository-wide and same-file precedent. The next step is to make precedent richer without pretending popularity is correctness.
+The first implementation already compares changed Rust test-module declarations with repository-wide and same-file precedent. The next step is to make precedent richer without pretending popularity is correctness.
 
 - #3 — scope-aware precedent and precedent tension
 - #4 — temporal precedent and convention drift
@@ -112,50 +126,48 @@ Questions become more valuable when their human answers can persist and eventual
 - #10 — explicit decision records / `teach`
 - #11 — lint incubation and promotion
 - #15 — claim provenance model
+- #62 / #74 / #75 — bounded agent context and longitudinal decision memory
 
-### 4. Engine, adapters, interfaces, and evaluation
+### 4. Coordination and concurrent work
 
-The underlying engine should support more analyzers and languages without turning into a pile of ad hoc scans or opaque scores.
+Cultist should help changes understand other active work without pretending that path overlap is the whole problem.
+
+- #96 — direct concurrent-change preflight baseline
+- #99 — real agent-heavy coordination corpus
+- #101 — offline active-change inventories and explicit coordination edges
+
+Direct shared paths are `PROVEN` from Git. Deeper generated, historical, policy, behavioral, or intent relationships remain separate evidence layers with their own provenance and counterexamples.
+
+### 5. Engine, interfaces, adapters, and evaluation
+
+The underlying engine should support more analyzers without turning into a pile of ad hoc scans or opaque scores.
 
 - #13 — local evidence index
-- #14 — progressive semantic/language adapters
+- #14 — progressive semantic adapters
 - #16 — dogfood corpus and precision-focused evaluation
 - #17 — optional bounded LLM explanations
 - #22 — stable machine-readable findings / JSON
 
-### 5. Concurrent work and agent context
-
-Cultist should help changes see relevant work around them before integration cost accumulates.
-
-- #62 — bounded agent context packets
-- #74 — `brief -> diff -> teach` agent edit lifecycle
-- #96 — concurrent-change preflight
-- #99 — real agent-heavy coordination corpus
-
-The first preflight slice is intentionally generic Git evidence: direct path overlap is `PROVEN`; deeper generated, historical, policy, or behavioral relationships remain separately earned evidence.
+The Rust adapter is the first deep source adapter. Add TypeScript, Python, or other language support when a concrete analyzer family and real corpus justify the parser/semantic investment; keep Git/repository evidence reusable across languages.
 
 ## Near-term sequence
 
 A useful order for the next few experiments is:
 
-1. **Claim provenance + machine-readable findings** (#15, #22)
-2. **Scoped precedent** (#3)
-3. **Counterexample-first output** (#6)
-4. **Dogfood corpus** (#16)
-5. **Temporal precedent** (#4)
-6. **Helper/dependency precedent** (#20, #21)
-7. **History and exception archaeology** (#8, #9, #12)
-8. **Agent context + concurrent-work evidence** (#62, #74, #96, #99)
-9. **Additional language adapters** only where held-out cases justify them
+1. keep claim provenance + machine-readable findings stable (#15, #22)
+2. dogfood direct preflight and explicit coordination evidence (#96, #99, #101)
+3. continue bounded agent context + decision memory (#62, #74, #75)
+4. deepen scoped/counterexample/temporal precedent (#3, #6, #4)
+5. continue generated/helper/dependency precedent (#20, #21 and related research)
+6. expand history and exception archaeology (#8, #9, #12)
+7. add language adapters only when a held-out discriminator earns them
 
 This is not a commitment to build everything in order. Small experiments that falsify an idea are valuable. The project should prefer evidence that a feature is useful over completing a grand architecture.
 
-## Canonical dogfood case
+## Canonical dogfood cases
 
-Cloud Hypervisor PR #8734 is currently the clearest example of the intended precedent behavior.
+Cloud Hypervisor PR #8734 remains a clear precedent example: repository-wide evidence favored `unit_tests`, while the changed `vfio.rs` file already contained `tests`. Cultist surfaced both facts and asked which scope should govern the change. During that dogfood run, the tool also exposed a bug in its own diff semantics, leading to a merge-base-aware fix.
 
-The repository-wide evidence favored `unit_tests`, while the changed `vfio.rs` file already contained `tests`. Cultist surfaced both facts and asked which scope should govern the change. During that dogfood run, the tool also exposed a bug in its own diff semantics, leading to a merge-base-aware fix.
+Stensibly supplies a complementary coordination corpus: parallel agents, stale evidence, explicit policy changes, duplicate lanes, handoffs, and reviewed lessons that later workers need to recover without old chat history. The #1624/#1625/#1629 overlap is an immediate example of why preflight coordination evidence matters.
 
-The newer concurrent-work dogfood adds a second standard: Cultist should surface direct overlap between parallel changes without claiming that disjoint paths are independent.
-
-That is the standard to aim for: the tool should be willing to find ambiguity in the repository, ambiguity in its own conclusions, and bugs in itself.
+That is the standard to aim for: Cultist should be willing to find ambiguity in a repository, ambiguity in its own conclusions, and weaknesses in its own development workflow — then preserve the lesson with enough provenance that a future worker does not have to rediscover it manually.


### PR DESCRIPTION
## Summary

Rebrand the current-facing project/docs from **cargo-cultist** to **Cultist** after the repository rename, and make the repository's own dogfood feedback loop explicit.

- make **Cultist** the product/protocol name in README and roadmap;
- keep `cargo-cultist` explicitly as the current Rust distribution name so `cargo cultist ...` continues to work;
- state that Rust-specific analyzers are the first semantic adapter, not the product boundary;
- call out repository-generic primitives such as Git history and direct concurrent-change preflight;
- add the newly landed `preflight` command to README usage;
- update the Cargo package description and repository URL to `teamleaderleo/cultist`;
- add `AGENTS.md` guidance telling workers to treat duplicate work, false assumptions, stale evidence, missing context, noisy findings, and useful counterexamples as potential Cultist dogfood evidence;
- require provenance, counterexamples/negative controls, and the smallest appropriate durable follow-up before turning task friction into product behavior.

## Boundary

This does **not** rename the Rust crate/binary, rewrite historical research receipts, or claim multi-language semantic support that does not exist yet. Language-specific adapters still have to earn their claims through the same provenance/counterexample discipline.

The agent guidance also does not authorize scope creep: workers should finish the requested task and capture useful lessons separately when incorporation would widen the current lane.

Active roadmap/research issues that used “Cargo Cultist” as the product proper name were cleaned up separately; Cargo-specific technical references remain where they actually refer to Cargo, libtest, metadata, aliases, or the current launcher.

## Validation

Documentation/package-metadata/guidance-only change. The branch changes `README.md`, `ROADMAP.md`, `Cargo.toml`, and adds `AGENTS.md`; there is no runtime behavior change.