### PR TITLE
research: add bounded offline project-memory packet

### DIFF
--- a/examples/project_memory_packet.rs
+++ b/examples/project_memory_packet.rs
@@ -2,7 +2,7 @@
 mod project_memory;
 
 use std::error::Error;
-use std::io::{self, Read};
+use std::io::{self, ErrorKind, Read};
 
 use project_memory::{MAX_PROJECT_MEMORY_BYTES, parse_project_memory_packet};
 
@@ -18,8 +18,11 @@ fn run() -> Result<(), Box<dyn Error>> {
     io::stdin()
         .take((MAX_PROJECT_MEMORY_BYTES + 1) as u64)
         .read_to_end(&mut input)?;
-    let packet = parse_project_memory_packet(&input)?;
-    let summary = packet.summary()?;
+    let packet = parse_project_memory_packet(&input)
+        .map_err(|error| io::Error::new(ErrorKind::InvalidData, error))?;
+    let summary = packet
+        .summary()
+        .map_err(|error| io::Error::new(ErrorKind::InvalidData, error))?;
     println!("{}", serde_json::to_string_pretty(&summary)?);
     Ok(())
 }

--- a/examples/project_memory_packet.rs
+++ b/examples/project_memory_packet.rs
@@ -1,0 +1,25 @@
+#[path = "../src/project_memory.rs"]
+mod project_memory;
+
+use std::error::Error;
+use std::io::{self, Read};
+
+use project_memory::{MAX_PROJECT_MEMORY_BYTES, parse_project_memory_packet};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("project-memory-packet: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut input = Vec::new();
+    io::stdin()
+        .take((MAX_PROJECT_MEMORY_BYTES + 1) as u64)
+        .read_to_end(&mut input)?;
+    let packet = parse_project_memory_packet(&input)?;
+    let summary = packet.summary()?;
+    println!("{}", serde_json::to_string_pretty(&summary)?);
+    Ok(())
+}

