### PR TITLE
research: retain first behavioral collaboration corpus

### DIFF
--- a/research/behavioral-episodes/cultist-collaboration-v1.json
+++ b/research/behavioral-episodes/cultist-collaboration-v1.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "episodes": [
+    {
+      "episode_id": "pull-140:main-head-movement:4f8f9fcd->85e0b08b",
+      "receipt": {
+        "schema_version": 1,
+        "repository": "teamleaderleo/cultist",
+        "revision": "4f8f9fcd8ef1dab1881d07d063a034d9d5d7f136",
+        "task": "pull-140-product-decision-changing-evidence",
+        "evidence_kind": "concurrent-main-head-movement",
+        "evidence_ref": "github:main@4f8f9fcd8ef1dab1881d07d063a034d9d5d7f136",
+        "delivery": "surfaced",
+        "consulted": true,
+        "outcome": "changed_next_action",
+        "action": "rebuild the product lane on current main and recheck live PR file overlap before opening pull request 140"
+      }
+    },
+    {
+      "episode_id": "github-actions:run/32242752523#active-work-heads-up",
+      "receipt": {
+        "schema_version": 1,
+        "repository": "teamleaderleo/cultist",
+        "revision": "0fa33cfbd7612478e03e29a328f2727b89a58789",
+        "task": "pull-140-product-decision-changing-evidence",
+        "evidence_kind": "active-work-heads-up",
+        "evidence_ref": "github-actions:run/32242752523#active-work-heads-up",
+        "delivery": "quiet",
+        "consulted": false,
+        "outcome": "correct_quiet_negative"
+      }
+    },
+    {
+      "episode_id": "project-memory:relation-admission:48839f62->d6c99b27",
+      "receipt": {
+        "schema_version": 1,
+        "repository": "teamleaderleo/cultist",
+        "revision": "48839f625721ba595b063fc8dfd21e365e6f24dc",
+        "task": "project-memory-relation-admission-review",
+        "evidence_kind": "project-memory-relation-strengthening",
+        "evidence_ref": "github:main@48839f625721ba595b063fc8dfd21e365e6f24dc:src/project_memory.rs",
+        "delivery": "surfaced",
+        "consulted": true,
+        "outcome": "changed_next_action",
+        "action": "open issue 163 and implement pull request 166 so the Rust project-memory boundary validates relation meaning and target mention"
+      }
+    }
+  ]
+}

--- a/research/behavioral-receipts/project-memory-relation-166.json
+++ b/research/behavioral-receipts/project-memory-relation-166.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "repository": "teamleaderleo/cultist",
+  "revision": "48839f625721ba595b063fc8dfd21e365e6f24dc",
+  "task": "project-memory-relation-admission-review",
+  "evidence_kind": "project-memory-relation-strengthening",
+  "evidence_ref": "github:main@48839f625721ba595b063fc8dfd21e365e6f24dc:src/project_memory.rs",
+  "delivery": "surfaced",
+  "consulted": true,
+  "outcome": "changed_next_action",
+  "action": "open issue 163 and implement pull request 166 so the Rust project-memory boundary validates relation meaning and target mention"
+}

--- a/tests/behavioral_corpus.rs
+++ b/tests/behavioral_corpus.rs
@@ -1,0 +1,48 @@
+#[allow(dead_code)]
+#[path = "../src/behavioral_episode.rs"]
+mod behavioral_episode;
+#[allow(dead_code)]
+#[path = "../src/behavioral_receipt.rs"]
+mod behavioral_receipt;
+
+use behavioral_episode::parse_behavioral_episode_batch;
+use behavioral_receipt::{BehavioralOutcome, BehavioralReceipt, Delivery};
+
+const CORPUS: &[u8] =
+    include_bytes!("../research/behavioral-episodes/cultist-collaboration-v1.json");
+const PROJECT_MEMORY_RECEIPT: &str =
+    include_str!("../research/behavioral-receipts/project-memory-relation-166.json");
+
+#[test]
+fn retained_cultist_collaboration_batch_is_valid_and_unique() {
+    let batch = parse_behavioral_episode_batch(CORPUS).unwrap();
+    assert_eq!(batch.episodes.len(), 3);
+
+    assert_eq!(batch.episodes[0].receipt.delivery, Delivery::Surfaced);
+    assert_eq!(
+        batch.episodes[0].receipt.outcome,
+        BehavioralOutcome::ChangedNextAction
+    );
+
+    assert_eq!(batch.episodes[1].receipt.delivery, Delivery::Quiet);
+    assert_eq!(
+        batch.episodes[1].receipt.outcome,
+        BehavioralOutcome::CorrectQuietNegative
+    );
+
+    assert_eq!(
+        batch.episodes[2].receipt.evidence_kind,
+        "project-memory-relation-strengthening"
+    );
+    assert_eq!(
+        batch.episodes[2].receipt.outcome,
+        BehavioralOutcome::ChangedNextAction
+    );
+}
+
+#[test]
+fn standalone_project_memory_receipt_matches_retained_episode() {
+    let batch = parse_behavioral_episode_batch(CORPUS).unwrap();
+    let standalone: BehavioralReceipt = serde_json::from_str(PROJECT_MEMORY_RECEIPT).unwrap();
+    assert_eq!(batch.episodes[2].receipt, standalone);
+}


### PR DESCRIPTION
## Goal

Give #137 a first retained multi-episode corpus after merged #157 receipts and #165 episode identity, while still avoiding aggregate scoring.

## Corpus

`research/behavioral-episodes/cultist-collaboration-v1.json` contains three unique real episodes:

1. #140 current-main movement surfaced, was consulted, and changed the next action to rebuild/recheck before opening the PR;
2. #140 active-work CI observed the live PR set and correctly stayed quiet on disjoint work;
3. review of merged #160 surfaced a project-memory relation-strengthening gap and changed the next action into #163/#166, which repaired the Rust admission boundary.

The third receipt is also retained standalone at:

```text
research/behavioral-receipts/project-memory-relation-166.json
```

## Standard-suite control

`tests/behavioral_corpus.rs` runs the merged #165 batch validator over the retained corpus, checks the positive/quiet outcome mix, and requires the standalone #166 receipt to be byte-for-semantics identical to the nested episode.

Episode IDs therefore make the three observations distinct while preventing copied IDs from being silently double-counted by later consumers.

## Boundary

- no aggregate actionability score;
- no promotion/demotion policy;
- no timestamp/causality inference;
- no worker/model identity;
- this is raw retained dogfood evidence only.

The branch is one commit ahead / zero behind current main `abfcaedf3f95e9a1d8ac6c9d98acfb1573eabcfb` at open time.

Refs #137 #157 #165 #166.