### PR TITLE
research: evaluate counterexample cohort refinements

### DIFF
--- a/examples/cohort_refinement.rs
+++ b/examples/cohort_refinement.rs
@@ -1,0 +1,27 @@
+#![allow(dead_code)]
+
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/cohort_refinement.rs"]
+mod cohort_refinement;
+
+use cohort_refinement::{RefinementRequest, evaluate_refinements};
+
+const MAX_INPUT_BYTES: u64 = 1024 * 1024;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut input = Vec::new();
+    io::stdin()
+        .take(MAX_INPUT_BYTES + 1)
+        .read_to_end(&mut input)?;
+    if input.len() as u64 > MAX_INPUT_BYTES {
+        return Err("cohort refinement input exceeds 1 MiB".into());
+    }
+
+    let request: RefinementRequest = serde_json::from_slice(&input)?;
+    let evaluation = evaluate_refinements(&request)?;
+    serde_json::to_writer_pretty(io::stdout().lock(), &evaluation)?;
+    println!();
+    Ok(())
+}

--- a/research/cohort-refinement.md
+++ b/research/cohort-refinement.md
@@ -125,6 +125,53 @@ If a counterexample lacks the admitted fact, expected: `incomplete_evidence` eve
 
 This prevents missing classification from masquerading as explained counterevidence.
 
+## Executed GitHub receipt
+
+Draft PR #168 ran the research-only generic evaluator against current main through the ordinary repository gates.
+
+Exact code head:
+
+```text
+eb5d0a801cd946693e0729672235a7beecc62f9f
+```
+
+GitHub Actions CI run `32244992654` / run number `1121` completed successfully. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work heads-up;
+- full `cargo test`, including the cohort-refinement controls;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The PR-only push-diff step remained skipped by workflow context.
+
+Generated provenance review dogfood run `32244992658` / run number `186` also completed successfully on the same head.
+
+Two earlier CI attempts were formatter-only controls. The first exposed the main rustfmt layout; the second found one remaining multiline condition. No semantic or Clippy change was required between the formatted head and the successful run.
+
+## What this adds beyond the retained Oxc probe
+
+The Oxc syntax replay proved one useful discriminator for one evidence family. This carrier adds a generic evaluation boundary that keeps fact production separate and tests four distinct outcomes:
+
+```text
+forward Oxc-like supplied facts
+  -> candidate
+
+reverse Oxc-like supplied facts
+  -> no_improvement
+
+identity-like singleton partition
+  -> overfit
+
+missing current/counterexample fact
+  -> unknown_current / incomplete_evidence
+```
+
+That is enough to reuse the same refinement evaluator with package/scope/generated/authored facts later without teaching it how those facts are produced.
+
 ## Boundary
 
 - fact production remains analyzer/language-specific;

