### PR TITLE
product: foreground decision-changing evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ Useful signals include:
 - a historical reason that had to be reconstructed manually;
 - a useful counterexample that weakens an existing heuristic;
 - an analyzer finding that was noisy, overconfident, incomplete, or missing an important `UNKNOWN`;
+- a surfaced finding that changed the next inspection, validation, coordination, or implementation step;
+- a surfaced finding that consumed attention and changed nothing;
 - repeated investigation that could become a deterministic probe;
 - a reviewed lesson that future agents would benefit from seeing before making the same edit.
 
@@ -42,15 +44,35 @@ When proposing a Cultist improvement from dogfood:
 
 A successful task can still expose a product problem. A failed task can still produce useful evidence. Neither automatically proves a general rule.
 
+## Dogfood the interruption
+
+When Cultist or repository evidence surfaces something during real work, preserve the consequence when it is observable. A small receipt can classify the episode without inventing a universal score:
+
+```text
+surfaced -> consulted -> changed next action
+surfaced -> consulted -> prevented/reversed a wrong turn
+surfaced -> useful context, same action
+surfaced -> ignored
+surfaced -> irrelevant
+surfaced -> stale / wrong coordinate
+surfaced -> needed stronger evidence
+candidate evidence stayed quiet -> correct negative
+```
+
+Record the concrete next action when one changed: another file opened, a test run, a generator invoked, a collaborator contacted, a patch changed, an assumption dropped, a decision preserved, or an investigation stopped because the missing discriminator became explicit.
+
+Issue #137 owns the behavioral product pressure test. It complements the existing research lanes. Continue useful JEI, review, applicability, decision-memory, representation, analyzer, and performance research; use these receipts to decide which evidence deserves prominent automatic delivery and which belongs in quieter or explicit-query views.
+
 ## Compose views instead of inventing competing truths
 
 Cultist has several agent-facing research views over shared repository evidence. Treat them as different jobs unless evidence proves otherwise:
 
-- lifecycle work (`brief -> diff -> teach`) asks **when** evidence should be recovered or preserved;
+- lifecycle work (`brief -> check/diff -> teach`) asks **when** evidence should be recovered or preserved;
 - just-enough-information work asks **what** evidence is worth selecting for the current task;
 - review intelligence asks **where** reviewer attention should go;
 - compact IR / C1 research asks **how** evidence should be represented or transmitted;
-- decision memory asks **what reviewed rationale should survive** for later work.
+- decision memory asks **what reviewed rationale should survive** for later work;
+- behavioral evaluation asks **whether surfaced evidence changed justified worker behavior enough to earn the interruption**.
 
 Do not create a new authority/provenance/unknown/freshness vocabulary merely because a new projection needs those facts. Prefer shared evidence primitives plus a task-specific projection.
 
@@ -69,10 +91,12 @@ Avoid unrelated implementation expansion merely because an idea occurred during 
 
 ## Agent-facing product test
 
-A recurring question for work in this repository is:
+Recurring questions for work in this repository are:
 
 > What did this task force the worker to discover manually that Cultist could have surfaced, bounded, or preserved for the next worker?
 
-If the answer is meaningful, treat the task as dogfood evidence and carry the lesson forward with provenance.
+> Which surfaced evidence changed the next justified inspection, validation, coordination, implementation, or preservation step?
 
-The goal is a repository that becomes easier to work in because prior workers leave behind earned, inspectable knowledge—not because later workers inherit their conversations or trust their conclusions blindly.
+If either answer is meaningful, treat the task as dogfood evidence and carry the lesson forward with provenance.
+
+The goal is a repository that becomes easier to work in because prior workers leave behind earned, inspectable knowledge and because current workers receive the evidence that earns their attention at the moment it can still change the work.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Cultist is an experiment in repository-aware evidence for software work: recover deterministic facts, keep provenance and counterexamples visible, and ask useful questions before inventing project rules.
 
+A second product test is increasingly important: **does the selected evidence change the next justified action, prevent an expensive wrong turn, or spare a later worker from repeating manual investigation?** Issue #137 tracks that behavioral pressure test while the existing JEI, review, decision-memory, applicability, representation, and analyzer research continues in parallel.
+
 > Status: early prototype. The current Rust distribution is named `cargo-cultist`; its public analyzer commands are deterministic, local, and read-only. Remote/project adapters that build evidence inventories live outside the core analyzer boundary.
 
 Rust is the first deep semantic adapter, not the product boundary. Several useful primitives are repository-generic already: Git history, claim provenance, concurrent-change preflight, active-work inventories, and repo-local decision-memory research.
