### PR TITLE
research: extract explicit hold-merge metadata

### DIFF
--- a/examples/coordination_edges.rs
+++ b/examples/coordination_edges.rs
@@ -1,0 +1,36 @@
+#[allow(dead_code)]
+#[path = "../src/coordination_edges.rs"]
+mod coordination_edges;
+
+use std::error::Error;
+use std::io::{self, Read, Write};
+
+use coordination_edges::{MAX_SNAPSHOT_BYTES, extract_snapshot};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("coordination-edges: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_SNAPSHOT_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_SNAPSHOT_BYTES {
+        return Err(format!(
+            "input exceeds coordination metadata limit of {MAX_SNAPSHOT_BYTES} bytes"
+        )
+        .into());
+    }
+
+    let input = String::from_utf8(bytes)?;
+    let report = extract_snapshot(&input)?;
+    let stdout = io::stdout();
+    let mut output = stdout.lock();
+    serde_json::to_writer_pretty(&mut output, &report)?;
+    writeln!(output)?;
+    Ok(())
+}

--- a/research/explicit-coordination-metadata.md
+++ b/research/explicit-coordination-metadata.md
@@ -1,0 +1,219 @@
+# Explicit coordination metadata research
+
+Date: 2026-08-19
+
+## Question
+
+Can a provider-side adapter recover a tiny, high-precision coordination relation from concrete project-authored work metadata without turning ordinary references or arbitrary prose into scheduling policy?
+
+This is the producer-side counterpart to product `preflight --inventory`, which already knows how to consume typed coordination edges.
+
+The first experiment intentionally supports **one sentence form only**:
+
+```text
+Do not merge while #N ...
+```
+
+when it begins a top-level author line.
+
+The emitted product edge is:
+
+```json
+{
+  "kind": "hold_merge_while",
+  "from": "#SOURCE",
+  "to": "#N",
+  "source": "github:pull/SOURCE"
+}
+```
+
+No merge action or scheduling authority follows from extraction.
+
+## Why start this narrowly
+
+Project prose contains many relationships whose English sounds adjacent but whose operational meaning differs:
+
+```text
+Refs #N
+Related: #N
+Parent: #N
+see #N
+after discussing #N
+may conflict with #N
+competing experiment for #N
+```
+
+Those remain references unless a separate discriminator earns stronger semantics.
+
+The extractor also ignores reviewed-looking phrases when they occur in:
+
+- blockquotes;
+- fenced code;
+- indented examples;
+- list-item examples.
+
+This is intentionally conservative. Missing a coordination edge is preferable to silently converting illustrative or semantically adjacent prose into project scheduling evidence.
+
+## Input contract
+
+The research analyzer consumes a provider-supplied JSON snapshot rather than fetching GitHub itself.
+
+Each admitted PR record binds:
+
+- canonical work ID (`#` + positive decimal number);
+- exact `github:pull/N` source identity;
+- exact 40-hex head SHA;
+- provider `updated_at` receipt;
+- bounded body text.
+
+Bounds:
+
+```text
+snapshot:       1 MiB
+work items:     128
+body per work:  128 KiB
+line:           32 KiB
+edges:          512
+```
+
+Unknown fields, unsupported schema/work kinds, duplicate work IDs, noncanonical source identity, and malformed head identity reject.
+
+A referenced endpoint must exist in the admitted work set. Self references and unresolved endpoints do not become edges. Duplicate exact edges collapse.
+
+## Public replay
+
+The committed fixture `research/fixtures/preflight-748-hold.json` snapshots public `teamleaderleo/preflight` PR #748 at:
+
+```text
+head:       a2e14c4265e3568d8f943906a53e3b0e16dca141
+updated_at: 2026-08-18T19:11:15Z
+```
+
+Its body ends with the top-level operative sentence:
+
+```text
+Do not merge while #703 is using current-main package evidence; this branch is intended to stay reviewable and green without moving the RC baseline underneath that gate.
+```
+
+Target #703 is present in the same admitted work set.
+
+The integration replay requires exactly one edge:
+
+```text
+hold_merge_while #748 -> #703
+source github:pull/748
+```
+
+and requires the source receipt to retain the exact #748 head, update coordinate, and matched clause.
+
+The implementation head after formatting passed repository CI run `32238211815`, job `96022810449`, including:
+
+- rustfmt;
+- Clippy with warnings denied;
+- the public replay and unit controls;
+- the always-on active-work heads-up;
+- full tests;
+- repository/history/CI-test/diff dogfood.
+
+## Negative controls
+
+Unit controls stay quiet for ordinary reference language and for quoted/fenced/indented/list examples.
+
+They also require:
+
+- self-reference does not promote;
+- unresolved target does not promote;
+- duplicate exact clauses yield one edge;
+- duplicate work IDs reject;
+- mismatched `github:pull/N` source identity rejects;
+- oversized input rejects before parsing.
+
+No second phrase is admitted merely because it seems intuitively equivalent.
+
+## Applicability boundary exposed by Cultist #111
+
+Cultist PR #111 supplied an important self-dogfood counterexample while this research was being designed.
+
+Its exact title/head/diff described an active-work prefilter identity repair, while its PR body described an unrelated repository warm-scan snapshot/cache feature.
+
+That means:
+
+> explicit project-authored prose can itself be stale, copied, or attached to the wrong current change coordinate.
+
+This extractor therefore makes a deliberately smaller claim than “the body describes current implementation intent.”
+
+A `source_receipt` records:
+
+```text
+source work ID
+source head SHA
+source updated_at
+exact matched clause
+```
+
+and the report keeps broader/current applicability `UNKNOWN` without independent evidence.
+
+For the first `hold_merge_while` form, the useful observed fact is simply:
+
+```text
+OBSERVED
+  the admitted current metadata for PR A contains an explicit instruction
+  to hold merge while admitted work B is active/relevant
+```
+
+Do not silently generalize that into:
+
+```text
+PR body == exact current implementation intent
+```
+
+A later provider adapter can invalidate/recompute the edge when source metadata/head coordinates move. Richer compact IR may eventually represent that validity directly.
+
+## Composition
+
+The intended path is:
+
+```text
+provider adapter
+  -> bounded current PR metadata snapshot
+  -> reviewed explicit-edge extractor
+  -> existing coordination_edges field
+  -> product preflight --inventory
+  -> advisory question / heads-up
+```
+
+The local product core does not need GitHub credentials or a prose parser.
+
+A cheap remote adapter can also prefilter bodies for the exact reviewed prefix and invoke the deterministic extractor only when a possible clause exists.
+
+## What this does not establish
+
+The experiment does not establish that:
+
+- every `Do not merge while` sentence remains applicable forever;
+- ordinary dependency/reference prose implies sequencing;
+- semantic body/diff agreement can be scored safely;
+- a hold edge means either change is wrong;
+- the current worker must stop;
+- Cultist should merge, close, rebase, or schedule work automatically.
+
+Those remain separate evidence/decision questions.
+
+## Next discriminator
+
+The strongest next dogfood step is to enrich Cultist's existing GitHub active-work adapter with current PR body metadata and use this extractor to emit `coordination_edges` into the already-landed inventory contract.
+
+The quiet path should remain cheap:
+
+```text
+no reviewed phrase prefix
+  -> no metadata extractor / coordination work
+
+possible exact prefix
+  -> deterministic extraction
+  -> product preflight composes path overlap + explicit edge evidence
+```
+
+A useful positive must have disjoint changed paths but an explicit edge, matching the #748/#703 species. Ordinary references must remain quiet.
+
+Refs #96, #101, #103, #105, #111, #115.

