### PR TITLE
research: test existing report primitives as terse safety control

### DIFF
--- a/tests/terse_existing_primitives.rs
+++ b/tests/terse_existing_primitives.rs
@@ -14,10 +14,12 @@ fn finding_with_hidden_limit() -> AnalysisReport {
         analysis: "terse-existing-primitives".to_string(),
         repository: "/repo".to_string(),
         claims: Vec::new(),
-        findings: vec![Finding::new("execution", "Target execution").with_claim(
-            Claim::new(ClaimKind::Proven, "target test passed")
-                .with_evidence(Evidence::new("execution covered Linux only")),
-        )],
+        findings: vec![
+            Finding::new("execution", "Target execution").with_claim(
+                Claim::new(ClaimKind::Proven, "target test passed")
+                    .with_evidence(Evidence::new("execution covered Linux only")),
+            ),
+        ],
     }
 }
 
@@ -78,10 +80,12 @@ fn blocked_without_question() -> AnalysisReport {
         analysis: "terse-existing-primitives".to_string(),
         repository: "/repo".to_string(),
         claims: Vec::new(),
-        findings: vec![Finding::new("execution", "Merge eligibility").with_claim(Claim::new(
-            ClaimKind::Unknown,
-            "exact-head target execution is missing",
-        ))],
+        findings: vec![
+            Finding::new("execution", "Merge eligibility").with_claim(Claim::new(
+                ClaimKind::Unknown,
+                "exact-head target execution is missing",
+            )),
+        ],
     }
 }
 

--- a/tests/terse_existing_primitives.rs
+++ b/tests/terse_existing_primitives.rs
@@ -1,0 +1,149 @@
+#[allow(dead_code)]
+#[path = "../src/finding.rs"]
+mod finding;
+#[allow(dead_code)]
+#[path = "../src/render.rs"]
+mod render;
+
+use finding::{AnalysisReport, Claim, ClaimKind, Evidence, Finding};
+use render::render_terse_analysis_report;
+
+fn finding_with_hidden_limit() -> AnalysisReport {
+    AnalysisReport {
+        schema_version: 1,
+        analysis: "terse-existing-primitives".to_string(),
+        repository: "/repo".to_string(),
+        claims: Vec::new(),
+        findings: vec![Finding::new("execution", "Target execution").with_claim(
+            Claim::new(ClaimKind::Proven, "target test passed")
+                .with_evidence(Evidence::new("execution covered Linux only")),
+        )],
+    }
+}
+
+fn finding_with_explicit_coverage_unknown() -> AnalysisReport {
+    AnalysisReport {
+        schema_version: 1,
+        analysis: "terse-existing-primitives".to_string(),
+        repository: "/repo".to_string(),
+        claims: Vec::new(),
+        findings: vec![
+            Finding::new("execution", "Target execution")
+                .with_claim(Claim::new(ClaimKind::Proven, "target test passed"))
+                .with_claim(Claim::new(
+                    ClaimKind::Unknown,
+                    "cross-platform coverage is not established",
+                )),
+        ],
+    }
+}
+
+fn precedent_with_hidden_counterexample() -> AnalysisReport {
+    AnalysisReport {
+        schema_version: 1,
+        analysis: "terse-existing-primitives".to_string(),
+        repository: "/repo".to_string(),
+        claims: Vec::new(),
+        findings: vec![Finding::new("precedent", "Local precedent").with_claim(
+            Claim::new(ClaimKind::Observed, "helper is the local precedent").with_evidence(
+                Evidence::new("one reviewed exception matches the current change scope"),
+            ),
+        )],
+    }
+}
+
+fn precedent_with_explicit_counterexample_claim() -> AnalysisReport {
+    AnalysisReport {
+        schema_version: 1,
+        analysis: "terse-existing-primitives".to_string(),
+        repository: "/repo".to_string(),
+        claims: Vec::new(),
+        findings: vec![
+            Finding::new("precedent", "Local precedent")
+                .with_claim(Claim::new(
+                    ClaimKind::Observed,
+                    "helper is the local precedent",
+                ))
+                .with_claim(Claim::new(
+                    ClaimKind::Observed,
+                    "one reviewed exception matches the current change scope",
+                )),
+        ],
+    }
+}
+
+fn blocked_without_question() -> AnalysisReport {
+    AnalysisReport {
+        schema_version: 1,
+        analysis: "terse-existing-primitives".to_string(),
+        repository: "/repo".to_string(),
+        claims: Vec::new(),
+        findings: vec![Finding::new("execution", "Merge eligibility").with_claim(Claim::new(
+            ClaimKind::Unknown,
+            "exact-head target execution is missing",
+        ))],
+    }
+}
+
+fn blocked_with_clearing_question() -> AnalysisReport {
+    AnalysisReport {
+        schema_version: 1,
+        analysis: "terse-existing-primitives".to_string(),
+        repository: "/repo".to_string(),
+        claims: Vec::new(),
+        findings: vec![
+            Finding::new("execution", "Merge eligibility")
+                .with_claim(Claim::new(
+                    ClaimKind::Unknown,
+                    "exact-head target execution is missing",
+                ))
+                .with_question("Run exact target execution at HEAD?"),
+        ],
+    }
+}
+
+#[test]
+fn promoting_a_coverage_boundary_to_unknown_makes_it_survive_terse_projection() {
+    let hidden = render_terse_analysis_report(&finding_with_hidden_limit());
+    let explicit = render_terse_analysis_report(&finding_with_explicit_coverage_unknown());
+
+    assert!(!hidden.contains("Linux only"));
+    assert!(!hidden.contains("cross-platform"));
+    assert!(explicit.contains("? cross-platform coverage is not established"));
+    assert_ne!(hidden, explicit);
+}
+
+#[test]
+fn promoting_a_counterexample_to_a_claim_makes_it_survive_terse_projection() {
+    let hidden = render_terse_analysis_report(&precedent_with_hidden_counterexample());
+    let explicit = render_terse_analysis_report(&precedent_with_explicit_counterexample_claim());
+
+    assert!(!hidden.contains("reviewed exception"));
+    assert!(explicit.contains("O one reviewed exception matches the current change scope"));
+    assert_ne!(hidden, explicit);
+}
+
+#[test]
+fn using_the_existing_question_field_preserves_a_clearing_step() {
+    let blocked = render_terse_analysis_report(&blocked_without_question());
+    let actionable = render_terse_analysis_report(&blocked_with_clearing_question());
+
+    assert!(!blocked.contains("Run exact target execution"));
+    assert!(actionable.contains("Q Run exact target execution at HEAD?"));
+    assert_ne!(blocked, actionable);
+}
+
+#[test]
+fn existing_primitives_are_a_competing_hypothesis_not_a_role_schema_proof() {
+    let coverage = render_terse_analysis_report(&finding_with_explicit_coverage_unknown());
+    let counterexample =
+        render_terse_analysis_report(&precedent_with_explicit_counterexample_claim());
+    let clearing = render_terse_analysis_report(&blocked_with_clearing_question());
+
+    // These strings show the decision-relevant information survives today,
+    // but they do not encode an explicit machine role such as "coverage limit"
+    // or "counterexample". A receiver still has to interpret claim text/kind.
+    assert!(coverage.contains("? cross-platform coverage is not established"));
+    assert!(counterexample.contains("O one reviewed exception"));
+    assert!(clearing.contains("Q Run exact target execution at HEAD?"));
+}


