### PR TITLE
docs: align current Cultist product, roadmap, and agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# Agent guidance
+
+Cultist is built by dogfooding the same repository-reasoning ideas it is trying to make useful for other projects.
+
+Do the requested task first. At the same time, pay attention to evidence that the work itself exposes about how Cultist could improve.
+
+## Feed useful friction back into the project
+
+If a task reveals something that made the work harder, less reliable, more repetitive, or easier to misunderstand, ask whether Cultist could have surfaced that fact earlier or preserved the lesson for the next worker.
+
+Useful signals include:
+
+- two workers, PRs, or branches independently doing overlapping work;
+- an important repository fact, convention, generated relationship, decision, or policy that was easy to miss;
+- a false assumption that later evidence disproves;
+- a stale or wrong evidence coordinate;
+- explicit prose whose applicability no longer matches the exact current change;
+- a historical reason that had to be reconstructed manually;
+- a useful counterexample that weakens an existing heuristic;
+- an analyzer finding that was noisy, overconfident, incomplete, or missing an important `UNKNOWN`;
+- repeated investigation that could become a deterministic probe;
+- a reviewed lesson that future agents would benefit from seeing before making the same edit.
+
+Do not turn every inconvenience into a feature. Preserve the distinction between:
+
+- an observation from this task;
+- a plausible reusable pattern;
+- a tested discriminator with counterexamples;
+- a product behavior that has earned promotion.
+
+## Prefer evidence over retrospective stories
+
+When proposing a Cultist improvement from dogfood:
+
+1. identify the exact task, change, file, issue, PR, commit, or repository evidence that exposed it;
+2. state what is **PROVEN**, **DERIVED**, **OBSERVED**, **INFERRED**, or **UNKNOWN**;
+3. search for a counterexample or negative control before generalizing;
+4. keep chronology separate from causality unless an explicit relationship establishes it;
+5. bind remote prose or metadata to its exact work/head/freshness coordinate before treating it as current intent;
+6. prefer a small deterministic probe or evidence packet before a broad heuristic;
+7. preserve failed experiments and weakened hypotheses when they teach a boundary.
+
+A successful task can still expose a product problem. A failed task can still produce useful evidence. Neither automatically proves a general rule.
+
+## Compose views instead of inventing competing truths
+
+Cultist has several agent-facing research views over shared repository evidence. Treat them as different jobs unless evidence proves otherwise:
+
+- lifecycle work (`brief -> diff -> teach`) asks **when** evidence should be recovered or preserved;
+- just-enough-information work asks **what** evidence is worth selecting for the current task;
+- review intelligence asks **where** reviewer attention should go;
+- compact IR / C1 research asks **how** evidence should be represented or transmitted;
+- decision memory asks **what reviewed rationale should survive** for later work.
+
+Do not create a new authority/provenance/unknown/freshness vocabulary merely because a new projection needs those facts. Prefer shared evidence primitives plus a task-specific projection.
+
+## Close the loop when it is useful
+
+When evidence is strong enough and the task scope permits it, incorporate the lesson through the smallest appropriate durable surface:
+
+- improve an existing analyzer or evidence contract;
+- add a focused regression or negative control;
+- record a research receipt;
+- update the relevant roadmap/research issue;
+- preserve reviewed rationale for future context/decision memory;
+- open a focused follow-up issue when the lesson is real but outside the current task.
+
+Avoid unrelated implementation expansion merely because an idea occurred during the task. If the lesson belongs elsewhere, leave an exact handoff with its evidence instead of silently widening scope.
+
+## Agent-facing product test
+
+A recurring question for work in this repository is:
+
+> What did this task force the worker to discover manually that Cultist could have surfaced, bounded, or preserved for the next worker?
+
+If the answer is meaningful, treat the task as dogfood evidence and carry the lesson forward with provenance.
+
+The goal is a repository that becomes easier to work in because prior workers leave behind earned, inspectable knowledge—not because later workers inherit their conversations or trust their conclusions blindly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
+# Rust distribution name retained so `cargo cultist ...` continues to work.
 name = "cargo-cultist"
 version = "0.1.0"
 edition = "2024"
-description = "Repository-aware analysis for Rust codebases"
-repository = "https://github.com/teamleaderleo/cargo-cultist"
+description = "Repository-aware evidence and analysis with Rust-focused adapters"
+repository = "https://github.com/teamleaderleo/cultist"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -1,41 +1,49 @@
-# cargo-cultist
+# Cultist
 
 **Find out why before you copy it.**
 
