### PR TITLE
feat: add explicit coordination inventory preflight

### DIFF
--- a/src/active_changes.rs
+++ b/src/active_changes.rs
@@ -1,0 +1,614 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::finding::{AnalysisReport, Claim, ClaimKind, Evidence, Finding, Location};
+
+const INVENTORY_SCHEMA_VERSION: u32 = 1;
+const MAX_INVENTORY_BYTES: usize = 1024 * 1024;
+const MAX_CHANGES: usize = 128;
+const MAX_CHANGED_PATHS: usize = 1024;
+const MAX_EDGES: usize = 512;
+const MAX_CHANGE_ID_BYTES: usize = 128;
+const MAX_REPOSITORY_BYTES: usize = 512;
+const MAX_SOURCE_BYTES: usize = 512;
+const MAX_PATH_BYTES: usize = 4096;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InventoryDocument {
+    schema_version: u32,
+    repository: String,
+    current_change: String,
+    changes: Vec<InventoryChange>,
+    #[serde(default)]
+    coordination_edges: Vec<CoordinationEdge>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InventoryChange {
+    id: String,
+    #[serde(default)]
+    changed_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum CoordinationKind {
+    DependsOn,
+    Blocks,
+    HoldMergeWhile,
+    Supersedes,
+}
+
+impl CoordinationKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::DependsOn => "depends_on",
+            Self::Blocks => "blocks",
+            Self::HoldMergeWhile => "hold_merge_while",
+            Self::Supersedes => "supersedes",
+        }
+    }
+
+    fn question(self) -> &'static str {
+        match self {
+            Self::DependsOn => {
+                "Should the dependency be integrated or settled before these changes proceed independently?"
+            }
+            Self::Blocks => {
+                "Should the blocked change pause, rebase, or coordinate ownership before proceeding?"
+            }
+            Self::HoldMergeWhile => {
+                "Should merge order be coordinated before either change advances the shared evidence baseline?"
+            }
+            Self::Supersedes => {
+                "Should the superseded change be retired or reconciled before parallel work continues?"
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CoordinationEdge {
+    kind: CoordinationKind,
+    from: String,
+    to: String,
+    source: String,
+}
+
+#[derive(Debug)]
+struct ValidatedInventory {
+    repository: String,
+    current_change: String,
+    changes: BTreeMap<String, BTreeSet<PathBuf>>,
+    coordination_edges: Vec<CoordinationEdge>,
+}
+
+pub fn build_active_inventory_analysis_report(
+    root: &Path,
+    inventory_path: &Path,
+    scope: Option<&Path>,
+) -> Result<AnalysisReport, Box<dyn Error>> {
+    let bytes = read_bounded_inventory(inventory_path)?;
+    let inventory = validate_inventory(serde_json::from_slice(&bytes)?)?;
+    Ok(analyze_inventory(root, &inventory, scope))
+}
+
+fn analyze_inventory(
+    root: &Path,
+    inventory: &ValidatedInventory,
+    scope: Option<&Path>,
+) -> AnalysisReport {
+    let mut analysis = AnalysisReport::new(
+        "preflight-active-inventory",
+        root.to_string_lossy().into_owned(),
+    );
+
+    analysis.claims.push(Claim::new(
+        ClaimKind::Observed,
+        format!(
+            "Admitted active-change inventory schema v{INVENTORY_SCHEMA_VERSION} for `{}` with {} active change(s) and {} coordination edge(s).",
+            inventory.repository,
+            inventory.changes.len(),
+            inventory.coordination_edges.len()
+        ),
+    ));
+
+    let current_paths = scoped_paths(
+        inventory
+            .changes
+            .get(&inventory.current_change)
+            .expect("validated inventory retains current change"),
+        scope,
+    );
+    analysis.claims.push(Claim::new(
+        ClaimKind::Observed,
+        format!(
+            "Current change `{}` records {} changed path(s) in the selected scope.",
+            inventory.current_change,
+            current_paths.len()
+        ),
+    ));
+
+    let mut direct_overlap_count = 0usize;
+    for (other_id, paths) in &inventory.changes {
+        if other_id == &inventory.current_change {
+            continue;
+        }
+        let other_paths = scoped_paths(paths, scope);
+        for path in current_paths.intersection(&other_paths) {
+            direct_overlap_count += 1;
+            let display = path.to_string_lossy().into_owned();
+            analysis.findings.push(
+                Finding::new(
+                    "preflight-inventory-path-overlap",
+                    "Active-change path overlap",
+                )
+                .at(Location::new(display.clone(), None))
+                .with_claim(
+                    Claim::new(
+                        ClaimKind::Observed,
+                        format!(
+                            "The admitted inventory records both `{}` and `{other_id}` modifying `{display}`.",
+                            inventory.current_change
+                        ),
+                    )
+                    .with_evidence(Evidence::new(format!(
+                        "Current change: `{}`.",
+                        inventory.current_change
+                    )))
+                    .with_evidence(Evidence::new(format!("Other active change: `{other_id}`."))),
+                )
+                .with_question(
+                    "Should ownership, ordering, or intent be coordinated before these changes proceed independently?",
+                ),
+            );
+        }
+    }
+
+    if direct_overlap_count == 0 {
+        analysis.claims.push(Claim::new(
+            ClaimKind::Observed,
+            "The admitted inventory records no direct path overlap between the current change and the other active changes in the selected scope.",
+        ));
+    }
+
+    let mut current_edge_count = 0usize;
+    for edge in &inventory.coordination_edges {
+        if edge.from != inventory.current_change && edge.to != inventory.current_change {
+            continue;
+        }
+        current_edge_count += 1;
+
+        let other = if edge.from == inventory.current_change {
+            edge.to.as_str()
+        } else {
+            edge.from.as_str()
+        };
+        let pair_has_overlap = pair_has_scoped_overlap(
+            inventory
+                .changes
+                .get(&inventory.current_change)
+                .expect("validated inventory retains current change"),
+            inventory
+                .changes
+                .get(other)
+                .expect("validated edge endpoints exist"),
+            scope,
+        );
+
+        let mut finding = Finding::new(
+            "preflight-explicit-coordination",
+            "Explicit coordination edge",
+        )
+        .with_claim(
+            Claim::new(
+                ClaimKind::Observed,
+                format!(
+                    "The admitted inventory records `{}` from `{}` to `{}`.",
+                    edge.kind.as_str(),
+                    edge.from,
+                    edge.to
+                ),
+            )
+            .with_evidence(Evidence::new(format!(
+                "Source reference: `{}`.",
+                edge.source
+            ))),
+        );
+
+        if !pair_has_overlap {
+            finding = finding.with_claim(Claim::new(
+                ClaimKind::Observed,
+                format!(
+                    "The inventory records no direct path overlap between `{}` and `{other}` in the selected scope.",
+                    inventory.current_change
+                ),
+            ));
+        }
+
+        finding = finding
+            .with_claim(Claim::new(
+                ClaimKind::Unknown,
+                "The inventory does not establish the operational consequence or intent beyond the declared coordination relation.",
+            ))
+            .with_question(edge.kind.question());
+
+        analysis.findings.push(finding);
+    }
+
+    if current_edge_count == 0 {
+        analysis.claims.push(Claim::new(
+            ClaimKind::Observed,
+            "The admitted inventory contains no explicit coordination edge involving the current change.",
+        ));
+    }
+
+    analysis.claims.push(Claim::new(
+        ClaimKind::Unknown,
+        "Inventory mode does not independently fetch provider objects or infer generated, historical, policy, or behavioral relationships absent from the supplied snapshot.",
+    ));
+
+    analysis
+}
+
+fn pair_has_scoped_overlap(
+    left: &BTreeSet<PathBuf>,
+    right: &BTreeSet<PathBuf>,
+    scope: Option<&Path>,
+) -> bool {
+    let left = scoped_paths(left, scope);
+    let right = scoped_paths(right, scope);
+    left.intersection(&right).next().is_some()
+}
+
+fn scoped_paths(paths: &BTreeSet<PathBuf>, scope: Option<&Path>) -> BTreeSet<PathBuf> {
+    match scope {
+        Some(scope) => paths
+            .iter()
+            .filter(|path| path.starts_with(scope))
+            .cloned()
+            .collect(),
+        None => paths.clone(),
+    }
+}
+
+fn read_bounded_inventory(path: &Path) -> Result<Vec<u8>, Box<dyn Error>> {
+    let metadata = std::fs::metadata(path)?;
+    if metadata.len() > MAX_INVENTORY_BYTES as u64 {
+        return Err(format!(
+            "active-change inventory exceeds the {MAX_INVENTORY_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let mut bytes = Vec::new();
+    File::open(path)?
+        .take((MAX_INVENTORY_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_INVENTORY_BYTES {
+        return Err(format!(
+            "active-change inventory exceeds the {MAX_INVENTORY_BYTES}-byte limit"
+        )
+        .into());
+    }
+    Ok(bytes)
+}
+
+fn validate_inventory(document: InventoryDocument) -> Result<ValidatedInventory, Box<dyn Error>> {
+    if document.schema_version != INVENTORY_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported active-change inventory schema {}; expected {INVENTORY_SCHEMA_VERSION}",
+            document.schema_version
+        )
+        .into());
+    }
+    validate_bounded_text(
+        &document.repository,
+        "repository",
+        MAX_REPOSITORY_BYTES,
+        false,
+    )?;
+    validate_change_id(&document.current_change)?;
+
+    if document.changes.is_empty() || document.changes.len() > MAX_CHANGES {
+        return Err(format!(
+            "active-change inventory must contain 1..={MAX_CHANGES} changes"
+        )
+        .into());
+    }
+    if document.coordination_edges.len() > MAX_EDGES {
+        return Err(format!(
+            "active-change inventory exceeds the {MAX_EDGES}-edge limit"
+        )
+        .into());
+    }
+
+    let mut changes = BTreeMap::new();
+    let mut total_paths = 0usize;
+    for change in document.changes {
+        validate_change_id(&change.id)?;
+        if changes.contains_key(&change.id) {
+            return Err(format!("duplicate active change id `{}`", change.id).into());
+        }
+
+        let mut paths = BTreeSet::new();
+        for raw_path in change.changed_paths {
+            let path = validate_relative_path(&raw_path)?;
+            if !paths.insert(path) {
+                return Err(format!(
+                    "active change `{}` contains duplicate path `{raw_path}`",
+                    change.id
+                )
+                .into());
+            }
+            total_paths += 1;
+            if total_paths > MAX_CHANGED_PATHS {
+                return Err(format!(
+                    "active-change inventory exceeds the {MAX_CHANGED_PATHS}-path limit"
+                )
+                .into());
+            }
+        }
+        changes.insert(change.id, paths);
+    }
+
+    if !changes.contains_key(&document.current_change) {
+        return Err(format!(
+            "current change `{}` is absent from the active-change inventory",
+            document.current_change
+        )
+        .into());
+    }
+
+    let mut seen_edges = BTreeSet::new();
+    for edge in &document.coordination_edges {
+        validate_change_id(&edge.from)?;
+        validate_change_id(&edge.to)?;
+        validate_bounded_text(&edge.source, "coordination source", MAX_SOURCE_BYTES, false)?;
+        if edge.from == edge.to {
+            return Err("coordination edge endpoints must be distinct".into());
+        }
+        if !changes.contains_key(&edge.from) {
+            return Err(format!(
+                "coordination edge references missing change `{}`",
+                edge.from
+            )
+            .into());
+        }
+        if !changes.contains_key(&edge.to) {
+            return Err(format!(
+                "coordination edge references missing change `{}`",
+                edge.to
+            )
+            .into());
+        }
+        if !seen_edges.insert((edge.kind, edge.from.clone(), edge.to.clone(), edge.source.clone())) {
+            return Err(format!(
+                "duplicate coordination edge `{}` from `{}` to `{}`",
+                edge.kind.as_str(),
+                edge.from,
+                edge.to
+            )
+            .into());
+        }
+    }
+
+    Ok(ValidatedInventory {
+        repository: document.repository,
+        current_change: document.current_change,
+        changes,
+        coordination_edges: document.coordination_edges,
+    })
+}
+
+fn validate_change_id(value: &str) -> Result<(), Box<dyn Error>> {
+    validate_bounded_text(value, "change id", MAX_CHANGE_ID_BYTES, true)
+}
+
+fn validate_bounded_text(
+    value: &str,
+    label: &str,
+    max_bytes: usize,
+    token: bool,
+) -> Result<(), Box<dyn Error>> {
+    if value.is_empty() || value.len() > max_bytes {
+        return Err(format!("{label} must contain 1..={max_bytes} bytes").into());
+    }
+    if value.chars().any(char::is_control) {
+        return Err(format!("{label} contains a control character").into());
+    }
+    if token && !value.bytes().all(|byte| byte.is_ascii_graphic()) {
+        return Err(format!("{label} must contain only printable non-space ASCII").into());
+    }
+    Ok(())
+}
+
+fn validate_relative_path(raw: &str) -> Result<PathBuf, Box<dyn Error>> {
+    if raw.is_empty() || raw.len() > MAX_PATH_BYTES {
+        return Err(format!("changed path must contain 1..={MAX_PATH_BYTES} bytes").into());
+    }
+    if raw.contains('\\') {
+        return Err(format!("changed path `{raw}` must use `/` separators").into());
+    }
+
+    let path = Path::new(raw);
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => parts.push(part.to_string_lossy().into_owned()),
+            _ => {
+                return Err(format!(
+                    "changed path `{raw}` must be a canonical relative path without traversal"
+                )
+                .into());
+            }
+        }
+    }
+    if parts.is_empty() || parts.join("/") != raw {
+        return Err(format!("changed path `{raw}` is not canonical").into());
+    }
+    Ok(PathBuf::from(raw))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    fn valid_document() -> &'static str {
+        r#"{
+            "schema_version": 1,
+            "repository": "teamleaderleo/preflight",
+            "current_change": "pr:748",
+            "changes": [
+                {"id": "pr:748", "changed_paths": ["preflight-cli/src/AgentJarStaging.java"]},
+                {"id": "pr:703", "changed_paths": ["preflight-desktop/src/report_authority.rs"]}
+            ],
+            "coordination_edges": [
+                {
+                    "kind": "hold_merge_while",
+                    "from": "pr:748",
+                    "to": "pr:703",
+                    "source": "github:pull/748"
+                }
+            ]
+        }"#
+    }
+
+    fn parse(document: &str) -> Result<ValidatedInventory, Box<dyn Error>> {
+        validate_inventory(serde_json::from_str(document)?)
+    }
+
+    fn unique_temp_file(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "cultist-active-inventory-{name}-{}-{nanos}.json",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn explicit_coordination_survives_disjoint_paths() {
+        let inventory = parse(valid_document()).unwrap();
+        let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
+
+        assert!(analysis.findings.iter().all(|finding| {
+            finding.kind != "preflight-inventory-path-overlap"
+        }));
+        let coordination: Vec<_> = analysis
+            .findings
+            .iter()
+            .filter(|finding| finding.kind == "preflight-explicit-coordination")
+            .collect();
+        assert_eq!(coordination.len(), 1);
+        assert!(coordination[0].claims.iter().any(|claim| {
+            claim.kind == ClaimKind::Observed
+                && claim.message.contains("hold_merge_while")
+        }));
+        assert!(coordination[0].claims.iter().any(|claim| {
+            claim.kind == ClaimKind::Unknown
+        }));
+        assert!(coordination[0].claims[0].evidence.iter().any(|evidence| {
+            evidence.message.contains("github:pull/748")
+        }));
+    }
+
+    #[test]
+    fn supplied_path_overlap_is_observed() {
+        let document = valid_document().replace(
+            "preflight-desktop/src/report_authority.rs",
+            "preflight-cli/src/AgentJarStaging.java",
+        );
+        let inventory = parse(&document).unwrap();
+        let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
+
+        let overlap = analysis
+            .findings
+            .iter()
+            .find(|finding| finding.kind == "preflight-inventory-path-overlap")
+            .unwrap();
+        assert_eq!(overlap.claims[0].kind, ClaimKind::Observed);
+    }
+
+    #[test]
+    fn unrelated_edges_are_ignored_for_current_change() {
+        let document = r#"{
+            "schema_version": 1,
+            "repository": "owner/repo",
+            "current_change": "pr:1",
+            "changes": [
+                {"id": "pr:1", "changed_paths": ["a"]},
+                {"id": "pr:2", "changed_paths": ["b"]},
+                {"id": "pr:3", "changed_paths": ["c"]}
+            ],
+            "coordination_edges": [
+                {"kind": "depends_on", "from": "pr:2", "to": "pr:3", "source": "github:pull/2"}
+            ]
+        }"#;
+        let inventory = parse(document).unwrap();
+        let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
+
+        assert!(analysis.findings.is_empty());
+        assert!(analysis.claims.iter().any(|claim| {
+            claim.message
+                .contains("no explicit coordination edge involving the current change")
+        }));
+    }
+
+    #[test]
+    fn rejects_unknown_edge_kind() {
+        let document = valid_document().replace("hold_merge_while", "vibes_with");
+        assert!(parse(&document).is_err());
+    }
+
+    #[test]
+    fn rejects_missing_edge_endpoint() {
+        let document = valid_document().replace("\"to\": \"pr:703\"", "\"to\": \"pr:999\"");
+        assert!(parse(&document).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_change_id() {
+        let document = valid_document().replace("\"id\": \"pr:703\"", "\"id\": \"pr:748\"");
+        assert!(parse(&document).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_edge() {
+        let document = valid_document().replace(
+            "            ]\n        }",
+            "                ,{\"kind\":\"hold_merge_while\",\"from\":\"pr:748\",\"to\":\"pr:703\",\"source\":\"github:pull/748\"}\n            ]\n        }",
+        );
+        assert!(parse(&document).is_err());
+    }
+
+    #[test]
+    fn rejects_traversing_path() {
+        let document = valid_document().replace(
+            "preflight-cli/src/AgentJarStaging.java",
+            "../outside",
+        );
+        assert!(parse(&document).is_err());
+    }
+
+    #[test]
+    fn rejects_oversized_inventory_file() {
+        let path = unique_temp_file("oversized");
+        fs::write(&path, vec![b'x'; MAX_INVENTORY_BYTES + 1]).unwrap();
+        assert!(build_active_inventory_analysis_report(Path::new("/repo"), &path, None).is_err());
+        fs::remove_file(path).unwrap();
+    }
+}

--- a/src/active_changes.rs
+++ b/src/active_changes.rs
@@ -10,30 +10,42 @@ use crate::finding::{AnalysisReport, Claim, ClaimKind, Evidence, Finding, Locati
 
 const INVENTORY_SCHEMA_VERSION: u32 = 1;
 const MAX_INVENTORY_BYTES: usize = 1024 * 1024;
-const MAX_CHANGES: usize = 128;
+const MAX_ACTIVE_WORK: usize = 128;
 const MAX_CHANGED_PATHS: usize = 1024;
 const MAX_EDGES: usize = 512;
-const MAX_CHANGE_ID_BYTES: usize = 128;
-const MAX_REPOSITORY_BYTES: usize = 512;
+const MAX_ID_BYTES: usize = 128;
+const MAX_KIND_BYTES: usize = 64;
+const MAX_TITLE_BYTES: usize = 512;
+const MAX_URL_BYTES: usize = 2048;
+const MAX_REF_BYTES: usize = 512;
+const MAX_SHA_BYTES: usize = 128;
+const MAX_TIME_BYTES: usize = 128;
 const MAX_SOURCE_BYTES: usize = 512;
 const MAX_PATH_BYTES: usize = 4096;
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct InventoryDocument {
+struct ActiveWorkInventory {
     schema_version: u32,
-    repository: String,
-    current_change: String,
-    changes: Vec<InventoryChange>,
+    source: String,
+    observed_at: String,
+    current: WorkItem,
+    active_work: Vec<WorkItem>,
     #[serde(default)]
     coordination_edges: Vec<CoordinationEdge>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct InventoryChange {
+struct WorkItem {
     id: String,
-    #[serde(default)]
+    kind: String,
+    title: String,
+    url: String,
+    head_ref: String,
+    head_sha: String,
+    updated_at: String,
+    draft: bool,
     changed_paths: Vec<String>,
 }
 
@@ -85,9 +97,11 @@ struct CoordinationEdge {
 
 #[derive(Debug)]
 struct ValidatedInventory {
-    repository: String,
-    current_change: String,
-    changes: BTreeMap<String, BTreeSet<PathBuf>>,
+    source: String,
+    observed_at: String,
+    current: WorkItem,
+    active_work: Vec<WorkItem>,
+    by_id: BTreeMap<String, WorkItem>,
     coordination_edges: Vec<CoordinationEdge>,
 }
 
@@ -114,35 +128,42 @@ fn analyze_inventory(
     analysis.claims.push(Claim::new(
         ClaimKind::Observed,
         format!(
-            "Admitted active-change inventory schema v{INVENTORY_SCHEMA_VERSION} for `{}` with {} active change(s) and {} coordination edge(s).",
-            inventory.repository,
-            inventory.changes.len(),
-            inventory.coordination_edges.len()
+            "Admitted active-work inventory schema v{INVENTORY_SCHEMA_VERSION} from `{}` observed at `{}`.",
+            inventory.source, inventory.observed_at
         ),
     ));
-
-    let current_paths = scoped_paths(
-        inventory
-            .changes
-            .get(&inventory.current_change)
-            .expect("validated inventory retains current change"),
-        scope,
-    );
     analysis.claims.push(Claim::new(
         ClaimKind::Observed,
         format!(
-            "Current change `{}` records {} changed path(s) in the selected scope.",
-            inventory.current_change,
+            "Current work `{}` is `{}` at head `{}` (updated `{}`, draft={}).",
+            inventory.current.id,
+            inventory.current.title,
+            inventory.current.head_sha,
+            inventory.current.updated_at,
+            inventory.current.draft
+        ),
+    ));
+
+    let current_paths = scoped_paths(&inventory.current.changed_paths, scope);
+    analysis.claims.push(Claim::new(
+        ClaimKind::Observed,
+        format!(
+            "Current work records {} changed path(s) in the selected scope.",
             current_paths.len()
         ),
     ));
 
     let mut direct_overlap_count = 0usize;
-    for (other_id, paths) in &inventory.changes {
-        if other_id == &inventory.current_change {
+    let mut candidates_examined = 0usize;
+    let mut self_candidates_excluded = 0usize;
+
+    for work in &inventory.active_work {
+        if same_work(&inventory.current, work) {
+            self_candidates_excluded += 1;
             continue;
         }
-        let other_paths = scoped_paths(paths, scope);
+        candidates_examined += 1;
+        let other_paths = scoped_paths(&work.changed_paths, scope);
         for path in current_paths.intersection(&other_paths) {
             direct_overlap_count += 1;
             let display = path.to_string_lossy().into_owned();
@@ -156,53 +177,52 @@ fn analyze_inventory(
                     Claim::new(
                         ClaimKind::Observed,
                         format!(
-                            "The admitted inventory records both `{}` and `{other_id}` modifying `{display}`.",
-                            inventory.current_change
+                            "The admitted inventory records both `{}` and `{}` modifying `{display}`.",
+                            inventory.current.id, work.id
                         ),
                     )
                     .with_evidence(Evidence::new(format!(
-                        "Current change: `{}`.",
-                        inventory.current_change
+                        "Other active work: `{}` — `{}` at head `{}` (updated `{}`).",
+                        work.id, work.title, work.head_sha, work.updated_at
                     )))
-                    .with_evidence(Evidence::new(format!("Other active change: `{other_id}`."))),
+                    .with_evidence(Evidence::new(format!("Provider reference: `{}`.", work.url))),
                 )
                 .with_question(
-                    "Should ownership, ordering, or intent be coordinated before these changes proceed independently?",
+                    "Is there anything worth reconciling before continuing on this path?",
                 ),
             );
         }
     }
 
+    analysis.claims.push(Claim::new(
+        ClaimKind::Observed,
+        format!(
+            "Examined {candidates_examined} active candidate(s) and excluded {self_candidates_excluded} self candidate(s)."
+        ),
+    ));
+
     if direct_overlap_count == 0 {
         analysis.claims.push(Claim::new(
             ClaimKind::Observed,
-            "The admitted inventory records no direct path overlap between the current change and the other active changes in the selected scope.",
+            "The admitted inventory records no direct path overlap between the current work and the other active work in the selected scope.",
         ));
     }
 
     let mut current_edge_count = 0usize;
     for edge in &inventory.coordination_edges {
-        if edge.from != inventory.current_change && edge.to != inventory.current_change {
+        if edge.from != inventory.current.id && edge.to != inventory.current.id {
             continue;
         }
         current_edge_count += 1;
-
-        let other = if edge.from == inventory.current_change {
+        let other_id = if edge.from == inventory.current.id {
             edge.to.as_str()
         } else {
             edge.from.as_str()
         };
-        let pair_has_overlap = pair_has_scoped_overlap(
-            inventory
-                .changes
-                .get(&inventory.current_change)
-                .expect("validated inventory retains current change"),
-            inventory
-                .changes
-                .get(other)
-                .expect("validated edge endpoints exist"),
-            scope,
-        );
+        let other = inventory
+            .by_id
+            .get(other_id)
+            .expect("validated coordination endpoint exists");
 
         let mut finding = Finding::new(
             "preflight-explicit-coordination",
@@ -219,17 +239,21 @@ fn analyze_inventory(
                 ),
             )
             .with_evidence(Evidence::new(format!(
-                "Source reference: `{}`.",
+                "Coordination source reference: `{}`.",
                 edge.source
+            )))
+            .with_evidence(Evidence::new(format!(
+                "Related active work: `{}` — `{}` at head `{}` (updated `{}`).",
+                other.id, other.title, other.head_sha, other.updated_at
             ))),
         );
 
-        if !pair_has_overlap {
+        if !pair_has_scoped_overlap(&inventory.current, other, scope) {
             finding = finding.with_claim(Claim::new(
                 ClaimKind::Observed,
                 format!(
-                    "The inventory records no direct path overlap between `{}` and `{other}` in the selected scope.",
-                    inventory.current_change
+                    "The admitted inventory records no direct path overlap between `{}` and `{other_id}` in the selected scope.",
+                    inventory.current.id
                 ),
             ));
         }
@@ -240,51 +264,51 @@ fn analyze_inventory(
                 "The inventory does not establish the operational consequence or intent beyond the declared coordination relation.",
             ))
             .with_question(edge.kind.question());
-
         analysis.findings.push(finding);
     }
 
     if current_edge_count == 0 {
         analysis.claims.push(Claim::new(
             ClaimKind::Observed,
-            "The admitted inventory contains no explicit coordination edge involving the current change.",
+            "The admitted inventory contains no explicit coordination edge involving the current work.",
         ));
     }
 
     analysis.claims.push(Claim::new(
         ClaimKind::Unknown,
-        "Inventory mode does not independently fetch provider objects or infer generated, historical, policy, or behavioral relationships absent from the supplied snapshot.",
+        "No direct path overlap is not evidence that active work is semantically independent.",
+    ));
+    analysis.claims.push(Claim::new(
+        ClaimKind::Unknown,
+        "Inventory mode does not independently fetch provider objects or infer generated, historical, policy, behavioral, ownership, or incompatibility relationships absent from the supplied snapshot.",
     ));
 
     analysis
 }
 
-fn pair_has_scoped_overlap(
-    left: &BTreeSet<PathBuf>,
-    right: &BTreeSet<PathBuf>,
-    scope: Option<&Path>,
-) -> bool {
-    let left = scoped_paths(left, scope);
-    let right = scoped_paths(right, scope);
-    left.intersection(&right).next().is_some()
+fn same_work(current: &WorkItem, other: &WorkItem) -> bool {
+    current.id == other.id || current.head_sha == other.head_sha
 }
 
-fn scoped_paths(paths: &BTreeSet<PathBuf>, scope: Option<&Path>) -> BTreeSet<PathBuf> {
-    match scope {
-        Some(scope) => paths
-            .iter()
-            .filter(|path| path.starts_with(scope))
-            .cloned()
-            .collect(),
-        None => paths.clone(),
-    }
+fn pair_has_scoped_overlap(current: &WorkItem, other: &WorkItem, scope: Option<&Path>) -> bool {
+    let current = scoped_paths(&current.changed_paths, scope);
+    let other = scoped_paths(&other.changed_paths, scope);
+    current.intersection(&other).next().is_some()
+}
+
+fn scoped_paths(paths: &[String], scope: Option<&Path>) -> BTreeSet<PathBuf> {
+    paths
+        .iter()
+        .map(PathBuf::from)
+        .filter(|path| scope.is_none_or(|scope| path.starts_with(scope)))
+        .collect()
 }
 
 fn read_bounded_inventory(path: &Path) -> Result<Vec<u8>, Box<dyn Error>> {
     let metadata = std::fs::metadata(path)?;
     if metadata.len() > MAX_INVENTORY_BYTES as u64 {
         return Err(format!(
-            "active-change inventory exceeds the {MAX_INVENTORY_BYTES}-byte limit"
+            "active-work inventory exceeds the {MAX_INVENTORY_BYTES}-byte limit"
         )
         .into());
     }
@@ -295,97 +319,74 @@ fn read_bounded_inventory(path: &Path) -> Result<Vec<u8>, Box<dyn Error>> {
         .read_to_end(&mut bytes)?;
     if bytes.len() > MAX_INVENTORY_BYTES {
         return Err(format!(
-            "active-change inventory exceeds the {MAX_INVENTORY_BYTES}-byte limit"
+            "active-work inventory exceeds the {MAX_INVENTORY_BYTES}-byte limit"
         )
         .into());
     }
     Ok(bytes)
 }
 
-fn validate_inventory(document: InventoryDocument) -> Result<ValidatedInventory, Box<dyn Error>> {
+fn validate_inventory(
+    mut document: ActiveWorkInventory,
+) -> Result<ValidatedInventory, Box<dyn Error>> {
     if document.schema_version != INVENTORY_SCHEMA_VERSION {
         return Err(format!(
-            "unsupported active-change inventory schema {}; expected {INVENTORY_SCHEMA_VERSION}",
+            "unsupported active-work inventory schema {}; expected {INVENTORY_SCHEMA_VERSION}",
             document.schema_version
         )
         .into());
     }
-    validate_bounded_text(
-        &document.repository,
-        "repository",
-        MAX_REPOSITORY_BYTES,
-        false,
-    )?;
-    validate_change_id(&document.current_change)?;
+    validate_bounded_text(&document.source, "source", MAX_SOURCE_BYTES, false)?;
+    validate_bounded_text(&document.observed_at, "observed_at", MAX_TIME_BYTES, false)?;
 
-    if document.changes.is_empty() || document.changes.len() > MAX_CHANGES {
+    if document.active_work.len() > MAX_ACTIVE_WORK {
         return Err(format!(
-            "active-change inventory must contain 1..={MAX_CHANGES} changes"
+            "active-work inventory exceeds the {MAX_ACTIVE_WORK}-candidate limit"
         )
         .into());
     }
     if document.coordination_edges.len() > MAX_EDGES {
         return Err(format!(
-            "active-change inventory exceeds the {MAX_EDGES}-edge limit"
+            "active-work inventory exceeds the {MAX_EDGES}-edge limit"
         )
         .into());
     }
 
-    let mut changes = BTreeMap::new();
     let mut total_paths = 0usize;
-    for change in document.changes {
-        validate_change_id(&change.id)?;
-        if changes.contains_key(&change.id) {
-            return Err(format!("duplicate active change id `{}`", change.id).into());
-        }
-
-        let mut paths = BTreeSet::new();
-        for raw_path in change.changed_paths {
-            let path = validate_relative_path(&raw_path)?;
-            if !paths.insert(path) {
-                return Err(format!(
-                    "active change `{}` contains duplicate path `{raw_path}`",
-                    change.id
-                )
-                .into());
-            }
-            total_paths += 1;
-            if total_paths > MAX_CHANGED_PATHS {
-                return Err(format!(
-                    "active-change inventory exceeds the {MAX_CHANGED_PATHS}-path limit"
-                )
-                .into());
-            }
-        }
-        changes.insert(change.id, paths);
+    normalize_work(&mut document.current, &mut total_paths)?;
+    for work in &mut document.active_work {
+        normalize_work(work, &mut total_paths)?;
     }
 
-    if !changes.contains_key(&document.current_change) {
-        return Err(format!(
-            "current change `{}` is absent from the active-change inventory",
-            document.current_change
-        )
-        .into());
+    let mut by_id = BTreeMap::new();
+    by_id.insert(document.current.id.clone(), document.current.clone());
+    for work in &document.active_work {
+        if same_work(&document.current, work) {
+            continue;
+        }
+        if by_id.insert(work.id.clone(), work.clone()).is_some() {
+            return Err(format!("duplicate active work id `{}`", work.id).into());
+        }
     }
 
     let mut seen_edges = BTreeSet::new();
     for edge in &document.coordination_edges {
-        validate_change_id(&edge.from)?;
-        validate_change_id(&edge.to)?;
+        validate_id(&edge.from)?;
+        validate_id(&edge.to)?;
         validate_bounded_text(&edge.source, "coordination source", MAX_SOURCE_BYTES, false)?;
         if edge.from == edge.to {
             return Err("coordination edge endpoints must be distinct".into());
         }
-        if !changes.contains_key(&edge.from) {
+        if !by_id.contains_key(&edge.from) {
             return Err(format!(
-                "coordination edge references missing change `{}`",
+                "coordination edge references missing active work `{}`",
                 edge.from
             )
             .into());
         }
-        if !changes.contains_key(&edge.to) {
+        if !by_id.contains_key(&edge.to) {
             return Err(format!(
-                "coordination edge references missing change `{}`",
+                "coordination edge references missing active work `{}`",
                 edge.to
             )
             .into());
@@ -402,15 +403,51 @@ fn validate_inventory(document: InventoryDocument) -> Result<ValidatedInventory,
     }
 
     Ok(ValidatedInventory {
-        repository: document.repository,
-        current_change: document.current_change,
-        changes,
+        source: document.source,
+        observed_at: document.observed_at,
+        current: document.current,
+        active_work: document.active_work,
+        by_id,
         coordination_edges: document.coordination_edges,
     })
 }
 
-fn validate_change_id(value: &str) -> Result<(), Box<dyn Error>> {
-    validate_bounded_text(value, "change id", MAX_CHANGE_ID_BYTES, true)
+fn normalize_work(work: &mut WorkItem, total_paths: &mut usize) -> Result<(), Box<dyn Error>> {
+    validate_id(&work.id)?;
+    validate_bounded_text(&work.kind, "work kind", MAX_KIND_BYTES, true)?;
+    validate_bounded_text(&work.title, "work title", MAX_TITLE_BYTES, false)?;
+    validate_bounded_text(&work.url, "work url", MAX_URL_BYTES, false)?;
+    validate_bounded_text(&work.head_ref, "head ref", MAX_REF_BYTES, true)?;
+    validate_bounded_text(&work.head_sha, "head sha", MAX_SHA_BYTES, true)?;
+    validate_bounded_text(&work.updated_at, "updated_at", MAX_TIME_BYTES, false)?;
+
+    let mut normalized = BTreeSet::new();
+    for raw_path in &work.changed_paths {
+        let path = validate_relative_path(raw_path)?;
+        if !normalized.insert(path) {
+            return Err(format!(
+                "active work `{}` contains duplicate path `{raw_path}`",
+                work.id
+            )
+            .into());
+        }
+        *total_paths += 1;
+        if *total_paths > MAX_CHANGED_PATHS {
+            return Err(format!(
+                "active-work inventory exceeds the {MAX_CHANGED_PATHS}-path limit"
+            )
+            .into());
+        }
+    }
+    work.changed_paths = normalized
+        .into_iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect();
+    Ok(())
+}
+
+fn validate_id(value: &str) -> Result<(), Box<dyn Error>> {
+    validate_bounded_text(value, "work id", MAX_ID_BYTES, true)
 }
 
 fn validate_bounded_text(
@@ -465,28 +502,37 @@ mod tests {
 
     use super::*;
 
-    fn valid_document() -> &'static str {
-        r#"{
-            "schema_version": 1,
-            "repository": "teamleaderleo/preflight",
-            "current_change": "pr:748",
-            "changes": [
-                {"id": "pr:748", "changed_paths": ["preflight-cli/src/AgentJarStaging.java"]},
-                {"id": "pr:703", "changed_paths": ["preflight-desktop/src/report_authority.rs"]}
-            ],
-            "coordination_edges": [
-                {
-                    "kind": "hold_merge_while",
-                    "from": "pr:748",
-                    "to": "pr:703",
-                    "source": "github:pull/748"
-                }
-            ]
-        }"#
+    fn work(id: &str, sha: &str, paths: &[&str]) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "kind": "pull_request",
+            "title": format!("Work {id}"),
+            "url": format!("https://example.invalid/{id}"),
+            "head_ref": format!("branch-{id}"),
+            "head_sha": sha,
+            "updated_at": "2026-08-19T00:00:00Z",
+            "draft": false,
+            "changed_paths": paths,
+        })
     }
 
-    fn parse(document: &str) -> Result<ValidatedInventory, Box<dyn Error>> {
-        validate_inventory(serde_json::from_str(document)?)
+    fn document(
+        current: serde_json::Value,
+        active_work: Vec<serde_json::Value>,
+        edges: Vec<serde_json::Value>,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "schema_version": 1,
+            "source": "github_pull_requests",
+            "observed_at": "2026-08-19T00:01:00Z",
+            "current": current,
+            "active_work": active_work,
+            "coordination_edges": edges,
+        })
+    }
+
+    fn parse(value: serde_json::Value) -> Result<ValidatedInventory, Box<dyn Error>> {
+        validate_inventory(serde_json::from_value(value)?)
     }
 
     fn unique_temp_file(name: &str) -> PathBuf {
@@ -501,8 +547,33 @@ mod tests {
     }
 
     #[test]
+    fn accepts_landed_research_inventory_without_edges() {
+        let current = work("#1", "aaa", &["src/a.rs"]);
+        let inventory = parse(document(
+            current.clone(),
+            vec![current, work("#2", "bbb", &["src/b.rs"])],
+            Vec::new(),
+        ))
+        .unwrap();
+        let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
+
+        assert!(analysis.findings.is_empty());
+        assert!(analysis.claims.iter().any(|claim| {
+            claim.message.contains("excluded 1 self candidate")
+        }));
+    }
+
+    #[test]
     fn explicit_coordination_survives_disjoint_paths() {
-        let inventory = parse(valid_document()).unwrap();
+        let current = work("#748", "aaa", &["preflight-cli/src/AgentJarStaging.java"]);
+        let other = work("#703", "bbb", &["preflight-desktop/src/report_authority.rs"]);
+        let edge = serde_json::json!({
+            "kind": "hold_merge_while",
+            "from": "#748",
+            "to": "#703",
+            "source": "github:pull/748"
+        });
+        let inventory = parse(document(current, vec![other], vec![edge])).unwrap();
         let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
 
         assert!(analysis.findings.iter().all(|finding| {
@@ -515,12 +586,12 @@ mod tests {
             .collect();
         assert_eq!(coordination.len(), 1);
         assert!(coordination[0].claims.iter().any(|claim| {
-            claim.kind == ClaimKind::Observed
-                && claim.message.contains("hold_merge_while")
+            claim.kind == ClaimKind::Observed && claim.message.contains("hold_merge_while")
         }));
-        assert!(coordination[0].claims.iter().any(|claim| {
-            claim.kind == ClaimKind::Unknown
-        }));
+        assert!(coordination[0]
+            .claims
+            .iter()
+            .any(|claim| claim.kind == ClaimKind::Unknown));
         assert!(coordination[0].claims[0].evidence.iter().any(|evidence| {
             evidence.message.contains("github:pull/748")
         }));
@@ -528,11 +599,9 @@ mod tests {
 
     #[test]
     fn supplied_path_overlap_is_observed() {
-        let document = valid_document().replace(
-            "preflight-desktop/src/report_authority.rs",
-            "preflight-cli/src/AgentJarStaging.java",
-        );
-        let inventory = parse(&document).unwrap();
+        let current = work("#1", "aaa", &["src/a.rs"]);
+        let other = work("#2", "bbb", &["src/a.rs"]);
+        let inventory = parse(document(current, vec![other], Vec::new())).unwrap();
         let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
 
         let overlap = analysis
@@ -544,64 +613,86 @@ mod tests {
     }
 
     #[test]
-    fn unrelated_edges_are_ignored_for_current_change() {
-        let document = r#"{
-            "schema_version": 1,
-            "repository": "owner/repo",
-            "current_change": "pr:1",
-            "changes": [
-                {"id": "pr:1", "changed_paths": ["a"]},
-                {"id": "pr:2", "changed_paths": ["b"]},
-                {"id": "pr:3", "changed_paths": ["c"]}
-            ],
-            "coordination_edges": [
-                {"kind": "depends_on", "from": "pr:2", "to": "pr:3", "source": "github:pull/2"}
-            ]
-        }"#;
-        let inventory = parse(document).unwrap();
+    fn unrelated_edges_are_ignored_for_current_work() {
+        let current = work("#1", "aaa", &["a"]);
+        let two = work("#2", "bbb", &["b"]);
+        let three = work("#3", "ccc", &["c"]);
+        let edge = serde_json::json!({
+            "kind": "depends_on",
+            "from": "#2",
+            "to": "#3",
+            "source": "github:pull/2"
+        });
+        let inventory = parse(document(current, vec![two, three], vec![edge])).unwrap();
         let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
 
         assert!(analysis.findings.is_empty());
         assert!(analysis.claims.iter().any(|claim| {
             claim.message
-                .contains("no explicit coordination edge involving the current change")
+                .contains("no explicit coordination edge involving the current work")
         }));
     }
 
     #[test]
     fn rejects_unknown_edge_kind() {
-        let document = valid_document().replace("hold_merge_while", "vibes_with");
-        assert!(parse(&document).is_err());
+        let value = document(
+            work("#1", "aaa", &["a"]),
+            vec![work("#2", "bbb", &["b"])],
+            vec![serde_json::json!({
+                "kind": "vibes_with",
+                "from": "#1",
+                "to": "#2",
+                "source": "fixture"
+            })],
+        );
+        assert!(parse(value).is_err());
     }
 
     #[test]
     fn rejects_missing_edge_endpoint() {
-        let document = valid_document().replace("\"to\": \"pr:703\"", "\"to\": \"pr:999\"");
-        assert!(parse(&document).is_err());
+        let value = document(
+            work("#1", "aaa", &["a"]),
+            vec![work("#2", "bbb", &["b"])],
+            vec![serde_json::json!({
+                "kind": "depends_on",
+                "from": "#1",
+                "to": "#999",
+                "source": "fixture"
+            })],
+        );
+        assert!(parse(value).is_err());
     }
 
     #[test]
-    fn rejects_duplicate_change_id() {
-        let document = valid_document().replace("\"id\": \"pr:703\"", "\"id\": \"pr:748\"");
-        assert!(parse(&document).is_err());
+    fn rejects_duplicate_active_work_id() {
+        let value = document(
+            work("#1", "aaa", &["a"]),
+            vec![work("#2", "bbb", &["b"]), work("#2", "ccc", &["c"])],
+            Vec::new(),
+        );
+        assert!(parse(value).is_err());
     }
 
     #[test]
     fn rejects_duplicate_edge() {
-        let document = valid_document().replace(
-            "            ]\n        }",
-            "                ,{\"kind\":\"hold_merge_while\",\"from\":\"pr:748\",\"to\":\"pr:703\",\"source\":\"github:pull/748\"}\n            ]\n        }",
+        let edge = serde_json::json!({
+            "kind": "depends_on",
+            "from": "#1",
+            "to": "#2",
+            "source": "fixture"
+        });
+        let value = document(
+            work("#1", "aaa", &["a"]),
+            vec![work("#2", "bbb", &["b"])],
+            vec![edge.clone(), edge],
         );
-        assert!(parse(&document).is_err());
+        assert!(parse(value).is_err());
     }
 
     #[test]
     fn rejects_traversing_path() {
-        let document = valid_document().replace(
-            "preflight-cli/src/AgentJarStaging.java",
-            "../outside",
-        );
-        assert!(parse(&document).is_err());
+        let value = document(work("#1", "aaa", &["../outside"]), Vec::new(), Vec::new());
+        assert!(parse(value).is_err());
     }
 
     #[test]

--- a/src/active_changes.rs
+++ b/src/active_changes.rs
@@ -307,10 +307,9 @@ fn scoped_paths(paths: &[String], scope: Option<&Path>) -> BTreeSet<PathBuf> {
 fn read_bounded_inventory(path: &Path) -> Result<Vec<u8>, Box<dyn Error>> {
     let metadata = std::fs::metadata(path)?;
     if metadata.len() > MAX_INVENTORY_BYTES as u64 {
-        return Err(format!(
-            "active-work inventory exceeds the {MAX_INVENTORY_BYTES}-byte limit"
-        )
-        .into());
+        return Err(
+            format!("active-work inventory exceeds the {MAX_INVENTORY_BYTES}-byte limit").into(),
+        );
     }
 
     let mut bytes = Vec::new();
@@ -318,10 +317,9 @@ fn read_bounded_inventory(path: &Path) -> Result<Vec<u8>, Box<dyn Error>> {
         .take((MAX_INVENTORY_BYTES + 1) as u64)
         .read_to_end(&mut bytes)?;
     if bytes.len() > MAX_INVENTORY_BYTES {
-        return Err(format!(
-            "active-work inventory exceeds the {MAX_INVENTORY_BYTES}-byte limit"
-        )
-        .into());
+        return Err(
+            format!("active-work inventory exceeds the {MAX_INVENTORY_BYTES}-byte limit").into(),
+        );
     }
     Ok(bytes)
 }
@@ -340,16 +338,12 @@ fn validate_inventory(
     validate_bounded_text(&document.observed_at, "observed_at", MAX_TIME_BYTES, false)?;
 
     if document.active_work.len() > MAX_ACTIVE_WORK {
-        return Err(format!(
-            "active-work inventory exceeds the {MAX_ACTIVE_WORK}-candidate limit"
-        )
-        .into());
+        return Err(
+            format!("active-work inventory exceeds the {MAX_ACTIVE_WORK}-candidate limit").into(),
+        );
     }
     if document.coordination_edges.len() > MAX_EDGES {
-        return Err(format!(
-            "active-work inventory exceeds the {MAX_EDGES}-edge limit"
-        )
-        .into());
+        return Err(format!("active-work inventory exceeds the {MAX_EDGES}-edge limit").into());
     }
 
     let mut total_paths = 0usize;
@@ -391,7 +385,12 @@ fn validate_inventory(
             )
             .into());
         }
-        if !seen_edges.insert((edge.kind, edge.from.clone(), edge.to.clone(), edge.source.clone())) {
+        if !seen_edges.insert((
+            edge.kind,
+            edge.from.clone(),
+            edge.to.clone(),
+            edge.source.clone(),
+        )) {
             return Err(format!(
                 "duplicate coordination edge `{}` from `{}` to `{}`",
                 edge.kind.as_str(),
@@ -558,15 +557,22 @@ mod tests {
         let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
 
         assert!(analysis.findings.is_empty());
-        assert!(analysis.claims.iter().any(|claim| {
-            claim.message.contains("excluded 1 self candidate")
-        }));
+        assert!(
+            analysis
+                .claims
+                .iter()
+                .any(|claim| { claim.message.contains("excluded 1 self candidate") })
+        );
     }
 
     #[test]
     fn explicit_coordination_survives_disjoint_paths() {
         let current = work("#748", "aaa", &["preflight-cli/src/AgentJarStaging.java"]);
-        let other = work("#703", "bbb", &["preflight-desktop/src/report_authority.rs"]);
+        let other = work(
+            "#703",
+            "bbb",
+            &["preflight-desktop/src/report_authority.rs"],
+        );
         let edge = serde_json::json!({
             "kind": "hold_merge_while",
             "from": "#748",
@@ -576,9 +582,12 @@ mod tests {
         let inventory = parse(document(current, vec![other], vec![edge])).unwrap();
         let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
 
-        assert!(analysis.findings.iter().all(|finding| {
-            finding.kind != "preflight-inventory-path-overlap"
-        }));
+        assert!(
+            analysis
+                .findings
+                .iter()
+                .all(|finding| { finding.kind != "preflight-inventory-path-overlap" })
+        );
         let coordination: Vec<_> = analysis
             .findings
             .iter()
@@ -588,13 +597,18 @@ mod tests {
         assert!(coordination[0].claims.iter().any(|claim| {
             claim.kind == ClaimKind::Observed && claim.message.contains("hold_merge_while")
         }));
-        assert!(coordination[0]
-            .claims
-            .iter()
-            .any(|claim| claim.kind == ClaimKind::Unknown));
-        assert!(coordination[0].claims[0].evidence.iter().any(|evidence| {
-            evidence.message.contains("github:pull/748")
-        }));
+        assert!(
+            coordination[0]
+                .claims
+                .iter()
+                .any(|claim| claim.kind == ClaimKind::Unknown)
+        );
+        assert!(
+            coordination[0].claims[0]
+                .evidence
+                .iter()
+                .any(|evidence| { evidence.message.contains("github:pull/748") })
+        );
     }
 
     #[test]
@@ -628,7 +642,8 @@ mod tests {
 
         assert!(analysis.findings.is_empty());
         assert!(analysis.claims.iter().any(|claim| {
-            claim.message
+            claim
+                .message
                 .contains("no explicit coordination edge involving the current work")
         }));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod active_changes;
 mod ci_test_filters;
 mod diff;
 mod finding;
@@ -14,6 +15,7 @@ use std::error::Error;
 use std::path::PathBuf;
 use std::process;
 
+use active_changes::build_active_inventory_analysis_report;
 use ci_test_filters::{analyze_ci_test_filters, build_ci_test_filter_analysis};
 use diff::{build_diff_analysis_report, git_repo_root};
 use finding::AnalysisReport;
@@ -42,8 +44,14 @@ struct DiffArgs {
 }
 
 #[derive(Debug, Eq, PartialEq)]
+enum PreflightSource {
+    Against(String),
+    Inventory(PathBuf),
+}
+
+#[derive(Debug, Eq, PartialEq)]
 struct PreflightArgs {
-    against: String,
+    source: PreflightSource,
     path: Option<PathBuf>,
     format: OutputFormat,
 }
@@ -129,7 +137,7 @@ fn run_preflight(args: Vec<String>) -> Result<(), Box<dyn Error>> {
     }
 
     let PreflightArgs {
-        against,
+        source,
         path,
         format,
     } = parse_preflight_args(args)?;
@@ -149,7 +157,27 @@ fn run_preflight(args: Vec<String>) -> Result<(), Box<dyn Error>> {
         .map_err(|_| "preflight path is outside the resolved Git repository")?;
     let scope = (!relative.as_os_str().is_empty()).then(|| relative.to_path_buf());
 
-    let analysis = build_preflight_analysis_report(&root, &against, scope.as_deref())?;
+    let analysis = match source {
+        PreflightSource::Against(against) => {
+            build_preflight_analysis_report(&root, &against, scope.as_deref())?
+        }
+        PreflightSource::Inventory(inventory) => {
+            let inventory = if inventory.is_absolute() {
+                inventory
+            } else {
+                env::current_dir()?.join(inventory)
+            };
+            let inventory = inventory.canonicalize()?;
+            if !inventory.is_file() {
+                return Err(format!(
+                    "active-change inventory is not a file: {}",
+                    inventory.display()
+                )
+                .into());
+            }
+            build_active_inventory_analysis_report(&root, &inventory, scope.as_deref())?
+        }
+    };
     emit_analysis(&analysis, format)
 }
 
@@ -309,6 +337,7 @@ fn parse_diff_args(args: Vec<String>) -> Result<DiffArgs, Box<dyn Error>> {
 
 fn parse_preflight_args(args: Vec<String>) -> Result<PreflightArgs, Box<dyn Error>> {
     let mut against = None;
+    let mut inventory = None;
     let mut path = None;
     let mut format = OutputFormat::Text;
     let mut args = args.into_iter();
@@ -320,6 +349,14 @@ fn parse_preflight_args(args: Vec<String>) -> Result<PreflightArgs, Box<dyn Erro
                     return Err("`--against` may only be specified once".into());
                 }
                 against = Some(args.next().ok_or("`--against` requires a Git revision")?);
+            }
+            "--inventory" => {
+                if inventory.is_some() {
+                    return Err("`--inventory` may only be specified once".into());
+                }
+                inventory = Some(PathBuf::from(
+                    args.next().ok_or("`--inventory` requires a JSON file")?,
+                ));
             }
             "--format" => {
                 format = parse_output_format(
@@ -344,8 +381,21 @@ fn parse_preflight_args(args: Vec<String>) -> Result<PreflightArgs, Box<dyn Erro
         }
     }
 
+    let source = match (against, inventory) {
+        (Some(against), None) => PreflightSource::Against(against),
+        (None, Some(inventory)) => PreflightSource::Inventory(inventory),
+        (Some(_), Some(_)) => {
+            return Err("preflight accepts only one of `--against REV` or `--inventory FILE`".into());
+        }
+        (None, None) => {
+            return Err(
+                "preflight requires exactly one of `--against REV` or `--inventory FILE`".into(),
+            );
+        }
+    };
+
     Ok(PreflightArgs {
-        against: against.ok_or("preflight requires `--against REV`")?,
+        source,
         path,
         format,
     })
@@ -414,7 +464,7 @@ fn print_help() {
     println!(
         "cargo-cultist {VERSION}\n\
 Repository-aware analysis for Rust codebases.\n\n\
-USAGE:\n    cargo cultist [--format text|json] [PATH]\n    cargo cultist diff [--base REV] [--format text|json] [PATH]\n    cargo cultist preflight --against REV [--format text|json] [PATH]\n    cargo cultist history [--max-commits N] [--format text|json] FILE\n    cargo cultist ci-tests [--format text|json] [PATH]\n    cargo-cultist [--format text|json] [PATH]\n    cargo-cultist diff [--base REV] [--format text|json] [PATH]\n    cargo-cultist preflight --against REV [--format text|json] [PATH]\n    cargo-cultist history [--max-commits N] [--format text|json] FILE\n    cargo-cultist ci-tests [--format text|json] [PATH]\n\n\
+USAGE:\n    cargo cultist [--format text|json] [PATH]\n    cargo cultist diff [--base REV] [--format text|json] [PATH]\n    cargo cultist preflight --against REV [--format text|json] [PATH]\n    cargo cultist preflight --inventory FILE [--format text|json] [PATH]\n    cargo cultist history [--max-commits N] [--format text|json] FILE\n    cargo cultist ci-tests [--format text|json] [PATH]\n    cargo-cultist [--format text|json] [PATH]\n    cargo-cultist diff [--base REV] [--format text|json] [PATH]\n    cargo-cultist preflight --against REV [--format text|json] [PATH]\n    cargo-cultist preflight --inventory FILE [--format text|json] [PATH]\n    cargo-cultist history [--max-commits N] [--format text|json] FILE\n    cargo-cultist ci-tests [--format text|json] [PATH]\n\n\
 COMMANDS:\n    diff       Inspect changed Rust code against repository precedent.\n    preflight  Compare concurrent change sets for collision evidence.\n    history    Explore which paths historically change with one file.\n    ci-tests   Compare supported CI test filters with explicit test-name evidence.\n\n\
 Without a command, cargo-cultist inspects repository-wide test-module naming\n\
 conventions without inventing a universal rule."
@@ -435,12 +485,13 @@ compares their names with repository-wide and same-file precedent."
 fn print_preflight_help() {
     println!(
         "cargo-cultist preflight\n\n\
-USAGE:\n    cargo cultist preflight --against REV [--format text|json] [PATH]\n\n\
-Compares current work with REV from their merge base and reports direct path\n\
-overlap as PROVEN collision evidence. Current work includes committed branch\n\
-changes plus staged and unstaged tracked changes.\n\n\
-Different paths remain semantically UNKNOWN in this first slice; future\n\
-enrichments can add generated, historical, policy, and behavioral evidence."
+USAGE:\n    cargo cultist preflight --against REV [--format text|json] [PATH]\n    cargo cultist preflight --inventory FILE [--format text|json] [PATH]\n\n\
+With --against, compares current work with REV from their merge base and reports\n\
+direct path overlap as PROVEN collision evidence. Current work includes committed\n\
+branch changes plus staged and unstaged tracked changes.\n\n\
+With --inventory, admits one bounded local active-change JSON snapshot, compares\n\
+its recorded changed paths, and surfaces typed explicit coordination edges as\n\
+OBSERVED supplied evidence. Inventory mode performs no provider/network fetch."
     );
 }
 
@@ -500,14 +551,49 @@ mod tests {
         ])
         .unwrap();
 
-        assert_eq!(parsed.against, "other-agent");
+        assert_eq!(
+            parsed.source,
+            PreflightSource::Against("other-agent".to_string())
+        );
         assert_eq!(parsed.path, Some(PathBuf::from("src")));
         assert_eq!(parsed.format, OutputFormat::Json);
     }
 
     #[test]
-    fn rejects_preflight_without_against() {
+    fn parses_preflight_inventory_path_and_format() {
+        let parsed = parse_preflight_args(vec![
+            "--inventory".to_string(),
+            "active.json".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+            "src".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            parsed.source,
+            PreflightSource::Inventory(PathBuf::from("active.json"))
+        );
+        assert_eq!(parsed.path, Some(PathBuf::from("src")));
+        assert_eq!(parsed.format, OutputFormat::Json);
+    }
+
+    #[test]
+    fn rejects_preflight_without_source() {
         assert!(parse_preflight_args(vec![]).is_err());
+    }
+
+    #[test]
+    fn rejects_preflight_with_both_sources() {
+        assert!(
+            parse_preflight_args(vec![
+                "--against".to_string(),
+                "other".to_string(),
+                "--inventory".to_string(),
+                "active.json".to_string(),
+            ])
+            .is_err()
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -385,7 +385,9 @@ fn parse_preflight_args(args: Vec<String>) -> Result<PreflightArgs, Box<dyn Erro
         (Some(against), None) => PreflightSource::Against(against),
         (None, Some(inventory)) => PreflightSource::Inventory(inventory),
         (Some(_), Some(_)) => {
-            return Err("preflight accepts only one of `--against REV` or `--inventory FILE`".into());
+            return Err(
+                "preflight accepts only one of `--against REV` or `--inventory FILE`".into(),
+            );
         }
         (None, None) => {
             return Err(


### PR DESCRIPTION
Starts #101 and composes with #96/#98/#99.

## What

Promotes the **already-landed #98 active-work inventory schema** into product `preflight` instead of creating a second format.

- add `cargo cultist preflight --inventory FILE [PATH]`
- keep `--against REV` as the existing local Git-ref mode; the two inputs are mutually exclusive
- accept the #98 schema-v1 fields: `source`, `observed_at`, `current`, `active_work`, work identity/head/freshness/draft metadata, and changed paths
- add optional backward-compatible `coordination_edges`
- admit inventory JSON through strict bounded product validation
- cap inventory bytes, candidates, total paths, edge count, IDs, titles, URLs, refs, SHAs, timestamps, sources, and path lengths
- require canonical relative `/`-separated paths with no traversal
- reject duplicate candidate IDs/paths/edges and missing edge endpoints
- preserve #98 self-exclusion semantics when current work appears in the remote inventory
- support the first reviewed explicit coordination vocabulary: `depends_on`, `blocks`, `hold_merge_while`, `supersedes`
- report supplied path overlap as `OBSERVED` with work/head/freshness/provider evidence
- report explicit coordination edges involving current work as a separate finding kind, preserving the supplied source reference
- preserve `UNKNOWN` for operational consequence and any relationship absent from the snapshot
- render through the existing shared text/JSON finding model

## Compatibility control

An ordinary #98-style inventory with no `coordination_edges` remains valid input. The research workflow can therefore feed the product command without a schema fork.

## Coordination discriminator

The new positive fixture is modeled on public Preflight #748/#703: two changes have disjoint paths, while the inventory records `hold_merge_while`. The analyzer must emit zero direct-overlap findings and one explicit-coordination finding with source reference plus related head/freshness evidence intact.

Negative controls cover unknown edge kind, missing endpoint, duplicate active-work ID, duplicate edge, traversal, oversized inventory, unrelated non-current edges, and supplied direct overlap.

## Boundary

Inventory mode is deterministic, local, read-only, and provider-agnostic. It does not fetch GitHub/Stensibly/provider objects or parse arbitrary PR prose. Provider adapters remain follow-up work.

The private internal corpus from #99 remains evaluation-only and is absent from public fixtures.

Refs #96 #98 #99 #101.