--- a/research/cohort-refinement.md
+++ b/research/cohort-refinement.md
@@ -1,0 +1,143 @@
+# Counterexample-driven cohort refinement
+
+Tracking: #142.
+
+## Why this starts above edit classification
+
+Cultist already earned the first concrete cohort-refinement discriminator before #142 existed.
+
+The retained Oxc replay in `research/rust-syntax-cohort-replay.md` shows:
+
+```text
+source rules.rs -> generated registries
+raw focused cohort:       99/100
+Rust syntax cohort:        99/99
+excluded docs-only edit:     1
+```
+
+The sole raw counterexample was the known license-notice/docs change. The reverse direction stayed:
+
+```text
+generated rules_enum.rs -> source rules.rs
+Rust syntax cohort: 94/100
+```
+
+All 100 reverse anchor edits changed Rust syntax, so the same discriminator correctly produced no improvement there.
+
+`src/generated_diff.rs` now carries equivalent source-change classification for product generated-companion evidence, and `examples/rust_syntax_cohort.rs` retains the generic historical probe. Reimplementing Rust edit classification under #142 would duplicate an earned fact producer.
+
+This carrier therefore starts one layer later:
+
+> Given observations already labeled with deterministic facts, which admitted discriminator creates a useful narrower cohort for the current change?
+
+## V0 input
+
+```text
+current_facts
+observations[]
+  id
+  support | counterexample
+  facts {key -> value}
+
+admitted discriminators[]
+min_support
+```
+
+The evaluator does not infer facts from prose, paths, commit subjects, or names. An analyzer/research adapter owns those facts.
+
+## Output
+
+Every discriminator preserves:
+
+- the original baseline support/counterexample counts;
+- every partition, including observations missing that fact;
+- current-change discriminator value when supplied;
+- exact counts in the current value cohort;
+- exact support/counterexamples excluded from the current cohort.
+
+No purity/confidence score is produced.
+
+V0 statuses:
+
+```text
+candidate
+  current cohort excludes at least one counterexample and retains min_support
+
+overfit
+  counterexamples are excluded but the current cohort has too little positive support
+
+no_improvement
+  the current cohort excludes no counterexample
+
+unknown_current
+  the current change lacks the discriminator or its value has no observed cohort
+
+incomplete_evidence
+  one or more counterexamples lack the discriminator fact, so exclusion cannot be treated as an explained exception
+```
+
+These statuses describe the supplied cohort experiment. `candidate` remains OBSERVED evidence; it grants no project policy.
+
+## First controls
+
+### Oxc forward result
+
+Synthetic observations reproduce the retained executed counts:
+
+```text
+99 support       edit_class=syntax_changed
+1 counterexample edit_class=comments_or_docs_only
+current           edit_class=syntax_changed
+```
+
+Expected:
+
+```text
+baseline       99 support / 1 counterexample
+current cohort 99 support / 0 counterexamples
+status         candidate
+```
+
+### Oxc reverse control
+
+```text
+94 support + 6 counterexamples
+all edit_class=syntax_changed
+```
+
+Expected: `no_improvement` with the current cohort identical to baseline.
+
+### Identity-like overfit control
+
+Four observations carry unique `commit` values. Selecting the current commit isolates one positive observation and one counterexample elsewhere.
+
+With `min_support=3`, expected: `overfit`.
+
+This rejects the easiest fixture-memorization path without hard-coding words such as `commit`, `path`, or `sha` as forbidden facts.
+
+### Missing current membership
+
+If the current change lacks the admitted fact, expected: `unknown_current`.
+
+### Missing counterexample classification
+
+If a counterexample lacks the admitted fact, expected: `incomplete_evidence` even when the current bucket otherwise appears pure.
+
+This prevents missing classification from masquerading as explained counterevidence.
+
+## Boundary
+
+- fact production remains analyzer/language-specific;
+- chronology never becomes a fact unless an independent producer establishes a temporal relation;
+- candidate refinement remains empirical cohort evidence;
+- the baseline is always retained;
+- excluded support remains visible alongside excluded counterexamples;
+- min-support is an explicit research parameter, not a universal product threshold;
+- no model is required;
+- no product CLI/report-schema change.
+
+## Next discriminator
+
+Run this evaluator over observations emitted from a real history adapter instead of synthetic count-preserving controls. The first candidate is the already-pinned Oxc source registry replay.
+
+Then test a second, independent discriminator family where useful counterexamples are split by package/scope or generated/authored status. Promotion is earned only if the generic evaluator improves more than one evidence family without turning fact production into a universal classifier.