--- a/research/project-memory.md
+++ b/research/project-memory.md
@@ -1,0 +1,167 @@
+# Project memory packet v0
+
+Issue #18 asks whether Git, PRs, issues, and reviews can become usable project memory while remote access remains optional.
+
+The first slice is deliberately smaller than a `why` engine. It defines one bounded offline packet for **explicit artifact relationships** and exercises it on the pinned Stensibly #1575 lineage from #41.
+
+## Boundary
+
+Core/research Rust consumes JSON only. It performs no network calls and does not invoke GitHub, Git, builds, tests, or repository commands.
+
+A future provider adapter may collect this packet. The packet remains independently inspectable and replayable after collection.
+
+The first reader is research-only:
+
+```text
+cargo run --example project_memory_packet < research/project-memory/stensibly-1575.json
+```
+
+It prints a compact summary of the anchor and its explicit links.
+
+## Packet v1
+
+A packet contains:
+
+```text
+schema_version
+repository owner/name
+anchor artifact
+bounded artifact list
+bounded explicit edge list
+```
+
+Artifacts preserve:
+
+```text
+kind: pull_request | issue
+number
+title
+state
+created_at / closed_at
+exact PR head/base revision when applicable
+changed paths when applicable
+bounded retained evidence text
+whether that retained text is complete
+```
+
+Edges are typed:
+
+```text
+closes
+follow_up_to
+continuation_from
+parent
+related
+```
+
+Every edge carries the exact retained evidence excerpt that establishes it. Validation requires that excerpt to occur in the source artifact's admitted evidence text. Both edge endpoints must be present in the packet.
+
+This gives the packet an intentionally narrow meaning:
+
+```text
+artifact A explicitly says relationship R to artifact B
+```
+
+Artifact dates do not create edges. Vector order does not create edges. Similar titles, nearby PR numbers, and touched-path overlap do not create edges.
+
+## Retained Stensibly #1575 discriminator
+
+Pinned anchor:
+
+```text
+teamleaderleo/stensibly
+PR #1575
+head 78a9061b2feebe71211f0034ff2705b7143f6ce9
+base 85cecf2608ad9e734a67518577fa85b9a08a550c
+```
+
+The retained packet contains five provider artifacts:
+
+```text
+PR #1569  Keep hosted mail contracts Convex-runtime neutral
+PR #1571  Keep Gmail semantic-admission indexes deployable
+PR #1573  Keep Gmail mailbox-disposition indexes deployable
+issue #1574  Catch overlong Convex index identifiers before production deploy
+PR #1575  Catch overlong Convex index identifiers in CI
+```
+
+The anchor explicitly establishes:
+
+```text
+PR #1575 closes issue #1574
+PR #1575 is a follow-up to #1569 / #1571 / #1573
+```
+
+The earlier deployment sequence also contains explicit continuation links:
+
+```text
+#1571 continues from #1569
+#1573 continues from #1569 / #1571
+```
+
+The packet keeps those relationship facts separate from the semantic content of each repair.
+
+That distinction is important. #1569 clears a Node-runtime bundling blocker. #1571 and #1573 each repair a different overlong Convex index identifier. #1575 then explicitly says ordinary CI had accepted **two** overlong `by_*` identifiers and adds one repository-wide regression that scans retained Convex TypeScript for the 64-character class.
+
+The useful evidence is therefore present without inventing a three-instance common failure class:
+
+```text
+explicit deployability predecessor: #1569
+explicit identifier-limit repairs:  #1571 / #1573
+explicit generalized guard:         #1575
+explicit follow-up issue:            #1574
+```
+
+A later analyzer may ask whether this is lesson promotion. V0 records the evidence needed for that question and leaves the interpretation separate.
+
+## Validation rules
+
+The parser rejects:
+
+- packets above 256 KiB;
+- unknown schema versions or machine fields;
+- malformed repository coordinates;
+- duplicate/missing artifact identities;
+- PR artifacts without exact lowercase 40-hex head/base coordinates;
+- issue artifacts carrying PR revision/path fields;
+- malformed repository-relative paths;
+- missing edge endpoints;
+- self-edges;
+- edge evidence absent from the source artifact text;
+- inconsistent open/closed timestamps.
+
+The ordinary test matrix retains the Stensibly packet and includes negative controls for invented edge evidence and missing endpoints.
+
+## What this earns
+
+For the first Stensibly adapter-gap case from the external registry, Cultist can now represent a useful provider-memory packet offline with:
+
+```text
+exact artifact identity
+exact PR revisions
+selected artifact text + completeness flag
+changed paths
+explicit cross-artifact relationships
+```
+
+This closes a meaningful portion of the gap exposed by the quiet Stensibly source scan while keeping remote provider work outside the normal Cultist process.
+
+## What remains open
+
+The next provider-side collector should stay bounded and explicit:
+
+```text
+selected anchor PR/issue
+-> fetch exact named artifacts
+-> preserve exact refs, dates, paths, and selected text
+-> parse only explicit relationship vocabulary
+-> emit packet
+```
+
+Chronological neighbors can be supplied later as separately typed adjacency evidence. They should never be upgraded to `follow_up_to` or causal lineage automatically.
+
+Reviews/comments can enter as their own artifact/evidence type after a concrete replay needs them. V0 avoids importing full discussion history preemptively.
+
+The retained Stensibly case now gives that collector an executable acceptance target. Linux Fieldwork remains the complementary corpus-intake gap: its valuable evidence spans issue/investigation/note material rather than one compact PR lineage.
+
+Refs #18 #41 #16 #138.

