### PR TITLE
research: preserve durable UNKNOWN handoffs

### DIFF
--- a/examples/durable_unknown.rs
+++ b/examples/durable_unknown.rs
@@ -1,0 +1,43 @@
+#![allow(dead_code)]
+
+use std::error::Error;
+use std::io::{self, Read};
+
+use serde::Deserialize;
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/justification.rs"]
+mod justification;
+
+use applicability::EvaluationContext;
+use durable_obligation::{ClearingEvidenceReceipt, DurableObligation, evaluate_obligation};
+
+const MAX_INPUT_BYTES: u64 = 1024 * 1024;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvaluationInput {
+    obligation: DurableObligation,
+    #[serde(default)]
+    receipts: Vec<ClearingEvidenceReceipt>,
+    context: EvaluationContext,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut input = Vec::new();
+    io::stdin()
+        .take(MAX_INPUT_BYTES + 1)
+        .read_to_end(&mut input)?;
+    if input.len() as u64 > MAX_INPUT_BYTES {
+        return Err("durable unknown input exceeds 1 MiB".into());
+    }
+
+    let request: EvaluationInput = serde_json::from_slice(&input)?;
+    let evaluation = evaluate_obligation(&request.obligation, &request.receipts, &request.context)?;
+    serde_json::to_writer_pretty(io::stdout().lock(), &evaluation)?;
+    println!();
+    Ok(())
+}

--- a/research/durable-unknown-obligation.md
+++ b/research/durable-unknown-obligation.md
@@ -1,0 +1,119 @@
+# Durable UNKNOWN obligation research receipt
+
+Tracking: #144. Stacked on the #141 justification-graph carrier.
+
+## Dogfood discriminator from #141
+
+The first justification graph required every obligation node to have a clearing edge. That is convenient for evaluating a graph containing known candidate evidence, but it fails the central durable-handoff case:
+
+```text
+worker finishes bounded investigation
+-> material discriminator remains missing
+-> clearing evidence does not exist yet
+-> preserve the open obligation for the next worker
+```
+
+Encoding a prospective clearing edge as if evidence already existed would confuse an expected future observation with an observed evidence object.
+
+This carrier therefore treats **the open durable record** and **arrived clearing receipts** as separate things.
+
+That counterexample was fed back into #141/#156 as well: an obligation node may now remain open with zero clearing edges instead of requiring a fabricated future evidence object.
+
+## v0 record
+
+```text
+DurableObligation
+  id
+  question
+  exact subject applicability requirements
+  established_evidence[]
+  missing_discriminator { kind, target }
+  clearing_conditions[]
+```
+
+A clearing condition names an exact typed discriminator plus exact applicability requirements. A supplied receipt must match both before it can participate in clearing.
+
+`established_evidence` is intentionally a bounded list of evidence IDs in this experiment. It preserves completed investigation for handoff without granting those strings authority or semantic lineage.
+
+## Evaluation
+
+The record and every candidate receipt reuse the shared applicability evaluator.
+
+```text
+subject APPLIES
+  + matching clearing receipt APPLIES
+    -> CLEARED
+
+subject APPLIES
+  + no matching/current clearing receipt
+    -> OPEN
+
+subject APPLIES
+  + matching receipt applicability UNKNOWN
+    -> UNKNOWN
+
+subject applicability UNKNOWN
+    -> UNKNOWN
+
+subject INVALID because the exact coordinate moved
+    -> REOPEN_REQUIRED
+```
+
+A semantically adjacent receipt with another discriminator kind remains unmatched even when it names the same target/revision.
+
+## Why `REOPEN_REQUIRED` exists
+
+An obligation captured for exact head A cannot silently become the obligation for head B. Head movement invalidates the old subject coordinate. The next worker/orchestrator can compile a fresh obligation for B while preserving the old record as a historical handoff receipt.
+
+This keeps reopening distinct from pretending the stale obligation is still current.
+
+## Standard-suite controls
+
+The stacked carrier tests:
+
+- open obligation with zero clearing evidence;
+- exact matching receipt clears;
+- exact subject head movement produces `reopen_required`;
+- missing current coordinate remains `unknown`;
+- semantically adjacent receipt does not clear;
+- record round-trips with completed evidence references for fresh-worker handoff;
+- a clearing condition must actually answer the declared missing discriminator.
+
+## Executed GitHub receipt
+
+Draft stacked PR #159 ran against exact parent #156 head:
+
+```text
+parent  9beaeaab2bece20a4e0bb9c880f510f740bf8cfb
+child   fd37861d73e966ed64538c60cc00bf32f8f928b2
+```
+
+GitHub Actions CI run `32243607858` / run number `1045` completed successfully on the stacked PR merge ref. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work heads-up;
+- full `cargo test` including the durable-obligation harness;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The PR-only push-diff step remained skipped by workflow context.
+
+The first current-stack CI attempt was a useful mechanical control: rustfmt rejected handwritten formatting in the new research files. Applying the exact formatter diff plus a fixture-local dead-code allowance for the standalone example allowed the next run to reach and pass Clippy/tests.
+
+## Boundary
+
+- discriminator `{kind,target}` is a research key, not a final universal evidence ontology;
+- receipt requirements use exact v1 matching against the clearing condition before applicability evaluation;
+- richer subject/predicate envelopes belong to #147;
+- probe discovery/cost belongs to #145;
+- this record grants no mutation, review, merge, or deployment authority;
+- solved records can remain as history, while current use always rechecks applicability.
+
+## Next discriminator
+
+The next useful experiment is #145: given this typed missing discriminator and a bounded set of available probe capabilities, select the cheapest admitted probe capable of producing a matching receipt. That experiment should consume this object rather than restating the missing question in prose.
+
+Keep planning forecasts separate from observed performance receipts. Current `PerfCounters` measure work after execution; a planner cost is an admitted forecast before execution and can later be calibrated against measured counters where the dimensions overlap.

