### PR TITLE
fix: compose Primary case project-memory evidence

### DIFF
--- a/src/project_memory.rs
+++ b/src/project_memory.rs
@@ -175,7 +175,7 @@ impl ProjectMemoryPacket {
                 &edge.evidence,
                 "edge evidence",
                 MAX_EDGE_EVIDENCE_BYTES,
-                false,
+                true,
             )?;
             if !source.evidence_text.contains(&edge.evidence) {
                 return Err(format!(
@@ -184,7 +184,7 @@ impl ProjectMemoryPacket {
                     display_ref(edge.to)
                 ));
             }
-            validate_edge_semantics(edge)?;
+            validate_edge_semantics(&self.repository, edge)?;
         }
 
         Ok(())
@@ -325,7 +325,15 @@ fn valid_repository_char(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')
 }
 
-fn validate_edge_semantics(edge: &ProjectMemoryEdge) -> Result<(), String> {
+fn validate_edge_semantics(repository: &str, edge: &ProjectMemoryEdge) -> Result<(), String> {
+    if edge
+        .evidence
+        .bytes()
+        .any(|byte| matches!(byte, b'\n' | b'\r'))
+    {
+        return validate_primary_case_edge(repository, edge);
+    }
+
     let Some(classified) = classify_relation(&edge.evidence) else {
         return Err(format!(
             "edge evidence for {} -> {} is not an admitted explicit relationship line",
@@ -346,6 +354,73 @@ fn validate_edge_semantics(edge: &ProjectMemoryEdge) -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+fn validate_primary_case_edge(repository: &str, edge: &ProjectMemoryEdge) -> Result<(), String> {
+    let Some(target) = primary_case_target(repository, &edge.evidence) else {
+        return Err(format!(
+            "multiline edge evidence for {} -> {} is not an admitted Primary case block",
+            display_ref(edge.from),
+            display_ref(edge.to)
+        ));
+    };
+    if edge.relation != MemoryRelation::Related {
+        return Err("Primary case evidence must use relation=related".to_string());
+    }
+    if target != edge.to.number {
+        return Err(format!(
+            "Primary case evidence names issue #{target}, not declared target {}",
+            display_ref(edge.to)
+        ));
+    }
+    Ok(())
+}
+
+fn primary_case_target(repository: &str, evidence: &str) -> Option<u64> {
+    let mut lines = evidence
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty());
+    if !lines.next()?.eq_ignore_ascii_case("Primary case:") {
+        return None;
+    }
+    let target = lines.next()?;
+    if lines.next().is_some() {
+        return None;
+    }
+    repository_issue_url_target(repository, target)
+}
+
+fn repository_issue_url_target(repository: &str, url: &str) -> Option<u64> {
+    let normalized = url.to_ascii_lowercase();
+    let repository = repository.to_ascii_lowercase();
+    for origin in ["https://github.com/", "https://redirect.github.com/"] {
+        let prefix = format!("{origin}{repository}/issues/");
+        if let Some(rest) = normalized.strip_prefix(&prefix) {
+            return positive_decimal_prefix(rest);
+        }
+    }
+    None
+}
+
+fn positive_decimal_prefix(value: &str) -> Option<u64> {
+    let bytes = value.as_bytes();
+    if bytes.is_empty() || bytes[0] == b'0' || !bytes[0].is_ascii_digit() {
+        return None;
+    }
+
+    let mut number = 0u64;
+    let mut cursor = 0usize;
+    while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+        number = number
+            .checked_mul(10)?
+            .checked_add((bytes[cursor] - b'0') as u64)?;
+        cursor += 1;
+    }
+    if cursor < bytes.len() && !matches!(bytes[cursor], b'/' | b'?' | b'#') {
+        return None;
+    }
+    Some(number)
 }
 
 fn classify_relation(evidence: &str) -> Option<MemoryRelation> {

--- a/tests/project_memory_primary_case.rs
+++ b/tests/project_memory_primary_case.rs
@@ -1,0 +1,124 @@
+#[allow(dead_code)]
+#[path = "../src/project_memory.rs"]
+mod project_memory;
+
+use project_memory::{
+    ArtifactKind, ArtifactRef, ArtifactState, MemoryRelation, PROJECT_MEMORY_SCHEMA_VERSION,
+    ProjectArtifact, ProjectMemoryEdge, ProjectMemoryPacket,
+};
+
+fn issue(number: u64, evidence_text: &str) -> ProjectArtifact {
+    ProjectArtifact {
+        reference: ArtifactRef {
+            kind: ArtifactKind::Issue,
+            number,
+        },
+        title: format!("Issue {number}"),
+        state: ArtifactState::Open,
+        created_at: "2026-08-19T00:00:00Z".to_string(),
+        closed_at: None,
+        revision: None,
+        changed_paths: Vec::new(),
+        evidence_text: evidence_text.to_string(),
+        evidence_complete: true,
+    }
+}
+
+fn packet(evidence: &str, relation: MemoryRelation, target: u64) -> ProjectMemoryPacket {
+    ProjectMemoryPacket {
+        schema_version: PROJECT_MEMORY_SCHEMA_VERSION,
+        repository: "teamleaderleo/linux-fieldwork".to_string(),
+        anchor: ArtifactRef {
+            kind: ArtifactKind::Issue,
+            number: 675,
+        },
+        artifacts: vec![
+            issue(675, evidence),
+            issue(609, "case 609"),
+            issue(611, "case 611"),
+        ],
+        edges: vec![ProjectMemoryEdge {
+            from: ArtifactRef {
+                kind: ArtifactKind::Issue,
+                number: 675,
+            },
+            relation,
+            to: ArtifactRef {
+                kind: ArtifactKind::Issue,
+                number: target,
+            },
+            evidence: evidence.to_string(),
+        }],
+    }
+}
+
+#[test]
+fn admits_exact_primary_case_block_from_issue_collector() {
+    let packet = packet(
+        "Primary case:\n\nhttps://github.com/teamleaderleo/linux-fieldwork/issues/609",
+        MemoryRelation::Related,
+        609,
+    );
+    packet.validate().unwrap();
+}
+
+#[test]
+fn admits_redirect_github_primary_case_url() {
+    let packet = packet(
+        "Primary case:\nhttps://redirect.github.com/teamleaderleo/linux-fieldwork/issues/609",
+        MemoryRelation::Related,
+        609,
+    );
+    packet.validate().unwrap();
+}
+
+#[test]
+fn primary_case_block_cannot_be_strengthened_to_closes() {
+    let packet = packet(
+        "Primary case:\nhttps://github.com/teamleaderleo/linux-fieldwork/issues/609",
+        MemoryRelation::Closes,
+        609,
+    );
+    let error = packet.validate().unwrap_err();
+    assert!(error.contains("must use relation=related"));
+}
+
+#[test]
+fn primary_case_block_cannot_escape_packet_repository() {
+    let packet = packet(
+        "Primary case:\nhttps://github.com/teamleaderleo/other-repo/issues/609",
+        MemoryRelation::Related,
+        609,
+    );
+    let error = packet.validate().unwrap_err();
+    assert!(error.contains("not an admitted Primary case block"));
+}
+
+#[test]
+fn primary_case_url_must_name_declared_target() {
+    let packet = packet(
+        "Primary case:\nhttps://github.com/teamleaderleo/linux-fieldwork/issues/609",
+        MemoryRelation::Related,
+        611,
+    );
+    let error = packet.validate().unwrap_err();
+    assert!(error.contains("names issue #609"));
+}
+
+#[test]
+fn primary_case_block_rejects_extra_nonempty_prose() {
+    let packet = packet(
+        "Primary case:\nhttps://github.com/teamleaderleo/linux-fieldwork/issues/609\nThis is also related to another case.",
+        MemoryRelation::Related,
+        609,
+    );
+    let error = packet.validate().unwrap_err();
+    assert!(error.contains("not an admitted Primary case block"));
+}
+
+#[test]
+fn multiline_related_line_cannot_bypass_single_line_relation_grammar() {
+    let packet = packet("Related: #609\nextra prose", MemoryRelation::Related, 609);
+    let error = packet.validate().unwrap_err();
+    assert!(error.contains("not an admitted Primary case block"));
+}


### PR DESCRIPTION
## Live semantic collision

Merged #166 and #167 touched disjoint file sets while changing opposite sides of the same project-memory packet contract.

#166 tightened offline edge admission to one explicit relation line whose relation and `#N` target are independently validated.

#167's issue collector emits exact source evidence shaped as:

```text
Primary case:

https://github.com/OWNER/REPO/issues/N
```

with `relation=related`.

Its carrier passed before #166 landed. Current main after both merges rejects that packet species: the evidence is multiline, `Primary case:` is outside the ordinary line classifier, and the target appears as an issue URL rather than `#N`.

Refs #172.

## Repair

Keep #166's single-line grammar unchanged for ordinary relationship prose.

Multiline edge evidence now takes a separate fail-closed path which admits only:

```text
Primary case:
<optional blank lines>
https://{github.com|redirect.github.com}/PACKET_REPOSITORY/issues/N
```

The validator proves:

- exactly one non-empty label + one non-empty target URL;
- label is `Primary case:` case-insensitively;
- URL origin is admitted;
- URL repository equals packet repository;
- issue number is canonical positive decimal;
- typed relation is exactly `related`;
- parsed issue number equals the declared edge target.

Every other multiline shape rejects.

## Controls

New standard-suite tests require:

- exact #167-shaped block accepted;
- redirect.github.com form accepted;
- Primary case evidence cannot be strengthened to `closes`;
- cross-repository target rejects;
- URL/edge target mismatch rejects;
- extra non-empty prose rejects;
- multiline `Related: #N\n...` cannot bypass #166's single-line rule.

Existing ordinary project-memory packets continue through the unchanged single-line classifier.

## Dogfood result

This is a concrete positive for semantic preflight research:

```text
#166 paths != #167 paths
Git overlap: none
semantic packet contract: collided
integration review after both landed: caught it
```

Exact-path preflight was correctly unable to claim independence; this episode gives future semantic-preflight work a real producer/consumer contract collision with zero path overlap.

The branch is one commit ahead / zero behind current main `9792bfeeb08404f9b798be42df61d2b950c58e62` at open time.

Refs #96 #137 #160 #166 #167 #172.