--- a/research/project-memory/stensibly-1575.json
+++ b/research/project-memory/stensibly-1575.json
@@ -1,0 +1,198 @@
+{
+  "schema_version": 1,
+  "repository": "teamleaderleo/stensibly",
+  "anchor": {
+    "kind": "pull_request",
+    "number": 1575
+  },
+  "artifacts": [
+    {
+      "reference": {
+        "kind": "pull_request",
+        "number": 1575
+      },
+      "title": "Catch overlong Convex index identifiers in CI",
+      "state": "closed",
+      "created_at": "2026-08-15T12:57:17Z",
+      "closed_at": "2026-08-15T13:00:58Z",
+      "revision": {
+        "head_sha": "78a9061b2feebe71211f0034ff2705b7143f6ce9",
+        "base_sha": "85cecf2608ad9e734a67518577fa85b9a08a550c",
+        "merged": true
+      },
+      "changed_paths": [
+        "test/convex-index-identifier-limit.test.ts"
+      ],
+      "evidence_text": "Closes #1574.\nFollow-up to production deployability repairs #1569/#1571/#1573.\n\nPrevent the same class of production-only Convex failure from merging again. Ordinary CI previously accepted two `by_*` index identifiers over Convex's 64-character limit; protected production schema analysis caught them only after merge.\n\nAdd one Bun regression that scans retained `convex/**/*.ts` string literals matching `by_*` and fails when any exceed 64 characters. Generated Convex files are excluded. The test also reconstructs the two historical mail index names from fragments and proves both exceed the production limit.",
+      "evidence_complete": false
+    },
+    {
+      "reference": {
+        "kind": "issue",
+        "number": 1574
+      },
+      "title": "Catch overlong Convex index identifiers before production deploy",
+      "state": "closed",
+      "created_at": "2026-08-15T12:56:28Z",
+      "closed_at": "2026-08-15T13:00:59Z",
+      "revision": null,
+      "changed_paths": [],
+      "evidence_text": "Programme: deployment reliability follow-up from #1568/#1570/#1572\nRelated: #1488 hosted mail production recovery\n\nTwo independent mail schemas passed ordinary repository CI and only failed later in protected Convex Production because their index names exceeded Convex's 64-character identifier limit. Add one source-level reversing control so ordinary CI catches that deployment class before merge.",
+      "evidence_complete": false
+    },
+    {
+      "reference": {
+        "kind": "pull_request",
+        "number": 1569
+      },
+      "title": "Keep hosted mail contracts Convex-runtime neutral",
+      "state": "closed",
+      "created_at": "2026-08-15T12:24:43Z",
+      "closed_at": "2026-08-15T12:31:18Z",
+      "revision": {
+        "head_sha": "ee1888efd3e59c5e3ebcaf449642145044983670",
+        "base_sha": "237beebb7e42aa1a8588a2d149cc313246f285ec",
+        "merged": true
+      },
+      "changed_paths": [
+        "package.json",
+        "src/mail-thread-contract.ts",
+        "test/mail-thread-runtime-neutral.test.ts",
+        "test/runtime/run-mail-thread-handle-runtime.ts"
+      ],
+      "evidence_text": "Closes #1568.\nContinuation from closed #1518 / merged #1524.\n\nRepair the production Convex deployment failure exposed after #1524. Ordinary Convex mail functions import the shared mail-thread contract; that contract imported `node:crypto`, so production `convex codegen --dry-run --typecheck enable` could not bundle the hosted outbound functions and the actual Convex deploy step never ran.",
+      "evidence_complete": false
+    },
+    {
+      "reference": {
+        "kind": "pull_request",
+        "number": 1571
+      },
+      "title": "Keep Gmail semantic-admission indexes deployable",
+      "state": "closed",
+      "created_at": "2026-08-15T12:35:46Z",
+      "closed_at": "2026-08-15T12:40:25Z",
+      "revision": {
+        "head_sha": "4301d87b7a46d88f3758139388a6ff9bb8ff67f7",
+        "base_sha": "8c322159d5f821cc213c2b0cfde65d4583793ff8",
+        "merged": true
+      },
+      "changed_paths": [
+        "convex/mailSemanticAdmission.ts",
+        "convex/mailSemanticAdmissionIndexes.test.ts",
+        "convex/mailSemanticAdmissionIndexes.ts",
+        "convex/mailSemanticAdmissionSchema.ts"
+      ],
+      "evidence_text": "Closes #1570.\nDeployment continuation from #1568/#1569; parent semantics merged in #1528/#1521.\n\nAfter #1569 cleared the `node:crypto` Convex bundle failure, production schema evaluation exposed the next blocker: one Gmail semantic-admission index name exceeds Convex's 64-character identifier limit, so the real Convex deployment still never runs.\n\nReplace that overlong identifier with a 63-character identifier, preserve exact field order, share the literal between schema declaration and both query sites, and add a focused 64-character-limit regression.",
+      "evidence_complete": false
+    },
+    {
+      "reference": {
+        "kind": "pull_request",
+        "number": 1573
+      },
+      "title": "Keep Gmail mailbox-disposition indexes deployable",
+      "state": "closed",
+      "created_at": "2026-08-15T12:48:20Z",
+      "closed_at": "2026-08-15T12:52:59Z",
+      "revision": {
+        "head_sha": "d26c8c2f02d1249abd40d1c3d17cefe72e024e5d",
+        "base_sha": "ca5d2c7fdf89666e523972ab6e81610d17b9611b",
+        "merged": true
+      },
+      "changed_paths": [
+        "convex/gmailMailboxDisposition.ts",
+        "convex/gmailMailboxDispositionIndexes.test.ts",
+        "convex/gmailMailboxDispositionSchema.ts"
+      ],
+      "evidence_text": "Closes #1572.\nParent: #1522 / merged #1565.\nDeployment continuation: #1568/#1569, #1570/#1571.\n\nProduction Convex analysis now gets past the outbound runtime and semantic-admission blockers, then rejects the merged #1522 exact-message disposition lane because its six-field index name exceeds Convex's 64-character identifier limit. This packet changes only that identifier so the already-merged semantics can deploy.\n\nRename that index to a 60-character identifier while preserving the exact indexed sequence and add a focused identifier-limit reversal.",
+      "evidence_complete": false
+    }
+  ],
+  "edges": [
+    {
+      "from": {
+        "kind": "pull_request",
+        "number": 1575
+      },
+      "relation": "closes",
+      "to": {
+        "kind": "issue",
+        "number": 1574
+      },
+      "evidence": "Closes #1574."
+    },
+    {
+      "from": {
+        "kind": "pull_request",
+        "number": 1575
+      },
+      "relation": "follow_up_to",
+      "to": {
+        "kind": "pull_request",
+        "number": 1569
+      },
+      "evidence": "Follow-up to production deployability repairs #1569/#1571/#1573."
+    },
+    {
+      "from": {
+        "kind": "pull_request",
+        "number": 1575
+      },
+      "relation": "follow_up_to",
+      "to": {
+        "kind": "pull_request",
+        "number": 1571
+      },
+      "evidence": "Follow-up to production deployability repairs #1569/#1571/#1573."
+    },
+    {
+      "from": {
+        "kind": "pull_request",
+        "number": 1575
+      },
+      "relation": "follow_up_to",
+      "to": {
+        "kind": "pull_request",
+        "number": 1573
+      },
+      "evidence": "Follow-up to production deployability repairs #1569/#1571/#1573."
+    },
+    {
+      "from": {
+        "kind": "pull_request",
+        "number": 1571
+      },
+      "relation": "continuation_from",
+      "to": {
+        "kind": "pull_request",
+        "number": 1569
+      },
+      "evidence": "Deployment continuation from #1568/#1569; parent semantics merged in #1528/#1521."
+    },
+    {
+      "from": {
+        "kind": "pull_request",
+        "number": 1573
+      },
+      "relation": "continuation_from",
+      "to": {
+        "kind": "pull_request",
+        "number": 1569
+      },
+      "evidence": "Deployment continuation: #1568/#1569, #1570/#1571."
+    },
+    {
+      "from": {
+        "kind": "pull_request",
+        "number": 1573
+      },
+      "relation": "continuation_from",
+      "to": {
+        "kind": "pull_request",
+        "number": 1571
+      },
+      "evidence": "Deployment continuation: #1568/#1569, #1570/#1571."
+    }
+  ]
+}