--- a/src/cohort_refinement.rs
+++ b/src/cohort_refinement.rs
@@ -1,0 +1,497 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+pub const COHORT_REFINEMENT_SCHEMA_VERSION: u32 = 1;
+const MAX_OBSERVATIONS: usize = 4096;
+const MAX_DISCRIMINATORS: usize = 64;
+const MAX_ID_BYTES: usize = 256;
+const MAX_FACT_BYTES: usize = 1024;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementRequest {
+    pub schema_version: u32,
+    pub min_support: usize,
+    pub current_facts: BTreeMap<String, String>,
+    pub discriminators: Vec<String>,
+    pub observations: Vec<CohortObservation>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CohortObservation {
+    pub id: String,
+    pub outcome: ObservationOutcome,
+    pub facts: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationOutcome {
+    Support,
+    Counterexample,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CohortCounts {
+    pub support: usize,
+    pub counterexamples: usize,
+}
+
+impl CohortCounts {
+    pub fn opportunities(self) -> usize {
+        self.support + self.counterexamples
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CohortPartition {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    pub counts: CohortCounts,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefinementStatus {
+    Candidate,
+    NoImprovement,
+    Overfit,
+    UnknownCurrent,
+    IncompleteEvidence,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorEvaluation {
+    pub discriminator: String,
+    pub status: RefinementStatus,
+    pub baseline: CohortCounts,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_cohort: Option<CohortCounts>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub excluded_support: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub excluded_counterexamples: Option<usize>,
+    pub partitions: Vec<CohortPartition>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementEvaluation {
+    pub schema_version: u32,
+    pub baseline: CohortCounts,
+    pub discriminators: Vec<DiscriminatorEvaluation>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RefinementError {
+    message: String,
+}
+
+impl RefinementError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for RefinementError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for RefinementError {}
+
+pub fn evaluate_refinements(
+    request: &RefinementRequest,
+) -> Result<RefinementEvaluation, RefinementError> {
+    validate_request(request)?;
+
+    let baseline = count_observations(&request.observations);
+    let mut discriminators = request.discriminators.clone();
+    discriminators.sort();
+
+    let evaluations = discriminators
+        .into_iter()
+        .map(|discriminator| evaluate_discriminator(request, baseline, discriminator))
+        .collect();
+
+    Ok(RefinementEvaluation {
+        schema_version: COHORT_REFINEMENT_SCHEMA_VERSION,
+        baseline,
+        discriminators: evaluations,
+    })
+}
+
+fn evaluate_discriminator(
+    request: &RefinementRequest,
+    baseline: CohortCounts,
+    discriminator: String,
+) -> DiscriminatorEvaluation {
+    let mut partition_counts = BTreeMap::<Option<String>, CohortCounts>::new();
+    for observation in &request.observations {
+        let value = observation.facts.get(&discriminator).cloned();
+        increment_counts(
+            partition_counts.entry(value).or_default(),
+            observation.outcome,
+        );
+    }
+
+    let partitions = partition_counts
+        .iter()
+        .map(|(value, counts)| CohortPartition {
+            value: value.clone(),
+            counts: *counts,
+        })
+        .collect::<Vec<_>>();
+
+    let Some(current_value) = request.current_facts.get(&discriminator).cloned() else {
+        return DiscriminatorEvaluation {
+            discriminator,
+            status: RefinementStatus::UnknownCurrent,
+            baseline,
+            current_value: None,
+            current_cohort: None,
+            excluded_support: None,
+            excluded_counterexamples: None,
+            partitions,
+        };
+    };
+
+    let current_cohort = partition_counts.get(&Some(current_value.clone())).copied();
+    let Some(current_cohort) = current_cohort else {
+        return DiscriminatorEvaluation {
+            discriminator,
+            status: RefinementStatus::UnknownCurrent,
+            baseline,
+            current_value: Some(current_value),
+            current_cohort: None,
+            excluded_support: None,
+            excluded_counterexamples: None,
+            partitions,
+        };
+    };
+
+    let missing = partition_counts.get(&None).copied().unwrap_or_default();
+    let excluded_support = baseline.support - current_cohort.support;
+    let excluded_counterexamples = baseline.counterexamples - current_cohort.counterexamples;
+
+    let status = if missing.counterexamples > 0 {
+        RefinementStatus::IncompleteEvidence
+    } else if excluded_counterexamples == 0 {
+        RefinementStatus::NoImprovement
+    } else if current_cohort.support < request.min_support {
+        RefinementStatus::Overfit
+    } else {
+        RefinementStatus::Candidate
+    };
+
+    DiscriminatorEvaluation {
+        discriminator,
+        status,
+        baseline,
+        current_value: Some(current_value),
+        current_cohort: Some(current_cohort),
+        excluded_support: Some(excluded_support),
+        excluded_counterexamples: Some(excluded_counterexamples),
+        partitions,
+    }
+}
+
+fn count_observations(observations: &[CohortObservation]) -> CohortCounts {
+    let mut counts = CohortCounts::default();
+    for observation in observations {
+        increment_counts(&mut counts, observation.outcome);
+    }
+    counts
+}
+
+fn increment_counts(counts: &mut CohortCounts, outcome: ObservationOutcome) {
+    match outcome {
+        ObservationOutcome::Support => counts.support += 1,
+        ObservationOutcome::Counterexample => counts.counterexamples += 1,
+    }
+}
+
+fn validate_request(request: &RefinementRequest) -> Result<(), RefinementError> {
+    if request.schema_version != COHORT_REFINEMENT_SCHEMA_VERSION {
+        return Err(RefinementError::new(format!(
+            "unsupported cohort refinement schema {}; expected {COHORT_REFINEMENT_SCHEMA_VERSION}",
+            request.schema_version
+        )));
+    }
+    if request.min_support == 0 {
+        return Err(RefinementError::new("min_support must be positive"));
+    }
+    if request.observations.is_empty() || request.observations.len() > MAX_OBSERVATIONS {
+        return Err(RefinementError::new(
+            "observation cohort must be bounded and non-empty",
+        ));
+    }
+    if request.discriminators.is_empty() || request.discriminators.len() > MAX_DISCRIMINATORS {
+        return Err(RefinementError::new(
+            "discriminator set must be bounded and non-empty",
+        ));
+    }
+
+    let mut observation_ids = BTreeSet::new();
+    for observation in &request.observations {
+        validate_atom(&observation.id, "observation id", MAX_ID_BYTES)?;
+        if !observation_ids.insert(observation.id.clone()) {
+            return Err(RefinementError::new(format!(
+                "duplicate observation id {}",
+                observation.id
+            )));
+        }
+        validate_facts(&observation.facts, "observation facts")?;
+    }
+    validate_facts(&request.current_facts, "current facts")?;
+
+    let mut discriminators = BTreeSet::new();
+    for discriminator in &request.discriminators {
+        validate_atom(discriminator, "discriminator", MAX_ID_BYTES)?;
+        if !discriminators.insert(discriminator.clone()) {
+            return Err(RefinementError::new(format!(
+                "duplicate discriminator {discriminator}"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_facts(facts: &BTreeMap<String, String>, field: &str) -> Result<(), RefinementError> {
+    for (key, value) in facts {
+        validate_atom(key, &format!("{field} key"), MAX_ID_BYTES)?;
+        validate_atom(value, &format!("{field} value"), MAX_FACT_BYTES)?;
+    }
+    Ok(())
+}
+
+fn validate_atom(value: &str, field: &str, max_bytes: usize) -> Result<(), RefinementError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > max_bytes
+        || value.contains('\0')
+    {
+        return Err(RefinementError::new(format!(
+            "{field} must be bounded canonical text"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn facts(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
+        entries
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+
+    fn observation(id: String, outcome: ObservationOutcome, facts: BTreeMap<String, String>) -> CohortObservation {
+        CohortObservation { id, outcome, facts }
+    }
+
+    fn request(
+        current_facts: BTreeMap<String, String>,
+        discriminators: Vec<&str>,
+        observations: Vec<CohortObservation>,
+    ) -> RefinementRequest {
+        RefinementRequest {
+            schema_version: COHORT_REFINEMENT_SCHEMA_VERSION,
+            min_support: 3,
+            current_facts,
+            discriminators: discriminators.into_iter().map(str::to_string).collect(),
+            observations,
+        }
+    }
+
+    #[test]
+    fn oxc_forward_docs_counterexample_becomes_candidate_refinement() {
+        let mut observations = Vec::new();
+        for index in 0..99 {
+            observations.push(observation(
+                format!("syntax-{index}"),
+                ObservationOutcome::Support,
+                facts(&[("edit_class", "syntax_changed")]),
+            ));
+        }
+        observations.push(observation(
+            "docs-license".to_string(),
+            ObservationOutcome::Counterexample,
+            facts(&[("edit_class", "comments_or_docs_only")]),
+        ));
+
+        let evaluation = evaluate_refinements(&request(
+            facts(&[("edit_class", "syntax_changed")]),
+            vec!["edit_class"],
+            observations,
+        ))
+        .unwrap();
+
+        let candidate = &evaluation.discriminators[0];
+        assert_eq!(evaluation.baseline, CohortCounts { support: 99, counterexamples: 1 });
+        assert_eq!(candidate.status, RefinementStatus::Candidate);
+        assert_eq!(candidate.current_cohort, Some(CohortCounts { support: 99, counterexamples: 0 }));
+        assert_eq!(candidate.excluded_counterexamples, Some(1));
+        assert_eq!(candidate.excluded_support, Some(0));
+    }
+
+    #[test]
+    fn reverse_oxc_syntax_cohort_reports_no_improvement() {
+        let mut observations = Vec::new();
+        for index in 0..94 {
+            observations.push(observation(
+                format!("support-{index}"),
+                ObservationOutcome::Support,
+                facts(&[("edit_class", "syntax_changed")]),
+            ));
+        }
+        for index in 0..6 {
+            observations.push(observation(
+                format!("counterexample-{index}"),
+                ObservationOutcome::Counterexample,
+                facts(&[("edit_class", "syntax_changed")]),
+            ));
+        }
+
+        let evaluation = evaluate_refinements(&request(
+            facts(&[("edit_class", "syntax_changed")]),
+            vec!["edit_class"],
+            observations,
+        ))
+        .unwrap();
+
+        assert_eq!(evaluation.discriminators[0].status, RefinementStatus::NoImprovement);
+        assert_eq!(evaluation.discriminators[0].current_cohort, Some(evaluation.baseline));
+    }
+
+    #[test]
+    fn singleton_identity_partition_is_rejected_as_overfit() {
+        let observations = vec![
+            observation(
+                "a".to_string(),
+                ObservationOutcome::Support,
+                facts(&[("commit", "a")]),
+            ),
+            observation(
+                "b".to_string(),
+                ObservationOutcome::Support,
+                facts(&[("commit", "b")]),
+            ),
+            observation(
+                "c".to_string(),
+                ObservationOutcome::Support,
+                facts(&[("commit", "c")]),
+            ),
+            observation(
+                "d".to_string(),
+                ObservationOutcome::Counterexample,
+                facts(&[("commit", "d")]),
+            ),
+        ];
+
+        let evaluation = evaluate_refinements(&request(
+            facts(&[("commit", "a")]),
+            vec!["commit"],
+            observations,
+        ))
+        .unwrap();
+
+        assert_eq!(evaluation.discriminators[0].status, RefinementStatus::Overfit);
+        assert_eq!(evaluation.discriminators[0].current_cohort.unwrap().support, 1);
+    }
+
+    #[test]
+    fn missing_current_discriminator_stays_unknown() {
+        let observations = vec![
+            observation(
+                "a".to_string(),
+                ObservationOutcome::Support,
+                facts(&[("edit_class", "syntax_changed")]),
+            ),
+            observation(
+                "b".to_string(),
+                ObservationOutcome::Counterexample,
+                facts(&[("edit_class", "comments_or_docs_only")]),
+            ),
+        ];
+
+        let evaluation = evaluate_refinements(&request(
+            BTreeMap::new(),
+            vec!["edit_class"],
+            observations,
+        ))
+        .unwrap();
+
+        assert_eq!(evaluation.discriminators[0].status, RefinementStatus::UnknownCurrent);
+        assert!(evaluation.discriminators[0].current_cohort.is_none());
+    }
+
+    #[test]
+    fn counterexample_missing_discriminator_fact_blocks_candidate() {
+        let observations = vec![
+            observation(
+                "a".to_string(),
+                ObservationOutcome::Support,
+                facts(&[("edit_class", "syntax_changed")]),
+            ),
+            observation(
+                "b".to_string(),
+                ObservationOutcome::Support,
+                facts(&[("edit_class", "syntax_changed")]),
+            ),
+            observation(
+                "c".to_string(),
+                ObservationOutcome::Support,
+                facts(&[("edit_class", "syntax_changed")]),
+            ),
+            observation(
+                "unknown".to_string(),
+                ObservationOutcome::Counterexample,
+                BTreeMap::new(),
+            ),
+        ];
+
+        let evaluation = evaluate_refinements(&request(
+            facts(&[("edit_class", "syntax_changed")]),
+            vec!["edit_class"],
+            observations,
+        ))
+        .unwrap();
+
+        assert_eq!(evaluation.discriminators[0].status, RefinementStatus::IncompleteEvidence);
+    }
+
+    #[test]
+    fn discriminator_output_order_is_stable() {
+        let observations = vec![observation(
+            "a".to_string(),
+            ObservationOutcome::Support,
+            facts(&[("z", "1"), ("a", "1")]),
+        )];
+        let evaluation = evaluate_refinements(&request(
+            facts(&[("z", "1"), ("a", "1")]),
+            vec!["z", "a"],
+            observations,
+        ))
+        .unwrap();
+
+        assert_eq!(evaluation.discriminators[0].discriminator, "a");
+        assert_eq!(evaluation.discriminators[1].discriminator, "z");
+    }
+}

--- a/src/cohort_refinement.rs
+++ b/src/cohort_refinement.rs
@@ -279,11 +279,7 @@ fn validate_facts(facts: &BTreeMap<String, String>, field: &str) -> Result<(), R
 }
 
 fn validate_atom(value: &str, field: &str, max_bytes: usize) -> Result<(), RefinementError> {
-    if value.is_empty()
-        || value.trim() != value
-        || value.len() > max_bytes
-        || value.contains('\0')
-    {
+    if value.is_empty() || value.trim() != value || value.len() > max_bytes || value.contains('\0') {
         return Err(RefinementError::new(format!(
             "{field} must be bounded canonical text"
         )));
@@ -302,7 +298,11 @@ mod tests {
             .collect()
     }
 
-    fn observation(id: String, outcome: ObservationOutcome, facts: BTreeMap<String, String>) -> CohortObservation {
+    fn observation(
+        id: String,
+        outcome: ObservationOutcome,
+        facts: BTreeMap<String, String>,
+    ) -> CohortObservation {
         CohortObservation { id, outcome, facts }
     }
 
@@ -344,9 +344,21 @@ mod tests {
         .unwrap();
 
         let candidate = &evaluation.discriminators[0];
-        assert_eq!(evaluation.baseline, CohortCounts { support: 99, counterexamples: 1 });
+        assert_eq!(
+            evaluation.baseline,
+            CohortCounts {
+                support: 99,
+                counterexamples: 1
+            }
+        );
         assert_eq!(candidate.status, RefinementStatus::Candidate);
-        assert_eq!(candidate.current_cohort, Some(CohortCounts { support: 99, counterexamples: 0 }));
+        assert_eq!(
+            candidate.current_cohort,
+            Some(CohortCounts {
+                support: 99,
+                counterexamples: 0
+            })
+        );
         assert_eq!(candidate.excluded_counterexamples, Some(1));
         assert_eq!(candidate.excluded_support, Some(0));
     }
@@ -376,8 +388,14 @@ mod tests {
         ))
         .unwrap();
 
-        assert_eq!(evaluation.discriminators[0].status, RefinementStatus::NoImprovement);
-        assert_eq!(evaluation.discriminators[0].current_cohort, Some(evaluation.baseline));
+        assert_eq!(
+            evaluation.discriminators[0].status,
+            RefinementStatus::NoImprovement
+        );
+        assert_eq!(
+            evaluation.discriminators[0].current_cohort,
+            Some(evaluation.baseline)
+        );
     }
 
     #[test]
@@ -412,8 +430,14 @@ mod tests {
         ))
         .unwrap();
 
-        assert_eq!(evaluation.discriminators[0].status, RefinementStatus::Overfit);
-        assert_eq!(evaluation.discriminators[0].current_cohort.unwrap().support, 1);
+        assert_eq!(
+            evaluation.discriminators[0].status,
+            RefinementStatus::Overfit
+        );
+        assert_eq!(
+            evaluation.discriminators[0].current_cohort.unwrap().support,
+            1
+        );
     }
 
     #[test]
@@ -431,14 +455,14 @@ mod tests {
             ),
         ];
 
-        let evaluation = evaluate_refinements(&request(
-            BTreeMap::new(),
-            vec!["edit_class"],
-            observations,
-        ))
-        .unwrap();
+        let evaluation =
+            evaluate_refinements(&request(BTreeMap::new(), vec!["edit_class"], observations))
+                .unwrap();
 
-        assert_eq!(evaluation.discriminators[0].status, RefinementStatus::UnknownCurrent);
+        assert_eq!(
+            evaluation.discriminators[0].status,
+            RefinementStatus::UnknownCurrent
+        );
         assert!(evaluation.discriminators[0].current_cohort.is_none());
     }
 
@@ -474,7 +498,10 @@ mod tests {
         ))
         .unwrap();
 
-        assert_eq!(evaluation.discriminators[0].status, RefinementStatus::IncompleteEvidence);
+        assert_eq!(
+            evaluation.discriminators[0].status,
+            RefinementStatus::IncompleteEvidence
+        );
     }
 
     #[test]

--- a/src/cohort_refinement.rs
+++ b/src/cohort_refinement.rs
@@ -279,7 +279,8 @@ fn validate_facts(facts: &BTreeMap<String, String>, field: &str) -> Result<(), R
 }
 
 fn validate_atom(value: &str, field: &str, max_bytes: usize) -> Result<(), RefinementError> {
-    if value.is_empty() || value.trim() != value || value.len() > max_bytes || value.contains('\0') {
+    if value.is_empty() || value.trim() != value || value.len() > max_bytes || value.contains('\0')
+    {
         return Err(RefinementError::new(format!(
             "{field} must be bounded canonical text"
         )));

--- a/src/cohort_refinement.rs
+++ b/src/cohort_refinement.rs
@@ -192,6 +192,8 @@ fn evaluate_discriminator(
         RefinementStatus::NoImprovement
     } else if current_cohort.support < request.min_support {
         RefinementStatus::Overfit
+    } else if !counterexample_rate_strictly_improves(current_cohort, baseline) {
+        RefinementStatus::NoImprovement
     } else {
         RefinementStatus::Candidate
     };
@@ -206,6 +208,16 @@ fn evaluate_discriminator(
         excluded_counterexamples: Some(excluded_counterexamples),
         partitions,
     }
+}
+
+fn counterexample_rate_strictly_improves(current: CohortCounts, baseline: CohortCounts) -> bool {
+    let current_counterexamples = current.counterexamples as u128;
+    let current_opportunities = current.opportunities() as u128;
+    let baseline_counterexamples = baseline.counterexamples as u128;
+    let baseline_opportunities = baseline.opportunities() as u128;
+
+    current_counterexamples * baseline_opportunities
+        < baseline_counterexamples * current_opportunities
 }
 
 fn count_observations(observations: &[CohortObservation]) -> CohortCounts {

--- a/tests/cohort_refinement.rs
+++ b/tests/cohort_refinement.rs
@@ -1,0 +1,4 @@
+#![allow(dead_code)]
+
+#[path = "../src/cohort_refinement.rs"]
+mod cohort_refinement;

--- a/tests/cohort_refinement_ratio.rs
+++ b/tests/cohort_refinement_ratio.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 #[path = "../src/cohort_refinement.rs"]
 mod cohort_refinement;
 

--- a/tests/cohort_refinement_ratio.rs
+++ b/tests/cohort_refinement_ratio.rs
@@ -1,0 +1,73 @@
+#[path = "../src/cohort_refinement.rs"]
+mod cohort_refinement;
+
+use std::collections::BTreeMap;
+
+use cohort_refinement::{
+    COHORT_REFINEMENT_SCHEMA_VERSION, CohortObservation, ObservationOutcome, RefinementRequest,
+    RefinementStatus, evaluate_refinements,
+};
+
+fn facts(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
+    entries
+        .iter()
+        .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+        .collect()
+}
+
+fn observation(id: String, outcome: ObservationOutcome, class: &str) -> CohortObservation {
+    CohortObservation {
+        id,
+        outcome,
+        facts: facts(&[("edit_class", class)]),
+    }
+}
+
+#[test]
+fn excluding_one_counterexample_cannot_worsen_counterexample_proportion() {
+    let mut observations = Vec::new();
+
+    for index in 0..3 {
+        observations.push(observation(
+            format!("selected-support-{index}"),
+            ObservationOutcome::Support,
+            "selected",
+        ));
+    }
+    observations.push(observation(
+        "selected-counterexample".to_string(),
+        ObservationOutcome::Counterexample,
+        "selected",
+    ));
+
+    for index in 0..97 {
+        observations.push(observation(
+            format!("excluded-support-{index}"),
+            ObservationOutcome::Support,
+            "excluded",
+        ));
+    }
+    observations.push(observation(
+        "excluded-counterexample".to_string(),
+        ObservationOutcome::Counterexample,
+        "excluded",
+    ));
+
+    let request = RefinementRequest {
+        schema_version: COHORT_REFINEMENT_SCHEMA_VERSION,
+        min_support: 3,
+        current_facts: facts(&[("edit_class", "selected")]),
+        discriminators: vec!["edit_class".to_string()],
+        observations,
+    };
+
+    let evaluation = evaluate_refinements(&request).unwrap();
+    let discriminator = &evaluation.discriminators[0];
+
+    assert_eq!(evaluation.baseline.support, 100);
+    assert_eq!(evaluation.baseline.counterexamples, 2);
+    assert_eq!(discriminator.current_cohort.unwrap().support, 3);
+    assert_eq!(discriminator.current_cohort.unwrap().counterexamples, 1);
+    assert_eq!(discriminator.excluded_counterexamples, Some(1));
+    assert_eq!(discriminator.status, RefinementStatus::NoImprovement);
+}


### PR DESCRIPTION
Progresses #142 with a research-only evaluator over supplied typed facts and support/counterexample observations.

## Result

The evaluator preserves baseline plus every discriminator partition and reports `candidate`, `no_improvement`, `overfit`, `unknown_current`, or `incomplete_evidence` without a scalar confidence score.

A `candidate` now requires all of these v0 conditions:

```text
counterexample discriminator evidence complete
excluded_counterexamples > 0
current support >= min_support
current counterexample proportion < baseline counterexample proportion
```

The proportion test uses exact integer cross multiplication over `u128`; no floating-point rounding or confidence score is introduced.

## Retained controls

- Oxc forward edit-class refinement: raw `99/100` -> syntax cohort `99/99` remains `candidate`;
- reverse Oxc `94/100` unchanged cohort remains `no_improvement`;
- singleton commit identity remains `overfit`;
- missing counterexample discriminator fact remains `incomplete_evidence`.

## #184 adversarial control

Issue #184 identified a false candidate:

```text
baseline: support=100, counterexamples=2, opportunities=102
selected: support=3,   counterexamples=1, opportunities=4
excluded: support=97, counterexamples=1
```

The previous implementation saw one excluded counterexample plus `min_support=3` and returned `candidate`, even though the counterexample rate regressed from `2/102` to `1/4`.

A dedicated regression test first proved the live failure on head `e9122a482eaec6f27e75cacd452a05faa1c0c20b`:

```text
CI run 32266326968 / job 96111610313 — failure
left:  Candidate
right: NoImprovement
```

The repaired head `85a9158d20bafbb3ec161d9283ca7f06b4ed5778` classifies that exact split as `no_improvement` using:

```text
current.counterexamples * baseline.opportunities
  < baseline.counterexamples * current.opportunities
```

## Validation

Exact repaired-head gates:

```text
CI run 32266580406 / job 96112440327 — success
Generated provenance review run 32266580474 — success
```

Full CI passed strict Clippy, all tests including the new ratio regression, project/review/closure/reference controls, active-work preflight, repository/history/CI-filter dogfood, and diff text + JSON dogfood.

Files: `src/cohort_refinement.rs`, `tests/cohort_refinement.rs`, `tests/cohort_refinement_ratio.rs`, `examples/cohort_refinement.rs`, `research/cohort-refinement.md`.

Research only; no product CLI/report-schema change.

Refs #6 #34 #35 #142 #184.