### PR TITLE
research: plan evidence acquisition from durable UNKNOWNs

### DIFF
--- a/examples/evidence_plan.rs
+++ b/examples/evidence_plan.rs
@@ -1,0 +1,33 @@
+#![allow(dead_code)]
+
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[path = "../src/justification.rs"]
+mod justification;
+
+use evidence_planner::{ProbePlanRequest, plan_evidence};
+
+const MAX_INPUT_BYTES: u64 = 1024 * 1024;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut input = Vec::new();
+    io::stdin()
+        .take(MAX_INPUT_BYTES + 1)
+        .read_to_end(&mut input)?;
+    if input.len() as u64 > MAX_INPUT_BYTES {
+        return Err("evidence planner input exceeds 1 MiB".into());
+    }
+
+    let request: ProbePlanRequest = serde_json::from_slice(&input)?;
+    let plan = plan_evidence(&request)?;
+    serde_json::to_writer_pretty(io::stdout().lock(), &plan)?;
+    println!();
+    Ok(())
+}

--- a/research/evidence-acquisition-planner.md
+++ b/research/evidence-acquisition-planner.md
@@ -1,0 +1,165 @@
+# Evidence acquisition planner research receipt
+
+Tracking: #145. Stacked on #144/#159 and #141/#156.
+
+## Question
+
+Given one material durable `UNKNOWN`, can Cultist select the smallest admitted evidence probe capable of changing that exact answer without confusing cheap evidence with sufficient evidence or granting permission to perform effects?
+
+## Earned input from #144
+
+The planner consumes the durable record directly:
+
+```text
+DurableObligation
+  subject applicability
+  missing_discriminator { kind, target }
+  clearing_conditions[]
+```
+
+It does not reparse the question prose to decide what evidence is needed.
+
+A candidate probe declares:
+
+```text
+id
+produces { kind, target }
+requirements
+probe effect class
+forecast cost
+```
+
+A probe is capable only when its produced discriminator exactly matches the obligation's missing discriminator and its exact output requirements match an admitted clearing condition.
+
+This is deliberately stronger than vocabulary overlap. A historical companion probe can be cheap and useful while remaining incapable of clearing an `exact-head target_test_result` obligation.
+
+## Candidate states
+
+Each probe receives one inspectable status:
+
+```text
+eligible
+incapable
+incompatible_clearing_condition
+invalid_coordinate
+missing_context
+effect_authority_required
+```
+
+The whole plan is:
+
+```text
+selected
+blocked
+unresolved
+stale_obligation
+```
+
+`unresolved` means no admitted probe can currently answer the obligation. It is a valid research-frontier result.
+
+`stale_obligation` means the durable obligation's own subject coordinate moved; the planner refuses to select new work against an obsolete question and requires a fresh obligation first.
+
+## Effect boundary
+
+Probe effect class is explicit:
+
+```text
+read_only
+external_read
+effectful
+```
+
+An effectful probe may be the only capable next discriminator. The planner can identify that fact while returning `blocked / effect_authority_required` when the caller has not admitted effectful work.
+
+Selection therefore answers:
+
+> Which admitted probe would be appropriate if its effect class is allowed?
+
+It does not itself execute the probe or mint execution authority.
+
+A `SelectedProbe` remains an **expected evidence contract** until the probe actually runs and produces a separate observed receipt. The planner cannot clear its own obligation merely by selecting a capable probe.
+
+## Forecast cost versus measured performance
+
+V0 `ProbeCost` is a pre-execution forecast:
+
+```text
+git_subprocesses
+rust_files_parsed
+remote_requests
+effectful_executions
+```
+
+Current `PerfCounters` on main are post-execution observations. Keep those concepts separate. A later calibration experiment can compare forecast and measured dimensions where they overlap.
+
+The first explicit policy is `conservative`:
+
+1. prefer read-only over external-read over effectful probes;
+2. then fewer remote requests;
+3. then fewer Git subprocesses;
+4. then fewer Rust files parsed;
+5. then fewer effectful executions;
+6. stable probe ID breaks exact ties.
+
+No hidden scalar cost score is produced.
+
+## Initial controls
+
+The carrier tests:
+
+- a cheaper historical probe is skipped when it cannot produce the required discriminator;
+- a stale exact-test probe cannot satisfy a current-head clearing condition;
+- the exact-head target execution probe is selected when effectful work is admitted;
+- the same capable probe returns `blocked` when effect authority is absent;
+- conservative policy prefers an eligible external read before an eligible effectful alternative;
+- no capable probe produces explicit `unresolved`;
+- missing current obligation context produces `blocked` instead of guessing;
+- moved obligation subject produces `stale_obligation` before probe selection;
+- simulated execution of the selected probe can emit the exact typed receipt that #144 evaluates from `open -> cleared`;
+- malformed effect/cost declarations fail explicitly.
+
+## Executed GitHub receipt
+
+Draft stacked PR #164 ran against exact parent #159 head:
+
+```text
+parent  1c1a0086a199168fd0e21445d103936183063dc7
+child   179a2b45267b36d9dfd92eddca93f70aac1744d4
+```
+
+GitHub Actions CI run `32244269156` / run number `1083` completed successfully on the stacked PR merge ref. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work heads-up;
+- full `cargo test` including the evidence-planner harness;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The PR-only push-diff step remained skipped by workflow context.
+
+Two preceding runs were useful controls:
+
+1. run `32243927421` exposed handwritten rustfmt differences before semantic validation;
+2. run `32244049236` passed format/Clippy and all planner semantics except one test assertion that expected the plural phrase `effectful executions` while the intentional validation error used singular `effectful execution`.
+
+The second failure changed only the test's string expectation. The planner contract stayed unchanged, and the next full run passed.
+
+## Boundary
+
+- candidate capability comes from typed probe declarations, never prose keyword inference;
+- planning does not strengthen the epistemic kind of the evidence produced;
+- historical co-change remains association evidence even when it is the cheapest probe;
+- selection is deterministic under the declared policy;
+- a selected effectful probe remains unexecuted until an external caller/orchestrator grants that action;
+- selection produces an expected receipt contract, not observed clearing evidence;
+- no model, network request, test command, or repository mutation occurs inside the planner;
+- planner output is research-only and does not change the product CLI/report schema.
+
+## Next discriminator
+
+Replay one real Cultist research frontier where two probes can answer the same typed discriminator at different costs. Then compare forecast work with existing performance receipts after execution.
+
+A second follow-up should test whether probe prerequisites need their own typed relation beyond output applicability. Keep v0 small until a real probe requires a prerequisite that cannot be represented by the current obligation/context coordinates.