--- a/src/project_memory.rs
+++ b/src/project_memory.rs
@@ -1,0 +1,384 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+pub const PROJECT_MEMORY_SCHEMA_VERSION: u32 = 1;
+pub const MAX_PROJECT_MEMORY_BYTES: usize = 256 * 1024;
+const MAX_ARTIFACTS: usize = 128;
+const MAX_EDGES: usize = 256;
+const MAX_TITLE_BYTES: usize = 512;
+const MAX_EVIDENCE_TEXT_BYTES: usize = 32 * 1024;
+const MAX_EDGE_EVIDENCE_BYTES: usize = 2 * 1024;
+const MAX_PATHS_PER_ARTIFACT: usize = 512;
+const MAX_PATH_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactKind {
+    PullRequest,
+    Issue,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactRef {
+    pub kind: ArtifactKind,
+    pub number: u64,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactState {
+    Open,
+    Closed,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RevisionCoordinate {
+    pub head_sha: String,
+    pub base_sha: String,
+    pub merged: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectArtifact {
+    pub reference: ArtifactRef,
+    pub title: String,
+    pub state: ArtifactState,
+    pub created_at: String,
+    pub closed_at: Option<String>,
+    pub revision: Option<RevisionCoordinate>,
+    #[serde(default)]
+    pub changed_paths: Vec<String>,
+    pub evidence_text: String,
+    pub evidence_complete: bool,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryRelation {
+    Closes,
+    FollowUpTo,
+    ContinuationFrom,
+    Parent,
+    Related,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectMemoryEdge {
+    pub from: ArtifactRef,
+    pub relation: MemoryRelation,
+    pub to: ArtifactRef,
+    pub evidence: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectMemoryPacket {
+    pub schema_version: u32,
+    pub repository: String,
+    pub anchor: ArtifactRef,
+    pub artifacts: Vec<ProjectArtifact>,
+    pub edges: Vec<ProjectMemoryEdge>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ProjectMemoryLinkSummary {
+    pub relation: MemoryRelation,
+    pub target: ArtifactRef,
+    pub evidence: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ProjectMemorySummary {
+    pub schema_version: u32,
+    pub repository: String,
+    pub anchor: ArtifactRef,
+    pub anchor_title: String,
+    pub artifact_count: usize,
+    pub edge_count: usize,
+    pub anchor_changed_paths: Vec<String>,
+    pub explicit_anchor_links: Vec<ProjectMemoryLinkSummary>,
+}
+
+pub fn parse_project_memory_packet(bytes: &[u8]) -> Result<ProjectMemoryPacket, String> {
+    if bytes.len() > MAX_PROJECT_MEMORY_BYTES {
+        return Err(format!(
+            "project-memory packet exceeds {} bytes",
+            MAX_PROJECT_MEMORY_BYTES
+        ));
+    }
+    let packet: ProjectMemoryPacket =
+        serde_json::from_slice(bytes).map_err(|error| format!("invalid project-memory JSON: {error}"))?;
+    packet.validate()?;
+    Ok(packet)
+}
+
+impl ProjectMemoryPacket {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.schema_version != PROJECT_MEMORY_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported project-memory schema version {}",
+                self.schema_version
+            ));
+        }
+        validate_repository(&self.repository)?;
+        validate_artifact_ref(self.anchor, "anchor")?;
+        if self.artifacts.is_empty() || self.artifacts.len() > MAX_ARTIFACTS {
+            return Err(format!(
+                "project-memory packet must contain 1..={MAX_ARTIFACTS} artifacts"
+            ));
+        }
+        if self.edges.len() > MAX_EDGES {
+            return Err(format!(
+                "project-memory packet may contain at most {MAX_EDGES} edges"
+            ));
+        }
+
+        let mut artifacts = BTreeMap::new();
+        for artifact in &self.artifacts {
+            artifact.validate()?;
+            if artifacts.insert(artifact.reference, artifact).is_some() {
+                return Err(format!(
+                    "duplicate project-memory artifact {}",
+                    display_ref(artifact.reference)
+                ));
+            }
+        }
+
+        if !artifacts.contains_key(&self.anchor) {
+            return Err("project-memory anchor is absent from artifacts".to_string());
+        }
+
+        for edge in &self.edges {
+            validate_artifact_ref(edge.from, "edge source")?;
+            validate_artifact_ref(edge.to, "edge target")?;
+            if edge.from == edge.to {
+                return Err("project-memory edges may not self-reference".to_string());
+            }
+            let Some(source) = artifacts.get(&edge.from) else {
+                return Err(format!(
+                    "project-memory edge source {} is absent",
+                    display_ref(edge.from)
+                ));
+            };
+            if !artifacts.contains_key(&edge.to) {
+                return Err(format!(
+                    "project-memory edge target {} is absent",
+                    display_ref(edge.to)
+                ));
+            }
+            validate_single_line_or_excerpt(
+                &edge.evidence,
+                "edge evidence",
+                MAX_EDGE_EVIDENCE_BYTES,
+                true,
+            )?;
+            if !source.evidence_text.contains(&edge.evidence) {
+                return Err(format!(
+                    "edge evidence for {} -> {} is absent from the source artifact evidence text",
+                    display_ref(edge.from),
+                    display_ref(edge.to)
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn summary(&self) -> Result<ProjectMemorySummary, String> {
+        self.validate()?;
+        let anchor = self
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.reference == self.anchor)
+            .ok_or("project-memory anchor is absent from artifacts")?;
+        let explicit_anchor_links = self
+            .edges
+            .iter()
+            .filter(|edge| edge.from == self.anchor)
+            .map(|edge| ProjectMemoryLinkSummary {
+                relation: edge.relation,
+                target: edge.to,
+                evidence: edge.evidence.clone(),
+            })
+            .collect();
+
+        Ok(ProjectMemorySummary {
+            schema_version: PROJECT_MEMORY_SCHEMA_VERSION,
+            repository: self.repository.clone(),
+            anchor: self.anchor,
+            anchor_title: anchor.title.clone(),
+            artifact_count: self.artifacts.len(),
+            edge_count: self.edges.len(),
+            anchor_changed_paths: anchor.changed_paths.clone(),
+            explicit_anchor_links,
+        })
+    }
+}
+
+impl ProjectArtifact {
+    fn validate(&self) -> Result<(), String> {
+        validate_artifact_ref(self.reference, "artifact")?;
+        validate_single_line_or_excerpt(&self.title, "artifact title", MAX_TITLE_BYTES, false)?;
+        validate_timestamp(&self.created_at, "created_at")?;
+        match (self.state, self.closed_at.as_deref()) {
+            (ArtifactState::Open, None) => {}
+            (ArtifactState::Closed, Some(value)) => validate_timestamp(value, "closed_at")?,
+            (ArtifactState::Open, Some(_)) => {
+                return Err(format!(
+                    "open artifact {} may not have closed_at",
+                    display_ref(self.reference)
+                ));
+            }
+            (ArtifactState::Closed, None) => {
+                return Err(format!(
+                    "closed artifact {} requires closed_at",
+                    display_ref(self.reference)
+                ));
+            }
+        }
+
+        validate_single_line_or_excerpt(
+            &self.evidence_text,
+            "artifact evidence text",
+            MAX_EVIDENCE_TEXT_BYTES,
+            true,
+        )?;
+        if self.changed_paths.len() > MAX_PATHS_PER_ARTIFACT {
+            return Err(format!(
+                "artifact {} exceeds the changed-path bound",
+                display_ref(self.reference)
+            ));
+        }
+        for path in &self.changed_paths {
+            validate_repository_path(path)?;
+        }
+
+        match self.reference.kind {
+            ArtifactKind::PullRequest => {
+                let Some(revision) = &self.revision else {
+                    return Err(format!(
+                        "pull request {} requires exact revision coordinates",
+                        self.reference.number
+                    ));
+                };
+                validate_sha(&revision.head_sha, "head_sha")?;
+                validate_sha(&revision.base_sha, "base_sha")?;
+                if revision.merged && self.state != ArtifactState::Closed {
+                    return Err(format!(
+                        "merged pull request {} must be closed",
+                        self.reference.number
+                    ));
+                }
+            }
+            ArtifactKind::Issue => {
+                if self.revision.is_some() {
+                    return Err(format!(
+                        "issue {} may not carry pull-request revision coordinates",
+                        self.reference.number
+                    ));
+                }
+                if !self.changed_paths.is_empty() {
+                    return Err(format!(
+                        "issue {} may not carry changed paths",
+                        self.reference.number
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn validate_artifact_ref(reference: ArtifactRef, label: &str) -> Result<(), String> {
+    if reference.number == 0 {
+        return Err(format!("{label} number must be positive"));
+    }
+    Ok(())
+}
+
+fn validate_repository(value: &str) -> Result<(), String> {
+    if value.len() > 200 || value.bytes().any(|byte| matches!(byte, b'\n' | b'\r')) {
+        return Err("repository coordinate is malformed or too long".to_string());
+    }
+    let Some((owner, repository)) = value.split_once('/') else {
+        return Err("repository coordinate must be owner/name".to_string());
+    };
+    if owner.is_empty()
+        || repository.is_empty()
+        || repository.contains('/')
+        || !owner.bytes().all(valid_repository_char)
+        || !repository.bytes().all(valid_repository_char)
+    {
+        return Err("repository coordinate must be canonical owner/name".to_string());
+    }
+    Ok(())
+}
+
+fn valid_repository_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')
+}
+
+fn validate_sha(value: &str, label: &str) -> Result<(), String> {
+    if value.len() != 40
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(format!("{label} must be an exact lowercase 40-hex Git object id"));
+    }
+    Ok(())
+}
+
+fn validate_timestamp(value: &str, label: &str) -> Result<(), String> {
+    if value.is_empty()
+        || value.len() > 64
+        || value.bytes().any(|byte| matches!(byte, b'\n' | b'\r'))
+    {
+        return Err(format!("{label} is malformed or too long"));
+    }
+    Ok(())
+}
+
+fn validate_single_line_or_excerpt(
+    value: &str,
+    label: &str,
+    max_bytes: usize,
+    allow_newlines: bool,
+) -> Result<(), String> {
+    if value.is_empty() || value.len() > max_bytes || value.contains('\0') {
+        return Err(format!("{label} is empty, malformed, or too long"));
+    }
+    if !allow_newlines && value.bytes().any(|byte| matches!(byte, b'\n' | b'\r')) {
+        return Err(format!("{label} must be single-line"));
+    }
+    Ok(())
+}
+
+fn validate_repository_path(path: &str) -> Result<(), String> {
+    if path.is_empty()
+        || path.len() > MAX_PATH_BYTES
+        || path.starts_with('/')
+        || path.contains('\\')
+        || path.contains('\0')
+        || path
+            .split('/')
+            .any(|component| component.is_empty() || matches!(component, "." | ".."))
+    {
+        return Err(format!("non-canonical repository-relative path `{path}`"));
+    }
+    Ok(())
+}
+
+fn display_ref(reference: ArtifactRef) -> String {
+    let kind = match reference.kind {
+        ArtifactKind::PullRequest => "pr",
+        ArtifactKind::Issue => "issue",
+    };
+    format!("{kind}#{}", reference.number)
+}

--- a/src/project_memory.rs
+++ b/src/project_memory.rs
@@ -111,8 +111,8 @@ pub fn parse_project_memory_packet(bytes: &[u8]) -> Result<ProjectMemoryPacket, 
             MAX_PROJECT_MEMORY_BYTES
         ));
     }
-    let packet: ProjectMemoryPacket =
-        serde_json::from_slice(bytes).map_err(|error| format!("invalid project-memory JSON: {error}"))?;
+    let packet: ProjectMemoryPacket = serde_json::from_slice(bytes)
+        .map_err(|error| format!("invalid project-memory JSON: {error}"))?;
     packet.validate()?;
     Ok(packet)
 }
@@ -330,7 +330,9 @@ fn validate_sha(value: &str, label: &str) -> Result<(), String> {
             .bytes()
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
     {
-        return Err(format!("{label} must be an exact lowercase 40-hex Git object id"));
+        return Err(format!(
+            "{label} must be an exact lowercase 40-hex Git object id"
+        ));
     }
     Ok(())
 }

--- a/tests/project_memory.rs
+++ b/tests/project_memory.rs
@@ -81,12 +81,13 @@ fn missing_edge_target_is_rejected() {
 #[test]
 fn issue_cannot_claim_pull_request_revision_coordinates() {
     let mut packet = parse_project_memory_packet(STENSIBLY_1575).unwrap();
+    let revision = packet.artifacts[0].revision.clone();
     let issue = packet
         .artifacts
         .iter_mut()
         .find(|artifact| artifact.reference.kind == ArtifactKind::Issue)
         .unwrap();
-    issue.revision = packet.artifacts[0].revision.clone();
+    issue.revision = revision;
 
     let error = packet.validate().unwrap_err();
     assert!(error.contains("may not carry pull-request revision coordinates"));

--- a/tests/project_memory.rs
+++ b/tests/project_memory.rs
@@ -1,0 +1,100 @@
+#[path = "../src/project_memory.rs"]
+mod project_memory;
+
+use project_memory::{
+    ArtifactKind, ArtifactRef, MAX_PROJECT_MEMORY_BYTES, MemoryRelation,
+    parse_project_memory_packet,
+};
+
+const STENSIBLY_1575: &[u8] =
+    include_bytes!("../research/project-memory/stensibly-1575.json");
+
+#[test]
+fn retained_stensibly_packet_preserves_explicit_lineage() {
+    let packet = parse_project_memory_packet(STENSIBLY_1575).unwrap();
+    let summary = packet.summary().unwrap();
+
+    assert_eq!(summary.repository, "teamleaderleo/stensibly");
+    assert_eq!(
+        summary.anchor,
+        ArtifactRef {
+            kind: ArtifactKind::PullRequest,
+            number: 1575,
+        }
+    );
+    assert_eq!(summary.artifact_count, 5);
+    assert_eq!(summary.edge_count, 7);
+    assert_eq!(
+        summary.anchor_changed_paths,
+        vec!["test/convex-index-identifier-limit.test.ts".to_string()]
+    );
+
+    let follow_ups: Vec<_> = summary
+        .explicit_anchor_links
+        .iter()
+        .filter(|link| link.relation == MemoryRelation::FollowUpTo)
+        .map(|link| link.target.number)
+        .collect();
+    assert_eq!(follow_ups, vec![1569, 1571, 1573]);
+
+    let closes: Vec<_> = summary
+        .explicit_anchor_links
+        .iter()
+        .filter(|link| link.relation == MemoryRelation::Closes)
+        .map(|link| link.target.number)
+        .collect();
+    assert_eq!(closes, vec![1574]);
+}
+
+#[test]
+fn chronology_alone_does_not_create_project_memory_links() {
+    let packet = parse_project_memory_packet(STENSIBLY_1575).unwrap();
+    let summary = packet.summary().unwrap();
+
+    // Five dated artifacts are present. The anchor exposes only the four links
+    // backed by exact retained text in PR #1575.
+    assert_eq!(summary.artifact_count, 5);
+    assert_eq!(summary.explicit_anchor_links.len(), 4);
+}
+
+#[test]
+fn invented_edge_evidence_is_rejected() {
+    let mut packet = parse_project_memory_packet(STENSIBLY_1575).unwrap();
+    packet.edges[1].evidence = "Chronology proves these changes caused the guard.".to_string();
+
+    let error = packet.validate().unwrap_err();
+    assert!(error.contains("absent from the source artifact evidence text"));
+}
+
+#[test]
+fn missing_edge_target_is_rejected() {
+    let mut packet = parse_project_memory_packet(STENSIBLY_1575).unwrap();
+    packet.edges[0].to = ArtifactRef {
+        kind: ArtifactKind::Issue,
+        number: 999_999,
+    };
+
+    let error = packet.validate().unwrap_err();
+    assert!(error.contains("edge target issue#999999 is absent"));
+}
+
+#[test]
+fn issue_cannot_claim_pull_request_revision_coordinates() {
+    let mut packet = parse_project_memory_packet(STENSIBLY_1575).unwrap();
+    let issue = packet
+        .artifacts
+        .iter_mut()
+        .find(|artifact| artifact.reference.kind == ArtifactKind::Issue)
+        .unwrap();
+    issue.revision = packet.artifacts[0].revision.clone();
+
+    let error = packet.validate().unwrap_err();
+    assert!(error.contains("may not carry pull-request revision coordinates"));
+}
+
+#[test]
+fn packet_input_is_bounded_before_json_parse() {
+    let bytes = vec![b' '; MAX_PROJECT_MEMORY_BYTES + 1];
+    let error = parse_project_memory_packet(&bytes).unwrap_err();
+    assert!(error.contains("exceeds"));
+}

--- a/tests/project_memory.rs
+++ b/tests/project_memory.rs
@@ -6,8 +6,7 @@ use project_memory::{
     parse_project_memory_packet,
 };
 
-const STENSIBLY_1575: &[u8] =
-    include_bytes!("../research/project-memory/stensibly-1575.json");
+const STENSIBLY_1575: &[u8] = include_bytes!("../research/project-memory/stensibly-1575.json");
 
 #[test]
 fn retained_stensibly_packet_preserves_explicit_lineage() {


### PR DESCRIPTION
## Goal

Start #18 with the smallest useful project-memory primitive: a bounded offline packet for explicit PR/issue relationships, exact revision coordinates, selected evidence text, and changed paths.

Remote/provider access remains outside the Cultist process. This PR adds no product CLI command and no network behavior.

## Packet v1

`src/project_memory.rs` defines a strict JSON packet containing:

```text
repository owner/name
anchor artifact
bounded artifact list
bounded explicit edge list
```

Artifacts preserve:

- `pull_request | issue` identity;
- title/state/date coordinates;
- exact lowercase 40-hex PR head/base coordinates;
- changed paths for PRs;
- bounded retained evidence text;
- whether the retained text is complete.

Edges are typed:

```text
closes
follow_up_to
continuation_from
parent
related
```

Every edge carries the exact retained excerpt that establishes the relationship. Validation requires that excerpt to occur in the source artifact's admitted evidence text and requires both endpoints to exist in the packet.

Dates, vector order, nearby PR numbers, similar titles, and path overlap create no relationship edges.

## Fail-closed bounds

The parser rejects:

- input above 256 KiB;
- unknown schema versions/fields;
- malformed repository coordinates;
- duplicate or missing artifact identities;
- PRs without exact head/base coordinates;
- issues carrying PR revision/path fields;
- malformed repository-relative paths;
- missing/self edge targets;
- edge evidence absent from source artifact text;
- inconsistent open/closed timestamps.

## Retained Stensibly discriminator

`research/project-memory/stensibly-1575.json` pins five public provider artifacts:

```text
#1569  hosted-mail Convex runtime repair
#1571  semantic-admission index-length repair
#1573  disposition index-length repair
#1574  follow-up issue for the repeated identifier class
#1575  repository-wide Convex identifier-limit guard
```

Anchor #1575 explicitly says:

```text
Closes #1574.
Follow-up to production deployability repairs #1569/#1571/#1573.
```

The packet also retains exact continuation text from #1571 and #1573.

The semantic distinction stays visible:

- #1569 is a deployability predecessor clearing a Node-runtime bundling blocker;
- #1571 and #1573 are the two concrete overlong-index repairs;
- #1575 explicitly says ordinary CI accepted two overlong `by_*` identifiers and adds one repository-wide 64-character guard.

V1 therefore records enough explicit evidence to ask about lesson promotion without manufacturing a three-instance common failure class or inferring causality from timing.

## Research reader

```text
cargo run --example project_memory_packet < research/project-memory/stensibly-1575.json
```

The reader is bounded and offline and prints only the validated anchor summary + explicit anchor links.

## Tests

`tests/project_memory.rs` keeps the retained fixture in the standard matrix and asserts:

- #1575 exposes exactly three explicit follow-up PRs and one closing issue;
- five dated artifacts produce only the four anchor links actually backed by retained text;
- invented relationship evidence rejects;
- missing targets reject;
- issue/PR coordinate type confusion rejects;
- oversized input rejects before JSON parsing.

## Boundary / next step

This is an evidence packet, not a `why` finding or causal graph.

The next provider-side experiment can collect a selected anchor plus exact named artifacts into this offline form. Explicit references stay separate from chronological adjacency. Reviews/comments should enter only when a concrete replay earns that extra evidence type.

The Stensibly adapter-gap case from #138 now has an executable acceptance target for the first project-memory collector. Linux Fieldwork remains the complementary issue/investigation/note intake case.

Progresses #18
Progresses #41
Related: #16 #138