### PR TITLE
research: test evidence roles for lossy projection

### DIFF
--- a/tests/evidence_role_projection.rs
+++ b/tests/evidence_role_projection.rs
@@ -1,0 +1,308 @@
+#[allow(dead_code)]
+#[path = "../src/finding.rs"]
+mod finding;
+#[allow(dead_code)]
+#[path = "../src/render.rs"]
+mod render;
+
+use finding::{AnalysisReport, Claim, ClaimKind, Evidence, Finding};
+use render::render_terse_analysis_report;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum EvidenceRole {
+    Support,
+    Counterexample,
+    Limit,
+    Clearing,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct TaggedEvidence {
+    role: EvidenceRole,
+    message: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum NextAction {
+    Proceed,
+    Hold,
+    RestrictScope,
+    ReconcileException,
+    ExecuteClearingStep,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct ProjectionCase {
+    id: &'static str,
+    level: ClaimKind,
+    claim: &'static str,
+    evidence: Vec<TaggedEvidence>,
+}
+
+impl ProjectionCase {
+    fn new(
+        id: &'static str,
+        level: ClaimKind,
+        claim: &'static str,
+        evidence: Vec<TaggedEvidence>,
+    ) -> Self {
+        Self {
+            id,
+            level,
+            claim,
+            evidence,
+        }
+    }
+
+    fn report(&self) -> AnalysisReport {
+        let mut claim = Claim::new(self.level, self.claim);
+        claim.evidence = self
+            .evidence
+            .iter()
+            .map(|evidence| Evidence::new(evidence.message))
+            .collect();
+
+        AnalysisReport {
+            schema_version: 1,
+            analysis: "evidence-role-projection".to_string(),
+            repository: "/repo".to_string(),
+            claims: Vec::new(),
+            findings: vec![Finding::new("projection-case", self.id).with_claim(claim)],
+        }
+    }
+}
+
+fn support(message: &'static str) -> TaggedEvidence {
+    TaggedEvidence {
+        role: EvidenceRole::Support,
+        message,
+    }
+}
+
+fn counterexample(message: &'static str) -> TaggedEvidence {
+    TaggedEvidence {
+        role: EvidenceRole::Counterexample,
+        message,
+    }
+}
+
+fn limit(message: &'static str) -> TaggedEvidence {
+    TaggedEvidence {
+        role: EvidenceRole::Limit,
+        message,
+    }
+}
+
+fn clearing(message: &'static str) -> TaggedEvidence {
+    TaggedEvidence {
+        role: EvidenceRole::Clearing,
+        message,
+    }
+}
+
+fn current_terse(case: &ProjectionCase) -> String {
+    render_terse_analysis_report(&case.report())
+}
+
+fn role_aware_projection(case: &ProjectionCase) -> String {
+    let mut output = format!(
+        "F1 projection-case\n  C1 {} {}",
+        level_token(case.level),
+        case.claim
+    );
+    for evidence in &case.evidence {
+        match evidence.role {
+            EvidenceRole::Support => {}
+            EvidenceRole::Counterexample => output.push_str("\n  E! counterexample"),
+            EvidenceRole::Limit => output.push_str("\n  E! limit"),
+            EvidenceRole::Clearing => output.push_str("\n  E! clearing"),
+        }
+    }
+    output.push('\n');
+    output
+}
+
+fn full_role_projection(case: &ProjectionCase) -> String {
+    let mut output = format!("{} {:?}: {}\n", case.id, case.level, case.claim);
+    for evidence in &case.evidence {
+        output.push_str(&format!("  {:?}: {}\n", evidence.role, evidence.message));
+    }
+    output
+}
+
+fn required_action(case: &ProjectionCase) -> NextAction {
+    if case
+        .evidence
+        .iter()
+        .any(|evidence| evidence.role == EvidenceRole::Clearing)
+    {
+        NextAction::ExecuteClearingStep
+    } else if case
+        .evidence
+        .iter()
+        .any(|evidence| evidence.role == EvidenceRole::Limit)
+    {
+        NextAction::RestrictScope
+    } else if case
+        .evidence
+        .iter()
+        .any(|evidence| evidence.role == EvidenceRole::Counterexample)
+    {
+        NextAction::ReconcileException
+    } else if case.level == ClaimKind::Unknown {
+        NextAction::Hold
+    } else {
+        NextAction::Proceed
+    }
+}
+
+fn action_from_role_aware_projection(projection: &str) -> NextAction {
+    if projection.contains("E! clearing") {
+        NextAction::ExecuteClearingStep
+    } else if projection.contains("E! limit") {
+        NextAction::RestrictScope
+    } else if projection.contains("E! counterexample") {
+        NextAction::ReconcileException
+    } else if projection.contains("  C1 ? ") {
+        NextAction::Hold
+    } else {
+        NextAction::Proceed
+    }
+}
+
+fn level_token(level: ClaimKind) -> &'static str {
+    match level {
+        ClaimKind::Proven => "P",
+        ClaimKind::Derived => "D",
+        ClaimKind::Observed => "O",
+        ClaimKind::Inferred => "I",
+        ClaimKind::Unknown => "?",
+    }
+}
+
+#[test]
+fn actual_terse_renderer_collapses_scope_limit_that_changes_action() {
+    let unrestricted = ProjectionCase::new(
+        "unrestricted",
+        ClaimKind::Proven,
+        "target test passed",
+        vec![support("target execution passed")],
+    );
+    let linux_only = ProjectionCase::new(
+        "linux-only",
+        ClaimKind::Proven,
+        "target test passed",
+        vec![
+            support("target execution passed"),
+            limit("receipt is valid only for linux-x86_64"),
+        ],
+    );
+
+    assert_eq!(current_terse(&unrestricted), current_terse(&linux_only));
+    assert_ne!(required_action(&unrestricted), required_action(&linux_only));
+    assert_ne!(
+        role_aware_projection(&unrestricted),
+        role_aware_projection(&linux_only)
+    );
+}
+
+#[test]
+fn actual_terse_renderer_collapses_counterexample_that_changes_action() {
+    let ordinary = ProjectionCase::new(
+        "ordinary",
+        ClaimKind::Observed,
+        "helper is the local precedent",
+        vec![support("six nearby callers use helper")],
+    );
+    let matching_exception = ProjectionCase::new(
+        "matching-exception",
+        ClaimKind::Observed,
+        "helper is the local precedent",
+        vec![
+            support("six nearby callers use helper"),
+            counterexample("one reviewed exception matches this change scope"),
+        ],
+    );
+
+    assert_eq!(current_terse(&ordinary), current_terse(&matching_exception));
+    assert_ne!(
+        required_action(&ordinary),
+        required_action(&matching_exception)
+    );
+    assert_ne!(
+        role_aware_projection(&ordinary),
+        role_aware_projection(&matching_exception)
+    );
+}
+
+#[test]
+fn actual_terse_renderer_collapses_clearing_evidence_that_changes_action() {
+    let blocked = ProjectionCase::new(
+        "blocked",
+        ClaimKind::Unknown,
+        "merge eligibility is unresolved",
+        vec![support("exact target execution is absent")],
+    );
+    let actionable = ProjectionCase::new(
+        "actionable",
+        ClaimKind::Unknown,
+        "merge eligibility is unresolved",
+        vec![
+            support("exact target execution is absent"),
+            clearing("run exact target execution at current head"),
+        ],
+    );
+
+    assert_eq!(current_terse(&blocked), current_terse(&actionable));
+    assert_eq!(required_action(&blocked), NextAction::Hold);
+    assert_eq!(
+        required_action(&actionable),
+        NextAction::ExecuteClearingStep
+    );
+    assert_ne!(
+        role_aware_projection(&blocked),
+        role_aware_projection(&actionable)
+    );
+}
+
+#[test]
+fn support_only_evidence_can_be_omitted_without_changing_modeled_action() {
+    let case = ProjectionCase::new(
+        "support-only",
+        ClaimKind::Proven,
+        "exact fixture replay passed",
+        vec![
+            support("fixture A passed"),
+            support("fixture B passed"),
+            support("fixture C passed"),
+        ],
+    );
+
+    let full = full_role_projection(&case);
+    let compact = role_aware_projection(&case);
+    assert!(compact.len() < full.len());
+    assert_eq!(
+        required_action(&case),
+        action_from_role_aware_projection(&compact)
+    );
+    assert!(!compact.contains("fixture A passed"));
+    assert!(!compact.contains("fixture B passed"));
+    assert!(!compact.contains("fixture C passed"));
+}
+
+#[test]
+fn role_aware_unknown_without_clearing_evidence_stays_hold() {
+    let blocked = ProjectionCase::new(
+        "blocked",
+        ClaimKind::Unknown,
+        "merge eligibility is unresolved",
+        vec![support("exact target execution is absent")],
+    );
+
+    let projection = role_aware_projection(&blocked);
+    assert_eq!(required_action(&blocked), NextAction::Hold);
+    assert_eq!(
+        action_from_role_aware_projection(&projection),
+        NextAction::Hold
+    );
+}


### PR DESCRIPTION
Research blocker experiment for #125 / #119 / #115, rebuilt directly on current main after the terse renderer merged.

## Question

Can the **actual merged terse projection** collapse two `AnalysisReport` objects that have identical claim text/provenance but different evidence that changes the modeled next action?

If yes, evidence role is a plausible missing input for decision-preserving compression. This does **not** make the provisional role vocabulary canonical.

## Real projection replay

The integration test imports the real current `finding.rs` and `render.rs`, constructs ordinary `AnalysisReport` findings/claims/evidence, and runs:

```text
render_terse_analysis_report(&report)
```

No parallel mock of the current terse renderer is used.

Three negative pairs keep finding kind, claim provenance, and claim text identical while changing only omitted evidence:

1. PROVEN receipt + no limit vs the same receipt + scope limit;
2. OBSERVED precedent + no counterexample vs the same precedent + matching reviewed counterexample;
3. UNKNOWN blocker + no clearing evidence vs the same blocker + exact clearing step.

The real terse renderer must produce identical output for each pair, while a small test-local action oracle produces different next actions.

## Provisional role-aware control

The test-local role vocabulary remains deliberately provisional:

```text
Support
Counterexample
Limit
Clearing
```

A tiny modeled role-aware projection keeps only non-support role markers. It must distinguish all three negative pairs. A support-only case demonstrates that multiple support messages can be omitted while preserving the modeled action and reducing bytes.

This proves only:

```text
some evidence omitted by the current terse projection can change a downstream decision
```

It does **not** prove these exact four roles belong in canonical `Evidence`, C1, JEI, review envelopes, or a future IR.

## Boundary

- test-only research harness;
- no production schema change;
- no new public renderer/CLI;
- no claim that evidence role changes epistemic strength;
- no claim that the test-local action oracle is product policy;
- no durable identity design.

Refs #115 #119 #121 #123 #125.