### PR TITLE
fix: validate project-memory relation semantics

### DIFF
--- a/src/project_memory.rs
+++ b/src/project_memory.rs
@@ -175,7 +175,7 @@ impl ProjectMemoryPacket {
                 &edge.evidence,
                 "edge evidence",
                 MAX_EDGE_EVIDENCE_BYTES,
-                true,
+                false,
             )?;
             if !source.evidence_text.contains(&edge.evidence) {
                 return Err(format!(
@@ -184,6 +184,7 @@ impl ProjectMemoryPacket {
                     display_ref(edge.to)
                 ));
             }
+            validate_edge_semantics(edge)?;
         }
 
         Ok(())
@@ -322,6 +323,95 @@ fn validate_repository(value: &str) -> Result<(), String> {
 
 fn valid_repository_char(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')
+}
+
+fn validate_edge_semantics(edge: &ProjectMemoryEdge) -> Result<(), String> {
+    let Some(classified) = classify_relation(&edge.evidence) else {
+        return Err(format!(
+            "edge evidence for {} -> {} is not an admitted explicit relationship line",
+            display_ref(edge.from),
+            display_ref(edge.to)
+        ));
+    };
+    if classified != edge.relation {
+        return Err(format!(
+            "edge relation {:?} disagrees with source evidence classified as {:?}",
+            edge.relation, classified
+        ));
+    }
+    if !evidence_mentions_reference(&edge.evidence, edge.to.number) {
+        return Err(format!(
+            "edge evidence does not explicitly mention target {}",
+            display_ref(edge.to)
+        ));
+    }
+    Ok(())
+}
+
+fn classify_relation(evidence: &str) -> Option<MemoryRelation> {
+    let normalized = evidence.trim().to_ascii_lowercase();
+    if [
+        "closes", "close", "closed", "fixes", "fix", "fixed", "resolves", "resolve", "resolved",
+    ]
+    .iter()
+    .any(|word| starts_with_relation_word(&normalized, word))
+    {
+        return Some(MemoryRelation::Closes);
+    }
+    if normalized.starts_with("follow-up to") || normalized.starts_with("follow up to") {
+        return Some(MemoryRelation::FollowUpTo);
+    }
+    if normalized.starts_with("continuation from")
+        || normalized.starts_with("deployment continuation")
+    {
+        return Some(MemoryRelation::ContinuationFrom);
+    }
+    if normalized.starts_with("parent:") {
+        return Some(MemoryRelation::Parent);
+    }
+    if normalized.starts_with("related:") {
+        return Some(MemoryRelation::Related);
+    }
+    None
+}
+
+fn starts_with_relation_word(value: &str, word: &str) -> bool {
+    value
+        .strip_prefix(word)
+        .is_some_and(|rest| rest.starts_with(char::is_whitespace))
+}
+
+fn evidence_mentions_reference(evidence: &str, target: u64) -> bool {
+    let bytes = evidence.as_bytes();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if bytes[index] != b'#' {
+            index += 1;
+            continue;
+        }
+        let mut cursor = index + 1;
+        if cursor >= bytes.len() || bytes[cursor] == b'0' || !bytes[cursor].is_ascii_digit() {
+            index += 1;
+            continue;
+        }
+        let mut number = 0u64;
+        while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+            let Some(next) = number
+                .checked_mul(10)
+                .and_then(|value| value.checked_add((bytes[cursor] - b'0') as u64))
+            else {
+                number = u64::MAX;
+                break;
+            };
+            number = next;
+            cursor += 1;
+        }
+        if number == target {
+            return true;
+        }
+        index = cursor.max(index + 1);
+    }
+    false
 }
 
 fn validate_sha(value: &str, label: &str) -> Result<(), String> {

--- a/tests/project_memory_relation_admission.rs
+++ b/tests/project_memory_relation_admission.rs
@@ -1,0 +1,92 @@
+#[allow(dead_code)]
+#[path = "../src/project_memory.rs"]
+mod project_memory;
+
+use project_memory::{ArtifactKind, ArtifactRef, MemoryRelation, ProjectMemoryPacket};
+
+const STENSIBLY_1575: &[u8] = include_bytes!("../research/project-memory/stensibly-1575.json");
+
+fn packet() -> ProjectMemoryPacket {
+    serde_json::from_slice(STENSIBLY_1575).unwrap()
+}
+
+#[test]
+fn retained_packet_still_admits_its_explicit_relationship_lines() {
+    packet().validate().unwrap();
+}
+
+#[test]
+fn related_excerpt_cannot_be_strengthened_to_closes() {
+    let mut packet = packet();
+    let anchor = packet.anchor;
+    let source = packet
+        .artifacts
+        .iter_mut()
+        .find(|artifact| artifact.reference == anchor)
+        .unwrap();
+    source.evidence_text.push_str("\nRelated: #1574");
+
+    packet.edges[0].relation = MemoryRelation::Closes;
+    packet.edges[0].evidence = "Related: #1574".to_string();
+
+    let error = packet.validate().unwrap_err();
+    assert!(error.contains("disagrees with source evidence"));
+}
+
+#[test]
+fn parent_excerpt_cannot_be_relabelled_follow_up() {
+    let mut packet = packet();
+    let anchor = packet.anchor;
+    let source = packet
+        .artifacts
+        .iter_mut()
+        .find(|artifact| artifact.reference == anchor)
+        .unwrap();
+    source.evidence_text.push_str("\nParent: #1569");
+
+    let edge = packet
+        .edges
+        .iter_mut()
+        .find(|edge| edge.to.number == 1569)
+        .unwrap();
+    edge.relation = MemoryRelation::FollowUpTo;
+    edge.evidence = "Parent: #1569".to_string();
+
+    let error = packet.validate().unwrap_err();
+    assert!(error.contains("disagrees with source evidence"));
+}
+
+#[test]
+fn relationship_line_must_name_the_declared_target() {
+    let mut packet = packet();
+    let edge = packet
+        .edges
+        .iter_mut()
+        .find(|edge| edge.to.number == 1569)
+        .unwrap();
+    edge.to = ArtifactRef {
+        kind: ArtifactKind::Issue,
+        number: 1574,
+    };
+
+    let error = packet.validate().unwrap_err();
+    assert!(error.contains("does not explicitly mention target"));
+}
+
+#[test]
+fn arbitrary_source_excerpt_cannot_be_given_a_typed_relation() {
+    let mut packet = packet();
+    let anchor = packet.anchor;
+    let source = packet
+        .artifacts
+        .iter_mut()
+        .find(|artifact| artifact.reference == anchor)
+        .unwrap();
+    source.evidence_text.push_str("\nSee #1574 for background.");
+
+    packet.edges[0].relation = MemoryRelation::Related;
+    packet.edges[0].evidence = "See #1574 for background.".to_string();
+
+    let error = packet.validate().unwrap_err();
+    assert!(error.contains("not an admitted explicit relationship line"));
+}


### PR DESCRIPTION
## Problem

Merged #160 proves that an edge excerpt occurs in source `evidence_text`, but it does not prove the typed `relation` agrees with that excerpt.

So this can currently pass the offline boundary:

```text
evidence: "Related: #1574"
relation: closes
target: issue #1574
```

The packet then strengthens literal `related` evidence into a typed `closes` link.

Refs #163.

## Repair

For every edge, the Rust validator now requires all of:

1. edge evidence is one bounded single relationship line;
2. that exact line occurs in the source artifact evidence text;
3. the line belongs to the deliberately admitted relationship vocabulary;
4. the classified relation equals `edge.relation`;
5. the same line explicitly contains the declared target `#N` using canonical positive-decimal reference syntax.

Current classifier mirrors the narrow v1 vocabulary used by the landed #162 provider collector:

```text
Closes/Close/Closed/Fixes/Fix/Fixed/Resolves/Resolve/Resolved -> closes
Follow-up to / Follow up to                                -> follow_up_to
Continuation from / Deployment continuation               -> continuation_from
Parent:                                                     -> parent
Related:                                                    -> related
```

Unsupported prose stays unclassified.

## Adversarial controls

New standard-suite tests require rejection of:

- `Related: #1574` relabelled `closes`;
- `Parent: #1569` relabelled `follow_up_to`;
- a valid follow-up line reused with another existing target it does not mention;
- arbitrary `See #1574 for background.` prose given a typed relation.

The retained Stensibly #1575 packet still has to validate unchanged.

## Collaboration receipt

This repair started on merged #160 main. While it was being prepared, #162 merged the GitHub collector/workflow. I inspected that change, confirmed it is disjoint from `src/project_memory.rs`, rebuilt this fix on exact new main `66b13054f5c7e29d89acb580fe8e2465aaf1a779`, and retained the collector files.

The branch is one commit ahead / zero behind at PR open time.

## Boundary

- exact line grammar only; no fuzzy NLP;
- relation admission does not grant authority or infer causality;
- chronology/path overlap still create no edge;
- mixed-relationship prose on one line remains a producer-side precision concern from the #162 review;
- timestamp strictness from #163 remains a separate follow-up.

Refs #18 #160 #162 #163.