### PR TITLE
research: prove compact envelopes need ambient context binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 syn = { version = "2.0", features = ["full", "visit"] }
 walkdir = "2.5"
+
+[dev-dependencies]
+sha2 = "0.11"

--- a/examples/report_fingerprint.rs
+++ b/examples/report_fingerprint.rs
@@ -1,0 +1,42 @@
+#![allow(dead_code)]
+
+#[path = "../src/compact_ir.rs"]
+mod compact_ir;
+#[path = "../src/finding.rs"]
+mod finding;
+#[path = "../src/report_fingerprint.rs"]
+mod report_fingerprint;
+
+use std::error::Error;
+use std::io::{self, Read};
+
+use compact_ir::MAX_C1_BYTES;
+use finding::AnalysisReport;
+use report_fingerprint::fingerprint_report;
+
+const MAX_JSON_INPUT_BYTES: usize = MAX_C1_BYTES * 2;
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("report-fingerprint: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_JSON_INPUT_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_JSON_INPUT_BYTES {
+        return Err(format!(
+            "report JSON exceeds the {MAX_JSON_INPUT_BYTES}-byte research input limit"
+        )
+        .into());
+    }
+
+    let input = String::from_utf8(bytes)?;
+    let report: AnalysisReport = serde_json::from_str(&input)?;
+    println!("{}", fingerprint_report(&report)?);
+    Ok(())
+}