@@ -17,6 +19,7 @@ Traditional linters are strongest after a rule is known. Cultist starts earlier.
 - Is another current change touching the same repository surface?
 - Why does this exception or guard exist?
 - What lesson from this completed work should be recoverable by the next worker?
+- Which current evidence changes what I should inspect, validate, coordinate, or preserve next?
 
 The core claim vocabulary is:
 
@@ -41,14 +44,19 @@ cargo cultist
 cargo cultist --format json
 ```
 
-### Diff-aware precedent
+### Change-time evidence
 
-`cargo cultist diff` analyzes the current change and applies supported change-time evidence such as Rust test-module precedent and generated-companion evidence.
+`cargo cultist check` and `cargo cultist diff` run the same existing change analyzer. `check` is a task-oriented alias; `diff` remains available for compatibility and for callers that prefer the exact underlying concept.
+
+The analyzer applies supported change-time evidence such as Rust test-module precedent and generated-companion evidence.
 
 ```bash
+cargo cultist check
+cargo cultist check --base origin/main
+cargo cultist check --base origin/main --format json
+
 cargo cultist diff
 cargo cultist diff --base origin/main
-cargo cultist diff --base origin/main --format json
 ```
 
 With `--base REV`, Cultist uses the merge base while still including local staged and unstaged work. Changed-file parse failures remain explicit uncertainty instead of becoming false absence claims.
@@ -117,6 +125,9 @@ C1 / compact IR (#113, #115)
 
 decision memory (#10 and research)
   -> WHAT reviewed rationale should survive for later workers?
+
+behavioral product pressure (#137)
+  -> DID the selected evidence change the next justified action or reduce rediscovery?
 ```
 
 A new view should reuse authority, provenance, freshness, counterexample, unknown, and omission semantics rather than inventing a parallel vocabulary merely because its output layout is different.
@@ -128,6 +139,8 @@ Research under #62 asks the pre-edit question:
 > What repository evidence would I regret missing before I modify this target?
 
 The packet work emphasizes bounded defaults, truncation receipts, explicit guidance, history, companions/counterexamples, decisions, and useful `UNKNOWN`s rather than giant repository summaries.
+
+The next complementary gate is behavioral: compare fresh workers with and without the selected packet and record whether evidence is consulted earlier, changes a decision, prevents a repeated failed approach, or only consumes attention.
 
 ### Compact C1 evidence grammar
 
@@ -153,7 +166,7 @@ BEFORE
   recover bounded evidence for the target
 
 DURING
-  reconcile the live diff with precedent, guidance, active work,
+  reconcile the live change with check/diff, precedent, guidance, active work,
   counterexamples, decisions, trust boundaries, and unknowns
 
 AFTER
@@ -169,7 +182,7 @@ Or more compactly:
 retrieve -> work -> reconcile -> preserve -> retrieve
 ```
 
-The product goal is not to make an agent understand Cultist as a separate ceremony. A worker should be able to ask for the evidence it needs, do the work, and leave useful reviewed knowledge behind.
+The product goal is to make Cultist fade into the work itself. A worker should be able to ask for the evidence it needs, do the work, and leave useful reviewed knowledge behind. The most prominent automatic evidence should earn its interruption by changing inspection, validation, coordination, or preservation behavior often enough to justify the attention cost.
 
 ## Research discipline
 
@@ -188,10 +201,23 @@ Some research examples intentionally execute repository tooling. Those effectful
 
 A successful experiment does not automatically become a lint or public feature. Failed experiments are retained when they expose a useful boundary.
 
+Behavioral evidence adds another useful promotion question:
+
+```text
+surfaced
+-> consulted?
+-> changed the next action?
+-> prevented or reversed a wrong turn?
+-> ignored / irrelevant / stale / needed stronger evidence?
+```
+
+This is an inspectable scorecard, not a single opaque risk or quality number.
+
 ## Usage while developing
 
 ```bash
 cargo run -- /path/to/a/rust/repository
