### PR TITLE
research: add typed behavioral evidence receipts

### DIFF
--- a/examples/behavioral_receipt.rs
+++ b/examples/behavioral_receipt.rs
@@ -1,0 +1,32 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/behavioral_receipt.rs"]
+mod behavioral_receipt;
+
+use behavioral_receipt::{BehavioralReceipt, MAX_BEHAVIORAL_RECEIPT_BYTES, validate_receipt};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("behavioral-receipt: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_BEHAVIORAL_RECEIPT_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_BEHAVIORAL_RECEIPT_BYTES {
+        return Err(format!(
+            "behavioral receipt exceeds the {MAX_BEHAVIORAL_RECEIPT_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let receipt: BehavioralReceipt = serde_json::from_slice(&bytes)?;
+    validate_receipt(&receipt)?;
+    println!("{}", serde_json::to_string_pretty(&receipt)?);
+    Ok(())
+}

--- a/research/behavioral-receipts.md
+++ b/research/behavioral-receipts.md
@@ -1,0 +1,122 @@
+# Behavioral evidence receipts
+
+Status: research experiment for #137.
+
+Cultist already records what evidence establishes. This experiment records a different fact about dogfood/evaluation episodes:
+
+> What happened to the worker's next action after a specific evidence candidate surfaced or correctly stayed quiet?
+
+The first schema is deliberately small and inspectable. It does not produce a score, rank an analyzer, or grant authority.
+
+## Receipt v1
+
+A receipt binds one evidence episode to:
+
+- repository identity;
+- exact 40-hex Git revision;
+- task identity;
+- evidence kind and evidence reference;
+- delivery state: `surfaced` or `quiet`;
+- whether the surfaced evidence was consulted;
+- one typed behavioral outcome;
+- one concrete changed next action when the outcome requires it.
+
+Current outcome vocabulary:
+
+```text
+changed_next_action
+prevented_or_reversed_wrong_turn
+useful_same_action
+ignored
+irrelevant
+stale_or_wrong_coordinate
+needed_stronger_evidence
+correct_quiet_negative
+```
+
+The vocabulary describes the observed episode. It does not claim why an analyzer behaved that way or whether the same result generalizes to another task.
+
+## Fail-closed combinations
+
+The validator rejects combinations that would blur the behavioral claim.
+
+Examples:
+
+```text
+quiet + consulted
+  -> invalid
+
+quiet + changed_next_action
+  -> invalid
+
+surfaced + correct_quiet_negative
+  -> invalid
+
+ignored + consulted
+  -> invalid
+
+changed_next_action + no concrete action
+  -> invalid
+
+useful_same_action + action
+  -> invalid
+```
+
+A `stale_or_wrong_coordinate` or `needed_stronger_evidence` receipt requires a concrete action because the useful behavioral fact is the recovery step the evidence forced.
+
+## Research validator
+
+```text
+cargo run --example behavioral_receipt < receipt.json
+```
+
+Input is bounded to 64 KiB. Unknown JSON fields, unsupported schema versions, non-exact revisions, malformed coordinates, and impossible outcome combinations reject explicitly.
+
+The validator prints the admitted typed receipt as JSON. It does not append to a database or mutate repository state.
+
+## First retained positive
+
+`research/behavioral-receipts/collaboration-140.json` records the collaboration episode from product PR #140.
+
+During that lane, `main` advanced while the branch was in progress. The new exact head was inspected, the landed file changes were checked, and the next action changed: rebuild the lane on current `main` and recheck live PR overlap before opening the PR.
+
+That is a useful first positive because the causal chain is directly observable:
+
+```text
+new current-main evidence surfaced
+-> evidence consulted
+-> branch plan changed
+-> stale-base integration risk avoided
+```
+
+It does not prove every head movement deserves an interruption. Quiet/disjoint controls remain necessary.
+
+## Relationship to behavioral A/B evaluation
+
+The receipt is a per-episode primitive. A later #137 A/B harness can compare tasks with and without selected Cultist evidence using collections of these receipts plus independent completion/inspection measurements.
+
+Useful aggregate questions can be computed later from raw receipts:
+
+```text
+How often was evidence consulted?
+How often did it change the next action?
+Which evidence families were repeatedly irrelevant?
+Which families exposed stale coordinates?
+Which candidates correctly stayed quiet?
+```
+
+Keep the raw episodes available so an aggregate never becomes the only explanation.
+
+## Boundary
+
+- v1 is Git-revision-bound;
+- evidence references are caller-supplied coordinates, not durable Cultist finding IDs;
+- action text is a bounded receipt, not an executable command or authority grant;
+- no model attribution or worker capability taxonomy;
+- no universal actionability score;
+- no automatic analyzer promotion/demotion;
+- no claim that `consulted` proves the evidence caused a successful final outcome.
+
+North star:
+
+> Preserve enough behavioral evidence to tell whether an interruption changed the work, without turning that observation into a hidden policy.

--- a/research/behavioral-receipts/active-work-140-quiet.json
+++ b/research/behavioral-receipts/active-work-140-quiet.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "repository": "teamleaderleo/cultist",
+  "revision": "0fa33cfbd7612478e03e29a328f2727b89a58789",
+  "task": "pull-140-product-decision-changing-evidence",
+  "evidence_kind": "active-work-heads-up",
+  "evidence_ref": "github-actions:run/32242752523#active-work-heads-up",
+  "delivery": "quiet",
+  "consulted": false,
+  "outcome": "correct_quiet_negative"
+}

--- a/research/behavioral-receipts/collaboration-140.json
+++ b/research/behavioral-receipts/collaboration-140.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "repository": "teamleaderleo/cultist",
+  "revision": "4f8f9fcd8ef1dab1881d07d063a034d9d5d7f136",
+  "task": "pull-140-product-decision-changing-evidence",
+  "evidence_kind": "concurrent-main-head-movement",
+  "evidence_ref": "github:main@4f8f9fcd8ef1dab1881d07d063a034d9d5d7f136",
+  "delivery": "surfaced",
+  "consulted": true,
+  "outcome": "changed_next_action",
+  "action": "rebuild the product lane on current main and recheck live PR file overlap before opening pull request 140"
+}