-`cargo-cultist` is an experiment in repository-aware analysis for Rust codebases.
+Cultist is an experiment in repository-aware evidence for software work: recover deterministic facts, keep provenance and counterexamples visible, and ask useful questions before inventing project rules.
 
-> Status: very early prototype. The public analyzer commands are deterministic, local, and read-only.
+> Status: early prototype. The current Rust distribution is named `cargo-cultist`; its public analyzer commands are deterministic, local, and read-only. Remote/project adapters that build evidence inventories live outside the core analyzer boundary.
 
-See [ROADMAP.md](ROADMAP.md) for the project thesis, design principles, and active research directions. The umbrella tracking issue is #19.
+Rust is the first deep semantic adapter, not the product boundary. Several useful primitives are repository-generic already: Git history, claim provenance, concurrent-change preflight, active-work inventories, and repo-local decision-memory research.
 
-Traditional linters are strongest when a rule is already known. `cargo-cultist` starts one step earlier: it gathers facts about what a repository actually does, identifies deviations or unexplained relationships, searches for counterexamples, and raises questions without pretending every observation is an error.
+See [ROADMAP.md](ROADMAP.md) for the thesis and current research map. Agents working on Cultist should also follow [AGENTS.md](AGENTS.md).
 
-The core evidence model distinguishes:
+Traditional linters are strongest after a rule is known. Cultist starts earlier. It gathers what a repository actually does, keeps contradictions and uncertainty visible, and helps a worker answer questions such as:
+
+- What evidence would I regret missing before I edit this target?
+- Does my live change disagree with local precedent or explicit project guidance?
+- Is another current change touching the same repository surface?
+- Why does this exception or guard exist?
+- What lesson from this completed work should be recoverable by the next worker?
+
+The core claim vocabulary is:
 
 - **PROVEN** — exact machine facts or guarantees;
 - **DERIVED** — deterministic conclusions from explicit facts;
-- **OBSERVED** — empirical repository patterns and correlations;
+- **OBSERVED** — empirical repository patterns or supplied observations;
 - **INFERRED** — plausible interpretations;
-- **UNKNOWN** — repository evidence is insufficient to recover the answer.
+- **UNKNOWN** — evidence is insufficient to recover the answer.
 
 Human-readable and JSON output are rendered from the same provenance-bearing finding model where the command produces findings.
 
-## Current commands
+## Current public commands
+
+The Rust package/binary remains `cargo-cultist`, so installed use is `cargo cultist ...`.
 
 ### Repository test-module conventions
 
-The default command inspects `#[cfg(test)]` modules and reports the names a repository actually uses. It calls out one-off names and files that mix multiple test-module names without turning the majority spelling into a universal rule.
+The default command inspects Rust `#[cfg(test)]` modules and reports the names a repository actually uses without promoting majority spelling into policy.
 
 ```bash
 cargo cultist
 cargo cultist --format json
 ```
 
-The interesting primitive is a **finding**, not a lint error: repository statistics are evidence, and a local exception can be intentional.
-
 ### Diff-aware precedent
 
-`cargo cultist diff` looks at test-module declarations added or renamed by the current change and compares them with existing repository-wide and file-local precedent.
+`cargo cultist diff` analyzes the current change and applies supported change-time evidence such as Rust test-module precedent and generated-companion evidence.
 
 ```bash
 cargo cultist diff
@@ -43,9 +51,29 @@ cargo cultist diff --base origin/main
 cargo cultist diff --base origin/main --format json
 ```
 
-With `--base REV`, Cargo Cultist finds the merge base between `REV` and `HEAD`, then analyzes the current working tree from that point so branch/PR semantics still include local staged or unstaged work.
+With `--base REV`, Cultist uses the merge base while still including local staged and unstaged work. Changed-file parse failures remain explicit uncertainty instead of becoming false absence claims.
 
