### PR TITLE
research: replay projection sizes on retained SmolRunner scan

### DIFF
--- a/tests/external_projection_compression.rs
+++ b/tests/external_projection_compression.rs
@@ -1,0 +1,62 @@
+#[allow(dead_code)]
+#[path = "../src/compact_ir.rs"]
+mod compact_ir;
+#[allow(dead_code)]
+#[path = "../src/finding.rs"]
+mod finding;
+#[allow(dead_code)]
+#[path = "../src/render.rs"]
+mod render;
+
+use finding::AnalysisReport;
+use render::{render_analysis_report, render_terse_analysis_report};
+
+const SMOLRUNNER_SCAN: &str = include_str!("fixtures/smolrunner_scan_ed3b70e.json");
+
+#[test]
+fn retained_smolrunner_scan_executes_the_real_projection_size_ladder() {
+    let report: AnalysisReport = serde_json::from_str(SMOLRUNNER_SCAN).unwrap();
+    assert_eq!(report.analysis, "test-module-conventions");
+    assert_eq!(report.findings.len(), 4);
+
+    let minified_json = serde_json::to_string(&report).unwrap();
+    let human = render_analysis_report(&report);
+    let c1 = compact_ir::encode_report(&report).unwrap();
+    let terse = render_terse_analysis_report(&report);
+
+    // Exact receipt for the retained external scan under the current v1
+    // report/render/C1 semantics. Changes here require deliberate remeasurement.
+    assert_eq!(SMOLRUNNER_SCAN.len(), 4037);
+    assert_eq!(minified_json.len(), 2672);
+    assert_eq!(human.len(), 1915);
+    assert_eq!(c1.len(), 1981);
+    assert_eq!(terse.len(), 957);
+
+    assert_eq!(compact_ir::decode_report(&c1).unwrap(), report);
+    assert!(c1.len() < minified_json.len());
+    assert!(terse.len() < c1.len());
+    assert!(terse.len() < human.len());
+
+    // External negative control: C1 is not universally smaller than the human
+    // renderer. Its invariant is lossless typed replay, not "fewest bytes".
+    assert!(human.len() < c1.len());
+}
+
+#[test]
+fn external_terse_projection_drops_only_expandable_receipts_in_this_fixture() {
+    let report: AnalysisReport = serde_json::from_str(SMOLRUNNER_SCAN).unwrap();
+    let terse = render_terse_analysis_report(&report);
+    let c1 = compact_ir::encode_report(&report).unwrap();
+
+    // The current external report's questions and observed claims remain visible.
+    assert!(terse.contains("F1 test-module-local-mix"));
+    assert!(terse.contains("Q Is the local mix deliberate"));
+    assert!(terse.contains("F4 test-module-one-off"));
+
+    // Provenance/support receipts stay recoverable from lossless C1 but are not
+    // retransmitted in the terse initial view.
+    assert!(!terse.contains("Repository counts:"));
+    assert!(!terse.contains("`mod publication_fault` is test-gated here."));
+    assert!(c1.contains("Repository counts:"));
+    assert!(c1.contains("`mod publication_fault` is test-gated here."));
+}