+cargo run -- check --base origin/main /path/to/a/rust/repository
 cargo run -- diff --base origin/main /path/to/a/rust/repository
 cargo run -- preflight --against some-ref /path/to/a/repository
 cargo run -- preflight --inventory /path/to/active-work.json /path/to/a/repository
@@ -205,6 +231,7 @@ After installing locally:
 cargo install --path .
 cd /path/to/a/repository
 cargo cultist
+cargo cultist check
 cargo cultist diff
 cargo cultist preflight --against other-ref
 cargo cultist history src/file.rs
@@ -219,6 +246,8 @@ CI runs formatting, Clippy, tests, and the public analyzers against Cultist itse
 
 Dogfood is product input. When work exposes duplicate effort, a missed repository fact, stale evidence, misleading metadata, a false assumption, a useful counterexample, or repeated manual investigation, preserve the exact evidence and ask whether the smallest useful Cultist improvement can surface it earlier next time.
 
+Also record the downstream consequence when it is visible: did the evidence change the next inspection, validation step, coordination decision, or implementation? Did the worker ignore it? Did a natural quiet case remain quiet? Those receipts help decide which evidence families deserve automatic delivery.
+
 Do not turn task friction into a universal rule without a discriminator and negative control.
 
 ## Current direction
@@ -226,6 +255,7 @@ Do not turn task friction into a universal rule without a discriminator and nega
 Near-term work is increasingly about composing independent evidence instead of adding broad opaque heuristics:
 
 - bounded pre-edit JEI and lifecycle integration;
