### PR TITLE
research: add behavioral episode identity

### DIFF
--- a/examples/behavioral_episode_batch.rs
+++ b/examples/behavioral_episode_batch.rs
@@ -1,0 +1,34 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/behavioral_episode.rs"]
+mod behavioral_episode;
+#[allow(dead_code)]
+#[path = "../src/behavioral_receipt.rs"]
+mod behavioral_receipt;
+
+use behavioral_episode::{MAX_BEHAVIORAL_EPISODE_BATCH_BYTES, parse_behavioral_episode_batch};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("behavioral-episode-batch: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_BEHAVIORAL_EPISODE_BATCH_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_BEHAVIORAL_EPISODE_BATCH_BYTES {
+        return Err(format!(
+            "behavioral episode batch exceeds the {MAX_BEHAVIORAL_EPISODE_BATCH_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let batch = parse_behavioral_episode_batch(&bytes)?;
+    println!("{}", serde_json::to_string_pretty(&batch)?);
+    Ok(())
+}

--- a/research/behavioral-episode-identity.md
+++ b/research/behavioral-episode-identity.md
@@ -1,0 +1,85 @@
+# Behavioral episode identity
+
+Tracking: #161, building on merged #157 / #137.
+
+Behavioral receipt v1 records one evidence-delivery outcome. It deliberately does not carry a durable observation identity. That is sufficient for reading a single receipt and unsafe for longitudinal aggregation, where copied receipts could otherwise be counted more than once.
+
+This experiment keeps v1 receipts unchanged and adds a small outer identity layer.
+
+## Episode wrapper
+
+```text
+BehavioralEpisode
+  episode_id
+  receipt: BehavioralReceipt v1
+
+BehavioralEpisodeBatch
+  schema_version
+  episodes[]
+```
+
+`episode_id` identifies the observed delivery episode. Repository/revision/task/evidence coordinates stay inside the receipt and continue to carry their original meaning.
+
+Example identities:
+
+```text
+pull-140:main-head-movement:4f8f9fcd->85e0b08b
+github-actions:run/32242752523#active-work-heads-up
+heldout:smolrunner-clone-01:treatment
+```
+
+The format is deliberately opaque beyond bounded canonical text. V1 does not parse semantics out of the ID.
+
+## Duplicate semantics
+
+A batch rejects duplicate episode IDs before any aggregate can count them.
+
+```text
+same episode_id + identical receipt
+  -> duplicate -> reject
+
+same episode_id + different receipt semantics
+  -> conflicting duplicate -> reject
+
+same receipt coordinates + distinct episode_id
+  -> independent delivery -> accept
+```
+
+This separates **observation identity** from **receipt content identity**. Content hashes can still be useful later, but editing an annotation or action sentence should not silently mint a second observation.
+
+## Retained controls
+
+The ordinary test harness wraps the two live #140 receipts already preserved by #157:
+
+1. main-head movement that changed the next action;
+2. active-work heads-up that correctly stayed quiet on disjoint work.
+
+The pair is accepted under distinct episode IDs.
+
+Adversarial controls require:
+
+- an exact copied episode to reject;
+- the same episode ID with changed outcome/action to reject as a conflict;
+- a repeated delivery of the same receipt under a new episode ID to remain distinct;
+- malformed IDs to reject;
+- oversized batches to reject before JSON parsing.
+
+## Research validator
+
+```text
+cargo run --example behavioral_episode_batch < batch.json
+```
+
+Input is bounded to 256 KiB and 512 episodes. Every nested receipt is revalidated through merged #157 before the batch is admitted.
+
+## Boundary
+
+- no aggregate actionability score;
+- no automatic analyzer promotion or demotion;
+- no worker/model identity field;
+- episode identity is observation identity, not Cultist finding semantic lineage;
+- no chronological or causal semantics are inferred from the ID;
+- receipt v1 remains unchanged and independently usable;
+- `observed_at` stays deferred until a real longitudinal query requires one timestamp contract.
+
+Once this survives dogfood, #137 can safely experiment with small aggregate views over unique admitted episodes while keeping raw receipts available for inspection.

--- a/src/behavioral_episode.rs
+++ b/src/behavioral_episode.rs
@@ -1,0 +1,119 @@
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::behavioral_receipt::{BehavioralReceipt, validate_receipt};
+
+pub const BEHAVIORAL_EPISODE_SCHEMA_VERSION: u32 = 1;
+pub const MAX_BEHAVIORAL_EPISODE_BATCH_BYTES: usize = 256 * 1024;
+const MAX_EPISODES: usize = 512;
+const MAX_EPISODE_ID_BYTES: usize = 1024;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralEpisode {
+    pub episode_id: String,
+    pub receipt: BehavioralReceipt,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralEpisodeBatch {
+    pub schema_version: u32,
+    pub episodes: Vec<BehavioralEpisode>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct BehavioralEpisodeError {
+    message: String,
+}
+
+impl BehavioralEpisodeError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for BehavioralEpisodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for BehavioralEpisodeError {}
+
+pub fn parse_behavioral_episode_batch(
+    bytes: &[u8],
+) -> Result<BehavioralEpisodeBatch, BehavioralEpisodeError> {
+    if bytes.len() > MAX_BEHAVIORAL_EPISODE_BATCH_BYTES {
+        return Err(BehavioralEpisodeError::new(format!(
+            "behavioral episode batch exceeds the {MAX_BEHAVIORAL_EPISODE_BATCH_BYTES}-byte limit"
+        )));
+    }
+
+    let batch: BehavioralEpisodeBatch = serde_json::from_slice(bytes).map_err(|error| {
+        BehavioralEpisodeError::new(format!("invalid behavioral episode JSON: {error}"))
+    })?;
+    validate_behavioral_episode_batch(&batch)?;
+    Ok(batch)
+}
+
+pub fn validate_behavioral_episode_batch(
+    batch: &BehavioralEpisodeBatch,
+) -> Result<(), BehavioralEpisodeError> {
+    if batch.schema_version != BEHAVIORAL_EPISODE_SCHEMA_VERSION {
+        return Err(BehavioralEpisodeError::new(format!(
+            "unsupported behavioral episode schema {}; expected {BEHAVIORAL_EPISODE_SCHEMA_VERSION}",
+            batch.schema_version
+        )));
+    }
+
+    if batch.episodes.is_empty() || batch.episodes.len() > MAX_EPISODES {
+        return Err(BehavioralEpisodeError::new(format!(
+            "behavioral episode batch must contain 1..={MAX_EPISODES} episodes"
+        )));
+    }
+
+    let mut by_id = BTreeMap::<&str, &BehavioralReceipt>::new();
+    for episode in &batch.episodes {
+        validate_episode_id(&episode.episode_id)?;
+        validate_receipt(&episode.receipt).map_err(|error| {
+            BehavioralEpisodeError::new(format!(
+                "episode `{}` contains an invalid behavioral receipt: {error}",
+                episode.episode_id
+            ))
+        })?;
+
+        if let Some(existing) = by_id.insert(&episode.episode_id, &episode.receipt) {
+            let kind = if existing == &episode.receipt {
+                "duplicate"
+            } else {
+                "conflicting duplicate"
+            };
+            return Err(BehavioralEpisodeError::new(format!(
+                "{kind} behavioral episode_id `{}`",
+                episode.episode_id
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_episode_id(value: &str) -> Result<(), BehavioralEpisodeError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_EPISODE_ID_BYTES
+        || value.contains('\0')
+        || value.chars().any(char::is_control)
+    {
+        return Err(BehavioralEpisodeError::new(
+            "episode_id must be a bounded non-empty canonical observation identity",
+        ));
+    }
+    Ok(())
+}

--- a/tests/behavioral_episode.rs
+++ b/tests/behavioral_episode.rs
@@ -1,0 +1,109 @@
+#[allow(dead_code)]
+#[path = "../src/behavioral_episode.rs"]
+mod behavioral_episode;
+#[allow(dead_code)]
+#[path = "../src/behavioral_receipt.rs"]
+mod behavioral_receipt;
+
+use behavioral_episode::{
+    BEHAVIORAL_EPISODE_SCHEMA_VERSION, BehavioralEpisode, BehavioralEpisodeBatch,
+    MAX_BEHAVIORAL_EPISODE_BATCH_BYTES, parse_behavioral_episode_batch,
+    validate_behavioral_episode_batch,
+};
+use behavioral_receipt::{BehavioralOutcome, BehavioralReceipt};
+
+fn retained_receipt(path: &str) -> BehavioralReceipt {
+    let json = match path {
+        "collaboration" => {
+            include_str!("../research/behavioral-receipts/collaboration-140.json")
+        }
+        "quiet" => include_str!("../research/behavioral-receipts/active-work-140-quiet.json"),
+        other => panic!("unknown retained receipt {other}"),
+    };
+    serde_json::from_str(json).unwrap()
+}
+
+fn retained_batch() -> BehavioralEpisodeBatch {
+    BehavioralEpisodeBatch {
+        schema_version: BEHAVIORAL_EPISODE_SCHEMA_VERSION,
+        episodes: vec![
+            BehavioralEpisode {
+                episode_id: "pull-140:main-head-movement:4f8f9fcd->85e0b08b".to_string(),
+                receipt: retained_receipt("collaboration"),
+            },
+            BehavioralEpisode {
+                episode_id: "github-actions:run/32242752523#active-work-heads-up".to_string(),
+                receipt: retained_receipt("quiet"),
+            },
+        ],
+    }
+}
+
+#[test]
+fn accepts_two_distinct_retained_collaboration_episodes() {
+    let batch = retained_batch();
+    validate_behavioral_episode_batch(&batch).unwrap();
+    assert_eq!(batch.episodes.len(), 2);
+}
+
+#[test]
+fn exact_duplicate_episode_id_rejects_instead_of_double_counting() {
+    let mut batch = retained_batch();
+    batch.episodes.push(batch.episodes[1].clone());
+    let error = validate_behavioral_episode_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate behavioral episode_id")
+    );
+}
+
+#[test]
+fn conflicting_same_episode_id_rejects_hard() {
+    let mut batch = retained_batch();
+    let mut conflicting = batch.episodes[0].clone();
+    conflicting.receipt.outcome = BehavioralOutcome::NeededStrongerEvidence;
+    conflicting.receipt.action = Some("inspect another exact evidence source".to_string());
+    batch.episodes.push(conflicting);
+
+    let error = validate_behavioral_episode_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("conflicting duplicate behavioral episode_id")
+    );
+}
+
+#[test]
+fn repeated_delivery_of_same_receipt_is_distinct_with_new_episode_id() {
+    let mut batch = retained_batch();
+    batch.episodes.push(BehavioralEpisode {
+        episode_id: "heldout:repeat-delivery-02".to_string(),
+        receipt: batch.episodes[1].receipt.clone(),
+    });
+    validate_behavioral_episode_batch(&batch).unwrap();
+    assert_eq!(batch.episodes.len(), 3);
+}
+
+#[test]
+fn rejects_noncanonical_episode_identity() {
+    let mut batch = retained_batch();
+    batch.episodes[0].episode_id = " bad\nepisode ".to_string();
+    let error = validate_behavioral_episode_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("canonical observation identity"));
+}
+
+#[test]
+fn batch_round_trips_without_changing_episode_identity() {
+    let batch = retained_batch();
+    let json = serde_json::to_vec(&batch).unwrap();
+    let decoded = parse_behavioral_episode_batch(&json).unwrap();
+    assert_eq!(decoded, batch);
+}
+
+#[test]
+fn oversized_batch_rejects_before_json_parsing() {
+    let bytes = vec![b' '; MAX_BEHAVIORAL_EPISODE_BATCH_BYTES + 1];
+    let error = parse_behavioral_episode_batch(&bytes).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}


### PR DESCRIPTION
## Goal

Progress #161 before #137 grows any longitudinal aggregate over merged #157 receipts.

Behavioral receipt v1 records one evidence-delivery outcome but deliberately carries no stable observation identity. A copied retained receipt could therefore be counted twice by a naive future scorecard.

This PR leaves receipt v1 unchanged and adds a bounded outer episode identity.

## Model

```text
BehavioralEpisode
  episode_id
  receipt: BehavioralReceipt v1

BehavioralEpisodeBatch
  schema_version
  episodes[]
```

`episode_id` names the observation event. Repository/revision/task/evidence coordinates remain inside the nested receipt.

## Duplicate semantics

The batch validator makes duplicate handling explicit before counting:

```text
same episode_id + identical receipt
  -> duplicate -> reject

same episode_id + changed receipt semantics
  -> conflicting duplicate -> reject

same receipt + distinct episode_id
  -> independent repeated delivery -> accept
```

Every nested v1 receipt is revalidated through merged #157.

## Retained controls

The test harness wraps both live #140 receipts already on main:

- action-changing current-main head movement;
- correct quiet active-work negative.

They are accepted as two distinct episodes.

Adversarial controls cover copied episode IDs, conflicting same-ID outcomes, repeated independent delivery, malformed IDs, round trip, and oversized input rejection.

## Research validator

```text
cargo run --example behavioral_episode_batch < batch.json
```

Admission is bounded to 256 KiB and 512 episodes.

## Boundary

- no aggregate actionability score;
- no analyzer promotion/demotion;
- no worker/model identity field;
- episode identity is observation identity, not finding semantic lineage;
- no timestamp/chronology semantics yet;
- receipt v1 stays independently usable.

The branch is one commit ahead / zero behind current main `48839f625721ba595b063fc8dfd21e365e6f24dc` at open time.

Refs #137 #157 #161 #127.