### PR TITLE
research: prototype terse report rendering

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -18,6 +18,62 @@ pub fn render_analysis_report(report: &AnalysisReport) -> String {
     output
 }
 
+/// Experimental agent-oriented projection over the same canonical AnalysisReport.
+///
+/// References are deliberately report-local in v0: F1 is the first finding,
+/// F1.C2 is its second claim, and C1 is the first report-level claim. They are
+/// not durable IDs and must not be persisted as cross-run identity.
+///
+/// This function is research-only until a public terse format and expansion
+/// contract earn promotion.
+#[allow(dead_code)]
+pub fn render_terse_analysis_report(report: &AnalysisReport) -> String {
+    let mut output = String::new();
+    let mut emitted = false;
+
+    for (index, claim) in report.claims.iter().enumerate() {
+        if claim.kind == ClaimKind::Unknown {
+            writeln!(output, "U C{} {}", index + 1, claim.message).unwrap();
+            emitted = true;
+        }
+    }
+
+    for (finding_index, finding) in report.findings.iter().enumerate() {
+        let finding_ref = format!("F{}", finding_index + 1);
+        write!(output, "{finding_ref} {}", finding.kind).unwrap();
+        if let Some(location) = &finding.location {
+            write!(output, " @{}", format_location(location)).unwrap();
+        }
+        output.push('\n');
+
+        for (claim_index, claim) in finding.claims.iter().enumerate() {
+            writeln!(
+                output,
+                "  C{} {} {}",
+                claim_index + 1,
+                claim_kind_token(claim.kind),
+                claim.message
+            )
+            .unwrap();
+        }
+
+        if let Some(question) = &finding.question {
+            writeln!(output, "  Q {question}").unwrap();
+        }
+
+        emitted = true;
+    }
+
+    if !emitted {
+        // This is intentionally literal rather than a pass/approval
+        // disposition: AnalysisReport currently proves only absence of
+        // findings in this projection, not that the change is globally "OK".
+        output.push_str("NO_FINDINGS\n");
+    }
+
+    output
+}
+
 fn write_finding(output: &mut String, finding: &Finding) {
     if let Some(location) = &finding.location {
         writeln!(output, "  at {}", format_location(location)).unwrap();
@@ -78,6 +134,17 @@ fn claim_kind_label(kind: ClaimKind) -> &'static str {
     }
 }
 