--- a/src/evidence_planner.rs
+++ b/src/evidence_planner.rs
@@ -1,0 +1,688 @@
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, evaluate_query,
+};
+use crate::durable_obligation::{
+    DiscriminatorKey, DurableObligation, DurableObligationStatus, evaluate_obligation,
+};
+
+pub const EVIDENCE_PLANNER_SCHEMA_VERSION: u32 = 1;
+const MAX_PROBES: usize = 128;
+const MAX_ID_BYTES: usize = 256;
+const MAX_TEXT_BYTES: usize = 4096;
+const MAX_COST_UNIT: u32 = 1_000_000;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProbePlanRequest {
+    pub schema_version: u32,
+    pub obligation: DurableObligation,
+    pub context: EvaluationContext,
+    pub probes: Vec<EvidenceProbe>,
+    pub allow_effectful: bool,
+    pub policy: ProbeSelectionPolicy,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceProbe {
+    pub id: String,
+    pub produces: DiscriminatorKey,
+    pub requirements: EvidenceRequirements,
+    pub effect: ProbeEffect,
+    pub cost: ProbeCost,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeEffect {
+    ReadOnly,
+    ExternalRead,
+    Effectful,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProbeCost {
+    pub git_subprocesses: u32,
+    pub rust_files_parsed: u32,
+    pub remote_requests: u32,
+    pub effectful_executions: u32,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeSelectionPolicy {
+    Conservative,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeCandidateStatus {
+    Eligible,
+    Incapable,
+    IncompatibleClearingCondition,
+    InvalidCoordinate,
+    MissingContext,
+    EffectAuthorityRequired,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProbeCandidateReceipt {
+    pub id: String,
+    pub status: ProbeCandidateStatus,
+    pub effect: ProbeEffect,
+    pub cost: ProbeCost,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidencePlanStatus {
+    Selected,
+    Blocked,
+    Unresolved,
+    StaleObligation,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SelectedProbe {
+    pub id: String,
+    pub produces: DiscriminatorKey,
+    pub requirements: EvidenceRequirements,
+    pub effect: ProbeEffect,
+    pub cost: ProbeCost,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidencePlan {
+    pub schema_version: u32,
+    pub obligation_id: String,
+    pub obligation_status: DurableObligationStatus,
+    pub status: EvidencePlanStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected: Option<SelectedProbe>,
+    pub candidates: Vec<ProbeCandidateReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct EvidencePlannerError {
+    message: String,
+}
+
+impl EvidencePlannerError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for EvidencePlannerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for EvidencePlannerError {}
+
+pub fn plan_evidence(request: &ProbePlanRequest) -> Result<EvidencePlan, EvidencePlannerError> {
+    validate_request(request)?;
+
+    let obligation_evaluation = evaluate_obligation(&request.obligation, &[], &request.context)
+        .map_err(|error| {
+            EvidencePlannerError::new(format!("obligation evaluation failed: {error}"))
+        })?;
+
+    if obligation_evaluation.status == DurableObligationStatus::ReopenRequired {
+        return Ok(EvidencePlan {
+            schema_version: EVIDENCE_PLANNER_SCHEMA_VERSION,
+            obligation_id: request.obligation.id.clone(),
+            obligation_status: obligation_evaluation.status,
+            status: EvidencePlanStatus::StaleObligation,
+            selected: None,
+            candidates: Vec::new(),
+        });
+    }
+
+    let mut candidates = request
+        .probes
+        .iter()
+        .map(|probe| {
+            evaluate_candidate(
+                &request.obligation,
+                &request.context,
+                request.allow_effectful,
+                probe,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    candidates.sort_by(|left, right| left.receipt.id.cmp(&right.receipt.id));
+
+    let selected_probe = candidates
+        .iter()
+        .filter(|candidate| candidate.receipt.status == ProbeCandidateStatus::Eligible)
+        .map(|candidate| candidate.probe)
+        .min_by(|left, right| compare_probe_cost(left, right, request.policy));
+
+    let status = if selected_probe.is_some() {
+        EvidencePlanStatus::Selected
+    } else if obligation_evaluation.status == DurableObligationStatus::Unknown
+        || candidates.iter().any(|candidate| {
+            matches!(
+                candidate.receipt.status,
+                ProbeCandidateStatus::MissingContext
+                    | ProbeCandidateStatus::EffectAuthorityRequired
+            )
+        })
+    {
+        EvidencePlanStatus::Blocked
+    } else {
+        EvidencePlanStatus::Unresolved
+    };
+
+    let selected = selected_probe.map(|probe| SelectedProbe {
+        id: probe.id.clone(),
+        produces: probe.produces.clone(),
+        requirements: probe.requirements.clone(),
+        effect: probe.effect,
+        cost: probe.cost,
+    });
+
+    Ok(EvidencePlan {
+        schema_version: EVIDENCE_PLANNER_SCHEMA_VERSION,
+        obligation_id: request.obligation.id.clone(),
+        obligation_status: obligation_evaluation.status,
+        status,
+        selected,
+        candidates: candidates
+            .into_iter()
+            .map(|candidate| candidate.receipt)
+            .collect(),
+    })
+}
+
+struct CandidateEvaluation<'a> {
+    probe: &'a EvidenceProbe,
+    receipt: ProbeCandidateReceipt,
+}
+
+fn evaluate_candidate<'a>(
+    obligation: &DurableObligation,
+    context: &EvaluationContext,
+    allow_effectful: bool,
+    probe: &'a EvidenceProbe,
+) -> Result<CandidateEvaluation<'a>, EvidencePlannerError> {
+    let status = if probe.produces != obligation.missing_discriminator {
+        ProbeCandidateStatus::Incapable
+    } else if !obligation.clearing_conditions.iter().any(|condition| {
+        condition.discriminator == probe.produces && condition.requirements == probe.requirements
+    }) {
+        ProbeCandidateStatus::IncompatibleClearingCondition
+    } else {
+        let applicability = evaluate_query(&ApplicabilityQuery {
+            schema_version: APPLICABILITY_SCHEMA_VERSION,
+            requirements: probe.requirements.clone(),
+            context: context.clone(),
+        })
+        .map_err(|error| {
+            EvidencePlannerError::new(format!("probe {} applicability failed: {error}", probe.id))
+        })?;
+
+        match applicability.status {
+            ApplicabilityStatus::Invalid => ProbeCandidateStatus::InvalidCoordinate,
+            ApplicabilityStatus::Unknown => ProbeCandidateStatus::MissingContext,
+            ApplicabilityStatus::Applies
+                if probe.effect == ProbeEffect::Effectful && !allow_effectful =>
+            {
+                ProbeCandidateStatus::EffectAuthorityRequired
+            }
+            ApplicabilityStatus::Applies => ProbeCandidateStatus::Eligible,
+        }
+    };
+
+    Ok(CandidateEvaluation {
+        probe,
+        receipt: ProbeCandidateReceipt {
+            id: probe.id.clone(),
+            status,
+            effect: probe.effect,
+            cost: probe.cost,
+        },
+    })
+}
+
+fn compare_probe_cost(
+    left: &EvidenceProbe,
+    right: &EvidenceProbe,
+    policy: ProbeSelectionPolicy,
+) -> Ordering {
+    match policy {
+        ProbeSelectionPolicy::Conservative => conservative_cost_key(left)
+            .cmp(&conservative_cost_key(right))
+            .then_with(|| left.id.cmp(&right.id)),
+    }
+}
+
+fn conservative_cost_key(probe: &EvidenceProbe) -> (u8, u32, u32, u32, u32) {
+    (
+        effect_rank(probe.effect),
+        probe.cost.remote_requests,
+        probe.cost.git_subprocesses,
+        probe.cost.rust_files_parsed,
+        probe.cost.effectful_executions,
+    )
+}
+
+fn effect_rank(effect: ProbeEffect) -> u8 {
+    match effect {
+        ProbeEffect::ReadOnly => 0,
+        ProbeEffect::ExternalRead => 1,
+        ProbeEffect::Effectful => 2,
+    }
+}
+
+fn validate_request(request: &ProbePlanRequest) -> Result<(), EvidencePlannerError> {
+    if request.schema_version != EVIDENCE_PLANNER_SCHEMA_VERSION {
+        return Err(EvidencePlannerError::new(format!(
+            "unsupported evidence planner schema {}; expected {EVIDENCE_PLANNER_SCHEMA_VERSION}",
+            request.schema_version
+        )));
+    }
+    if request.probes.len() > MAX_PROBES {
+        return Err(EvidencePlannerError::new(
+            "probe inventory exceeds the admitted boundary",
+        ));
+    }
+
+    let mut ids = BTreeSet::new();
+    for probe in &request.probes {
+        validate_probe(probe)?;
+        if !ids.insert(probe.id.clone()) {
+            return Err(EvidencePlannerError::new(format!(
+                "duplicate probe id {}",
+                probe.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_probe(probe: &EvidenceProbe) -> Result<(), EvidencePlannerError> {
+    validate_id(&probe.id, "probe id")?;
+    validate_id(&probe.produces.kind, "probe discriminator kind")?;
+    validate_text(&probe.produces.target, "probe discriminator target")?;
+    require_coordinates(&probe.requirements)?;
+    validate_cost(probe)?;
+    Ok(())
+}
+
+fn validate_cost(probe: &EvidenceProbe) -> Result<(), EvidencePlannerError> {
+    let costs = [
+        probe.cost.git_subprocesses,
+        probe.cost.rust_files_parsed,
+        probe.cost.remote_requests,
+        probe.cost.effectful_executions,
+    ];
+    if costs.into_iter().any(|cost| cost > MAX_COST_UNIT) {
+        return Err(EvidencePlannerError::new(format!(
+            "probe {} cost exceeds the admitted boundary",
+            probe.id
+        )));
+    }
+
+    match probe.effect {
+        ProbeEffect::ReadOnly
+            if probe.cost.remote_requests != 0 || probe.cost.effectful_executions != 0 =>
+        {
+            Err(EvidencePlannerError::new(format!(
+                "read-only probe {} cannot forecast remote requests or effectful executions",
+                probe.id
+            )))
+        }
+        ProbeEffect::ExternalRead if probe.cost.remote_requests == 0 => {
+            Err(EvidencePlannerError::new(format!(
+                "external-read probe {} must forecast at least one remote request",
+                probe.id
+            )))
+        }
+        ProbeEffect::ExternalRead if probe.cost.effectful_executions != 0 => {
+            Err(EvidencePlannerError::new(format!(
+                "external-read probe {} cannot forecast effectful executions",
+                probe.id
+            )))
+        }
+        ProbeEffect::Effectful if probe.cost.effectful_executions == 0 => {
+            Err(EvidencePlannerError::new(format!(
+                "effectful probe {} must forecast at least one effectful execution",
+                probe.id
+            )))
+        }
+        _ => Ok(()),
+    }
+}
+
+fn require_coordinates(requirements: &EvidenceRequirements) -> Result<(), EvidencePlannerError> {
+    if requirements.repository.is_none()
+        && requirements.revision.is_none()
+        && requirements.work.is_none()
+        && requirements.scope.is_none()
+    {
+        return Err(EvidencePlannerError::new(
+            "probe requirements must carry at least one applicability coordinate",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_id(value: &str, field: &str) -> Result<(), EvidencePlannerError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_ID_BYTES
+        || value.contains('\0')
+    {
+        return Err(EvidencePlannerError::new(format!(
+            "{field} must be a bounded canonical identifier"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, field: &str) -> Result<(), EvidencePlannerError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_TEXT_BYTES
+        || value.contains('\0')
+    {
+        return Err(EvidencePlannerError::new(format!(
+            "{field} must be bounded non-empty text"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::durable_obligation::{
+        ClearingCondition, ClearingEvidenceReceipt, DURABLE_OBLIGATION_SCHEMA_VERSION,
+    };
+
+    fn requirements(revision: Option<&str>) -> EvidenceRequirements {
+        EvidenceRequirements {
+            repository: Some("owner/repo".to_string()),
+            revision: revision.map(str::to_string),
+            work: None,
+            scope: None,
+        }
+    }
+
+    fn discriminator(kind: &str) -> DiscriminatorKey {
+        DiscriminatorKey {
+            kind: kind.to_string(),
+            target: "cargo test target_t".to_string(),
+        }
+    }
+
+    fn obligation() -> DurableObligation {
+        DurableObligation {
+            schema_version: DURABLE_OBLIGATION_SCHEMA_VERSION,
+            id: "U17".to_string(),
+            question: "Does target T pass at this exact head?".to_string(),
+            subject: requirements(Some("head-a")),
+            established_evidence: vec!["E-history".to_string()],
+            missing_discriminator: discriminator("target_test_result"),
+            clearing_conditions: vec![ClearingCondition {
+                discriminator: discriminator("target_test_result"),
+                requirements: requirements(Some("head-a")),
+            }],
+        }
+    }
+
+    fn context(revision: Option<&str>) -> EvaluationContext {
+        EvaluationContext {
+            repository: Some("owner/repo".to_string()),
+            revision: revision.map(str::to_string),
+            work: None,
+            path: None,
+        }
+    }
+
+    fn probe(
+        id: &str,
+        kind: &str,
+        revision: Option<&str>,
+        effect: ProbeEffect,
+        cost: ProbeCost,
+    ) -> EvidenceProbe {
+        EvidenceProbe {
+            id: id.to_string(),
+            produces: discriminator(kind),
+            requirements: requirements(revision),
+            effect,
+            cost,
+        }
+    }
+
+    fn request(probes: Vec<EvidenceProbe>, allow_effectful: bool) -> ProbePlanRequest {
+        ProbePlanRequest {
+            schema_version: EVIDENCE_PLANNER_SCHEMA_VERSION,
+            obligation: obligation(),
+            context: context(Some("head-a")),
+            probes,
+            allow_effectful,
+            policy: ProbeSelectionPolicy::Conservative,
+        }
+    }
+
+    #[test]
+    fn selects_capable_exact_head_probe_and_skips_cheaper_incapable_work() {
+        let plan = plan_evidence(&request(
+            vec![
+                probe(
+                    "history",
+                    "historical_companion",
+                    Some("head-a"),
+                    ProbeEffect::ReadOnly,
+                    ProbeCost {
+                        git_subprocesses: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+                probe(
+                    "stale-test",
+                    "target_test_result",
+                    Some("old-head"),
+                    ProbeEffect::Effectful,
+                    ProbeCost {
+                        effectful_executions: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+                probe(
+                    "exact-test",
+                    "target_test_result",
+                    Some("head-a"),
+                    ProbeEffect::Effectful,
+                    ProbeCost {
+                        effectful_executions: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+            ],
+            true,
+        ))
+        .unwrap();
+
+        assert_eq!(plan.status, EvidencePlanStatus::Selected);
+        assert_eq!(plan.selected.as_ref().unwrap().id, "exact-test");
+        assert_eq!(plan.candidates[0].id, "exact-test");
+        assert_eq!(plan.candidates[0].status, ProbeCandidateStatus::Eligible);
+        assert_eq!(plan.candidates[1].status, ProbeCandidateStatus::Incapable);
+        assert_eq!(
+            plan.candidates[2].status,
+            ProbeCandidateStatus::IncompatibleClearingCondition
+        );
+    }
+
+    #[test]
+    fn effectful_capability_can_be_selected_without_granting_execution_authority() {
+        let plan = plan_evidence(&request(
+            vec![probe(
+                "exact-test",
+                "target_test_result",
+                Some("head-a"),
+                ProbeEffect::Effectful,
+                ProbeCost {
+                    effectful_executions: 1,
+                    ..ProbeCost::default()
+                },
+            )],
+            false,
+        ))
+        .unwrap();
+
+        assert_eq!(plan.status, EvidencePlanStatus::Blocked);
+        assert!(plan.selected.is_none());
+        assert_eq!(
+            plan.candidates[0].status,
+            ProbeCandidateStatus::EffectAuthorityRequired
+        );
+    }
+
+    #[test]
+    fn conservative_policy_prefers_read_only_capability_before_effectful_probe() {
+        let mut record = obligation();
+        record.missing_discriminator = discriminator("provider_current");
+        record.clearing_conditions[0].discriminator = discriminator("provider_current");
+
+        let mut request = request(
+            vec![
+                probe(
+                    "remote-current",
+                    "provider_current",
+                    Some("head-a"),
+                    ProbeEffect::ExternalRead,
+                    ProbeCost {
+                        remote_requests: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+                probe(
+                    "effectful-current",
+                    "provider_current",
+                    Some("head-a"),
+                    ProbeEffect::Effectful,
+                    ProbeCost {
+                        effectful_executions: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+            ],
+            true,
+        );
+        request.obligation = record;
+
+        let plan = plan_evidence(&request).unwrap();
+        assert_eq!(plan.selected.as_ref().unwrap().id, "remote-current");
+    }
+
+    #[test]
+    fn no_capable_probe_leaves_an_explicit_unresolved_frontier() {
+        let plan = plan_evidence(&request(
+            vec![probe(
+                "history",
+                "historical_companion",
+                Some("head-a"),
+                ProbeEffect::ReadOnly,
+                ProbeCost {
+                    git_subprocesses: 1,
+                    ..ProbeCost::default()
+                },
+            )],
+            true,
+        ))
+        .unwrap();
+
+        assert_eq!(plan.status, EvidencePlanStatus::Unresolved);
+        assert!(plan.selected.is_none());
+        assert_eq!(plan.candidates[0].status, ProbeCandidateStatus::Incapable);
+    }
+
+    #[test]
+    fn missing_current_coordinate_blocks_planning_instead_of_guessing() {
+        let mut request = request(Vec::new(), true);
+        request.context = context(None);
+
+        let plan = plan_evidence(&request).unwrap();
+        assert_eq!(plan.status, EvidencePlanStatus::Blocked);
+        assert_eq!(plan.obligation_status, DurableObligationStatus::Unknown);
+    }
+
+    #[test]
+    fn moved_obligation_subject_requires_reopen_before_new_probe_selection() {
+        let mut request = request(Vec::new(), true);
+        request.context = context(Some("head-b"));
+
+        let plan = plan_evidence(&request).unwrap();
+        assert_eq!(plan.status, EvidencePlanStatus::StaleObligation);
+        assert_eq!(
+            plan.obligation_status,
+            DurableObligationStatus::ReopenRequired
+        );
+    }
+
+    #[test]
+    fn selected_probe_can_produce_a_receipt_that_clears_the_same_obligation() {
+        let request = request(
+            vec![probe(
+                "exact-test",
+                "target_test_result",
+                Some("head-a"),
+                ProbeEffect::Effectful,
+                ProbeCost {
+                    effectful_executions: 1,
+                    ..ProbeCost::default()
+                },
+            )],
+            true,
+        );
+        let plan = plan_evidence(&request).unwrap();
+        let selected = plan.selected.unwrap();
+
+        let receipt = ClearingEvidenceReceipt {
+            id: "executed-test-receipt".to_string(),
+            discriminator: selected.produces,
+            requirements: selected.requirements,
+        };
+        let evaluation =
+            evaluate_obligation(&request.obligation, &[receipt], &request.context).unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Cleared);
+    }
+
+    #[test]
+    fn malformed_effect_forecast_fails_explicitly() {
+        let error = plan_evidence(&request(
+            vec![probe(
+                "bad-test",
+                "target_test_result",
+                Some("head-a"),
+                ProbeEffect::Effectful,
+                ProbeCost::default(),
+            )],
+            true,
+        ))
+        .unwrap_err();
+
+        assert!(error.to_string().contains("effectful execution"));
+    }
+}

--- a/tests/evidence_planner.rs
+++ b/tests/evidence_planner.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[path = "../src/justification.rs"]
+mod justification;


### PR DESCRIPTION
Progresses #145 with a research-only evidence planner over the now-landed durable UNKNOWN contract.

## Planner contract

The planner consumes:

```text
DurableObligation
+ current applicability context
+ bounded typed probe inventory
```

Probe capability must match the exact missing discriminator and admitted clearing condition before forecast cost is considered. Predicted probe cost remains separate from measured `PerfCounters`.

The carrier preserves distinct outcomes for selected, blocked, unresolved, and stale-obligation cases; it grants no execution or effect authority.

## Current-main promotion receipt

After #159 landed as `2e0a6be9e70a4544fd522cbbe7f0189ac1e69012`, the four planner blobs were flattened directly onto that exact main tree. A parallel stale rebase briefly reintroduced #159's four already-landed files; that ancestry was rejected and the branch was restored to the clean planner-only state:

```text
head: 4875ceb6c217a7a6585615bb51392095d2dec2c7
commits: 1
files: 4
```

Ordinary CI:

```text
run: 32273217896
job: 96134395801
result: success
```

Generated-provenance review:

```text
run: 32273217926
job: 96134395663
result: success
```

Formatter, strict Clippy, project/review/closure/external-reference guards, active-work preflight, all planner tests, and repository/history/CI-filter/diff dogfood passed. Main remained at the exact base through the gate.

A prior stacked run (`32271827426`) also passed on the clean #159 semantics; the direct-main run above is the promotion authority.

## Boundary / next

Research only; no product CLI/report-schema change and no probe execution.

With #210 typed applicability and this planner both on main, #216 can now be reduced from its historical composition stack to its actual four-file observation-frontier→probe bridge.

Files: `src/evidence_planner.rs`, `tests/evidence_planner.rs`, `examples/evidence_plan.rs`, `research/evidence-acquisition-planner.md`.

Refs #14 #49 #62 #106 #109 #123 #141 #144 #145 #159 #216.