-When repository-wide and file-local precedent disagree, the analyzer surfaces **precedent tension** instead of silently choosing a winner. Changed-file parse failures remain explicit uncertainty instead of being converted into an observed absence claim.
+### Concurrent-change preflight
+
+Local ref mode compares two concurrent Git change sets from their merge base:
+
+```bash
+cargo cultist preflight --against other-agent
+cargo cultist preflight --against origin/main --format json
+```
+
+Direct shared paths are deterministic collision evidence. Different paths remain semantically unknown until an independent evidence source establishes a generated, historical, policy, or explicit coordination relationship.
+
+Inventory mode accepts a bounded provider/orchestrator-supplied active-change snapshot:
+
+```bash
+cargo cultist preflight --inventory active-work.json
+cargo cultist preflight --inventory active-work.json --format json
+```
+
+The landed inventory contract can carry exact work identity/head/freshness/path observations plus explicit coordination edges such as `depends_on`, `blocks`, `hold_merge_while`, and `supersedes`. The core command does not fetch GitHub itself.
+
+Cultist's own PR CI dogfoods a GitHub adapter for this contract. Common disjoint runs use a cheap exact-path prefilter and stay quiet; possible overlaps pay for the fuller deterministic analyzer. Research adapters also explore unpublished branches, but bare-branch activity is not enabled by default because divergence alone does not prove somebody is still working there.
 
 ### Historical companions
 
@@ -57,63 +85,95 @@ cargo cultist history --max-commits 200 src/protocol.rs
 cargo cultist history --format json src/protocol.rs
 ```
 
-The explorer:
-
-- excludes revert commits and broad commits from its first comparison cohort;
-- reports directional support/opportunity counts;
-- preserves representative examples and absence counterexamples;
-- annotates current companion files that explicitly identify themselves as generated;
-- keeps limitations visible, including rename-history and semantic-cohort gaps.
-
-Historical co-change remains correlation evidence. Real-repository replays have already shown why direction and cohort selection matter: in Oxc, Rust-syntax-changing edits to the source rule registry moved with two generated registries in 99/99 sampled commits, while the reverse generated-to-source relation was 94/100. See `research/history-companion-replay.md` and `research/rust-syntax-cohort-replay.md` for the retained receipts.
+The explorer preserves directional support/opportunity counts, examples, absence counterexamples, exclusions, and known cohort limitations. Historical co-change remains association evidence rather than required-update policy.
 
 ### CI test-filter inventory
 
-`cargo cultist ci-tests` looks for a deliberately narrow GitHub Actions command family:
-
-```text
-cargo [ +TOOLCHAIN ] test --lib FILTER
-```
-
-and compares the literal selector with explicit Rust `#[test]` function names plus declared module names used as conservative qualifier hints.
+`cargo cultist ci-tests` analyzes a deliberately narrow GitHub Actions Cargo/libtest selector family and compares literal selectors with conservative source inventories.
 
 ```bash
 cargo cultist ci-tests
 cargo cultist ci-tests --format json
 ```
 
-A zero syntax match is reported with separate claims:
+Unsupported shell forms, ambiguous targets, unknown flags, generated tests, and parse gaps are skipped or surfaced conservatively rather than guessed through.
+
+## Agent-facing research views
+
+Several current ideas are intentionally **different projections over shared repository evidence**, not competing sources of truth:
 
 ```text
-PROVEN
-  The supported workflow command and filter exist.
+edit lifecycle (#74)
+  -> WHEN should evidence be recovered, reconciled, or preserved?
 
-OBSERVED
-  The explicit source inventory has no matching test/module name.
+just-enough information / JEI (#106)
+  -> WHAT evidence is worth selecting for this task now?
 
-UNKNOWN
-  Macro-generated or build-time tests may exist outside the syntax inventory.
+review intelligence (#109)
+  -> WHERE should scarce reviewer attention go?
+
+C1 / compact IR (#113, #115)
+  -> HOW should evidence be represented and transmitted efficiently?
+
+decision memory (#10 and research)
+  -> WHAT reviewed rationale should survive for later workers?
 ```
 
-Unsupported shell forms, ambiguous package/integration/bin targets, unknown flags, and parse failures are skipped or surfaced conservatively instead of guessed through.
+A new view should reuse authority, provenance, freshness, counterexample, unknown, and omission semantics rather than inventing a parallel vocabulary merely because its output layout is different.
 
-This check has a retained real-world witness: a pinned Tantivy workflow stayed green while `cargo test --lib test_rollback` selected zero tests, and Cargo Cultist identified that exact selector/location. The full acceptance receipt lives in `research/ci-test-filter-replay.md`.
+### Bounded context packets
 
-## Research layer
+Research under #62 asks the pre-edit question:
 
-The repository also contains standalone research examples and receipts that deliberately sit outside the public read-only command surface.
+> What repository evidence would I regret missing before I modify this target?
 