### PR DESCRIPTION
Counter-hypothesis for #125 / #126.

## Question

Do we actually need a canonical `EvidenceRole` field to keep decision-changing information visible in terse output, or can producers already promote important material into existing `Claim` / `question` primitives?

## Controls

The integration fixture uses the actual merged `render_terse_analysis_report` and compares three hidden-vs-explicit representations.

### Coverage boundary

Hidden form:

```text
PROVEN target test passed
  evidence: execution covered Linux only
```

Explicit existing-primitives form:

```text
PROVEN target test passed
UNKNOWN cross-platform coverage is not established
```

The current terse renderer drops the hidden evidence but retains the explicit UNKNOWN.

### Counterexample

Hidden form keeps the matching reviewed exception inside generic Evidence.

Explicit form promotes it to a second OBSERVED claim. The current terse renderer retains it.

### Clearing step

Blocked form contains only the UNKNOWN. The explicit form uses the existing finding `question` field:

```text
Q Run exact target execution at HEAD?
```

The current terse renderer retains the question.

## What a positive result would mean

It would weaken the naive conclusion from #126:

```text
"we need EvidenceRole in the canonical report"
```

into the narrower result:

```text
"decision-changing information must be represented above generic receipt prose before lossy projection"
```

The remaining question would be whether existing Claim/question semantics are precise enough for machine consumers, or whether a smaller typed boundary/frontier vocabulary is still earned.

## Boundary

- test-only research fixture;
- no production schema/renderer changes;
- no claim that an OBSERVED counterexample claim carries an explicit `counterexample` role;
- no claim that free-text questions are a final machine action protocol;
- this is deliberately an alternative hypothesis to the role enum, not another proposal layered on top.

Refs #106 #109 #115 #119 #121 #125 #126.