+- behavioral A/B evaluation of selected evidence across held-out tasks (#137);
 - review-attention projections over the same evidence;
 - active-change coordination with explicit identity/freshness boundaries;
 - decision-memory authority/applicability research;
@@ -233,6 +263,7 @@ Near-term work is increasingly about composing independent evidence instead of a
 - explicit repository guidance and instruction freshness;
 - compact interoperable machine representations;
 - performance work proportional to the evidence actually needed;
+- promotion, demotion, or quieting of evidence families based on inspectable interruption outcomes;
 - promotion of repeated, well-understood consensus into deterministic policy.
 
 Optional model-assisted explanation can sit on top of bounded evidence later. The deterministic evidence packet must remain useful without a model.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,6 +26,35 @@ deterministic facts
 
 The primitive is a **finding**, not an error. A good finding says what the repository evidence shows, what it does not establish, and why a worker may want to look.
 
+## Product pressure test
+
+Issue #137 adds a behavioral lens across the existing research program:
+
+> Does selected Cultist evidence change the next justified action, prevent an expensive wrong turn, or reduce important repository knowledge that a later worker has to rediscover manually?
+
+This complements provenance and precision rather than replacing them. A finding can be epistemically careful and still cost attention without changing a decision. Another finding can justify its interruption repeatedly by sending workers toward a missing validation step, active collaborator, reviewed decision, generated output, or decisive counterexample.
+
+Useful behavioral receipts include:
+
+```text
+surfaced
+-> consulted
+-> next inspection / validation / coordination / implementation changed
+-> wrong turn prevented or reversed
+```
+
+and quiet/negative outcomes such as:
+
+```text
+surfaced -> ignored
+surfaced -> irrelevant
+surfaced -> stale before action
+surfaced -> needed stronger evidence
+candidate evidence suppressed -> quiet case stayed quiet
+```
+
+These receipts should remain inspectable. Cultist does not need one universal actionability score.
+
 ## Agent work loop
 
 The newer agent-facing work composes those primitives across time:
@@ -36,7 +65,7 @@ BEFORE CODE
   recover the evidence most likely to matter before the edit
 
 DURING CODE
-  diff / preflight / evidence queries
+  check / diff / preflight / evidence queries
   reconcile live work with repository precedent, guidance,
   active changes, decisions, counterexamples, and unknowns
 
@@ -54,7 +83,7 @@ Compact form:
 retrieve -> work -> reconcile -> preserve -> retrieve
 ```
 
-Lifecycle composition is tracked in #74. Bounded pre-edit context work is tracked in #62.
+Lifecycle composition is tracked in #74. Bounded pre-edit context work is tracked in #62. Behavioral evaluation is tracked in #137.
 
 ## Different views, shared evidence
 
@@ -62,7 +91,7 @@ Several research directions answer different questions. They should compose rath
 
 ### Lifecycle: when?
 
-`brief -> diff -> teach` asks **when** evidence should be recovered, reconciled, and preserved.
+`brief -> check/diff -> teach` asks **when** evidence should be recovered, reconciled, and preserved.
 
 Tracking: #74, #62, #10.
 
@@ -93,6 +122,14 @@ Tracking: #113, #115.
 Decision-memory work asks **what reviewed rationale should remain recoverable** after the original task and conversation are gone.
 
 Tracking: #10 plus decision-memory research under #75.
+
+### Behavioral product pressure: did it help?
+
+Behavioral evaluation asks **whether the selected evidence changed the worker's justified behavior enough to earn its attention cost**.
+
+The first important comparison is held-out work with and without selected Cultist evidence while repository/task state stays equivalent. Record first relevant inspection, irrelevant expansion, known failed approaches, validation choices, coordination choices, and completion outcome.
+
+Tracking: #137, #16.
 
 A new projection should not invent a second provenance, authority, freshness, counterexample, unknown, or omission vocabulary merely because its layout differs.
 
@@ -136,6 +173,14 @@ This boundary is especially important for project-memory and coordination adapte
 
 If the repository cannot recover why an important-looking workaround, exception, stale branch, or metadata claim exists, say so instead of fabricating intent.
 
+### Earn the interruption
+
+Automatic evidence should increasingly justify the attention it consumes. High-value families repeatedly change inspection, validation, coordination, or preservation behavior. Lower-value observations can remain available through explicit queries, research views, or quieter projections.
+
+The action relevance of a finding is separate from its epistemic claim kind. A `PROVEN` fact can still be irrelevant to the current decision; an `UNKNOWN` can be highly actionable when it identifies the missing discriminator blocking safe progress.
+
+Tracking: #137, #109.
+
 ### Keep the core deterministic and bounded
 
 Model-assisted explanation may help interpret selected evidence, but the deterministic evidence packet must remain useful without a model. Remote/provider integrations should produce explicit bounded artifacts that local analyzers can validate.
@@ -156,9 +201,9 @@ Tracking: #11.
 
 ### Learn from the work itself
 
-Cultist development is part of the evaluation corpus. Duplicate work, stale evidence, failed experiments, noisy findings, metadata mismatch, and repeated manual archaeology are candidate product evidence.
+Cultist development is part of the evaluation corpus. Duplicate work, stale evidence, failed experiments, noisy findings, metadata mismatch, repeated manual archaeology, and action-changing findings are candidate product evidence.
 
-Workers should preserve the exact episode, test the generalization, and use the smallest appropriate durable follow-up. See `AGENTS.md`.
+Workers should preserve the exact episode, test the generalization, record the downstream consequence when observable, and use the smallest appropriate durable follow-up. See `AGENTS.md`.
 
 ## Workstreams
 
@@ -205,8 +250,9 @@ Current product supports local ref comparison and bounded active-work inventorie
 - #74 — before/during/after lifecycle
 - #106 — JEI work envelopes
 - #109 — review intelligence envelopes
+- #137 — behavioral decision-changing evidence evaluation
 
-The goal is evidence selected for the current decision, not giant repository summaries.
+The goal is evidence selected for the current decision, not giant repository summaries. Behavioral replays should test whether the selection changes investigation or action usefully.
 
 ### 6. Machine protocols and interoperability
 
@@ -229,16 +275,17 @@ Work should be proportional to the evidence actually needed. Cheap irrelevant pa
 
 - #16 — dogfood/evaluation corpus
 - #41 — Stensibly agentic organizational-history corpus
+- #137 — behavioral A/B and interruption outcomes
 - SmolRunner replay research
 
-Evaluation should include positive controls, quiet negatives, false assumptions, failed proofs, duplicate lanes, and second-order regressions—not only successful detections.
+Evaluation should include positive controls, quiet negatives, false assumptions, failed proofs, duplicate lanes, second-order regressions, and whether surfaced evidence actually changed behavior.
 
 ## Current product evidence
 
 Cultist already has executable slices of several parts of this roadmap:
 
 - provenance-bearing shared text/JSON findings;
-- changed-first diff analysis;
+- changed-first diff analysis, also exposed through the task-oriented `check` alias;
 - historical companion evidence with examples/counterexamples;
 - CI test-selector analysis;
 - generated-companion evidence;
@@ -255,21 +302,24 @@ These are evidence primitives and experiments, not a claim that the full agent l
 
 The most useful next work is composition and discrimination rather than adding broad new feature families:
 
-1. make pre-edit JEI consume the strongest already-earned evidence without becoming a context dump;
-2. connect live diff/preflight evidence to the same task envelope during work;
-3. keep review-attention output a projection over shared evidence rather than a second analyzer universe;
-4. improve explicit project-memory applicability/freshness before trusting remote prose as current intent;
-5. continue decision-memory authority research from current main after failed/stale carrier experiments;
-6. evolve compact representation only when a new semantic primitive has earned a stable contract;
-7. measure interruption/context economics and retire noisy evidence families;
-8. keep performance work proportional to evidence demand.
+1. run the #137 behavioral A/B gate on held-out tasks while #62/#106 packet work continues;
+2. make pre-edit JEI consume the strongest already-earned evidence without becoming a context dump;
+3. connect live check/diff/preflight evidence to the same task envelope during work;
+4. keep review-attention output a projection over shared evidence rather than a second analyzer universe;
+5. improve explicit project-memory applicability/freshness before trusting remote prose as current intent;
+6. continue decision-memory authority research from current main after failed/stale carrier experiments;
+7. evolve compact representation as new semantic primitives earn stable contracts;
+8. measure interruption/context economics and promote, demote, or quiet evidence families from receipts;
+9. keep performance work proportional to evidence demand.
 
 This is not a commitment to build everything in order. Small experiments that falsify an assumption are valuable, and failed carriers should be retired instead of remaining fake active work.
 
 ## Product test
 
-A useful recurring question is:
+Useful recurring questions are:
 
 > What did this worker have to discover manually that the repository could have surfaced, bounded, or preserved before the same mistake or investigation happens again?
 
-Cultist earns its place when the answer becomes progressively smaller without replacing project judgment with opaque automation.
+> Which surfaced evidence changed the next justified inspection, validation, coordination, implementation, or preservation step?
+
+Cultist earns its place as those manual rediscovery and avoidable wrong-turn burdens become progressively smaller without replacing project judgment with opaque automation.

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         args.remove(0);
     }
 
-    if args.first().is_some_and(|arg| arg == "diff") {
+    if args.first().is_some_and(|arg| is_change_command(arg)) {
         args.remove(0);
         return run_diff(args);
     }
@@ -120,6 +120,10 @@ fn run() -> Result<(), Box<dyn Error>> {
     let report = analyze_test_modules(&root)?;
     let analysis = build_test_module_analysis(&root, &report);
     emit_analysis(&analysis, format)
+}
+
+fn is_change_command(arg: &str) -> bool {
+    matches!(arg, "check" | "diff")
 }
 
 fn run_diff(args: Vec<String>) -> Result<(), Box<dyn Error>> {
@@ -470,67 +474,115 @@ fn parse_output_format(value: &str) -> Result<OutputFormat, String> {
 
 fn print_help() {
     println!(
-        "cargo-cultist {VERSION}\n\
-Repository-aware analysis for Rust codebases.\n\n\
-USAGE:\n    cargo cultist [--format text|json] [PATH]\n    cargo cultist diff [--base REV] [--format text|json] [PATH]\n    cargo cultist preflight --against REV [--format text|json] [PATH]\n    cargo cultist preflight --inventory FILE [--format text|json] [PATH]\n    cargo cultist history [--max-commits N] [--format text|json] FILE\n    cargo cultist ci-tests [--format text|json] [PATH]\n    cargo-cultist [--format text|json] [PATH]\n    cargo-cultist diff [--base REV] [--format text|json] [PATH]\n    cargo-cultist preflight --against REV [--format text|json] [PATH]\n    cargo-cultist preflight --inventory FILE [--format text|json] [PATH]\n    cargo-cultist history [--max-commits N] [--format text|json] FILE\n    cargo-cultist ci-tests [--format text|json] [PATH]\n\n\
-COMMANDS:\n    diff       Inspect changed Rust code against repository precedent.\n    preflight  Compare concurrent change sets for collision evidence.\n    history    Explore which paths historically change with one file.\n    ci-tests   Compare supported CI test filters with explicit test-name evidence.\n\n\
-Without a command, cargo-cultist inspects repository-wide test-module naming\n\
-conventions without inventing a universal rule."
+        r#"cargo-cultist {VERSION}
+Recover repository evidence that can change the next justified action.
+
+USAGE:
+    cargo cultist [--format text|json] [PATH]
+    cargo cultist check [--base REV] [--format text|json] [PATH]
+    cargo cultist diff [--base REV] [--format text|json] [PATH]
+    cargo cultist preflight --against REV [--format text|json] [PATH]
+    cargo cultist preflight --inventory FILE [--format text|json] [PATH]
+    cargo cultist history [--max-commits N] [--format text|json] FILE
+    cargo cultist ci-tests [--format text|json] [PATH]
+    cargo-cultist [--format text|json] [PATH]
+    cargo-cultist check [--base REV] [--format text|json] [PATH]
+    cargo-cultist diff [--base REV] [--format text|json] [PATH]
+    cargo-cultist preflight --against REV [--format text|json] [PATH]
+    cargo-cultist preflight --inventory FILE [--format text|json] [PATH]
+    cargo-cultist history [--max-commits N] [--format text|json] FILE
+    cargo-cultist ci-tests [--format text|json] [PATH]
+
+COMMANDS:
+    check      Inspect live work using the same analyzer and report model as diff.
+    diff       Inspect live work against repository evidence and precedent.
+    preflight  Compare concurrent change sets for collision evidence.
+    history    Explore which paths historically change with one file.
+    ci-tests   Compare supported CI test filters with explicit test-name evidence.
+
+Without a command, cargo-cultist inspects repository-wide test-module naming
+conventions without inventing a universal rule."#
     );
 }
 
 fn print_diff_help() {
     println!(
-        "cargo-cultist diff\n\n\
-USAGE:\n    cargo cultist diff [--base REV] [--format text|json] [PATH]\n\n\
-By default, compares the working tree (including staged changes) against HEAD.\n\
-With --base REV, compares changes from the merge base of REV and HEAD.\n\n\
-The first diff-aware check looks for added or renamed #[cfg(test)] modules and\n\
-compares their names with repository-wide and same-file precedent."
+        r#"cargo-cultist check / diff
+
+USAGE:
+    cargo cultist check [--base REV] [--format text|json] [PATH]
+    cargo cultist diff [--base REV] [--format text|json] [PATH]
+
+`check` and `diff` execute the same change analyzer and emit the same report.
+By default, the analyzer compares the working tree (including staged changes) against HEAD.
+With --base REV, it compares changes from the merge base of REV and HEAD.
+
+Supported evidence currently includes changed Rust test-module precedent and
+generated-companion analysis when the repository provides the required evidence."#
     );
 }
 
 fn print_preflight_help() {
     println!(
-        "cargo-cultist preflight\n\n\
-USAGE:\n    cargo cultist preflight --against REV [--format text|json] [PATH]\n    cargo cultist preflight --inventory FILE [--format text|json] [PATH]\n\n\
-With --against, compares current work with REV from their merge base and reports\n\
-direct path overlap as PROVEN collision evidence. Current work includes committed\n\
-branch changes plus staged and unstaged tracked changes.\n\n\
-With --inventory, admits one bounded local active-change JSON snapshot, compares\n\
-its recorded changed paths, and surfaces typed explicit coordination edges as\n\
-OBSERVED supplied evidence. Inventory mode performs no provider/network fetch."
+        r#"cargo-cultist preflight
+
+USAGE:
+    cargo cultist preflight --against REV [--format text|json] [PATH]
+    cargo cultist preflight --inventory FILE [--format text|json] [PATH]
+
+With --against, compares current work with REV from their merge base and reports
+direct path overlap as PROVEN collision evidence. Current work includes committed
+branch changes plus staged and unstaged tracked changes.
+
+With --inventory, admits one bounded local active-change JSON snapshot, compares
+its recorded changed paths, and surfaces typed explicit coordination edges as
+OBSERVED supplied evidence. Inventory mode performs no provider/network fetch."#
     );
 }
 
 fn print_history_help() {
     println!(
-        "cargo-cultist history\n\n\
-USAGE:\n    cargo cultist history [--max-commits N] [--format text|json] FILE\n\n\
-Explores the most recent non-merge commits touching FILE and reports which\n\
-other paths changed in the same considered commits. Revert commits and broad\n\
-commits changing more than 100 paths are excluded from the first-pass cohort.\n\n\
-This is research instrumentation for temporal and negative-space precedent.\n\
-It reports associations, examples, and counterexamples without turning\n\
-co-change frequency into a correctness claim."
+        r#"cargo-cultist history
+
+USAGE:
+    cargo cultist history [--max-commits N] [--format text|json] FILE
+
+Explores the most recent non-merge commits touching FILE and reports which
+other paths changed in the same considered commits. Revert commits and broad
+commits changing more than 100 paths are excluded from the first-pass cohort.
+
+This is research instrumentation for temporal and negative-space precedent.
+It reports associations, examples, and counterexamples without turning
+co-change frequency into a correctness claim."#
     );
 }
 
 fn print_ci_tests_help() {
     println!(
-        "cargo-cultist ci-tests\n\n\
-USAGE:\n    cargo cultist ci-tests [--format text|json] [PATH]\n\n\
-Research instrumentation for CI test-filter drift. The first slice recognizes\n\
-literal single-line `cargo [ +TOOLCHAIN ] test --lib FILTER` commands in GitHub Actions and\n\
-compares FILTER with explicit #[test] function names plus declared Rust module names.\n\n\
-A zero syntax match remains a question. Macro-generated or build-time tests\n\
-are represented as UNKNOWN until authoritative test-listing evidence exists."
+        r#"cargo-cultist ci-tests
+
+USAGE:
+    cargo cultist ci-tests [--format text|json] [PATH]
+
+Research instrumentation for CI test-filter drift. The first slice recognizes
+literal single-line `cargo [ +TOOLCHAIN ] test --lib FILTER` commands in GitHub Actions and
+compares FILTER with explicit #[test] function names plus declared Rust module names.
+
+A zero syntax match remains a question. Macro-generated or build-time tests
+are represented as UNKNOWN until authoritative test-listing evidence exists."#
     );
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recognizes_check_and_diff_as_the_same_change_command() {
+        assert!(is_change_command("check"));
+        assert!(is_change_command("diff"));
+        assert!(!is_change_command("history"));
+    }
 
     #[test]
     fn parses_diff_base_path_and_format() {


### PR DESCRIPTION
## Goal

Turn the skeptical product review into a complementary product/evaluation lens while keeping the active research program moving.

Refs #137.

## Product wording

README/roadmap/agent guidance now ask an additional question alongside provenance and precision:

> Did the selected evidence change the next justified action, prevent an expensive wrong turn, or reduce important repository knowledge the next worker would otherwise rediscover?

Dogfood receipts can record outcomes such as:

```text
surfaced -> consulted -> changed next action
surfaced -> prevented/reversed a wrong turn
surfaced -> useful context, same action
surfaced -> ignored / irrelevant / stale / needed stronger evidence
candidate evidence stayed quiet -> correct negative
```

This is intentionally an inspectable behavioral lens rather than one opaque actionability/risk score.

The docs explicitly keep JEI, review, applicability, decision-memory, representation, analyzer, and performance research active in parallel.

## `check` alias

Add:

```text
cargo cultist check [--base REV] [--format text|json] [PATH]
```

`check` is a thin alias over the existing `diff` path:

- same argument parser;
- same `build_diff_analysis_report` analyzer;
- same text/JSON report model;
- `diff` remains supported.

This gives the during-work lifecycle a task-oriented verb without creating a second analyzer or changing report semantics.

## Collaboration dogfood

This lane started from then-current main. While it was being prepared, #126 and #132 merged. Before opening this PR I:

1. detected the branch was two commits behind;
2. inspected those landed changes;
3. confirmed they only added projection/evidence-role tests;
4. rebuilt this commit on the new exact main head;
5. rechecked current open PRs (#133, #136, #138, #139) and confirmed their changed-file sets are disjoint from this lane.

The PR is therefore one commit ahead / zero behind at open time.

## Validation

The ordinary repository CI should exercise rustfmt, Clippy, full tests, repository dogfood, history/CI-test analyzers, and PR diff text/JSON. The new unit control verifies `check` and `diff` route through the same change-command discriminator.

No analyzer semantics, finding schema, or authority behavior are changed.