### PR TITLE
research: retain divergent branch heads-up adapter

### DIFF
--- a/research/divergent-branch-heads-up.md
+++ b/research/divergent-branch-heads-up.md
@@ -1,0 +1,239 @@
+# Divergent branch heads-up research
+
+Date: 2026-08-19
+
+## Question
+
+Can Cultist treat **unpublished divergent remote branches** as a second live-work source without confusing old/squash-merged branches with active work or increasing the normal interruption rate?
+
+This extends the PR-only active-work experiment from #98/#100 under the broader concurrent-change proposal in #96.
+
+The branch layer stays advisory and reuses the same `WorkItem` inventory vocabulary:
+
+```text
+open PR metadata
++ bounded divergent remote branches
+-> active-work inventory
+-> exact path overlap / pre-edit focus
+```
+
+Branch-name similarity is never used as evidence.
+
+## Adapter candidate
+
+The research adapter lives in `scripts/divergent_branch_inventory.py`.
+
+It starts from the landed GitHub PR inventory and adds remote branches only when they satisfy explicit lifecycle/evidence gates.
+
+### PR heads win over duplicate branch identities
+
+If an open PR already represents a branch head, the branch is excluded. The richer PR item carries provider URL, draft state, and PR freshness, so a second `branch:*` work item would be duplicate evidence.
+
+### Git divergence is necessary but not sufficient
+
+Candidate refs come from:
+
+```text
+git branch -r --no-merged origin/main
+```
+
+and their changed paths are measured from the exact merge base with `origin/main`.
+
+This catches real unpublished branch work, but the first dogfood exposed a major Git-only lifecycle trap: **squash-merged PR heads remain topologically unmerged**.
+
+PR #103 was squash-merged to `main`; its source branch `feature/preflight-active-inventory` therefore still appeared under `git branch --no-merged` even though the work had already been integrated.
+
+The first research run failed precisely because the original negative control assumed Git ancestry would retire that branch.
+
+### Provider lifecycle repairs squash-merge ambiguity
+
+The adapter now also retrieves the most recently updated 100 closed/merged PR heads.
+
+A branch candidate is retired only when its **current branch name + exact current head SHA** matches a closed/merged PR head from that observed window.
+
+```text
+same branch name + same head SHA as closed/merged PR
+  -> retire exact head
+
+same branch later advances to a new SHA
+  -> eligible again
+```
+
+This keeps provider lifecycle evidence separate from Git ancestry.
+
+The closed-PR head window is explicit and bounded. If GitHub reports more than 100 closed/merged PRs in the observed window, the adapter records truncation rather than pretending old heads were exhaustively classified.
+
+### Branch candidate budget
+
+After open-PR and exact closed-PR-head exclusions, candidates are ordered by exact commit timestamp and capped at 20.
+
+The inventory records:
+
+- base ref;
+- number of open PR heads excluded;
+- recent closed PR heads seen;
+- whether the closed-PR window truncated;
+- exact closed-PR branch heads retired;
+- candidate count before branch cap;
+- returned branch count;
+- omitted branch count;
+- branch cap;
+- selection order;
+- explicit `branch_name_similarity_used = false`.
+
+## Executed dogfood
+
+### First run: useful failure
+
+Run:
+
+```text
+run: 32232628351
+job: 96005566152
+```
+
+The adapter correctly discovered unpublished `experiment/divergent-branch-heads-up`, but the control expecting `feature/preflight-active-inventory` to be absent failed.
+
+That was not a false implementation failure; the **control premise had gone stale**. PR #103 had since merged via squash, so the feature branch was no longer identical to current `main` by commit ancestry even though its exact work had already been accepted.
+
+This produced the stronger lifecycle rule above.
+
+### Final branch inventory receipt
+
+Final research run:
+
+```text
+run:      32233054642
+job:      96006879211
+artifact: 9357939745
+sha256:   45860982f7ed855b5f992b894a9360294cf16110ce7283f603ebb034e67e16a9
+```
+
+Observed branch receipt:
+
+```text
+open PR heads excluded:              3
+recent closed/merged PR heads seen: 48
+closed-PR head window truncated:    false
+exact closed-PR branch heads retired: 23
+unmerged non-PR branch candidates:   7
+branch candidates returned:          7
+branch candidates omitted:           0
+max branch candidates:              20
+branch-name similarity used:        false
+```
+
+So in this repository the retirement window was complete for the observed closed/merged PR set, and no candidate was lost to the branch cap.
+
+### Natural carrier stayed quiet
+
+The #107 carrier changed only its research workflow. With the combined open-PR + branch inventory, the normal research advisory emitted no heads-up.
+
+The same combined inventory, after removing the research-only `adapter_receipts` field, was accepted by the **product** command:
+
+```text
+cargo cultist preflight --inventory /tmp/product-active-work.json --format json .
+```
+
+Product result:
+
+```text
+analysis: preflight-active-inventory
+findings: []
+```
+
+This proves branch work items can reuse the landed strict product inventory schema without inventing a second product format.
+
+### Pre-edit focus found real unpublished work
+
+At observation time, `experiment/divergent-branch-heads-up` had **no PR** and changed:
+
+```text
+scripts/divergent_branch_inventory.py
+```
+
+A focus query before the carrier touched that path emitted:
+
+```text
+branch:experiment/divergent-branch-heads-up
+d99c27e5
+2026-08-19T16:28:01+08:00
+focus overlap: scripts/divergent_branch_inventory.py
+```
+
+This is the intended pre-PR heads-up: exact branch identity, exact head, exact freshness, exact path, no ownership/duplication conclusion.
+
+### Cross-PR noise matrix
+
+The same inventory snapshot was replayed with each open PR substituted as `current`:
+
+```text
+#107 heads-up count: 0
+#102 heads-up count: 0
+#95  heads-up count: 0
+```
+
+Seven branch candidates were present, yet none produced a natural direct-path interruption for the three open PRs in the snapshot.
+
+That is encouraging quietness evidence, not proof that branch awareness is universally low-noise.
+
+## Product boundary discovered: scope is not intent
+
+The merged product interface:
+
+```text
+cargo cultist preflight --inventory FILE [PATH]
+```
+
+uses `[PATH]` as an **analysis scope over observed `current.changed_paths`**.
+
+The pre-edit research query instead accepts caller-supplied focus paths that may not have been changed yet.
+
+These are different claims:
+
+```text
+current.changed_paths
+  -> provider/work-item observation
+
+focus path
+  -> caller-supplied intended inspection/edit target
+```
+
+Do not encode pre-edit intent by lying in `current.changed_paths`.
+
+A future product-facing pre-edit interface needs a separate intent/focus input rather than overloading observed work metadata.
+
+## Why branch awareness is not auto-enabled yet
+
+The current sample is good:
+
+- exact unpublished branch positive;
+- quiet natural carrier;
+- quiet matrix across all open PRs;
+- product inventory compatibility;
+- squash-merge lifecycle false positive fixed;
+- no branch-budget truncation in the observed repo.
+
+But one important bound still needs repeated dogfood: exact closed-PR-head retirement currently uses a bounded recent-100 provider window. The current repository had only 48 observed closed/merged PR heads, so the run was complete; larger repositories may need a more targeted branch-to-PR lifecycle query before this becomes a default always-on source.
+
+For now this adapter is research instrumentation that can feed the landed product inventory format.
+
+## Next discriminators
+
+1. Run the adapter on repositories with more than 100 closed PRs and prove truncation remains visible rather than turning old squash-merged branches into silent truth.
+2. Evaluate a targeted provider query for each selected branch head so lifecycle lookup scales with the bounded branch candidate set rather than repository-wide closed-PR history.
+3. Keep pre-edit focus separate from observed changed paths; decide whether it belongs in `brief`, a `preflight --focus`, or a future intent-aware inventory version.
+4. Continue classifying naturally surfaced branch heads-ups as:
+
+```text
+useful
+irrelevant
+missing stronger evidence
+misleading
+```
+
+## Product principle
+
+> Git says whether histories merged. Provider metadata says whether a work item was accepted, closed, or superseded. Live coordination needs both.
+
+Refs #96, #98, #100, #101, #103, #62, #74.