-Current research includes:
+The packet work emphasizes bounded defaults, truncation receipts, explicit guidance, history, companions/counterexamples, decisions, and useful `UNKNOWN`s rather than giant repository summaries.
 
-- Rust-syntax cohorts for refining historical comparison sets;
-- explicit generated-file and Rust generator-ownership evidence;
-- execution-aware libtest `--list` verification of CI selectors;
-- agentic-history corpora from Stensibly and SmolRunner;
-- bounded repository-evidence packets for coding agents.
+### Compact C1 evidence grammar
 
-Some research examples intentionally execute repository tooling. In particular, Cargo/libtest listing can compile code and run build scripts. Those experiments carry an explicit effect boundary and are not silently invoked by the ordinary analyzer commands.
+Merged research provides a lossless C1 encoding of the current `AnalysisReport` model. The converter remains an example rather than a second product binary:
 
-The research lifecycle is intentional:
+```bash
+cargo run --example cultist_c1 < report.json
+cargo run --example cultist_c1 -- --decode < report.c1
+```
+
+C1 is structural compression only. It does not select JEI, rank evidence, change authority, or abbreviate meaning. Current machine-report deserialization fails on unknown fields so unsupported future semantics cannot be silently erased during down-conversion.
+
+### Decision memory
+
+Repo-local decision-memory research explores how intentional exceptions and earned project rationale can become version-controlled evidence for future work. Decision records are evidence, not implicit suppressions, and a model-generated sentence does not become project truth merely because it was written down.
+
+## The work loop
+
+The larger agent lifecycle being explored is:
+
+```text
+BEFORE
+  recover bounded evidence for the target
+
+DURING
+  reconcile the live diff with precedent, guidance, active work,
+  counterexamples, decisions, trust boundaries, and unknowns
+
+AFTER
+  preserve an intentional decision or earned lesson when appropriate
+
+NEXT WORKER
+  retrieves that repository memory before repeating the same investigation
+```
+
+Or more compactly:
+
+```text
+retrieve -> work -> reconcile -> preserve -> retrieve
+```
+
+The product goal is not to make an agent understand Cultist as a separate ceremony. A worker should be able to ask for the evidence it needs, do the work, and leave useful reviewed knowledge behind.
+
+## Research discipline
+
+The repository contains standalone examples and durable receipts for experiments that are not public product features. The preferred research lifecycle is:
 
 ```text
 hypothesis
@@ -124,16 +184,18 @@ hypothesis
 -> keep, weaken, split, reject, or promote
 ```
 
-A successful experiment does not automatically become a lint or public feature.
+Some research examples intentionally execute repository tooling. Those effectful experiments carry explicit boundaries and are not silently invoked by ordinary analyzer commands.
 
-## Usage
+A successful experiment does not automatically become a lint or public feature. Failed experiments are retained when they expose a useful boundary.
 
-From this repository while developing:
+## Usage while developing
 
 ```bash
 cargo run -- /path/to/a/rust/repository
 cargo run -- diff --base origin/main /path/to/a/rust/repository
-cargo run -- history /path/to/a/rust/repository/src/file.rs
+cargo run -- preflight --against some-ref /path/to/a/repository
+cargo run -- preflight --inventory /path/to/active-work.json /path/to/a/repository
+cargo run -- history /path/to/a/repository/src/file.rs
 cargo run -- ci-tests /path/to/a/rust/repository
 ```
 
@@ -141,40 +203,36 @@ After installing locally:
 
 ```bash
 cargo install --path .
-cd /path/to/a/rust/repository
+cd /path/to/a/repository
 cargo cultist
 cargo cultist diff
+cargo cultist preflight --against other-ref
 cargo cultist history src/file.rs
 cargo cultist ci-tests
 ```
 
-The binary can also be invoked directly:
-
-```bash
-cargo-cultist .
-cargo-cultist diff --base origin/main .
-cargo-cultist history src/file.rs
-cargo-cultist ci-tests .
-```
+The binary can also be invoked directly as `cargo-cultist`.
 
 ## Dogfooding
 
-CI runs formatting, Clippy, and tests, then dogfoods the public analyzers and their JSON output against Cargo Cultist itself. Pull-request and push CI run diff analysis against the relevant base/current change.
+CI runs formatting, Clippy, tests, and the public analyzers against Cultist itself. Pull-request CI also runs the non-blocking active-work heads-up.
 