--- a/research/fixtures/preflight-748-hold.json
+++ b/research/fixtures/preflight-748-hold.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "source": "github_public_replay",
+  "work": [
+    {
+      "id": "#748",
+      "kind": "pull_request",
+      "source": "github:pull/748",
+      "head_sha": "a2e14c4265e3568d8f943906a53e3b0e16dca141",
+      "updated_at": "2026-08-18T19:11:15Z",
+      "body": "Refs #727.\n\nThis is the isolated cleanup half of #727 on current `main` `2aba5c7e6cb01304493a76df1838d7e4856bfce3`.\n\nDeterministic production defect: current success registers the staged JAR with `deleteOnExit()` and then its private parent directory. Reproducing that exact order in a fresh OpenJDK 21 process leaves the parent directory behind after normal wrapper exit while the child JAR is removed.\n\nBounded correction:\n- replace the two independent delete-on-exit registrations with one shutdown cleanup owner;\n- that owner deletes the exact staged JAR first, then its exact private parent;\n- failure to register cleanup fails staging and the existing immediate-failure cleanup removes both paths;\n- add a subprocess lifecycle regression that invokes the production staging path, waits for JVM exit, and requires both staged child and private parent absent.\n\nThis PR deliberately does **not** change Windows/ACL staging-root selection or creation semantics. #727 remains open for the separate creation-time owner-only ACL boundary under shared `ProgramData` fallback.\n\nDo not merge while #703 is using current-main package evidence; this branch is intended to stay reviewable and green without moving the RC baseline underneath that gate."
+    },
+    {
+      "id": "#703",
+      "kind": "pull_request",
+      "source": "github:pull/703",
+      "head_sha": "866e4466259a51857e932f0e78032363cb3ab908",
+      "updated_at": "2026-08-19T09:20:17Z",
+      "body": ""
+    }
+  ]
+}