--- a/tests/fixtures/smolrunner_scan_ed3b70e.json
+++ b/tests/fixtures/smolrunner_scan_ed3b70e.json
@@ -1,0 +1,131 @@
+{
+  "schema_version": 1,
+  "analysis": "test-module-conventions",
+  "repository": "/home/runner/work/cultist/cultist/target",
+  "claims": [
+    {
+      "kind": "observed",
+      "message": "Found 130 test-gated modules across 4 distinct names.",
+      "evidence": [
+        {
+          "message": "Repository counts: `tests`=127, `clone_identity_tests`=1, `publication_fault`=1, `publication_fault_tests`=1."
+        }
+      ]
+    },
+    {
+      "kind": "observed",
+      "message": "`tests` is the most frequent test-module name (127 of 130)."
+    }
+  ],
+  "findings": [
+    {
+      "kind": "test-module-local-mix",
+      "title": "File-local test-module naming mix",
+      "location": {
+        "path": "src/unix_personal_worker_store.rs"
+      },
+      "claims": [
+        {
+          "kind": "observed",
+          "message": "This file uses 3 different names for test-gated modules: `publication_fault`, `publication_fault_tests`, `tests`.",
+          "evidence": [
+            {
+              "message": "`mod publication_fault` is test-gated here.",
+              "location": {
+                "path": "src/unix_personal_worker_store.rs",
+                "line": 35
+              }
+            },
+            {
+              "message": "`mod publication_fault_tests` is test-gated here.",
+              "location": {
+                "path": "src/unix_personal_worker_store.rs",
+                "line": 37
+              }
+            },
+            {
+              "message": "`mod tests` is test-gated here.",
+              "location": {
+                "path": "src/unix_personal_worker_store.rs",
+                "line": 1326
+              }
+            }
+          ]
+        }
+      ],
+      "question": "Is the local mix deliberate, or would one name make the file easier to read?"
+    },
+    {
+      "kind": "test-module-one-off",
+      "title": "One-off test-module name",
+      "location": {
+        "path": "src/disposable_attempt_catalog.rs",
+        "line": 1092
+      },
+      "claims": [
+        {
+          "kind": "observed",
+          "message": "`clone_identity_tests` appears once across 130 test-gated modules.",
+          "evidence": [
+            {
+              "message": "`mod clone_identity_tests` is declared here.",
+              "location": {
+                "path": "src/disposable_attempt_catalog.rs",
+                "line": 1092
+              }
+            }
+          ]
+        }
+      ],
+      "question": "Is this one-off name intentionally scoped, or an accidental deviation from local precedent?"
+    },
+    {
+      "kind": "test-module-one-off",
+      "title": "One-off test-module name",
+      "location": {
+        "path": "src/unix_personal_worker_store.rs",
+        "line": 35
+      },
+      "claims": [
+        {
+          "kind": "observed",
+          "message": "`publication_fault` appears once across 130 test-gated modules.",
+          "evidence": [
+            {
+              "message": "`mod publication_fault` is declared here.",
+              "location": {
+                "path": "src/unix_personal_worker_store.rs",
+                "line": 35
+              }
+            }
+          ]
+        }
+      ],
+      "question": "Is this one-off name intentionally scoped, or an accidental deviation from local precedent?"
+    },
+    {
+      "kind": "test-module-one-off",
+      "title": "One-off test-module name",
+      "location": {
+        "path": "src/unix_personal_worker_store.rs",
+        "line": 37
+      },
+      "claims": [
+        {
+          "kind": "observed",
+          "message": "`publication_fault_tests` appears once across 130 test-gated modules.",
+          "evidence": [
+            {
+              "message": "`mod publication_fault_tests` is declared here.",
+              "location": {
+                "path": "src/unix_personal_worker_store.rs",
+                "line": 37
+              }
+            }
+          ]
+        }
+      ],
+      "question": "Is this one-off name intentionally scoped, or an accidental deviation from local precedent?"
+    }
+  ]
+}


### PR DESCRIPTION
External replay for #119 / #132 using the retained read-only SmolRunner dogfood artifact from merged #129.

## Source receipt

Pinned external target from #129:

```text
teamleaderleo/smolrunner@ed3b70e375a57eabce26f2311f798f75b33bdeb0
```

The executed cold scan covered 259 Rust parses and produced 4 findings. This PR retains that exact `scan.json` as a 4,037-byte fixture and runs the **actual current Rust** renderers/encoder over it.

Original carrier receipt:

```text
workflow run  32240366281
artifact      9360596386
digest        sha256:9794b9958627cb1b88d5f347496a1fc76b720d789ab8f66f1a48067989f2bf2b
```

## Executed assertions if CI passes

The test pins exact current-v1 sizes:

```text
pretty retained JSON   4037 bytes
minified JSON          2672
human text             1915
C1 lossless            1981
terse                    957
```

This external case preserves the useful part of the synthetic ladder:

```text
C1 < minified JSON
terse < C1
terse < human
```

but deliberately records a counterexample to an easy overgeneralization:

```text
human text < C1
```

by 66 bytes on this report.

So C1's earned property is **lossless typed replay with less overhead than JSON on tested reports**, not "always shorter than human prose."

## Semantic boundary

The external terse view keeps the four finding claims/questions but omits support/provenance receipt strings such as repository counts and exact module declaration evidence. C1 retains those strings and round-trips to the exact report.

This PR does not claim those omissions are universally safe; #125/#126 contain the decision-preservation negative controls. This fixture only records that the omitted entries in this particular external scan are support receipts while the actionable questions remain visible.

## Boundary

- research fixture only;
- no external repository commands or rerun;
- no production renderer/schema changes;
- exact size assertions are versioned receipts and should change only through deliberate remeasurement;
- one external report is not a population-level compression benchmark.

Refs #16 #67 #115 #119 #125 #129 #132.