--- a/src/behavioral_receipt.rs
+++ b/src/behavioral_receipt.rs
@@ -1,0 +1,217 @@
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+pub const BEHAVIORAL_RECEIPT_SCHEMA_VERSION: u32 = 1;
+pub const MAX_BEHAVIORAL_RECEIPT_BYTES: usize = 64 * 1024;
+const MAX_COORDINATE_BYTES: usize = 1024;
+const MAX_ACTION_BYTES: usize = 2048;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralReceipt {
+    pub schema_version: u32,
+    pub repository: String,
+    pub revision: String,
+    pub task: String,
+    pub evidence_kind: String,
+    pub evidence_ref: String,
+    pub delivery: Delivery,
+    pub consulted: bool,
+    pub outcome: BehavioralOutcome,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Delivery {
+    Surfaced,
+    Quiet,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BehavioralOutcome {
+    ChangedNextAction,
+    PreventedOrReversedWrongTurn,
+    UsefulSameAction,
+    Ignored,
+    Irrelevant,
+    StaleOrWrongCoordinate,
+    NeededStrongerEvidence,
+    CorrectQuietNegative,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct BehavioralReceiptError {
+    message: String,
+}
+
+impl BehavioralReceiptError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for BehavioralReceiptError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for BehavioralReceiptError {}
+
+pub fn validate_receipt(receipt: &BehavioralReceipt) -> Result<(), BehavioralReceiptError> {
+    if receipt.schema_version != BEHAVIORAL_RECEIPT_SCHEMA_VERSION {
+        return Err(BehavioralReceiptError::new(format!(
+            "unsupported behavioral receipt schema {}; expected {BEHAVIORAL_RECEIPT_SCHEMA_VERSION}",
+            receipt.schema_version
+        )));
+    }
+
+    validate_coordinate(&receipt.repository, "repository")?;
+    validate_git_revision(&receipt.revision)?;
+    validate_coordinate(&receipt.task, "task")?;
+    validate_coordinate(&receipt.evidence_kind, "evidence_kind")?;
+    validate_coordinate(&receipt.evidence_ref, "evidence_ref")?;
+    validate_action(receipt.action.as_deref())?;
+
+    match receipt.delivery {
+        Delivery::Quiet => validate_quiet(receipt),
+        Delivery::Surfaced => validate_surfaced(receipt),
+    }
+}
+
+fn validate_quiet(receipt: &BehavioralReceipt) -> Result<(), BehavioralReceiptError> {
+    if receipt.consulted {
+        return Err(BehavioralReceiptError::new(
+            "quiet evidence cannot be marked consulted",
+        ));
+    }
+    if receipt.outcome != BehavioralOutcome::CorrectQuietNegative {
+        return Err(BehavioralReceiptError::new(
+            "quiet delivery requires outcome=correct_quiet_negative",
+        ));
+    }
+    if receipt.action.is_some() {
+        return Err(BehavioralReceiptError::new(
+            "correct quiet negatives cannot record a changed next action",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_surfaced(receipt: &BehavioralReceipt) -> Result<(), BehavioralReceiptError> {
+    if receipt.outcome == BehavioralOutcome::CorrectQuietNegative {
+        return Err(BehavioralReceiptError::new(
+            "surfaced evidence cannot use outcome=correct_quiet_negative",
+        ));
+    }
+
+    if receipt.outcome == BehavioralOutcome::Ignored {
+        if receipt.consulted {
+            return Err(BehavioralReceiptError::new(
+                "ignored evidence cannot be marked consulted",
+            ));
+        }
+        if receipt.action.is_some() {
+            return Err(BehavioralReceiptError::new(
+                "ignored evidence cannot record a changed next action",
+            ));
+        }
+        return Ok(());
+    }
+
+    if !receipt.consulted {
+        return Err(BehavioralReceiptError::new(format!(
+            "outcome={} requires consulted=true",
+            outcome_name(receipt.outcome)
+        )));
+    }
+
+    match receipt.outcome {
+        BehavioralOutcome::ChangedNextAction
+        | BehavioralOutcome::PreventedOrReversedWrongTurn
+        | BehavioralOutcome::StaleOrWrongCoordinate
+        | BehavioralOutcome::NeededStrongerEvidence => {
+            if receipt.action.is_none() {
+                return Err(BehavioralReceiptError::new(format!(
+                    "outcome={} requires a concrete action",
+                    outcome_name(receipt.outcome)
+                )));
+            }
+        }
+        BehavioralOutcome::UsefulSameAction | BehavioralOutcome::Irrelevant => {
+            if receipt.action.is_some() {
+                return Err(BehavioralReceiptError::new(format!(
+                    "outcome={} must omit action because the next action did not change",
+                    outcome_name(receipt.outcome)
+                )));
+            }
+        }
+        BehavioralOutcome::Ignored | BehavioralOutcome::CorrectQuietNegative => unreachable!(),
+    }
+
+    Ok(())
+}
+
+fn validate_coordinate(value: &str, field: &str) -> Result<(), BehavioralReceiptError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_COORDINATE_BYTES
+        || value.contains('\0')
+        || value.chars().any(char::is_control)
+    {
+        return Err(BehavioralReceiptError::new(format!(
+            "{field} must be a bounded non-empty canonical coordinate"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_git_revision(revision: &str) -> Result<(), BehavioralReceiptError> {
+    if revision.len() != 40
+        || !revision
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(BehavioralReceiptError::new(
+            "revision must be an exact 40-character lowercase Git object id",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_action(action: Option<&str>) -> Result<(), BehavioralReceiptError> {
+    let Some(action) = action else {
+        return Ok(());
+    };
+    if action.is_empty()
+        || action.trim() != action
+        || action.len() > MAX_ACTION_BYTES
+        || action.contains('\0')
+        || action.chars().any(char::is_control)
+    {
+        return Err(BehavioralReceiptError::new(
+            "action must be bounded, non-empty, and single-line when present",
+        ));
+    }
+    Ok(())
+}
+
+fn outcome_name(outcome: BehavioralOutcome) -> &'static str {
+    match outcome {
+        BehavioralOutcome::ChangedNextAction => "changed_next_action",
+        BehavioralOutcome::PreventedOrReversedWrongTurn => "prevented_or_reversed_wrong_turn",
+        BehavioralOutcome::UsefulSameAction => "useful_same_action",
+        BehavioralOutcome::Ignored => "ignored",
+        BehavioralOutcome::Irrelevant => "irrelevant",
+        BehavioralOutcome::StaleOrWrongCoordinate => "stale_or_wrong_coordinate",
+        BehavioralOutcome::NeededStrongerEvidence => "needed_stronger_evidence",
+        BehavioralOutcome::CorrectQuietNegative => "correct_quiet_negative",
+    }
+}

--- a/tests/behavioral_receipt.rs
+++ b/tests/behavioral_receipt.rs
@@ -1,0 +1,152 @@
+#[allow(dead_code)]
+#[path = "../src/behavioral_receipt.rs"]
+mod behavioral_receipt;
+
+use behavioral_receipt::{
+    BEHAVIORAL_RECEIPT_SCHEMA_VERSION, BehavioralOutcome, BehavioralReceipt, Delivery,
+    validate_receipt,
+};
+
+fn receipt(outcome: BehavioralOutcome) -> BehavioralReceipt {
+    BehavioralReceipt {
+        schema_version: BEHAVIORAL_RECEIPT_SCHEMA_VERSION,
+        repository: "teamleaderleo/cultist".to_string(),
+        revision: "4f8f9fcd8ef1dab1881d07d063a034d9d5d7f136".to_string(),
+        task: "issue-137-behavioral-pressure".to_string(),
+        evidence_kind: "generated-companion-missing".to_string(),
+        evidence_ref: "report-fingerprint/F1".to_string(),
+        delivery: Delivery::Surfaced,
+        consulted: true,
+        outcome,
+        action: None,
+    }
+}
+
+#[test]
+fn accepts_surfaced_action_change_with_concrete_action() {
+    let mut value = receipt(BehavioralOutcome::ChangedNextAction);
+    value.action = Some("run cargo generator before continuing".to_string());
+    validate_receipt(&value).unwrap();
+}
+
+#[test]
+fn accepts_prevented_wrong_turn_with_concrete_action() {
+    let mut value = receipt(BehavioralOutcome::PreventedOrReversedWrongTurn);
+    value.action = Some("drop the stale implementation approach".to_string());
+    validate_receipt(&value).unwrap();
+}
+
+#[test]
+fn accepts_correct_quiet_negative() {
+    let mut value = receipt(BehavioralOutcome::CorrectQuietNegative);
+    value.delivery = Delivery::Quiet;
+    value.consulted = false;
+    validate_receipt(&value).unwrap();
+}
+
+#[test]
+fn accepts_ignored_surfaced_evidence() {
+    let mut value = receipt(BehavioralOutcome::Ignored);
+    value.consulted = false;
+    validate_receipt(&value).unwrap();
+}
+
+#[test]
+fn rejects_action_change_without_concrete_action() {
+    let value = receipt(BehavioralOutcome::ChangedNextAction);
+    let error = validate_receipt(&value).unwrap_err();
+    assert!(error.to_string().contains("requires a concrete action"));
+}
+
+#[test]
+fn rejects_unconsulted_outcome_that_claims_interpretation() {
+    let mut value = receipt(BehavioralOutcome::Irrelevant);
+    value.consulted = false;
+    let error = validate_receipt(&value).unwrap_err();
+    assert!(error.to_string().contains("requires consulted=true"));
+}
+
+#[test]
+fn rejects_action_on_useful_same_action_receipt() {
+    let mut value = receipt(BehavioralOutcome::UsefulSameAction);
+    value.action = Some("keep doing the same thing".to_string());
+    let error = validate_receipt(&value).unwrap_err();
+    assert!(error.to_string().contains("must omit action"));
+}
+
+#[test]
+fn rejects_quiet_receipt_with_nonquiet_outcome() {
+    let mut value = receipt(BehavioralOutcome::Irrelevant);
+    value.delivery = Delivery::Quiet;
+    value.consulted = false;
+    let error = validate_receipt(&value).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("requires outcome=correct_quiet_negative")
+    );
+}
+
+#[test]
+fn rejects_surfaced_receipt_claiming_quiet_negative() {
+    let value = receipt(BehavioralOutcome::CorrectQuietNegative);
+    let error = validate_receipt(&value).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("cannot use outcome=correct_quiet_negative")
+    );
+}
+
+#[test]
+fn rejects_nonexact_revision_coordinate() {
+    let mut value = receipt(BehavioralOutcome::UsefulSameAction);
+    value.revision = "main".to_string();
+    let error = validate_receipt(&value).unwrap_err();
+    assert!(error.to_string().contains("exact 40-character"));
+}
+
+#[test]
+fn rejects_unknown_machine_fields() {
+    let json = serde_json::json!({
+        "schema_version": BEHAVIORAL_RECEIPT_SCHEMA_VERSION,
+        "repository": "teamleaderleo/cultist",
+        "revision": "4f8f9fcd8ef1dab1881d07d063a034d9d5d7f136",
+        "task": "issue-137-behavioral-pressure",
+        "evidence_kind": "preflight-explicit-coordination",
+        "evidence_ref": "report-fingerprint/F1",
+        "delivery": "surfaced",
+        "consulted": true,
+        "outcome": "useful_same_action",
+        "future_semantics": true
+    });
+
+    let error = serde_json::from_value::<BehavioralReceipt>(json).unwrap_err();
+    assert!(error.to_string().contains("unknown field"));
+}
+
+#[test]
+fn exact_receipt_round_trips() {
+    let mut value = receipt(BehavioralOutcome::NeededStrongerEvidence);
+    value.action = Some("retrieve exact-head project memory".to_string());
+    let json = serde_json::to_string(&value).unwrap();
+    let decoded: BehavioralReceipt = serde_json::from_str(&json).unwrap();
+    validate_receipt(&decoded).unwrap();
+    assert_eq!(decoded, value);
+}
+
+#[test]
+fn retained_collaboration_receipt_is_valid_action_change_evidence() {
+    let fixture = include_str!("../research/behavioral-receipts/collaboration-140.json");
+    let receipt: BehavioralReceipt = serde_json::from_str(fixture).unwrap();
+    validate_receipt(&receipt).unwrap();
+    assert_eq!(receipt.delivery, Delivery::Surfaced);
+    assert!(receipt.consulted);
+    assert_eq!(receipt.outcome, BehavioralOutcome::ChangedNextAction);
+    assert!(
+        receipt
+            .action
+            .as_deref()
+            .is_some_and(|action| action.contains("rebuild the product lane"))
+    );
+}

--- a/tests/behavioral_receipt_quiet.rs
+++ b/tests/behavioral_receipt_quiet.rs
@@ -1,0 +1,16 @@
+#[allow(dead_code)]
+#[path = "../src/behavioral_receipt.rs"]
+mod behavioral_receipt;
+
+use behavioral_receipt::{BehavioralOutcome, BehavioralReceipt, Delivery, validate_receipt};
+
+#[test]
+fn retained_active_work_quiet_control_is_valid() {
+    let fixture = include_str!("../research/behavioral-receipts/active-work-140-quiet.json");
+    let receipt: BehavioralReceipt = serde_json::from_str(fixture).unwrap();
+    validate_receipt(&receipt).unwrap();
+    assert_eq!(receipt.delivery, Delivery::Quiet);
+    assert!(!receipt.consulted);
+    assert_eq!(receipt.outcome, BehavioralOutcome::CorrectQuietNegative);
+    assert!(receipt.action.is_none());
+}


### PR DESCRIPTION
## Goal

Make #137's behavioral product pressure test executable at the per-episode level.

Cultist already records what evidence establishes. This PR adds a small research receipt for a different observation:

> What happened to the worker's next action after a specific evidence candidate surfaced or correctly stayed quiet?

## Receipt v1

One strict JSON object records:

```text
repository
exact 40-hex Git revision
task
evidence_kind
evidence_ref
delivery: surfaced | quiet
consulted: bool
outcome
action? 
```

Outcomes are deliberately inspectable rather than scalar:

```text
changed_next_action
prevented_or_reversed_wrong_turn
useful_same_action
ignored
irrelevant
stale_or_wrong_coordinate
needed_stronger_evidence
correct_quiet_negative
```

## Fail-closed semantics

Impossible combinations reject, including:

- quiet + consulted;
- quiet + action-changing outcome;
- surfaced + correct quiet negative;
- ignored + consulted/action;
- action-changing/stale/stronger-evidence outcomes without a concrete recovery action;
- same-action/irrelevant outcomes carrying a changed action;
- non-exact revision coordinates;
- unknown machine fields/schema versions.

No ranking or analyzer score is produced.

## Research validator

```text
cargo run --example behavioral_receipt < receipt.json
```

Input is bounded to 64 KiB. The example validates and reprints the typed receipt; it does not append to a store or mutate repository state.

## First retained real positive

`research/behavioral-receipts/collaboration-140.json` records the #140 collaboration episode:

```text
main moved while the product lane was in progress
-> exact new head inspected
-> landed file sets checked
-> next action changed
-> lane rebuilt on current main before PR open
```

The standard test matrix parses and validates that retained receipt.

## Collaboration dogfood

This branch itself had to exercise the same behavior twice while being prepared:

1. #133 merged after the lane started;
2. #139 merged after the first re-anchor;
3. both were inspected for overlap;
4. the branch was rebuilt on each exact new main head;
5. it is one commit ahead / zero behind at PR open time.

The new files are disjoint from current external-corpus/projection work.

## Boundary

- research-only receipt primitive;
- Git-revision-bound v1;
- caller-supplied evidence references, not durable Cultist finding IDs;
- bounded action text is a receipt, not an executable command or authority grant;
- no model/worker taxonomy;
- no automatic promotion/demotion;
- `consulted` does not prove causality for the final task outcome.

Refs #137 #16 #109.