--- a/src/durable_obligation.rs
+++ b/src/durable_obligation.rs
@@ -1,0 +1,443 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, evaluate_query,
+};
+use crate::justification::RelationReceipt;
+
+pub const DURABLE_OBLIGATION_SCHEMA_VERSION: u32 = 1;
+const MAX_ID_BYTES: usize = 256;
+const MAX_TEXT_BYTES: usize = 4096;
+const MAX_ESTABLISHED_EVIDENCE: usize = 256;
+const MAX_CLEARING_CONDITIONS: usize = 64;
+const MAX_RECEIPTS: usize = 512;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DurableObligation {
+    pub schema_version: u32,
+    pub id: String,
+    pub question: String,
+    pub subject: EvidenceRequirements,
+    pub established_evidence: Vec<String>,
+    pub missing_discriminator: DiscriminatorKey,
+    pub clearing_conditions: Vec<ClearingCondition>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorKey {
+    pub kind: String,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClearingCondition {
+    pub discriminator: DiscriminatorKey,
+    pub requirements: EvidenceRequirements,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClearingEvidenceReceipt {
+    pub id: String,
+    pub discriminator: DiscriminatorKey,
+    pub requirements: EvidenceRequirements,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DurableObligationStatus {
+    Open,
+    Cleared,
+    Unknown,
+    ReopenRequired,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DurableObligationEvaluation {
+    pub schema_version: u32,
+    pub id: String,
+    pub status: DurableObligationStatus,
+    pub subject_applicability: ApplicabilityStatus,
+    pub clearing: RelationReceipt,
+    pub unmatched_receipts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DurableObligationError {
+    message: String,
+}
+
+impl DurableObligationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for DurableObligationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for DurableObligationError {}
+
+pub fn evaluate_obligation(
+    obligation: &DurableObligation,
+    receipts: &[ClearingEvidenceReceipt],
+    context: &EvaluationContext,
+) -> Result<DurableObligationEvaluation, DurableObligationError> {
+    validate_obligation(obligation)?;
+    validate_receipts(receipts)?;
+
+    let subject_applicability = evaluate_requirements(&obligation.subject, context, "subject")?;
+    let mut clearing = RelationReceipt::default();
+    let mut unmatched_receipts = Vec::new();
+
+    for receipt in receipts {
+        let Some(condition) = obligation.clearing_conditions.iter().find(|condition| {
+            condition.discriminator == receipt.discriminator
+                && condition.requirements == receipt.requirements
+        }) else {
+            unmatched_receipts.push(receipt.id.clone());
+            continue;
+        };
+
+        debug_assert_eq!(condition.requirements, receipt.requirements);
+        let applicability = evaluate_requirements(
+            &receipt.requirements,
+            context,
+            &format!("clearing receipt {}", receipt.id),
+        )?;
+        push_receipt(&mut clearing, receipt.id.clone(), applicability);
+    }
+
+    clearing.applies.sort();
+    clearing.invalid.sort();
+    clearing.unknown.sort();
+    unmatched_receipts.sort();
+
+    let status = match subject_applicability {
+        ApplicabilityStatus::Invalid => DurableObligationStatus::ReopenRequired,
+        ApplicabilityStatus::Unknown => DurableObligationStatus::Unknown,
+        ApplicabilityStatus::Applies if !clearing.applies.is_empty() => {
+            DurableObligationStatus::Cleared
+        }
+        ApplicabilityStatus::Applies if !clearing.unknown.is_empty() => {
+            DurableObligationStatus::Unknown
+        }
+        ApplicabilityStatus::Applies => DurableObligationStatus::Open,
+    };
+
+    Ok(DurableObligationEvaluation {
+        schema_version: DURABLE_OBLIGATION_SCHEMA_VERSION,
+        id: obligation.id.clone(),
+        status,
+        subject_applicability,
+        clearing,
+        unmatched_receipts,
+    })
+}
+
+fn evaluate_requirements(
+    requirements: &EvidenceRequirements,
+    context: &EvaluationContext,
+    label: &str,
+) -> Result<ApplicabilityStatus, DurableObligationError> {
+    let evaluation = evaluate_query(&ApplicabilityQuery {
+        schema_version: APPLICABILITY_SCHEMA_VERSION,
+        requirements: requirements.clone(),
+        context: context.clone(),
+    })
+    .map_err(|error| {
+        DurableObligationError::new(format!("{label} applicability failed: {error}"))
+    })?;
+    Ok(evaluation.status)
+}
+
+fn validate_obligation(obligation: &DurableObligation) -> Result<(), DurableObligationError> {
+    if obligation.schema_version != DURABLE_OBLIGATION_SCHEMA_VERSION {
+        return Err(DurableObligationError::new(format!(
+            "unsupported durable obligation schema {}; expected {DURABLE_OBLIGATION_SCHEMA_VERSION}",
+            obligation.schema_version
+        )));
+    }
+
+    validate_id(&obligation.id, "obligation id")?;
+    validate_text(&obligation.question, "obligation question")?;
+    validate_discriminator(&obligation.missing_discriminator)?;
+    require_coordinates(&obligation.subject, "obligation subject")?;
+
+    if obligation.established_evidence.len() > MAX_ESTABLISHED_EVIDENCE {
+        return Err(DurableObligationError::new(
+            "established evidence exceeds the admitted boundary",
+        ));
+    }
+    let mut established = BTreeSet::new();
+    for id in &obligation.established_evidence {
+        validate_id(id, "established evidence id")?;
+        if !established.insert(id.clone()) {
+            return Err(DurableObligationError::new(format!(
+                "duplicate established evidence id {id}"
+            )));
+        }
+    }
+
+    if obligation.clearing_conditions.is_empty()
+        || obligation.clearing_conditions.len() > MAX_CLEARING_CONDITIONS
+    {
+        return Err(DurableObligationError::new(
+            "durable obligation must declare a bounded non-empty clearing condition set",
+        ));
+    }
+
+    let mut conditions = BTreeSet::new();
+    for condition in &obligation.clearing_conditions {
+        validate_discriminator(&condition.discriminator)?;
+        require_coordinates(&condition.requirements, "clearing condition requirements")?;
+        let key = (
+            condition.discriminator.clone(),
+            serde_json::to_string(&condition.requirements).map_err(|error| {
+                DurableObligationError::new(format!(
+                    "failed to canonicalize clearing requirements: {error}"
+                ))
+            })?,
+        );
+        if !conditions.insert(key) {
+            return Err(DurableObligationError::new(
+                "duplicate durable obligation clearing condition",
+            ));
+        }
+    }
+
+    if !obligation
+        .clearing_conditions
+        .iter()
+        .any(|condition| condition.discriminator == obligation.missing_discriminator)
+    {
+        return Err(DurableObligationError::new(
+            "at least one clearing condition must answer the missing discriminator",
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_receipts(receipts: &[ClearingEvidenceReceipt]) -> Result<(), DurableObligationError> {
+    if receipts.len() > MAX_RECEIPTS {
+        return Err(DurableObligationError::new(
+            "clearing receipts exceed the admitted boundary",
+        ));
+    }
+
+    let mut ids = BTreeSet::new();
+    for receipt in receipts {
+        validate_id(&receipt.id, "clearing receipt id")?;
+        validate_discriminator(&receipt.discriminator)?;
+        require_coordinates(&receipt.requirements, "clearing receipt requirements")?;
+        if !ids.insert(receipt.id.clone()) {
+            return Err(DurableObligationError::new(format!(
+                "duplicate clearing receipt id {}",
+                receipt.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn require_coordinates(
+    requirements: &EvidenceRequirements,
+    label: &str,
+) -> Result<(), DurableObligationError> {
+    if requirements.repository.is_none()
+        && requirements.revision.is_none()
+        && requirements.work.is_none()
+        && requirements.scope.is_none()
+    {
+        return Err(DurableObligationError::new(format!(
+            "{label} must carry at least one applicability coordinate"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_discriminator(discriminator: &DiscriminatorKey) -> Result<(), DurableObligationError> {
+    validate_id(&discriminator.kind, "discriminator kind")?;
+    validate_text(&discriminator.target, "discriminator target")
+}
+
+fn validate_id(value: &str, field: &str) -> Result<(), DurableObligationError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_ID_BYTES
+        || value.contains('\0')
+    {
+        return Err(DurableObligationError::new(format!(
+            "{field} must be a bounded canonical identifier"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, field: &str) -> Result<(), DurableObligationError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_TEXT_BYTES
+        || value.contains('\0')
+    {
+        return Err(DurableObligationError::new(format!(
+            "{field} must be bounded non-empty text"
+        )));
+    }
+    Ok(())
+}
+
+fn push_receipt(receipt: &mut RelationReceipt, id: String, status: ApplicabilityStatus) {
+    match status {
+        ApplicabilityStatus::Applies => receipt.applies.push(id),
+        ApplicabilityStatus::Invalid => receipt.invalid.push(id),
+        ApplicabilityStatus::Unknown => receipt.unknown.push(id),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn requirements(repository: &str, revision: Option<&str>) -> EvidenceRequirements {
+        EvidenceRequirements {
+            repository: Some(repository.to_string()),
+            revision: revision.map(str::to_string),
+            work: None,
+            scope: None,
+        }
+    }
+
+    fn discriminator() -> DiscriminatorKey {
+        DiscriminatorKey {
+            kind: "target_test_result".to_string(),
+            target: "cargo test target_t".to_string(),
+        }
+    }
+
+    fn obligation() -> DurableObligation {
+        DurableObligation {
+            schema_version: DURABLE_OBLIGATION_SCHEMA_VERSION,
+            id: "U17".to_string(),
+            question: "Does target T pass at this exact head?".to_string(),
+            subject: requirements("owner/repo", Some("head-a")),
+            established_evidence: vec!["E-history".to_string(), "E-guidance".to_string()],
+            missing_discriminator: discriminator(),
+            clearing_conditions: vec![ClearingCondition {
+                discriminator: discriminator(),
+                requirements: requirements("owner/repo", Some("head-a")),
+            }],
+        }
+    }
+
+    fn context(revision: Option<&str>) -> EvaluationContext {
+        EvaluationContext {
+            repository: Some("owner/repo".to_string()),
+            revision: revision.map(str::to_string),
+            work: None,
+            path: None,
+        }
+    }
+
+    fn receipt(revision: &str) -> ClearingEvidenceReceipt {
+        ClearingEvidenceReceipt {
+            id: format!("test-{revision}"),
+            discriminator: discriminator(),
+            requirements: requirements("owner/repo", Some(revision)),
+        }
+    }
+
+    #[test]
+    fn durable_unknown_can_exist_before_any_clearing_evidence_arrives() {
+        let evaluation = evaluate_obligation(&obligation(), &[], &context(Some("head-a"))).unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Open);
+        assert!(evaluation.clearing.applies.is_empty());
+    }
+
+    #[test]
+    fn exact_matching_receipt_clears_the_obligation() {
+        let evaluation = evaluate_obligation(
+            &obligation(),
+            &[receipt("head-a")],
+            &context(Some("head-a")),
+        )
+        .unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Cleared);
+        assert_eq!(evaluation.clearing.applies, vec!["test-head-a"]);
+    }
+
+    #[test]
+    fn moved_subject_coordinate_requires_reopen() {
+        let evaluation = evaluate_obligation(
+            &obligation(),
+            &[receipt("head-a")],
+            &context(Some("head-b")),
+        )
+        .unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::ReopenRequired);
+        assert_eq!(
+            evaluation.subject_applicability,
+            ApplicabilityStatus::Invalid
+        );
+        assert_eq!(evaluation.clearing.invalid, vec!["test-head-a"]);
+    }
+
+    #[test]
+    fn missing_current_coordinate_remains_unknown() {
+        let evaluation = evaluate_obligation(&obligation(), &[], &context(None)).unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Unknown);
+        assert_eq!(
+            evaluation.subject_applicability,
+            ApplicabilityStatus::Unknown
+        );
+    }
+
+    #[test]
+    fn semantically_adjacent_receipt_does_not_clear() {
+        let mut wrong = receipt("head-a");
+        wrong.discriminator.kind = "target_test_listing".to_string();
+        let evaluation =
+            evaluate_obligation(&obligation(), &[wrong], &context(Some("head-a"))).unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Open);
+        assert_eq!(evaluation.unmatched_receipts, vec!["test-head-a"]);
+    }
+
+    #[test]
+    fn durable_record_round_trips_for_fresh_worker_handoff() {
+        let record = obligation();
+        let encoded = serde_json::to_string(&record).unwrap();
+        let decoded: DurableObligation = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, record);
+        assert_eq!(
+            decoded.established_evidence,
+            vec!["E-history", "E-guidance"]
+        );
+    }
+
+    #[test]
+    fn clearing_condition_must_answer_declared_missing_discriminator() {
+        let mut record = obligation();
+        record.clearing_conditions[0].discriminator.kind = "provider_current".to_string();
+        let error = evaluate_obligation(&record, &[], &context(Some("head-a"))).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("answer the missing discriminator")
+        );
+    }
+}

--- a/tests/durable_obligation.rs
+++ b/tests/durable_obligation.rs
@@ -1,0 +1,8 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/justification.rs"]
+mod justification;


### PR DESCRIPTION
Progresses #144 with a durable record for one bounded material `UNKNOWN` that can survive worker replacement and clear/reopen from exact evidence coordinates.

## Contract

The landed #156 graph exposed a necessary distinction:

```text
DurableObligation
  expected missing discriminator + clearing conditions

ClearingEvidenceReceipt
  evidence that has actually arrived
```

An obligation may exist OPEN before any clearing receipt exists. This carrier never manufactures prospective evidence nodes.

A v0 durable obligation carries a stable local ID, bounded question, exact subject requirements, completed evidence refs, typed missing discriminator `{kind,target}`, and exact clearing conditions. A receipt participates only when its discriminator and applicability requirements exactly match an admitted clearing condition.

States:

```text
open             subject applies; no current matching clearing receipt
cleared          subject applies; matching clearing receipt applies
unknown          required coordinate/receipt applicability is unknown
reopen_required  exact subject coordinate became invalid
```

## Controls

The standard harness covers open-before-evidence, exact clearing, moved-head reopen, missing-current-coordinate UNKNOWN, adjacent evidence that cannot clear, JSON handoff retention, and clearing-condition/discriminator consistency.

## Current-main promotion receipt

After #156 landed as `ae7bdd9887d95634ab5b218d2efacdad54175ae8`, the four durable-UNKNOWN blobs were flattened directly onto that exact main tree:

```text
head: a2482b2e558c08268ab66ad8560201efeb470a59
commits: 1
files: 4
```

Ordinary CI:

```text
run: 32272797687
job: 96133020649
result: success
```

Formatter, strict Clippy, project/review/closure/external-reference guards, active-work preflight, full tests, and repository/history/CI-filter/diff dogfood all passed. Main remained at the exact base through the gate.

A prior stacked run (`32271747406`) also passed on the clean #156 semantics before the parent merged; this current-main run is the promotion authority.

## Boundary / next

Research only; `{kind,target}` remains a research discriminator key, and no product CLI/report-schema or action authority changes.

The next earned child is #164: evidence acquisition planning over durable UNKNOWN obligations.

Files: `src/durable_obligation.rs`, `tests/durable_obligation.rs`, `examples/durable_unknown.rs`, `research/durable-unknown-obligation.md`.

Refs #62 #74 #106 #109 #123 #141 #144 #145 #147 #156 #164.