--- a/src/report_fingerprint.rs
+++ b/src/report_fingerprint.rs
@@ -31,11 +31,12 @@ impl FromStr for ReportFingerprint {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let expected_prefix = format!("{REPORT_FINGERPRINT_SCHEME}:");
-        let digest = value
-            .strip_prefix(&expected_prefix)
-            .ok_or(ReportFingerprintError::InvalidFormat(
-                "unsupported report fingerprint scheme",
-            ))?;
+        let digest =
+            value
+                .strip_prefix(&expected_prefix)
+                .ok_or(ReportFingerprintError::InvalidFormat(
+                    "unsupported report fingerprint scheme",
+                ))?;
 
         if digest.len() != SHA256_HEX_BYTES {
             return Err(ReportFingerprintError::InvalidFormat(
@@ -132,9 +133,7 @@ fn hex_digit(nibble: u8) -> char {
 mod tests {
     use super::*;
     use crate::compact_ir::decode_report;
-    use crate::finding::{
-        Claim, ClaimKind, Evidence, Finding, Location, REPORT_SCHEMA_VERSION,
-    };
+    use crate::finding::{Claim, ClaimKind, Evidence, Finding, Location, REPORT_SCHEMA_VERSION};
 
     fn small_report() -> AnalysisReport {
         AnalysisReport {
@@ -163,11 +162,9 @@ mod tests {
                             .with_evidence(Evidence::new("github:pull/10")),
                     )
                     .with_question("Coordinate ownership?"),
-                Finding::new("explicit-coordination", "Explicit coordination")
-                    .with_claim(Claim::new(
-                        ClaimKind::Observed,
-                        "hold_merge_while #10 > #11",
-                    )),
+                Finding::new("explicit-coordination", "Explicit coordination").with_claim(
+                    Claim::new(ClaimKind::Observed, "hold_merge_while #10 > #11"),
+                ),
             ],
         }
     }
@@ -235,9 +232,7 @@ mod tests {
         claim.findings[0].claims[0].message.push('!');
 
         let mut evidence = report.clone();
-        evidence.findings[0].claims[0].evidence[0]
-            .message
-            .push('!');
+        evidence.findings[0].claims[0].evidence[0].message.push('!');
 
         let mut question = report.clone();
         question.findings[0].question = Some("Different question?".to_string());

--- a/src/report_fingerprint.rs
+++ b/src/report_fingerprint.rs
@@ -1,0 +1,296 @@
+use std::error::Error;
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use sha2::{Digest, Sha256};
+
+use crate::compact_ir::{CompactError, encode_report};
+use crate::finding::AnalysisReport;
+
+pub const REPORT_FINGERPRINT_SCHEME: &str = "cultist-report-c1-sha256-v1";
+const SHA256_HEX_BYTES: usize = 64;
+
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub struct ReportFingerprint(String);
+
+impl ReportFingerprint {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ReportFingerprint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl FromStr for ReportFingerprint {
+    type Err = ReportFingerprintError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let expected_prefix = format!("{REPORT_FINGERPRINT_SCHEME}:");
+        let digest = value
+            .strip_prefix(&expected_prefix)
+            .ok_or(ReportFingerprintError::InvalidFormat(
+                "unsupported report fingerprint scheme",
+            ))?;
+
+        if digest.len() != SHA256_HEX_BYTES {
+            return Err(ReportFingerprintError::InvalidFormat(
+                "SHA-256 report fingerprint must contain exactly 64 hex characters",
+            ));
+        }
+        if !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(ReportFingerprintError::InvalidFormat(
+                "report fingerprint digest must use lowercase hexadecimal",
+            ));
+        }
+
+        Ok(Self(value.to_string()))
+    }
+}
+
+impl Serialize for ReportFingerprint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ReportFingerprint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        value.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug)]
+pub enum ReportFingerprintError {
+    Compact(CompactError),
+    InvalidFormat(&'static str),
+}
+
+impl fmt::Display for ReportFingerprintError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Compact(error) => write!(formatter, "cannot fingerprint report: {error}"),
+            Self::InvalidFormat(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl Error for ReportFingerprintError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Compact(error) => Some(error),
+            Self::InvalidFormat(_) => None,
+        }
+    }
+}
+
+impl From<CompactError> for ReportFingerprintError {
+    fn from(error: CompactError) -> Self {
+        Self::Compact(error)
+    }
+}
+
+pub fn fingerprint_report(
+    report: &AnalysisReport,
+) -> Result<ReportFingerprint, ReportFingerprintError> {
+    let canonical_c1 = encode_report(report)?;
+    let digest = Sha256::digest(canonical_c1.as_bytes());
+    let mut hex = String::with_capacity(SHA256_HEX_BYTES);
+    for byte in digest {
+        hex.push(hex_digit(byte >> 4));
+        hex.push(hex_digit(byte & 0x0f));
+    }
+
+    Ok(ReportFingerprint(format!(
+        "{REPORT_FINGERPRINT_SCHEME}:{hex}"
+    )))
+}
+
+fn hex_digit(nibble: u8) -> char {
+    match nibble {
+        0..=9 => char::from(b'0' + nibble),
+        10..=15 => char::from(b'a' + (nibble - 10)),
+        _ => unreachable!("nibble is masked to four bits"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compact_ir::decode_report;
+    use crate::finding::{
+        Claim, ClaimKind, Evidence, Finding, Location, REPORT_SCHEMA_VERSION,
+    };
+
+    fn small_report() -> AnalysisReport {
+        AnalysisReport {
+            schema_version: REPORT_SCHEMA_VERSION,
+            analysis: "a".to_string(),
+            repository: "r".to_string(),
+            claims: vec![Claim::new(ClaimKind::Observed, "m")],
+            findings: Vec::new(),
+        }
+    }
+
+    fn representative_report() -> AnalysisReport {
+        AnalysisReport {
+            schema_version: REPORT_SCHEMA_VERSION,
+            analysis: "preflight-inventory".to_string(),
+            repository: "/repo".to_string(),
+            claims: vec![Claim::new(
+                ClaimKind::Unknown,
+                "semantic independence is unresolved",
+            )],
+            findings: vec![
+                Finding::new("direct-overlap", "Direct path overlap")
+                    .at(Location::new("src/auth.rs", Some(12)))
+                    .with_claim(
+                        Claim::new(ClaimKind::Proven, "both work items modify src/auth.rs")
+                            .with_evidence(Evidence::new("github:pull/10")),
+                    )
+                    .with_question("Coordinate ownership?"),
+                Finding::new("explicit-coordination", "Explicit coordination")
+                    .with_claim(Claim::new(
+                        ClaimKind::Observed,
+                        "hold_merge_while #10 > #11",
+                    )),
+            ],
+        }
+    }
+
+    #[test]
+    fn exact_small_report_has_stable_known_fingerprint() {
+        let fingerprint = fingerprint_report(&small_report()).unwrap();
+        assert_eq!(
+            fingerprint.as_str(),
+            "cultist-report-c1-sha256-v1:6f26b3b5673e76878bc3f0d575d8a8347543920cd50c3a92b5eb18d23c0dbfa6"
+        );
+    }
+
+    #[test]
+    fn repeated_fingerprints_are_identical() {
+        let report = representative_report();
+        assert_eq!(
+            fingerprint_report(&report).unwrap(),
+            fingerprint_report(&report).unwrap()
+        );
+    }
+
+    #[test]
+    fn json_formatting_does_not_change_typed_report_fingerprint() {
+        let report = representative_report();
+        let minified = serde_json::to_string(&report).unwrap();
+        let pretty = serde_json::to_string_pretty(&report).unwrap();
+        assert_ne!(minified, pretty);
+
+        let from_minified: AnalysisReport = serde_json::from_str(&minified).unwrap();
+        let from_pretty: AnalysisReport = serde_json::from_str(&pretty).unwrap();
+        assert_eq!(
+            fingerprint_report(&from_minified).unwrap(),
+            fingerprint_report(&from_pretty).unwrap()
+        );
+    }
+
+    #[test]
+    fn c1_round_trip_preserves_fingerprint() {
+        let report = representative_report();
+        let c1 = encode_report(&report).unwrap();
+        let decoded = decode_report(&c1).unwrap();
+        assert_eq!(
+            fingerprint_report(&report).unwrap(),
+            fingerprint_report(&decoded).unwrap()
+        );
+    }
+
+    #[test]
+    fn finding_reorder_changes_exact_snapshot_fingerprint() {
+        let report = representative_report();
+        let mut reordered = report.clone();
+        reordered.findings.reverse();
+        assert_ne!(
+            fingerprint_report(&report).unwrap(),
+            fingerprint_report(&reordered).unwrap()
+        );
+    }
+
+    #[test]
+    fn semantic_snapshot_mutations_change_fingerprint() {
+        let report = representative_report();
+
+        let mut claim = report.clone();
+        claim.findings[0].claims[0].message.push('!');
+
+        let mut evidence = report.clone();
+        evidence.findings[0].claims[0].evidence[0]
+            .message
+            .push('!');
+
+        let mut question = report.clone();
+        question.findings[0].question = Some("Different question?".to_string());
+
+        let mut location = report.clone();
+        location.findings[0].location.as_mut().unwrap().line = Some(13);
+
+        let baseline = fingerprint_report(&report).unwrap();
+        for changed in [claim, evidence, question, location] {
+            assert_ne!(baseline, fingerprint_report(&changed).unwrap());
+        }
+    }
+
+    #[test]
+    fn unsupported_report_schema_rejects_before_hashing() {
+        let mut report = small_report();
+        report.schema_version += 1;
+        assert!(matches!(
+            fingerprint_report(&report),
+            Err(ReportFingerprintError::Compact(_))
+        ));
+    }
+
+    #[test]
+    fn fingerprint_text_parser_fails_closed() {
+        let valid = fingerprint_report(&small_report()).unwrap();
+        assert_eq!(valid.as_str().parse::<ReportFingerprint>().unwrap(), valid);
+
+        let wrong_scheme = valid.as_str().replacen(
+            REPORT_FINGERPRINT_SCHEME,
+            "cultist-report-json-sha256-v1",
+            1,
+        );
+        assert!(wrong_scheme.parse::<ReportFingerprint>().is_err());
+
+        let short = format!("{REPORT_FINGERPRINT_SCHEME}:abcd");
+        assert!(short.parse::<ReportFingerprint>().is_err());
+
+        let uppercase = valid.as_str().to_ascii_uppercase();
+        assert!(uppercase.parse::<ReportFingerprint>().is_err());
+
+        let non_hex = format!("{REPORT_FINGERPRINT_SCHEME}:{}g", "0".repeat(63));
+        assert!(non_hex.parse::<ReportFingerprint>().is_err());
+    }
+
+    #[test]
+    fn fingerprint_serde_revalidates_wire_value() {
+        let fingerprint = fingerprint_report(&small_report()).unwrap();
+        let json = serde_json::to_string(&fingerprint).unwrap();
+        let decoded: ReportFingerprint = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, fingerprint);
+
+        let invalid = format!("\"{REPORT_FINGERPRINT_SCHEME}:abcd\"");
+        assert!(serde_json::from_str::<ReportFingerprint>(&invalid).is_err());
+    }
+}

--- a/tests/ambient_context_binding.rs
+++ b/tests/ambient_context_binding.rs
@@ -1,0 +1,222 @@
+#[allow(dead_code)]
+#[path = "../src/compact_ir.rs"]
+mod compact_ir;
+#[allow(dead_code)]
+#[path = "../src/finding.rs"]
+mod finding;
+#[allow(dead_code)]
+#[path = "../src/report_fingerprint.rs"]
+mod report_fingerprint;
+
+use finding::{AnalysisReport, Claim, ClaimKind, REPORT_SCHEMA_VERSION};
+use report_fingerprint::{ReportFingerprint, fingerprint_report};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct AmbientContext<'a> {
+    repository: Option<&'a str>,
+    revision: Option<&'a str>,
+    task: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct ContextRequirements {
+    repository: bool,
+    revision: bool,
+    task: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct BoundEnvelopeIdentity {
+    report: ReportFingerprint,
+    repository: Option<String>,
+    revision: Option<String>,
+    task: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum BindError {
+    MissingRepository,
+    MissingRevision,
+    MissingTask,
+}
+
+fn bind_context(
+    report: &AnalysisReport,
+    context: AmbientContext<'_>,
+    requirements: ContextRequirements,
+) -> Result<BoundEnvelopeIdentity, BindError> {
+    let repository = required_value(
+        context.repository,
+        requirements.repository,
+        BindError::MissingRepository,
+    )?;
+    let revision = required_value(
+        context.revision,
+        requirements.revision,
+        BindError::MissingRevision,
+    )?;
+    let task = required_value(context.task, requirements.task, BindError::MissingTask)?;
+
+    Ok(BoundEnvelopeIdentity {
+        report: fingerprint_report(report).expect("research fixture report should fingerprint"),
+        repository,
+        revision,
+        task,
+    })
+}
+
+fn required_value(
+    value: Option<&str>,
+    required: bool,
+    missing: BindError,
+) -> Result<Option<String>, BindError> {
+    if required {
+        return value.map(|value| Some(value.to_string())).ok_or(missing);
+    }
+    Ok(None)
+}
+
+fn report_without_revision_semantics() -> AnalysisReport {
+    AnalysisReport {
+        schema_version: REPORT_SCHEMA_VERSION,
+        analysis: "context-binding-research".to_string(),
+        repository: "teamleaderleo/cultist".to_string(),
+        claims: vec![Claim::new(
+            ClaimKind::Observed,
+            "the selected local convention is `tests`",
+        )],
+        findings: Vec::new(),
+    }
+}
+
+#[test]
+fn report_fingerprint_does_not_change_when_only_external_revision_moves() {
+    let report = report_without_revision_semantics();
+    let before = AmbientContext {
+        repository: Some("teamleaderleo/cultist"),
+        revision: Some("aaaaaaaa"),
+        task: Some("T1"),
+    };
+    let after = AmbientContext {
+        revision: Some("bbbbbbbb"),
+        ..before
+    };
+
+    assert_ne!(before, after);
+    assert_eq!(
+        fingerprint_report(&report).unwrap(),
+        fingerprint_report(&report).unwrap()
+    );
+}
+
+#[test]
+fn requiring_revision_makes_the_bound_identity_change_when_head_moves() {
+    let report = report_without_revision_semantics();
+    let requirements = ContextRequirements {
+        repository: true,
+        revision: true,
+        task: false,
+    };
+    let before = bind_context(
+        &report,
+        AmbientContext {
+            repository: Some("teamleaderleo/cultist"),
+            revision: Some("aaaaaaaa"),
+            task: Some("T1"),
+        },
+        requirements,
+    )
+    .unwrap();
+    let after = bind_context(
+        &report,
+        AmbientContext {
+            repository: Some("teamleaderleo/cultist"),
+            revision: Some("bbbbbbbb"),
+            task: Some("T1"),
+        },
+        requirements,
+    )
+    .unwrap();
+
+    assert_eq!(before.report, after.report);
+    assert_ne!(before, after);
+    assert_ne!(before.revision, after.revision);
+}
+
+#[test]
+fn missing_required_revision_fails_closed_instead_of_guessing_from_ambient_state() {
+    let report = report_without_revision_semantics();
+    let result = bind_context(
+        &report,
+        AmbientContext {
+            repository: Some("teamleaderleo/cultist"),
+            revision: None,
+            task: Some("T1"),
+        },
+        ContextRequirements {
+            repository: true,
+            revision: true,
+            task: false,
+        },
+    );
+
+    assert_eq!(result, Err(BindError::MissingRevision));
+}
+
+#[test]
+fn unrequired_context_dimensions_do_not_pollute_the_bound_identity() {
+    let report = report_without_revision_semantics();
+    let requirements = ContextRequirements {
+        repository: true,
+        revision: false,
+        task: false,
+    };
+    let first = bind_context(
+        &report,
+        AmbientContext {
+            repository: Some("teamleaderleo/cultist"),
+            revision: Some("aaaaaaaa"),
+            task: Some("T1"),
+        },
+        requirements,
+    )
+    .unwrap();
+    let second = bind_context(
+        &report,
+        AmbientContext {
+            repository: Some("teamleaderleo/cultist"),
+            revision: Some("bbbbbbbb"),
+            task: Some("T2"),
+        },
+        requirements,
+    )
+    .unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(first.revision, None);
+    assert_eq!(first.task, None);
+}
+
+#[test]
+fn report_snapshot_identity_and_context_identity_remain_separate_values() {
+    let report = report_without_revision_semantics();
+    let bound = bind_context(
+        &report,
+        AmbientContext {
+            repository: Some("teamleaderleo/cultist"),
+            revision: Some("aaaaaaaa"),
+            task: Some("T1"),
+        },
+        ContextRequirements {
+            repository: true,
+            revision: true,
+            task: true,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(bound.report, fingerprint_report(&report).unwrap());
+    assert_eq!(bound.repository.as_deref(), Some("teamleaderleo/cultist"));
+    assert_eq!(bound.revision.as_deref(), Some("aaaaaaaa"));
+    assert_eq!(bound.task.as_deref(), Some("T1"));
+}

--- a/tests/report_fingerprint.rs
+++ b/tests/report_fingerprint.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 
-#[path = "../src/finding.rs"]
-mod finding;
 #[path = "../src/compact_ir.rs"]
 mod compact_ir;
+#[path = "../src/finding.rs"]
+mod finding;
 #[path = "../src/report_fingerprint.rs"]
 mod report_fingerprint;

--- a/tests/report_fingerprint.rs
+++ b/tests/report_fingerprint.rs
@@ -1,0 +1,8 @@
+#![allow(dead_code)]
+
+#[path = "../src/finding.rs"]
+mod finding;
+#[path = "../src/compact_ir.rs"]
+mod compact_ir;
+#[path = "../src/report_fingerprint.rs"]
+mod report_fingerprint;


### PR DESCRIPTION
Starts #134 as a stacked research control on top of #131.

## Question

Does an exact `AnalysisReport` fingerprint also prove that the receiver is using the report in the same repository/revision/task context?

No. This fixture makes that boundary executable.

## Real fingerprint + external context

The test imports the actual #131 C1/SHA-256 report fingerprint implementation.

It constructs one report whose typed semantics do not contain a Git revision, then evaluates it under two external contexts:

```text
repo teamleaderleo/cultist
revision aaaaaaaa
```

and:

```text
repo teamleaderleo/cultist
revision bbbbbbbb
```

The report fingerprint remains identical because the report bytes/semantics are identical.

A tiny test-local `BoundEnvelopeIdentity` then binds only context dimensions declared required by the consumer. Requiring revision makes the two bound identities differ; omitting required revision fails with `MissingRevision` instead of guessing.

## Negative-overbinding control

When the fixture requires only repository identity, changes to revision/task are deliberately absent from the bound identity and do not change it. This tests the JEI side too: do not force every possible context coordinate into every message.

## What this proves if green

```text
report fingerprint
  != repository-state freshness
```

and:

```text
relative terse shorthand is safe only inside an envelope/session that proves the context dimensions required for that use
```

## Boundary

- test-only outer binding model;
- no production envelope grammar/hash;
- no duplicate applicability evaluator;
- no claim that every report requires revision/task/provider coordinates;
- semantic lineage remains separate from report snapshot and ambient context identity.

This PR is stacked on `research/c1-report-fingerprint`; it should be rebased/retargeted if #131 lands.

Refs #115 #119 #123 #127 #131 #134.