### PR TITLE
research: mutation-test evidence projections

### DIFF
--- a/research/evidence-mutation-testing.md
+++ b/research/evidence-mutation-testing.md
@@ -1,0 +1,218 @@
+# Evidence mutation testing
+
+Tracking: #146. Builds on the merged #125 evidence-role projection fixture, #123/#124 applicability semantics, #131 exact report fingerprint, #157 behavioral receipts, and #165 behavioral episode identity.
+
+## Question
+
+When Cultist intentionally omits, misbinds, or changes evidence-bearing state in a terse/JEI/review projection, can adversarial mutation tests show which owning semantic contract changed?
+
+The carrier reuses independent deterministic evaluators instead of inventing one universal decision language.
+
+## Oracle 1: evidence-role next action
+
+The merged role-projection fixture models:
+
+```text
+support
+counterexample
+limit
+clearing
+```
+
+and derives one test-local `NextAction`:
+
+```text
+proceed
+hold
+restrict_scope
+reconcile_exception
+execute_clearing_step
+```
+
+V0 mutations remove one evidence role and compare the canonical and mutated actions.
+
+Observed controls:
+
+```text
+support-only omission
+  Proceed -> Proceed
+  survived this fixture/action oracle
+
+limit omission
+  RestrictScope -> Proceed
+  killed
+
+counterexample omission
+  ReconcileException -> Proceed
+  killed
+
+clearing omission
+  ExecuteClearingStep -> Hold
+  killed
+```
+
+One adversarial fixture carries both counterexample and limit evidence. The action oracle prioritizes the limit, so dropping the counterexample leaves `RestrictScope -> RestrictScope`. That mutation survives the immediate-action oracle while still losing a material exception receipt.
+
+This keeps the key boundary explicit:
+
+> `survived` describes one fixture under one oracle. It never grants canonical deletion of the omitted evidence.
+
+## Oracle 2: exact applicability
+
+The second control reuses the shared #123/#124 applicability evaluator directly. Evidence in the fixture requires exact revision `head-a`; repository/work coordinates are present but unrequired.
+
+```text
+move required revision head-a -> head-b
+  applies -> invalid
+  killed
+
+drop required revision from current context
+  applies -> unknown
+  killed
+
+move repository coordinate the evidence did not require
+  applies -> applies
+  survived this applicability oracle
+```
+
+A mutation is evaluated against the coordinates the evidence actually declared. Extra ambient coordinates do not become hidden applicability requirements.
+
+## Oracle 3: exact report snapshot identity
+
+The third control reuses merged `src/report_fingerprint.rs`, whose production-shaped contract is:
+
+```text
+AnalysisReport
+-> validated deterministic C1 bytes
+-> SHA-256
+-> cultist-report-c1-sha256-v1:<digest>
+```
+
+The mutation harness deliberately excludes the old positional-delta application fixture from #128. It asks only properties owned by the reusable exact-snapshot fingerprint.
+
+Controls:
+
+```text
+pure finding reorder
+  fingerprint A -> fingerprint B
+  killed
+
+claim semantic mutation
+  fingerprint A -> fingerprint B
+  killed
+
+pretty-JSON serialize + typed parse
+  fingerprint A -> fingerprint A
+  survived
+```
+
+The representation-only control is important. JSON whitespace/layout can change while the typed `AnalysisReport` and its C1 fingerprint remain identical. Conversely, finding order belongs to exact snapshot identity even when the finding semantics themselves are individually unchanged.
+
+This oracle proves exact snapshot identity only. It does not establish semantic lineage across changed reports or apply a positional delta to another base.
+
+## Composing oracles
+
+Three independent species now make one aggregate mutation score even less useful:
+
+```text
+next action preserved?
+applicability preserved?
+exact snapshot identity preserved?
+material evidence role preserved?
+semantic lineage preserved?
+reopen/clearing condition preserved?
+```
+
+A mutation may survive one oracle and fail another. Every mutation receipt stays tied to the evaluator that owns its verdict.
+
+## Relationship to behavioral receipts
+
+Merged #157 records observed worker outcomes such as `changed_next_action`, `needed_stronger_evidence`, `stale_or_wrong_coordinate`, and `correct_quiet_negative`. Merged #165 wraps those receipts in stable episode identity.
+
+Keep deterministic mutation identity and behavioral episode identity separate:
+
+```text
+mutation kind/id
+  semantic edit applied by the research harness
+
+episode_id
+  real receiver observation
+```
+
+A future A/B replay may join the two by explicit episode ID. Deterministic fixtures never fabricate behavioral receipts.
+
+## Earlier executed receipts
+
+The first two-oracle carrier passed on rebased head:
+
+```text
+9b1fcde5ac278ca87c64a32d9e2f0e8cb53614e0
+```
+
+CI run `32245648698` / #1163 and generated-provenance run `32245648545` / #198 succeeded.
+
+Main later advanced through behavioral corpus, project-memory collectors/admission hardening, JEI budget pilots, explicit scope-history research, and project-memory lineage controls. The original #125 projection fixture remained byte-identical, so the two-oracle carrier was replayed as one commit on main `3db534cfee58da530978c032666f0c1b4f149dfd`.
+
+Replay head:
+
+```text
+905c538634cb8d287fc43f1cef94d051755825fc
+```
+
+CI run `32249802071` / #1317 and provenance run `32249802194` / #240 passed, including the newer project-memory lineage control.
+
+## Latest-main three-oracle replay
+
+Main then advanced again with #191's explicit scoped agent-context envelope. That landed on:
+
+```text
+fe285be0aa9e1a476430b154ed6ec84f77011d32
+```
+
+Its landed file set is disjoint from the mutation/fingerprint paths. The mutation carrier was rebuilt as one semantic commit on that exact main and gained Oracle 3 through the reusable report fingerprint module.
+
+Exact compacted semantic head:
+
+```text
+6b015047d7651a85aa8d02906fde667a31a64f08
+```
+
+GitHub Actions CI run `32250509751` / run number `1349` completed successfully. It passed:
+
+- `cargo fmt --check`;
+- strict Clippy;
+- project-memory lineage controls;
+- active-work preflight;
+- full tests including all three mutation oracles;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+Generated provenance review dogfood run `32250509645` / run number `250` also completed successfully on the same head.
+
+The first identity-oracle attempt stopped at rustfmt before Clippy/tests. After the exact formatter delta, the formatted intermediate head passed CI #1346 + provenance #249; the branch was then compacted back to the one semantic commit above and revalidated through CI #1349 + provenance #250.
+
+## Next mutations
+
+Two high-value independent species remain:
+
+1. ambient context binding (#134/#136), once its owning evaluator is reusable on current main;
+2. durable clearing/reopen semantics (#144/#159), preferably after the owning research types land or can be composed without copying them into this carrier.
+
+The old positional delta application model remains fixture-local in `tests/delta_identity.rs`. Keep it there until a reusable owner-backed delta/base evaluator exists. Exact report fingerprinting already gives the mutation lane the identity property it can legitimately test today.
+
+## Boundary
+
+- research/test-only;
+- no `AnalysisReport` schema change;
+- no public terse format change;
+- no aggregate mutation score;
+- survived mutation is fixture-and-oracle-local evidence;
+- exact snapshot identity is separate from semantic lineage;
+- behavioral episodes remain optional observations, never the deterministic oracle itself;
+- no model dependency.
+
+North star:
+
+> Mutate one semantic contract at a time and make the owning evaluator prove whether the edit preserves the property that consumer actually relies on.

--- a/tests/evidence_mutation_applicability.rs
+++ b/tests/evidence_mutation_applicability.rs
@@ -1,0 +1,127 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+
+use applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, evaluate_query,
+};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum ApplicabilityMutation {
+    MoveRequiredRevision,
+    DropRequiredRevisionContext,
+    MoveUnrequiredRepository,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum MutationVerdict {
+    Survived,
+    Killed,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct ApplicabilityMutationReceipt {
+    mutation: ApplicabilityMutation,
+    before: ApplicabilityStatus,
+    after: ApplicabilityStatus,
+    verdict: MutationVerdict,
+}
+
+fn query(context: EvaluationContext) -> ApplicabilityQuery {
+    ApplicabilityQuery {
+        schema_version: APPLICABILITY_SCHEMA_VERSION,
+        requirements: EvidenceRequirements {
+            revision: Some("head-a".to_string()),
+            ..EvidenceRequirements::default()
+        },
+        context,
+    }
+}
+
+fn baseline_context() -> EvaluationContext {
+    EvaluationContext {
+        repository: Some("owner/repo".to_string()),
+        revision: Some("head-a".to_string()),
+        work: Some("#17".to_string()),
+        path: None,
+    }
+}
+
+fn mutate_context(
+    context: &EvaluationContext,
+    mutation: ApplicabilityMutation,
+) -> EvaluationContext {
+    let mut mutated = context.clone();
+    match mutation {
+        ApplicabilityMutation::MoveRequiredRevision => {
+            mutated.revision = Some("head-b".to_string());
+        }
+        ApplicabilityMutation::DropRequiredRevisionContext => {
+            mutated.revision = None;
+        }
+        ApplicabilityMutation::MoveUnrequiredRepository => {
+            mutated.repository = Some("other/repo".to_string());
+        }
+    }
+    mutated
+}
+
+fn mutation_receipt(mutation: ApplicabilityMutation) -> ApplicabilityMutationReceipt {
+    let context = baseline_context();
+    let before = evaluate_query(&query(context.clone())).unwrap().status;
+    let after = evaluate_query(&query(mutate_context(&context, mutation)))
+        .unwrap()
+        .status;
+    let verdict = if before == after {
+        MutationVerdict::Survived
+    } else {
+        MutationVerdict::Killed
+    };
+    ApplicabilityMutationReceipt {
+        mutation,
+        before,
+        after,
+        verdict,
+    }
+}
+
+#[test]
+fn moving_exact_required_revision_kills_applicability_mutation() {
+    assert_eq!(
+        mutation_receipt(ApplicabilityMutation::MoveRequiredRevision),
+        ApplicabilityMutationReceipt {
+            mutation: ApplicabilityMutation::MoveRequiredRevision,
+            before: ApplicabilityStatus::Applies,
+            after: ApplicabilityStatus::Invalid,
+            verdict: MutationVerdict::Killed,
+        }
+    );
+}
+
+#[test]
+fn removing_required_revision_context_kills_applicability_mutation() {
+    assert_eq!(
+        mutation_receipt(ApplicabilityMutation::DropRequiredRevisionContext),
+        ApplicabilityMutationReceipt {
+            mutation: ApplicabilityMutation::DropRequiredRevisionContext,
+            before: ApplicabilityStatus::Applies,
+            after: ApplicabilityStatus::Unknown,
+            verdict: MutationVerdict::Killed,
+        }
+    );
+}
+
+#[test]
+fn moving_coordinate_that_evidence_did_not_require_survives_this_oracle() {
+    assert_eq!(
+        mutation_receipt(ApplicabilityMutation::MoveUnrequiredRepository),
+        ApplicabilityMutationReceipt {
+            mutation: ApplicabilityMutation::MoveUnrequiredRepository,
+            before: ApplicabilityStatus::Applies,
+            after: ApplicabilityStatus::Applies,
+            verdict: MutationVerdict::Survived,
+        }
+    );
+}

--- a/tests/evidence_mutation_report_identity.rs
+++ b/tests/evidence_mutation_report_identity.rs
@@ -1,0 +1,119 @@
+#![allow(dead_code)]
+
+#[path = "../src/compact_ir.rs"]
+mod compact_ir;
+#[path = "../src/finding.rs"]
+mod finding;
+#[path = "../src/report_fingerprint.rs"]
+mod report_fingerprint;
+
+use finding::{
+    AnalysisReport, Claim, ClaimKind, Evidence, Finding, Location, REPORT_SCHEMA_VERSION,
+};
+use report_fingerprint::{ReportFingerprint, fingerprint_report};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum SnapshotMutation {
+    ReorderFindings,
+    ChangeClaimSemantics,
+    PrettyJsonRoundTrip,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum MutationVerdict {
+    Survived,
+    Killed,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct SnapshotMutationReceipt {
+    mutation: SnapshotMutation,
+    before: ReportFingerprint,
+    after: ReportFingerprint,
+    verdict: MutationVerdict,
+}
+
+fn representative_report() -> AnalysisReport {
+    AnalysisReport {
+        schema_version: REPORT_SCHEMA_VERSION,
+        analysis: "mutation-report-identity".to_string(),
+        repository: "/repo".to_string(),
+        claims: vec![Claim::new(
+            ClaimKind::Unknown,
+            "semantic independence is unresolved",
+        )],
+        findings: vec![
+            Finding::new("direct-overlap", "Direct path overlap")
+                .at(Location::new("src/auth.rs", Some(12)))
+                .with_claim(
+                    Claim::new(ClaimKind::Proven, "both work items modify src/auth.rs")
+                        .with_evidence(Evidence::new("github:pull/10")),
+                )
+                .with_question("Coordinate ownership?"),
+            Finding::new("explicit-coordination", "Explicit coordination").with_claim(Claim::new(
+                ClaimKind::Observed,
+                "hold_merge_while #10 > #11",
+            )),
+        ],
+    }
+}
+
+fn mutate(report: &AnalysisReport, mutation: SnapshotMutation) -> AnalysisReport {
+    match mutation {
+        SnapshotMutation::ReorderFindings => {
+            let mut mutated = report.clone();
+            mutated.findings.reverse();
+            mutated
+        }
+        SnapshotMutation::ChangeClaimSemantics => {
+            let mut mutated = report.clone();
+            mutated.findings[0].claims[0].message.push('!');
+            mutated
+        }
+        SnapshotMutation::PrettyJsonRoundTrip => {
+            let pretty = serde_json::to_string_pretty(report).unwrap();
+            serde_json::from_str(&pretty).unwrap()
+        }
+    }
+}
+
+fn mutation_receipt(mutation: SnapshotMutation) -> SnapshotMutationReceipt {
+    let report = representative_report();
+    let before = fingerprint_report(&report).unwrap();
+    let after = fingerprint_report(&mutate(&report, mutation)).unwrap();
+    let verdict = if before == after {
+        MutationVerdict::Survived
+    } else {
+        MutationVerdict::Killed
+    };
+    SnapshotMutationReceipt {
+        mutation,
+        before,
+        after,
+        verdict,
+    }
+}
+
+#[test]
+fn finding_reorder_kills_exact_snapshot_identity_mutation() {
+    let receipt = mutation_receipt(SnapshotMutation::ReorderFindings);
+    assert_eq!(receipt.mutation, SnapshotMutation::ReorderFindings);
+    assert_eq!(receipt.verdict, MutationVerdict::Killed);
+    assert_ne!(receipt.before, receipt.after);
+}
+
+#[test]
+fn claim_semantic_change_kills_exact_snapshot_identity_mutation() {
+    let receipt = mutation_receipt(SnapshotMutation::ChangeClaimSemantics);
+    assert_eq!(receipt.mutation, SnapshotMutation::ChangeClaimSemantics);
+    assert_eq!(receipt.verdict, MutationVerdict::Killed);
+    assert_ne!(receipt.before, receipt.after);
+}
+
+#[test]
+fn json_representation_change_survives_typed_snapshot_identity_oracle() {
+    let receipt = mutation_receipt(SnapshotMutation::PrettyJsonRoundTrip);
+    assert_eq!(receipt.mutation, SnapshotMutation::PrettyJsonRoundTrip);
+    assert_eq!(receipt.verdict, MutationVerdict::Survived);
+    assert_eq!(receipt.before, receipt.after);
+}

--- a/tests/evidence_role_projection.rs
+++ b/tests/evidence_role_projection.rs
@@ -180,6 +180,63 @@ fn level_token(level: ClaimKind) -> &'static str {
     }
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum MutationKind {
+    Support,
+    Counterexample,
+    Limit,
+    Clearing,
+}
+
+impl MutationKind {
+    fn role(self) -> EvidenceRole {
+        match self {
+            Self::Support => EvidenceRole::Support,
+            Self::Counterexample => EvidenceRole::Counterexample,
+            Self::Limit => EvidenceRole::Limit,
+            Self::Clearing => EvidenceRole::Clearing,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum MutationVerdict {
+    Survived,
+    Killed,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct MutationReceipt {
+    mutation: MutationKind,
+    before: NextAction,
+    after: NextAction,
+    verdict: MutationVerdict,
+}
+
+fn mutate(case: &ProjectionCase, mutation: MutationKind) -> ProjectionCase {
+    let mut mutated = case.clone();
+    mutated
+        .evidence
+        .retain(|evidence| evidence.role != mutation.role());
+    mutated
+}
+
+fn mutation_receipt(case: &ProjectionCase, mutation: MutationKind) -> MutationReceipt {
+    let before = required_action(case);
+    let after = required_action(&mutate(case, mutation));
+    let verdict = if before == after {
+        MutationVerdict::Survived
+    } else {
+        MutationVerdict::Killed
+    };
+    MutationReceipt {
+        mutation,
+        before,
+        after,
+        verdict,
+    }
+}
+
 #[test]
 fn actual_terse_renderer_collapses_scope_limit_that_changes_action() {
     let unrestricted = ProjectionCase::new(
@@ -304,5 +361,122 @@ fn role_aware_unknown_without_clearing_evidence_stays_hold() {
     assert_eq!(
         action_from_role_aware_projection(&projection),
         NextAction::Hold
+    );
+}
+
+#[test]
+fn mutation_testing_accepts_support_omission_in_support_only_case() {
+    let case = ProjectionCase::new(
+        "support-only-mutation",
+        ClaimKind::Proven,
+        "exact fixture replay passed",
+        vec![support("fixture A passed"), support("fixture B passed")],
+    );
+
+    assert_eq!(
+        mutation_receipt(&case, MutationKind::Support),
+        MutationReceipt {
+            mutation: MutationKind::Support,
+            before: NextAction::Proceed,
+            after: NextAction::Proceed,
+            verdict: MutationVerdict::Survived,
+        }
+    );
+}
+
+#[test]
+fn mutation_testing_kills_hidden_limit_omission() {
+    let case = ProjectionCase::new(
+        "limit-mutation",
+        ClaimKind::Proven,
+        "target test passed",
+        vec![
+            support("target execution passed"),
+            limit("receipt is valid only for linux-x86_64"),
+        ],
+    );
+
+    assert_eq!(
+        mutation_receipt(&case, MutationKind::Limit),
+        MutationReceipt {
+            mutation: MutationKind::Limit,
+            before: NextAction::RestrictScope,
+            after: NextAction::Proceed,
+            verdict: MutationVerdict::Killed,
+        }
+    );
+}
+
+#[test]
+fn mutation_testing_kills_counterexample_omission() {
+    let case = ProjectionCase::new(
+        "counterexample-mutation",
+        ClaimKind::Observed,
+        "helper is the local precedent",
+        vec![
+            support("six nearby callers use helper"),
+            counterexample("one reviewed exception matches this change scope"),
+        ],
+    );
+
+    assert_eq!(
+        mutation_receipt(&case, MutationKind::Counterexample),
+        MutationReceipt {
+            mutation: MutationKind::Counterexample,
+            before: NextAction::ReconcileException,
+            after: NextAction::Proceed,
+            verdict: MutationVerdict::Killed,
+        }
+    );
+}
+
+#[test]
+fn mutation_testing_kills_clearing_omission() {
+    let case = ProjectionCase::new(
+        "clearing-mutation",
+        ClaimKind::Unknown,
+        "merge eligibility is unresolved",
+        vec![
+            support("exact target execution is absent"),
+            clearing("run exact target execution at current head"),
+        ],
+    );
+
+    assert_eq!(
+        mutation_receipt(&case, MutationKind::Clearing),
+        MutationReceipt {
+            mutation: MutationKind::Clearing,
+            before: NextAction::ExecuteClearingStep,
+            after: NextAction::Hold,
+            verdict: MutationVerdict::Killed,
+        }
+    );
+}
+
+#[test]
+fn survived_mutation_is_fixture_local_when_another_role_already_controls_action() {
+    let case = ProjectionCase::new(
+        "masked-counterexample-mutation",
+        ClaimKind::Observed,
+        "helper is the local precedent",
+        vec![
+            support("six nearby callers use helper"),
+            counterexample("one reviewed exception matches this change scope"),
+            limit("current evidence applies only to the target package"),
+        ],
+    );
+
+    assert_eq!(
+        mutation_receipt(&case, MutationKind::Counterexample),
+        MutationReceipt {
+            mutation: MutationKind::Counterexample,
+            before: NextAction::RestrictScope,
+            after: NextAction::RestrictScope,
+            verdict: MutationVerdict::Survived,
+        }
+    );
+    assert_ne!(
+        role_aware_projection(&case),
+        role_aware_projection(&mutate(&case, MutationKind::Counterexample))
     );
 }


### PR DESCRIPTION
Progresses #146 with research-only mutation controls over three independent owner-backed semantics.

## Oracle 1 — evidence-role next action

- support-only omission: `Proceed -> Proceed` (survived this fixture/action oracle);
- limit omission: `RestrictScope -> Proceed` (killed);
- counterexample omission: `ReconcileException -> Proceed` (killed);
- clearing omission: `ExecuteClearingStep -> Hold` (killed).

A counterexample+limit control shows why survival stays oracle-local: dropping the counterexample can preserve the immediate action while losing a material receipt.

## Oracle 2 — exact applicability

Reuses merged #123/#124 applicability:

- required revision movement: `applies -> invalid` (killed);
- missing required revision context: `applies -> unknown` (killed);
- movement of an unrequired repository coordinate: `applies -> applies` (survived this oracle).

## Oracle 3 — exact report snapshot identity

Reuses merged `src/report_fingerprint.rs` / #131 only; positional-delta application remains in its test-local #128 fixture.

- pure finding reorder changes the exact C1/SHA-256 report fingerprint (killed);
- claim semantic mutation changes the fingerprint (killed);
- pretty-JSON serialize + typed parse preserves the fingerprint (survived).

This proves exact snapshot identity, not semantic lineage or stale positional-delta application.

## Latest-main replay

Main advanced through #191 to `fe285be0aa9e1a476430b154ed6ec84f77011d32`; its scoped agent-context files are disjoint from the mutation/fingerprint lane. #173 was rebuilt as one semantic commit on that exact main.

Exact compacted semantic head `6b015047d7651a85aa8d02906fde667a31a64f08` passed CI run `32250509751` / #1349 and generated-provenance run `32250509645` / #250: format, strict Clippy, project-memory lineage controls, active-work preflight, all three mutation oracles, and repository/history/CI-filter/diff dogfood succeeded.

The first identity-oracle attempt stopped only at rustfmt; the formatted intermediate passed CI #1346 + provenance #249, then the branch was compacted and revalidated.

The exact receipt is retained in `research/evidence-mutation-testing.md`.

## Boundary

- research/test-only;
- no report schema/public terse-format change;
- no aggregate mutation score;
- survived mutation is fixture-and-oracle-local;
- exact snapshot identity remains separate from semantic lineage;
- behavioral observations remain optional external receipts.

Next owner-backed candidates are ambient context binding and durable clearing/reopen once their evaluators can be composed without copying research-local state models.

Refs #123 #125 #127 #131 #134 #146 #157 #165.