--- a/src/coordination_edges.rs
+++ b/src/coordination_edges.rs
@@ -1,0 +1,465 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+const SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const MAX_SNAPSHOT_BYTES: usize = 1024 * 1024;
+const MAX_WORK_ITEMS: usize = 128;
+const MAX_BODY_BYTES: usize = 128 * 1024;
+const MAX_BODY_LINE_BYTES: usize = 32 * 1024;
+const MAX_SOURCE_BYTES: usize = 512;
+const MAX_KIND_BYTES: usize = 64;
+const MAX_TIME_BYTES: usize = 128;
+const MAX_EDGES: usize = 512;
+const HOLD_PREFIX: &str = "Do not merge while #";
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct EdgeError {
+    message: String,
+}
+
+impl EdgeError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for EdgeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for EdgeError {}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WorkMetadataSnapshot {
+    schema_version: u32,
+    source: String,
+    work: Vec<WorkMetadata>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WorkMetadata {
+    id: String,
+    kind: String,
+    source: String,
+    head_sha: String,
+    updated_at: String,
+    body: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoordinationKind {
+    HoldMergeWhile,
+}
+
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct CoordinationEdge {
+    pub kind: CoordinationKind,
+    pub from: String,
+    pub to: String,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct SourceReceipt {
+    pub kind: CoordinationKind,
+    pub from: String,
+    pub to: String,
+    pub source: String,
+    pub source_head_sha: String,
+    pub source_updated_at: String,
+    pub matched_clause: String,
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize)]
+pub struct ExtractionStats {
+    pub work_items_examined: usize,
+    pub operative_clauses_matched: usize,
+    pub self_references_ignored: usize,
+    pub unresolved_endpoints_ignored: usize,
+    pub duplicate_edges_ignored: usize,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ExtractionReport {
+    pub schema_version: u32,
+    pub analysis: String,
+    pub source: String,
+    pub coordination_edges: Vec<CoordinationEdge>,
+    pub source_receipts: Vec<SourceReceipt>,
+    pub stats: ExtractionStats,
+    pub unknowns: Vec<String>,
+}
+
+pub fn extract_snapshot(input: &str) -> Result<ExtractionReport, EdgeError> {
+    if input.len() > MAX_SNAPSHOT_BYTES {
+        return Err(EdgeError::new(format!(
+            "coordination metadata snapshot is {} bytes; maximum is {MAX_SNAPSHOT_BYTES}",
+            input.len()
+        )));
+    }
+
+    let snapshot: WorkMetadataSnapshot = serde_json::from_str(input)
+        .map_err(|error| EdgeError::new(format!("invalid coordination metadata snapshot: {error}")))?;
+    validate_snapshot(&snapshot)?;
+
+    let known_ids = snapshot
+        .work
+        .iter()
+        .map(|work| work.id.as_str())
+        .collect::<BTreeSet<_>>();
+
+    let mut edge_receipts = BTreeMap::<CoordinationEdge, SourceReceipt>::new();
+    let mut stats = ExtractionStats {
+        work_items_examined: snapshot.work.len(),
+        ..ExtractionStats::default()
+    };
+
+    for work in &snapshot.work {
+        let mut fence: Option<(char, usize)> = None;
+        for raw_line in work.body.lines() {
+            let line = raw_line.trim_end_matches('\r');
+            if line.len() > MAX_BODY_LINE_BYTES {
+                return Err(EdgeError::new(format!(
+                    "{} body contains a line larger than {MAX_BODY_LINE_BYTES} bytes",
+                    work.id
+                )));
+            }
+
+            if let Some((marker, width)) = fence {
+                if closes_fence(line, marker, width) {
+                    fence = None;
+                }
+                continue;
+            }
+            if let Some(opened) = opens_fence(line) {
+                fence = Some(opened);
+                continue;
+            }
+
+            let Some(target) = hold_merge_target(line) else {
+                continue;
+            };
+            stats.operative_clauses_matched += 1;
+
+            if target == work.id {
+                stats.self_references_ignored += 1;
+                continue;
+            }
+            if !known_ids.contains(target.as_str()) {
+                stats.unresolved_endpoints_ignored += 1;
+                continue;
+            }
+
+            let edge = CoordinationEdge {
+                kind: CoordinationKind::HoldMergeWhile,
+                from: work.id.clone(),
+                to: target.clone(),
+                source: work.source.clone(),
+            };
+            let receipt = SourceReceipt {
+                kind: edge.kind,
+                from: edge.from.clone(),
+                to: edge.to.clone(),
+                source: edge.source.clone(),
+                source_head_sha: work.head_sha.clone(),
+                source_updated_at: work.updated_at.clone(),
+                matched_clause: line.to_string(),
+            };
+
+            if edge_receipts.insert(edge, receipt).is_some() {
+                stats.duplicate_edges_ignored += 1;
+            }
+            if edge_receipts.len() > MAX_EDGES {
+                return Err(EdgeError::new(format!(
+                    "coordination edge count exceeds maximum {MAX_EDGES}"
+                )));
+            }
+        }
+    }
+
+    let coordination_edges = edge_receipts.keys().cloned().collect::<Vec<_>>();
+    let source_receipts = edge_receipts.values().cloned().collect::<Vec<_>>();
+
+    Ok(ExtractionReport {
+        schema_version: SNAPSHOT_SCHEMA_VERSION,
+        analysis: "explicit-coordination-metadata".to_string(),
+        source: snapshot.source,
+        coordination_edges,
+        source_receipts,
+        stats,
+        unknowns: vec![
+            "A body-derived edge proves only that the admitted source metadata contained the reviewed operative clause at the recorded head/update coordinates; implementation intent or continued applicability beyond that clause remains unknown without independent evidence.".to_string(),
+        ],
+    })
+}
+
+fn validate_snapshot(snapshot: &WorkMetadataSnapshot) -> Result<(), EdgeError> {
+    if snapshot.schema_version != SNAPSHOT_SCHEMA_VERSION {
+        return Err(EdgeError::new(format!(
+            "unsupported coordination metadata schema {}; expected {SNAPSHOT_SCHEMA_VERSION}",
+            snapshot.schema_version
+        )));
+    }
+    validate_bounded_nonempty("snapshot source", &snapshot.source, MAX_SOURCE_BYTES)?;
+    if snapshot.work.len() > MAX_WORK_ITEMS {
+        return Err(EdgeError::new(format!(
+            "work item count {} exceeds maximum {MAX_WORK_ITEMS}",
+            snapshot.work.len()
+        )));
+    }
+
+    let mut ids = BTreeSet::new();
+    for work in &snapshot.work {
+        validate_work_id(&work.id)?;
+        if !ids.insert(work.id.as_str()) {
+            return Err(EdgeError::new(format!("duplicate work id `{}`", work.id)));
+        }
+        validate_bounded_nonempty("work kind", &work.kind, MAX_KIND_BYTES)?;
+        if work.kind != "pull_request" {
+            return Err(EdgeError::new(format!(
+                "unsupported work kind `{}` for {}; expected `pull_request`",
+                work.kind, work.id
+            )));
+        }
+        validate_bounded_nonempty("work source", &work.source, MAX_SOURCE_BYTES)?;
+        let expected_source = format!("github:pull/{}", &work.id[1..]);
+        if work.source != expected_source {
+            return Err(EdgeError::new(format!(
+                "work source `{}` does not match canonical source `{expected_source}` for {}",
+                work.source, work.id
+            )));
+        }
+        if work.head_sha.len() != 40 || !work.head_sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(EdgeError::new(format!(
+                "{} head_sha must be exactly 40 hexadecimal characters",
+                work.id
+            )));
+        }
+        validate_bounded_nonempty("work updated_at", &work.updated_at, MAX_TIME_BYTES)?;
+        if work.body.len() > MAX_BODY_BYTES {
+            return Err(EdgeError::new(format!(
+                "{} body is {} bytes; maximum is {MAX_BODY_BYTES}",
+                work.id,
+                work.body.len()
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_bounded_nonempty(label: &str, value: &str, maximum: usize) -> Result<(), EdgeError> {
+    if value.is_empty() {
+        return Err(EdgeError::new(format!("{label} must not be empty")));
+    }
+    if value.len() > maximum {
+        return Err(EdgeError::new(format!(
+            "{label} is {} bytes; maximum is {maximum}",
+            value.len()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_work_id(id: &str) -> Result<(), EdgeError> {
+    let Some(digits) = id.strip_prefix('#') else {
+        return Err(EdgeError::new(format!(
+            "invalid work id `{id}`; expected # followed by a positive decimal number"
+        )));
+    };
+    if digits.is_empty()
+        || digits.starts_with('0')
+        || !digits.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Err(EdgeError::new(format!(
+            "invalid work id `{id}`; expected canonical positive decimal form"
+        )));
+    }
+    Ok(())
+}
+
+fn hold_merge_target(line: &str) -> Option<String> {
+    let rest = line.strip_prefix(HOLD_PREFIX)?;
+    let digit_count = rest
+        .bytes()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if digit_count == 0 {
+        return None;
+    }
+
+    let digits = &rest[..digit_count];
+    if digits.starts_with('0') {
+        return None;
+    }
+    let tail = &rest[digit_count..];
+    if !tail.starts_with(' ') || tail.trim().is_empty() {
+        return None;
+    }
+
+    Some(format!("#{digits}"))
+}
+
+fn opens_fence(line: &str) -> Option<(char, usize)> {
+    let first = line.chars().next()?;
+    if first != '`' && first != '~' {
+        return None;
+    }
+    let width = line.chars().take_while(|character| *character == first).count();
+    (width >= 3).then_some((first, width))
+}
+
+fn closes_fence(line: &str, marker: char, minimum_width: usize) -> bool {
+    let width = line
+        .chars()
+        .take_while(|character| *character == marker)
+        .count();
+    width >= minimum_width && line[width..].trim().is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sha(byte: char) -> String {
+        std::iter::repeat_n(byte, 40).collect()
+    }
+
+    fn snapshot(entries: Vec<serde_json::Value>) -> String {
+        serde_json::to_string(&json!({
+            "schema_version": 1,
+            "source": "test",
+            "work": entries,
+        }))
+        .unwrap()
+    }
+
+    fn work(id: &str, body: &str) -> serde_json::Value {
+        json!({
+            "id": id,
+            "kind": "pull_request",
+            "source": format!("github:pull/{}", &id[1..]),
+            "head_sha": sha('a'),
+            "updated_at": "2026-08-19T00:00:00Z",
+            "body": body,
+        })
+    }
+
+    #[test]
+    fn extracts_only_reviewed_top_level_hold_clause() {
+        let input = snapshot(vec![
+            work(
+                "#748",
+                "Refs #703.\nDo not merge while #703 is using current-main package evidence; keep the baseline still.\n",
+            ),
+            work("#703", ""),
+        ]);
+        let report = extract_snapshot(&input).unwrap();
+        assert_eq!(report.coordination_edges.len(), 1);
+        assert_eq!(report.coordination_edges[0].from, "#748");
+        assert_eq!(report.coordination_edges[0].to, "#703");
+        assert_eq!(report.coordination_edges[0].source, "github:pull/748");
+        assert_eq!(report.source_receipts[0].source_head_sha, sha('a'));
+    }
+
+    #[test]
+    fn ordinary_reference_language_stays_quiet() {
+        let input = snapshot(vec![
+            work(
+                "#748",
+                "Refs #703\nRelated: #703\nParent: #703\nsee #703\nafter discussing #703\nthis may conflict with #703\nCompeting replacement experiment for #703\n",
+            ),
+            work("#703", ""),
+        ]);
+        let report = extract_snapshot(&input).unwrap();
+        assert!(report.coordination_edges.is_empty());
+    }
+
+    #[test]
+    fn quoted_fenced_indented_and_list_examples_stay_quiet() {
+        let input = snapshot(vec![
+            work(
+                "#748",
+                "> Do not merge while #703 is active\n```text\nDo not merge while #703 is active\n```\n    Do not merge while #703 is active\n- Do not merge while #703 is active\n",
+            ),
+            work("#703", ""),
+        ]);
+        let report = extract_snapshot(&input).unwrap();
+        assert!(report.coordination_edges.is_empty());
+    }
+
+    #[test]
+    fn self_and_unresolved_endpoints_are_not_promoted() {
+        let input = snapshot(vec![work(
+            "#748",
+            "Do not merge while #748 is active\nDo not merge while #999 is active\n",
+        )]);
+        let report = extract_snapshot(&input).unwrap();
+        assert!(report.coordination_edges.is_empty());
+        assert_eq!(report.stats.self_references_ignored, 1);
+        assert_eq!(report.stats.unresolved_endpoints_ignored, 1);
+    }
+
+    #[test]
+    fn duplicate_exact_edges_collapse() {
+        let input = snapshot(vec![
+            work(
+                "#748",
+                "Do not merge while #703 is active\nDo not merge while #703 is active\n",
+            ),
+            work("#703", ""),
+        ]);
+        let report = extract_snapshot(&input).unwrap();
+        assert_eq!(report.coordination_edges.len(), 1);
+        assert_eq!(report.stats.duplicate_edges_ignored, 1);
+    }
+
+    #[test]
+    fn source_receipt_keeps_applicability_coordinate_without_strengthening_claim() {
+        let input = snapshot(vec![
+            work("#748", "Do not merge while #703 is active\n"),
+            work("#703", ""),
+        ]);
+        let report = extract_snapshot(&input).unwrap();
+        assert_eq!(report.source_receipts[0].source_updated_at, "2026-08-19T00:00:00Z");
+        assert!(report.unknowns[0].contains("continued applicability"));
+    }
+
+    #[test]
+    fn rejects_duplicate_work_ids_and_noncanonical_sources() {
+        let duplicate = snapshot(vec![work("#748", ""), work("#748", "")]);
+        assert!(extract_snapshot(&duplicate).is_err());
+
+        let input = serde_json::to_string(&json!({
+            "schema_version": 1,
+            "source": "test",
+            "work": [{
+                "id": "#748",
+                "kind": "pull_request",
+                "source": "github:pull/999",
+                "head_sha": sha('a'),
+                "updated_at": "2026-08-19T00:00:00Z",
+                "body": ""
+            }]
+        }))
+        .unwrap();
+        assert!(extract_snapshot(&input).is_err());
+    }
+
+    #[test]
+    fn rejects_oversized_snapshot_before_parsing() {
+        let input = "x".repeat(MAX_SNAPSHOT_BYTES + 1);
+        assert!(extract_snapshot(&input).is_err());
+    }
+}

--- a/src/coordination_edges.rs
+++ b/src/coordination_edges.rs
@@ -312,12 +312,21 @@ fn hold_merge_target(line: &str) -> Option<String> {
     Some(format!("#{digits}"))
 }
 
+fn fence_content(line: &str) -> Option<&str> {
+    let indent = line.bytes().take_while(|byte| *byte == b' ').count();
+    if indent > 3 {
+        return None;
+    }
+    Some(&line[indent..])
+}
+
 fn opens_fence(line: &str) -> Option<(char, usize)> {
-    let first = line.chars().next()?;
+    let content = fence_content(line)?;
+    let first = content.chars().next()?;
     if first != '`' && first != '~' {
         return None;
     }
-    let width = line
+    let width = content
         .chars()
         .take_while(|character| *character == first)
         .count();
@@ -325,11 +334,14 @@ fn opens_fence(line: &str) -> Option<(char, usize)> {
 }
 
 fn closes_fence(line: &str, marker: char, minimum_width: usize) -> bool {
-    let width = line
+    let Some(content) = fence_content(line) else {
+        return false;
+    };
+    let width = content
         .chars()
         .take_while(|character| *character == marker)
         .count();
-    width >= minimum_width && line[width..].trim().is_empty()
+    width >= minimum_width && content[width..].trim().is_empty()
 }
 
 #[cfg(test)]
@@ -396,7 +408,7 @@ mod tests {
         let input = snapshot(vec![
             work(
                 "#748",
-                "> Do not merge while #703 is active\n```text\nDo not merge while #703 is active\n```\n    Do not merge while #703 is active\n- Do not merge while #703 is active\n",
+                "> Do not merge while #703 is active\n```text\nDo not merge while #703 is active\n```\n   ~~~text\nDo not merge while #703 is active\n   ~~~\n    Do not merge while #703 is active\n- Do not merge while #703 is active\n",
             ),
             work("#703", ""),
         ]);

--- a/src/coordination_edges.rs
+++ b/src/coordination_edges.rs
@@ -108,8 +108,9 @@ pub fn extract_snapshot(input: &str) -> Result<ExtractionReport, EdgeError> {
         )));
     }
 
-    let snapshot: WorkMetadataSnapshot = serde_json::from_str(input)
-        .map_err(|error| EdgeError::new(format!("invalid coordination metadata snapshot: {error}")))?;
+    let snapshot: WorkMetadataSnapshot = serde_json::from_str(input).map_err(|error| {
+        EdgeError::new(format!("invalid coordination metadata snapshot: {error}"))
+    })?;
     validate_snapshot(&snapshot)?;
 
     let known_ids = snapshot
@@ -239,7 +240,8 @@ fn validate_snapshot(snapshot: &WorkMetadataSnapshot) -> Result<(), EdgeError> {
                 work.source, work.id
             )));
         }
-        if work.head_sha.len() != 40 || !work.head_sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        if work.head_sha.len() != 40 || !work.head_sha.bytes().all(|byte| byte.is_ascii_hexdigit())
+        {
             return Err(EdgeError::new(format!(
                 "{} head_sha must be exactly 40 hexadecimal characters",
                 work.id
@@ -315,7 +317,10 @@ fn opens_fence(line: &str) -> Option<(char, usize)> {
     if first != '`' && first != '~' {
         return None;
     }
-    let width = line.chars().take_while(|character| *character == first).count();
+    let width = line
+        .chars()
+        .take_while(|character| *character == first)
+        .count();
     (width >= 3).then_some((first, width))
 }
 
@@ -432,7 +437,10 @@ mod tests {
             work("#703", ""),
         ]);
         let report = extract_snapshot(&input).unwrap();
-        assert_eq!(report.source_receipts[0].source_updated_at, "2026-08-19T00:00:00Z");
+        assert_eq!(
+            report.source_receipts[0].source_updated_at,
+            "2026-08-19T00:00:00Z"
+        );
         assert!(report.unknowns[0].contains("continued applicability"));
     }
 

--- a/tests/coordination_edges.rs
+++ b/tests/coordination_edges.rs
@@ -6,10 +6,8 @@ use coordination_edges::{CoordinationKind, extract_snapshot};
 
 #[test]
 fn replays_public_preflight_748_hold_merge_clause() {
-    let report = extract_snapshot(include_str!(
-        "../research/fixtures/preflight-748-hold.json"
-    ))
-    .unwrap();
+    let report =
+        extract_snapshot(include_str!("../research/fixtures/preflight-748-hold.json")).unwrap();
 
     assert_eq!(report.coordination_edges.len(), 1);
     let edge = &report.coordination_edges[0];

--- a/tests/coordination_edges.rs
+++ b/tests/coordination_edges.rs
@@ -1,0 +1,33 @@
+#[allow(dead_code)]
+#[path = "../src/coordination_edges.rs"]
+mod coordination_edges;
+
+use coordination_edges::{CoordinationKind, extract_snapshot};
+
+#[test]
+fn replays_public_preflight_748_hold_merge_clause() {
+    let report = extract_snapshot(include_str!(
+        "../research/fixtures/preflight-748-hold.json"
+    ))
+    .unwrap();
+
+    assert_eq!(report.coordination_edges.len(), 1);
+    let edge = &report.coordination_edges[0];
+    assert_eq!(edge.kind, CoordinationKind::HoldMergeWhile);
+    assert_eq!(edge.from, "#748");
+    assert_eq!(edge.to, "#703");
+    assert_eq!(edge.source, "github:pull/748");
+
+    let receipt = &report.source_receipts[0];
+    assert_eq!(
+        receipt.source_head_sha,
+        "a2e14c4265e3568d8f943906a53e3b0e16dca141"
+    );
+    assert_eq!(receipt.source_updated_at, "2026-08-18T19:11:15Z");
+    assert!(
+        receipt
+            .matched_clause
+            .starts_with("Do not merge while #703 is using current-main package evidence")
+    );
+    assert_eq!(report.stats.unresolved_endpoints_ignored, 0);
+}


### PR DESCRIPTION
Starts the first producer-side implementation slice of #105 and composes with #101/#103.

## Question

Can a provider-supplied metadata analyzer recover one deliberately reviewed coordination relation from explicit project prose while ordinary references, examples, and unresolved endpoints stay quiet?

## First admitted phrase

Only a top-level author line beginning exactly:

```text
Do not merge while #N ...
```

is eligible for `hold_merge_while`.

This intentionally does **not** match:

- `Refs #N`
- `Related: #N`
- `Parent: #N`
- `see #N`
- `after discussing #N`
- `may conflict with #N`
- blockquotes
- fenced code
- indented examples
- list-item examples
- arbitrary mentions of competing/replacement work

## Input boundary

The research snapshot is bounded and strict:

- schema v1 only;
- <= 1 MiB total;
- <= 128 work items;
- GitHub PR IDs must use canonical `#<positive decimal>` form;
- source must exactly match `github:pull/<id>`;
- exact 40-hex head SHA and bounded `updated_at` are required;
- body <= 128 KiB and individual lines <= 32 KiB;
- unknown fields reject.

Endpoints must resolve inside the admitted work set. Self references and unresolved targets do not become edges. Duplicate exact edges collapse.

## Output boundary

`coordination_edges` uses the existing product edge shape:

```json
{
  "kind": "hold_merge_while",
  "from": "#748",
  "to": "#703",
  "source": "github:pull/748"
}
```

A separate research `source_receipt` binds the extraction to the source PR's exact head SHA, `updated_at`, and matched clause. The report explicitly keeps broader/current implementation intent UNKNOWN; an explicit body clause is evidence, not automatic proof that every other part of the metadata still describes the current diff.

That applicability boundary is motivated by the real Cultist #111 body/head/diff mismatch captured on #105.

## Public replay

`research/fixtures/preflight-748-hold.json` pins public Preflight #748 at head `a2e14c42...` and target #703. The exact top-level sentence:

```text
Do not merge while #703 is using current-main package evidence; ...
```

must yield exactly one edge with exact source/head/update receipt.

Unit negatives cover ordinary references, quoted/fenced/list examples, self/unresolved endpoints, duplicate edges, bad source identity, duplicate work IDs, and oversized input.

## Boundary

Research analyzer/example only. It does not fetch GitHub, mutate work, schedule merges, or parse arbitrary prose. A provider adapter can later populate the snapshot and copy reviewed edges into the already-landed active-work inventory format.

Refs #96 #101 #103 #105 #111 #115.