--- a/scripts/divergent_branch_inventory.py
+++ b/scripts/divergent_branch_inventory.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Enrich the landed active-work inventory with bounded divergent remote branches."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from urllib.parse import quote
+
+from active_work_heads_up_ci import build_inventory, graphql, page_info
+
+BASE_REF = "origin/main"
+MAX_BRANCH_CANDIDATES = 20
+MAX_RECENT_CLOSED_PRS = 100
+
+RECENT_CLOSED_PR_HEADS_QUERY = r"""
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(
+      states: [CLOSED, MERGED]
+      first: 100
+      orderBy: {field: UPDATED_AT, direction: DESC}
+    ) {
+      nodes {
+        number
+        headRefName
+        headRefOid
+        mergedAt
+        closedAt
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}
+"""
+
+
+def git_text(args: list[str]) -> str:
+    return subprocess.check_output(["git", *args], text=True).strip()
+
+
+def git_lines(args: list[str]) -> list[str]:
+    output = subprocess.check_output(["git", *args], text=True)
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def remote_ref_metadata() -> dict[str, tuple[str, str]]:
+    records = git_lines(
+        [
+            "for-each-ref",
+            "--format=%(refname:short)%09%(objectname)%09%(committerdate:iso-strict)",
+            "refs/remotes/origin",
+        ]
+    )
+    metadata: dict[str, tuple[str, str]] = {}
+    for record in records:
+        fields = record.split("\t")
+        if len(fields) != 3:
+            continue
+        ref, sha, committed_at = fields
+        metadata[ref] = (sha, committed_at)
+    return metadata
+
+
+def unmerged_remote_refs() -> set[str]:
+    return set(
+        git_lines(
+            [
+                "branch",
+                "-r",
+                "--no-merged",
+                BASE_REF,
+                "--format=%(refname:short)",
+            ]
+        )
+    )
+
+
+def recent_closed_pr_heads(repo: str) -> tuple[set[tuple[str, str]], bool]:
+    owner, name = repo.split("/", 1)
+    result = graphql(
+        RECENT_CLOSED_PR_HEADS_QUERY,
+        {"owner": owner, "name": name},
+    )
+    data = result.get("data")
+    repository = data.get("repository") if isinstance(data, dict) else None
+    pull_requests = (
+        repository.get("pullRequests") if isinstance(repository, dict) else None
+    )
+    if not isinstance(pull_requests, dict):
+        raise RuntimeError("could not retrieve recent closed pull requests")
+    nodes = pull_requests.get("nodes")
+    if not isinstance(nodes, list):
+        raise RuntimeError("recent closed pull-request connection is missing nodes")
+
+    heads = {
+        (str(node["headRefName"]), str(node["headRefOid"]))
+        for node in nodes
+        if isinstance(node, dict)
+        and node.get("headRefName")
+        and node.get("headRefOid")
+    }
+    truncated, _cursor = page_info(pull_requests)
+    return heads, truncated
+
+
+def changed_paths(ref: str) -> list[str]:
+    merge_base = git_text(["merge-base", BASE_REF, ref])
+    return sorted(
+        set(
+            git_lines(
+                [
+                    "-c",
+                    "core.quotepath=false",
+                    "diff",
+                    "--name-only",
+                    "--no-renames",
+                    merge_base,
+                    ref,
+                    "--",
+                ]
+            )
+        )
+    )
+
+
+def branch_work_item(repo: str, ref: str, sha: str, committed_at: str) -> dict[str, object]:
+    branch = ref.removeprefix("origin/")
+    return {
+        "id": f"branch:{branch}",
+        "kind": "branch",
+        "title": branch,
+        "url": f"https://github.com/{repo}/tree/{quote(branch, safe='/')}",
+        "head_ref": branch,
+        "head_sha": sha,
+        "updated_at": committed_at,
+        "draft": False,
+        "changed_paths": changed_paths(ref),
+    }
+
+
+def build_combined_inventory(repo: str, current_number: int) -> dict[str, object]:
+    inventory = build_inventory(repo, current_number)
+    active_work = inventory["active_work"]
+    if not isinstance(active_work, list):
+        raise RuntimeError("active_work must be a list")
+
+    open_pr_heads = {
+        str(work["head_ref"])
+        for work in active_work
+        if isinstance(work, dict) and work.get("kind") == "pull_request"
+    }
+    retired_exact_heads, retired_window_truncated = recent_closed_pr_heads(repo)
+
+    metadata = remote_ref_metadata()
+    unmerged = unmerged_remote_refs()
+    candidates: list[tuple[str, str, str]] = []
+    retired_exact_branch_heads_excluded = 0
+    for ref in unmerged:
+        if ref in {"origin/HEAD", BASE_REF} or not ref.startswith("origin/"):
+            continue
+        branch = ref.removeprefix("origin/")
+        if branch in open_pr_heads:
+            continue
+        values = metadata.get(ref)
+        if values is None:
+            continue
+        sha, committed_at = values
+        if (branch, sha) in retired_exact_heads:
+            retired_exact_branch_heads_excluded += 1
+            continue
+        candidates.append((ref, sha, committed_at))
+
+    candidates.sort(key=lambda item: (item[2], item[0]), reverse=True)
+    omitted = max(0, len(candidates) - MAX_BRANCH_CANDIDATES)
+    selected = candidates[:MAX_BRANCH_CANDIDATES]
+
+    branch_work = [
+        branch_work_item(repo, ref, sha, committed_at)
+        for ref, sha, committed_at in selected
+    ]
+    branch_work = [work for work in branch_work if work["changed_paths"]]
+
+    inventory["source"] = (
+        "github_pull_requests+git_remote_divergent_branches+recent_closed_pr_heads"
+    )
+    active_work.extend(branch_work)
+    inventory["adapter_receipts"] = {
+        "branch_base_ref": BASE_REF,
+        "open_pr_heads_excluded": len(open_pr_heads),
+        "recent_closed_pr_heads_seen": len(retired_exact_heads),
+        "recent_closed_pr_head_limit": MAX_RECENT_CLOSED_PRS,
+        "recent_closed_pr_head_window_truncated": retired_window_truncated,
+        "retired_exact_branch_heads_excluded": retired_exact_branch_heads_excluded,
+        "unmerged_non_pr_branch_candidates": len(candidates),
+        "branch_candidates_returned": len(branch_work),
+        "branch_candidates_omitted": omitted,
+        "max_branch_candidates": MAX_BRANCH_CANDIDATES,
+        "selection": "most recent commit timestamp first",
+        "branch_name_similarity_used": False,
+        "retirement_rule": (
+            "exclude branch only when current branch name+head SHA exactly matches "
+            "a recent closed/merged PR head; an advanced head becomes eligible again"
+        ),
+    }
+    return inventory
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: divergent_branch_inventory.py OUTPUT.json")
+
+    repo = os.environ["GITHUB_REPOSITORY"]
+    current_number = int(os.environ["CURRENT_PR"])
+    inventory = build_combined_inventory(repo, current_number)
+    output = Path(sys.argv[1])
+    output.write_text(json.dumps(inventory, indent=2) + "\n")
+
+    receipts = inventory["adapter_receipts"]
+    print(
+        "branch inventory: "
+        f"{receipts['branch_candidates_returned']} returned, "
+        f"{receipts['branch_candidates_omitted']} omitted, "
+        f"{receipts['open_pr_heads_excluded']} open-PR head(s) excluded, "
+        f"{receipts['retired_exact_branch_heads_excluded']} exact closed-PR head(s) retired"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Research follow-up under #96 for live work that exists **before a PR**.

## What remains in this PR

The temporary replay workflow is removed. The durable artifacts are:

- `scripts/divergent_branch_inventory.py` — bounded PR + divergent-branch inventory adapter;
- `research/divergent-branch-heads-up.md` — executed receipts, lifecycle failure, quietness matrix, and product boundary.

The adapter reuses the landed #98/#100 work-item schema and the product #103 `preflight --inventory` contract. It does not invent a second product format.

## Branch admission

A remote branch is not surfaced merely because it exists or has a relevant-looking name.

The research adapter:

1. starts from the open-PR inventory;
2. excludes branch heads already represented by open PRs;
3. discovers refs not merged by Git ancestry into `origin/main`;
4. retires an exact current branch `name + head SHA` when that same exact head appears among the recently observed closed/merged PR heads;
5. orders remaining candidates by exact commit timestamp;
6. returns at most 20 and records omissions;
7. measures exact paths from each branch's merge base;
8. records that branch-name similarity was not used.

The exact-head retirement rule matters because squash-merged PR branches are not ancestors of `main`.

## Dogfood failure that improved the model

The first run (`32232628351`, job `96005566152`) failed because the original control assumed `feature/preflight-active-inventory` would be excluded by Git ancestry.

PR #103 had been squash-merged. Its source branch therefore still looked `--no-merged` even though the work had been accepted.

The repair combines Git divergence with provider lifecycle:

```text
Git says histories have not merged
+ GitHub says this exact branch head already belonged to a closed/merged PR
-> retire that exact head

branch advances to a new SHA later
-> eligible again
```

## Final executed receipt

Run `32233054642`, job `96006879211` succeeded.

Artifact:

```text
id:     9357939745
sha256: 45860982f7ed855b5f992b894a9360294cf16110ce7283f603ebb034e67e16a9
```

Observed adapter receipt:

```text
open PR heads excluded:                3
recent closed/merged PR heads seen:   48
closed-PR head window truncated:      false
exact closed-PR branch heads retired: 23
unmerged non-PR branch candidates:     7
branch candidates returned:            7
branch candidates omitted:             0
max branch candidates:                20
branch-name similarity used:          false
```

### Natural quietness

The #107 carrier stayed quiet with the combined PR + branch inventory.

The same inventory, after removing research-only adapter receipts, was admitted by product:

```text
cargo cultist preflight --inventory FILE --format json .
```

and produced zero findings for the disjoint carrier.

### Pre-edit focus positive

Before the carrier touched the adapter path, focus mode surfaced the still-unpublished work:

```text
branch:experiment/divergent-branch-heads-up
d99c27e5
2026-08-19T16:28:01+08:00
focus overlap: scripts/divergent_branch_inventory.py
```

### Noise matrix

Replaying the same snapshot with every open PR as current produced:

```text
#107 heads-up count: 0
#102 heads-up count: 0
#95  heads-up count: 0
```

Seven branch candidates existed, but none interrupted the three open PRs in that snapshot.

## Why this is not auto-enabled yet

The observed repo was fully covered by the recent-100 closed/merged-PR window: only 48 heads were returned, so the lifecycle receipt was not truncated.

In a larger repository that bound can truncate. Until we dogfood a targeted branch-to-PR lifecycle lookup or another corpus beyond the window, this stays an explicit research adapter rather than silently broadening the always-on PR advisory.

## Product boundary

Product `preflight --inventory FILE [PATH]` treats `[PATH]` as **scope over observed current changes**. The research focus path is **caller-supplied pre-edit intent**. We deliberately do not falsify `current.changed_paths` to make pre-edit focus work.

A future product-facing focus/intent interface should keep those claims separate.

Refs #96, #98, #100, #101, #103, #62, #74.