-The tool is expected to inspect its own changes without special treatment. Disposable fixtures and pinned external replays are used when a detector needs a stronger discriminator; temporary network-heavy research workflows are retired after their evidence is recorded.
+Dogfood is product input. When work exposes duplicate effort, a missed repository fact, stale evidence, misleading metadata, a false assumption, a useful counterexample, or repeated manual investigation, preserve the exact evidence and ask whether the smallest useful Cultist improvement can surface it earlier next time.
 
-## Active research directions
+Do not turn task friction into a universal rule without a discriminator and negative control.
 
-Near-term work is increasingly about composing independent evidence instead of adding broad heuristics:
+## Current direction
 
-- richer scoped and temporal precedent with explicit counterexamples;
-- generated-artifact ownership and missing-companion questions;
-- exception archaeology and expired-workaround evidence packets;
-- helper/dependency intent and locally expanded idioms;
-- explicit repository-guidance freshness and instruction lifecycle;
-- bounded agent context packets that optimize selected evidence per byte instead of context volume;
-- promotion of repeated, well-understood human consensus into deterministic policy.
+Near-term work is increasingly about composing independent evidence instead of adding broad opaque heuristics:
 
-Optional model-assisted explanation can sit on top of bounded evidence later. The deterministic finding must remain useful without a model.
+- bounded pre-edit JEI and lifecycle integration;
+- review-attention projections over the same evidence;
+- active-change coordination with explicit identity/freshness boundaries;
+- decision-memory authority/applicability research;
+- richer scoped and temporal precedent with counterexamples;
+- explicit repository guidance and instruction freshness;
+- compact interoperable machine representations;
+- performance work proportional to the evidence actually needed;
+- promotion of repeated, well-understood consensus into deterministic policy.
 
-The goal is to explore the space between a known lint rule and handing an entire repository to an AI and asking it to figure everything out.
+Optional model-assisted explanation can sit on top of bounded evidence later. The deterministic evidence packet must remain useful without a model.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,17 @@
 # Roadmap
 
-`cargo-cultist` explores repository reasoning between two familiar extremes:
+Cultist explores repository reasoning between two familiar extremes:
 
 - deterministic tools that enforce rules we already know; and
 - unconstrained AI review that is asked to infer everything from a codebase.
 
-The project goal is to make the middle useful.
+The project goal is to make the middle useful: recover bounded repository evidence, preserve what that evidence does and does not establish, and make the next human or agent less likely to repeat avoidable investigation.
 
-## Core loop
+Rust currently provides the deepest semantic adapter and the `cargo-cultist` distribution, but Cultist's evidence model is repository-oriented. Git history, provenance, active-change coordination, decision memory, and explicit project guidance can apply independently of source language.
+
+Umbrella tracking issue: #19.
+
+## Core evidence loop
 
 ```text
 deterministic facts
@@ -15,124 +19,257 @@ deterministic facts
   -> counterexample search
   -> questions worth asking
   -> optional explanation
-  -> human decision
+  -> human/project decision
   -> preserved rationale
   -> promote stable consensus into deterministic policy
 ```
 
-The primitive is a **finding**, not an error. A good finding says what the repository evidence shows, what it does not establish, and why a human may want to look.
+The primitive is a **finding**, not an error. A good finding says what the repository evidence shows, what it does not establish, and why a worker may want to look.
+
+## Agent work loop
+
+The newer agent-facing work composes those primitives across time:
+
+```text
+BEFORE CODE
+  brief / JEI
+  recover the evidence most likely to matter before the edit
+
+DURING CODE
+  diff / preflight / evidence queries
+  reconcile live work with repository precedent, guidance,
+  active changes, decisions, counterexamples, and unknowns
+
+AFTER CODE
+  teach / reviewed decision / promoted rule
+  preserve an earned lesson when there is one
+
+NEXT WORKER
+  retrieves the reviewed repository memory
+```
+
+Compact form:
+
+```text
+retrieve -> work -> reconcile -> preserve -> retrieve
+```
+
+Lifecycle composition is tracked in #74. Bounded pre-edit context work is tracked in #62.
+
+## Different views, shared evidence
+
+Several research directions answer different questions. They should compose rather than create parallel truth systems.
+
+### Lifecycle: when?
+
+`brief -> diff -> teach` asks **when** evidence should be recovered, reconciled, and preserved.
+
+Tracking: #74, #62, #10.
+
+### Just-enough information: what?
+
+JEI work asks **what** evidence is worth spending the worker's attention/context budget on for the current task.
+
+Selection should favor explicit authority/decisions, exact action facts, counterevidence, active/freshness information, local precedent, and useful unknowns before broad context volume.
+
+Tracking: #106.
+
+### Review intelligence: where?
+
+Review envelopes ask **where** scarce reviewer attention should go and what evidence would change the review decision. A review view should reuse the same facts rather than invent an opaque risk score.
+
+Tracking: #109.
+
+### Compact representation: how?
+
+C1 and compact-IR research ask **how** evidence should be transmitted efficiently and interoperably.
+
+Merged C1 work is a lossless structural encoding of the current `AnalysisReport`; it deliberately does not perform JEI selection or semantic abbreviation. The broader compact-IR work can add explicit validity, omission, transition, invalidation, supersession, and reopen semantics as those concepts earn a stable representation.
+
+Tracking: #113, #115.
+
+### Decision memory: what survives?
+
+Decision-memory work asks **what reviewed rationale should remain recoverable** after the original task and conversation are gone.
+
+Tracking: #10 plus decision-memory research under #75.
+
+A new projection should not invent a second provenance, authority, freshness, counterexample, unknown, or omission vocabulary merely because its layout differs.
 
 ## Principles
 
 ### Ask questions before inventing rules
 