+#[allow(dead_code)]
+fn claim_kind_token(kind: ClaimKind) -> &'static str {
+    match kind {
+        ClaimKind::Proven => "P",
+        ClaimKind::Derived => "D",
+        ClaimKind::Observed => "O",
+        ClaimKind::Inferred => "I",
+        ClaimKind::Unknown => "?",
+    }
+}
+
 fn analysis_title(analysis: &str) -> String {
     analysis
         .split(['-', '_'])
@@ -131,11 +198,104 @@ mod tests {
     }
 
     #[test]
+    fn terse_renders_clean_report_as_literal_no_findings() {
+        let report = AnalysisReport {
+            schema_version: 1,
+            analysis: "diff-precedent".to_string(),
+            repository: "/repo".to_string(),
+            claims: vec![Claim::new(ClaimKind::Derived, "One file changed.")],
+            findings: Vec::new(),
+        };
+
+        assert_eq!(render_terse_analysis_report(&report), "NO_FINDINGS\n");
+    }
+
+    #[test]
+    fn terse_does_not_turn_claim_only_report_into_ok_disposition() {
+        let report = AnalysisReport {
+            schema_version: 1,
+            analysis: "example".to_string(),
+            repository: "/repo".to_string(),
+            claims: vec![Claim::new(
+                ClaimKind::Inferred,
+                "This may be routine, but the canonical report does not approve it.",
+            )],
+            findings: Vec::new(),
+        };
+
+        let rendered = render_terse_analysis_report(&report);
+        assert_eq!(rendered, "NO_FINDINGS\n");
+        assert!(!rendered.contains("OK"));
+    }
+
+    #[test]
+    fn terse_keeps_report_level_unknown_visible() {
+        let report = AnalysisReport {
+            schema_version: 1,
+            analysis: "example".to_string(),
+            repository: "/repo".to_string(),
+            claims: vec![Claim::new(
+                ClaimKind::Unknown,
+                "Target-native execution has not run.",
+            )],
+            findings: Vec::new(),
+        };
+
+        assert_eq!(
+            render_terse_analysis_report(&report),
+            "U C1 Target-native execution has not run.\n"
+        );
+    }
+
+    #[test]
+    fn terse_uses_report_local_refs_and_omits_evidence_prose() {
+        let report = AnalysisReport {
+            schema_version: 1,
+            analysis: "diff-precedent".to_string(),
+            repository: "/repo".to_string(),
+            claims: Vec::new(),
+            findings: vec![
+                Finding::new("precedent-tension", "Example tension")
+                    .at(Location::new("src/lib.rs", Some(42)))
+                    .with_claim(
+                        Claim::new(ClaimKind::Observed, "Two scopes disagree.").with_evidence(
+                            Evidence::at(
+                                "Verbose supporting evidence should stay expandable.",
+                                Location::new("src/lib.rs", Some(10)),
+                            ),
+                        ),
+                    )
+                    .with_claim(Claim::new(
+                        ClaimKind::Unknown,
+                        "The repository does not state which scope wins.",
+                    ))
+                    .with_question("Which scope is intentional here?"),
+            ],
+        };
+
+        let rendered = render_terse_analysis_report(&report);
+        assert_eq!(
+            rendered,
+            "F1 precedent-tension @src/lib.rs:42\n  C1 O Two scopes disagree.\n  C2 ? The repository does not state which scope wins.\n  Q Which scope is intentional here?\n"
+        );
+        assert!(!rendered.contains("Verbose supporting evidence"));
+    }
+
+    #[test]
     fn labels_every_claim_kind() {
         assert_eq!(claim_kind_label(ClaimKind::Proven), "PROVEN");
         assert_eq!(claim_kind_label(ClaimKind::Derived), "DERIVED");
         assert_eq!(claim_kind_label(ClaimKind::Observed), "OBSERVED");
         assert_eq!(claim_kind_label(ClaimKind::Inferred), "INFERRED");
         assert_eq!(claim_kind_label(ClaimKind::Unknown), "UNKNOWN");
+    }
+
+    #[test]
+    fn tokens_every_claim_kind() {
+        assert_eq!(claim_kind_token(ClaimKind::Proven), "P");
+        assert_eq!(claim_kind_token(ClaimKind::Derived), "D");
+        assert_eq!(claim_kind_token(ClaimKind::Observed), "O");
+        assert_eq!(claim_kind_token(ClaimKind::Inferred), "I");
+        assert_eq!(claim_kind_token(ClaimKind::Unknown), "?");
     }
 }


### PR DESCRIPTION
## Summary

First code experiment for #119 / #115, still intentionally below public CLI/protocol commitment.

- add `render_terse_analysis_report(&AnalysisReport)` alongside the existing human text renderer;
- keep the same canonical `AnalysisReport` object as the only semantic source;
- render a no-finding/non-UNKNOWN report as literal `NO_FINDINGS` rather than inventing an `OK`/approval disposition;
- surface findings with deterministic report-local `F1`, `F2`, ... references;
- surface claim provenance with compact `P` / `D` / `O` / `I` / `?` tokens;
- retain finding location, claim messages, material `UNKNOWN`, and the current question;
- omit supporting evidence prose from the terse projection so it remains available through richer renderers instead of being retransmitted every time;
- add controls for clean/no-finding output, claim-only no-finding output, report-level UNKNOWN, deterministic local refs, provenance tokens, and evidence-prose omission.

## Projection boundary

The renderer may omit information, but it must not strengthen the canonical report while doing so.

`AnalysisReport` currently has no typed pass/approved/ok disposition. Therefore:

```text
findings == []
```

can justify `NO_FINDINGS`; it does not by itself justify `OK`.

An adversarial control now supplies zero findings plus a nontrivial INFERRED report-level claim and requires the terse projection to remain `NO_FINDINGS`, never an approval-like token.

## Important boundary

This PR deliberately does **not** add `--format terse` yet and does not claim durable IDs.

`F1`, `F1.C2`, etc. are report-local only. The current machine schema has no stable claim/finding identities, so cross-run expansion should not be invented until #115 earns an identity/fingerprint contract.

The renderer/helper are explicitly marked research-only so Clippy does not force premature CLI exposure merely to make the experiment reachable in non-test builds.

## Why this composes rather than competes

This is a projection over the same `AnalysisReport` used by text/JSON. It does not create a second evidence model, selection policy, or authority layer:

- C1 asks how the full report can be structurally carried;
- JEI asks what evidence should be selected;
- review envelopes ask where attention should go;
- terse rendering tests how little of an already-selected report can be transmitted without strengthening meaning.

Refs #115 #119 #116 #120 #122.