### PR TITLE
fix: reject underspecified applicability queries

### DIFF
--- a/src/applicability.rs
+++ b/src/applicability.rs
@@ -259,6 +259,16 @@ impl PathScope {
 }
 
 fn validate_requirements(requirements: &EvidenceRequirements) -> Result<(), ApplicabilityError> {
+    if requirements.repository.is_none()
+        && requirements.revision.is_none()
+        && requirements.work.is_none()
+        && requirements.scope.is_none()
+    {
+        return Err(ApplicabilityError::new(
+            "at least one explicit applicability requirement is required",
+        ));
+    }
+
     validate_coordinate(
         requirements.repository.as_deref(),
         "requirements.repository",
@@ -551,9 +561,26 @@ mod tests {
     }
 
     #[test]
+    fn rejects_empty_requirements_instead_of_treating_them_as_global() {
+        let error = evaluate_query(&query(
+            EvidenceRequirements::default(),
+            EvaluationContext::default(),
+        ))
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("at least one explicit applicability requirement")
+        );
+    }
+
+    #[test]
     fn rejects_unknown_schema_and_unknown_json_fields() {
         let mut unsupported = query(
-            EvidenceRequirements::default(),
+            EvidenceRequirements {
+                work: Some("#1".to_string()),
+                ..EvidenceRequirements::default()
+            },
             EvaluationContext::default(),
         );
         unsupported.schema_version = 2;


### PR DESCRIPTION
Follow-up repair to merged #124 / #123.

## Problem

`EvidenceRequirements::default()` contains no repository, revision, work, or scope constraints. The merged evaluator therefore produced zero dimension evaluations and fell through to:

```text
status = applies
```

That turns a producer omission bug into accidental **global applicability**:

```text
producer forgets to state where evidence is valid
-> requirements = {}
-> evidence appears applicable everywhere
```

For shared JEI/review/decision-memory/active-work substrate, that is the wrong fail mode.

## Fix

Applicability schema v1 now requires at least one explicit requirement:

- repository;
- revision;
- work;
- or path scope.

An all-empty requirement object is rejected as underspecified rather than interpreted as global.

If a real use case later needs intentionally global/unscoped evidence, it should earn an **explicit marker** instead of overloading absence of constraints.

## Controls

- add `rejects_empty_requirements_instead_of_treating_them_as_global`;
- update the unknown-schema control to start from an otherwise-valid query so it still tests schema rejection rather than the new underspecification guard;
- preserve exact matching, mismatch>missing precedence, path scope semantics, machine round-trip, and unknown-field rejection.

## Boundary

No change to epistemic provenance, authority, disposition, wall-clock freshness, or product CLI. This only closes the vacuous-applicability hole in the shared exact-coordinate primitive.

Refs #115 #120 #122 #123 #124.