-Repository statistics are evidence, not policy. If a repository uses `unit_tests` 89 times and `tests` 33 times, that does not automatically make `unit_tests` correct everywhere.
+Repository statistics are evidence, not policy. Popularity alone does not make a convention correct for every scope.
 
 ### Keep scope visible
 
-Precedent can differ at the same time across a file, crate, repository, and recent history. When those scopes disagree, Cultist should show the tension instead of hiding it in one score.
+Precedent can differ across a file, package/crate, repository, recent history, explicit project guidance, and current work. When those scopes disagree, Cultist should expose the tension rather than flatten it into one score.
 
-Tracking issue: #3.
+Tracking: #3.
 
 ### Search counterexamples first
 
-Before emitting a precedent-based finding, look for exceptions and ask whether those exceptions share a reason that applies to the changed code.
+Before promoting precedent or association into a stronger claim, look for exceptions and ask whether they reveal a narrower cohort, scope, or reason.
 
-Tracking issue: #6.
+Tracking: #6.
 
 ### Preserve provenance
 
-Cultist should distinguish:
+Cultist distinguishes:
 
 - **PROVEN** — exact machine facts or guarantees;
 - **DERIVED** — deterministic conclusions from explicit facts;
-- **OBSERVED** — empirical repository patterns;
+- **OBSERVED** — empirical or provider-supplied observations;
 - **INFERRED** — plausible interpretations;
-- **UNKNOWN** — evidence is insufficient to recover the reason.
+- **UNKNOWN** — evidence is insufficient to recover the answer.
 
-Tracking issue: #15.
+Tracking: #15.
+
+### Applicability is separate from source authority
+
+An explicit source can still be stale, copied, or attached to the wrong current work coordinate. Remote prose and metadata should remain bound to exact work identity/head/freshness evidence. Contradictory exact-head evidence can make the source's current applicability unknown without declaring the source itself untrustworthy.
+
+This boundary is especially important for project-memory and coordination adapters (#18, #105).
 
 ### `UNKNOWN` is useful
 
-If nobody can recover why an important-looking workaround, constant, suppression, or special case exists, that is useful knowledge debt. Cultist should say so instead of fabricating intent.
+If the repository cannot recover why an important-looking workaround, exception, stale branch, or metadata claim exists, say so instead of fabricating intent.
 
-### Keep the core local and deterministic
+### Keep the core deterministic and bounded
 
-Model-assisted explanations may eventually help interpret evidence, but the tool must remain useful without an LLM. A model should receive a bounded evidence packet and should not be responsible for discovering the underlying facts.
+Model-assisted explanation may help interpret selected evidence, but the deterministic evidence packet must remain useful without a model. Remote/provider integrations should produce explicit bounded artifacts that local analyzers can validate.
 
-Tracking issue: #17.
+Tracking: #17.
 
 ### Teach the project why
 
-When humans decide an exception is intentional, the reason should be preservable in version control so future analysis can distinguish a known exception from forgotten folklore.
+When maintainers accept an intentional exception or project decision, the reason should be preservable in version control so later work can distinguish reviewed rationale from forgotten folklore.
 
-Tracking issue: #10.
+Tracking: #10.
 
 ### Promote mature questions into rules
 
-If the same fuzzy review question repeatedly receives the same human answer, it may be ready to become a deterministic lint or project rule. Cultist should help incubate that transition while preserving the rationale.
+Repeated, stable human consensus can become deterministic policy, but promotion is an explicit project decision rather than automatic statistical enforcement.
 
-Tracking issue: #11.
+Tracking: #11.
+
+### Learn from the work itself
+
+Cultist development is part of the evaluation corpus. Duplicate work, stale evidence, failed experiments, noisy findings, metadata mismatch, and repeated manual archaeology are candidate product evidence.
+
+Workers should preserve the exact episode, test the generalization, and use the smallest appropriate durable follow-up. See `AGENTS.md`.
 
 ## Workstreams
 
-### 1. Precedent engine
+### 1. Precedent and repository relationships
 
-The first implementation already compares changed test-module declarations with repository-wide and same-file precedent. The next step is to make precedent richer without pretending popularity is correctness.
-
-- #3 — scope-aware precedent and precedent tension
+- #3 — scope-aware precedent and tension
 - #4 — temporal precedent and convention drift
-- #5 — convention entropy and first-exception risk
 - #6 — counterexample-first findings
-- #7 — negative-space associations
-- #20 — locally expanded idioms that duplicate helpers
-- #21 — package and dependency intent
+- #20 — locally expanded idioms and helper precedent
+- #21 — package/dependency intent
+- historical companion and generated-relationship work
 
-### 2. Archaeology
+Historical co-change remains association evidence until stronger repository evidence establishes a stronger relation.
 
-Repositories accumulate historical reasons that disappear from the final source code. Cultist should recover those reasons when possible and expose when they have been lost.
+### 2. Archaeology and project memory
 
 - #8 — exception archaeology
-- #9 — historical fossils and expired workarounds
+- #9 — historical fossils / expired workarounds
 - #12 — `why` mode and evidence packets
 - #18 — Git, PRs, issues, and reviews as project memory
+- #38 — explicit repository guidance as higher-authority precedent
+
+The question is not only “what changed?” but “what did the repository believe, what happened, and what lesson became durable?”
 
 ### 3. Institutional memory and policy
 
-Questions become more valuable when their human answers can persist and eventually become enforceable policy.
-
 - #10 — explicit decision records / `teach`
 - #11 — lint incubation and promotion
-- #15 — claim provenance model
+- #75 — decision-memory research
 
-### 4. Engine, interfaces, and evaluation
+A model may propose rationale; reviewed repository state is what makes rationale durable project evidence.
 
-The underlying engine should support more analyzers without turning into a pile of ad hoc scans or opaque scores.
+### 4. Concurrent work and coordination
+
+- #96 — preflight collision analysis
+- #101 — explicit coordination edges in active-change inventories
+- #105 — producer-side project metadata adapters
+
+Current product supports local ref comparison and bounded active-work inventories. Cultist dogfoods an always-on PR heads-up that stays quiet for disjoint exact paths. Unpublished branch awareness remains research-only until branch activity/intent has a better discriminator than mere divergence.
+
+### 5. Agent context, JEI, and review
+
+- #62 — bounded pre-edit agent context packets
+- #74 — before/during/after lifecycle
+- #106 — JEI work envelopes
+- #109 — review intelligence envelopes
+
+The goal is evidence selected for the current decision, not giant repository summaries.
+
+### 6. Machine protocols and interoperability
+
+- #22 — stable JSON findings
+- #113 — C1 compact evidence grammar
+- #115 — compact Cultist IR / context-relative protocol research
+
+Machine formats should preserve meaning, provenance, unknowns, and omissions. Unsupported future semantics should fail explicitly rather than disappear during down-conversion.
+
+### 7. Engine and performance
 
 - #13 — local evidence index
 - #14 — progressive semantic adapters
-- #16 — dogfood corpus and precision-focused evaluation
-- #17 — optional bounded LLM explanations
-- #22 — stable machine-readable findings / JSON
+- #48 / #49 — performance measurement and demand-driven execution
+- #50 — reusable repository snapshots / summaries
+
+Work should be proportional to the evidence actually needed. Cheap irrelevant paths should stay cheap; expensive semantic/history layers should activate on demand.
+
+### 8. Evaluation corpora
+
+- #16 — dogfood/evaluation corpus
+- #41 — Stensibly agentic organizational-history corpus
+- SmolRunner replay research
+
+Evaluation should include positive controls, quiet negatives, false assumptions, failed proofs, duplicate lanes, and second-order regressions—not only successful detections.
+
+## Current product evidence
+
+Cultist already has executable slices of several parts of this roadmap:
+
+- provenance-bearing shared text/JSON findings;
+- changed-first diff analysis;
+- historical companion evidence with examples/counterexamples;
+- CI test-selector analysis;
+- generated-companion evidence;
+- direct concurrent-change preflight;
+- bounded provider-supplied active-work preflight with explicit coordination edges;
+- an always-on, non-blocking PR active-work heads-up in Cultist's own CI;
+- research decision memory and pre-edit agent context packets;
+- lossless compact C1 report encoding;
+- performance work counters and demand-driven execution research.
+
+These are evidence primitives and experiments, not a claim that the full agent lifecycle is finished.
 
 ## Near-term sequence
 
-A useful order for the next few experiments is:
+The most useful next work is composition and discrimination rather than adding broad new feature families:
 
-1. **Claim provenance + machine-readable findings** (#15, #22)
-2. **Scoped precedent** (#3)
-3. **Counterexample-first output** (#6)
-4. **Dogfood corpus** (#16)
-5. **Temporal precedent** (#4)
-6. **Helper/dependency precedent** (#20, #21)
-7. **History and exception archaeology** (#8, #9, #12)
+1. make pre-edit JEI consume the strongest already-earned evidence without becoming a context dump;
+2. connect live diff/preflight evidence to the same task envelope during work;
+3. keep review-attention output a projection over shared evidence rather than a second analyzer universe;
+4. improve explicit project-memory applicability/freshness before trusting remote prose as current intent;
+5. continue decision-memory authority research from current main after failed/stale carrier experiments;
+6. evolve compact representation only when a new semantic primitive has earned a stable contract;
+7. measure interruption/context economics and retire noisy evidence families;
+8. keep performance work proportional to evidence demand.
 
-This is not a commitment to build everything in order. Small experiments that falsify an idea are valuable. The project should prefer evidence that a feature is useful over completing a grand architecture.
+This is not a commitment to build everything in order. Small experiments that falsify an assumption are valuable, and failed carriers should be retired instead of remaining fake active work.
 
-## Canonical dogfood case
+## Product test
 
-Cloud Hypervisor PR #8734 is currently the clearest example of the intended behavior.
+A useful recurring question is:
 
-The repository-wide evidence favored `unit_tests`, while the changed `vfio.rs` file already contained `tests`. Cultist surfaced both facts and asked which scope should govern the change. During that dogfood run, the tool also exposed a bug in its own diff semantics, leading to a merge-base-aware fix.
+> What did this worker have to discover manually that the repository could have surfaced, bounded, or preserved before the same mistake or investigation happens again?
 
-That is the standard to aim for: the tool should be willing to find ambiguity in the repository, ambiguity in its own conclusions, and bugs in itself.
+Cultist earns its place when the answer becomes progressively smaller without replacing project judgment with opaque automation.


### PR DESCRIPTION
Supersedes stale #102 by rebuilding the useful rebrand/dogfood material directly on current main after preflight, active-work, C1, JEI/review, and compact-IR work landed or opened.

## What

- make **Cultist** the product/evidence-system name while retaining `cargo-cultist` as the current Rust distribution;
- update Cargo package repository metadata to `teamleaderleo/cultist`;
- document current public `preflight --against` and `preflight --inventory` surfaces;
- document the always-on PR active-work dogfood and the research-only branch boundary;
- add `AGENTS.md` guidance for feeding duplicate work, stale evidence, false assumptions, metadata mismatch, counterexamples, and failed experiments back into Cultist with provenance;
- explain the newer agent-facing concepts as complementary views over shared evidence:
  - lifecycle = **when**;
  - JEI = **what**;
  - review intelligence = **where attention goes**;
  - C1/compact IR = **how evidence is carried**;
  - decision memory = **what survives**;
- add an applicability rule motivated by the real #111 counterexample: explicit PR prose does not silently outrank contradictory exact-head/diff evidence;
- refresh the roadmap around current workstreams and composition rather than the original 2024-era near-term sequence.

## Boundary

Documentation/guidance/package metadata only. No crate/binary rename, analyzer behavior change, new authority, or claim that research-only `brief`, JEI, review envelopes, decision memory, or bare-branch sensing are already public product features.

The current Rust launcher remains `cargo-cultist` / `cargo cultist`.

Refs #102 #19 #62 #74 #96 #105 #106 #109 #113 #115.