### PR TITLE
research: add descriptive behavioral episode summary

### DIFF
--- a/examples/behavioral_summary.rs
+++ b/examples/behavioral_summary.rs
@@ -1,0 +1,39 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+#[allow(dead_code)]
+#[path = "../src/behavioral_episode.rs"]
+mod behavioral_episode;
+#[allow(dead_code)]
+#[path = "../src/behavioral_receipt.rs"]
+mod behavioral_receipt;
+#[path = "../src/behavioral_summary.rs"]
+mod behavioral_summary;
+
+use behavioral_episode::{MAX_BEHAVIORAL_EPISODE_BATCH_BYTES, parse_behavioral_episode_batch};
+use behavioral_summary::summarize_behavioral_episodes;
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("behavioral-summary: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_BEHAVIORAL_EPISODE_BATCH_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_BEHAVIORAL_EPISODE_BATCH_BYTES {
+        return Err(format!(
+            "behavioral episode batch exceeds the {MAX_BEHAVIORAL_EPISODE_BATCH_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let batch = parse_behavioral_episode_batch(&bytes)?;
+    let summary = summarize_behavioral_episodes(&batch)?;
+    println!("{}", serde_json::to_string_pretty(&summary)?);
+    Ok(())
+}

--- a/research/behavioral-summary.md
+++ b/research/behavioral-summary.md
@@ -1,0 +1,96 @@
+# Descriptive behavioral summary
+
+Tracking: #137, building on merged #157 / #165 / #169.
+
+Cultist now has a small retained set of uniquely identified behavioral evidence episodes. Before using those episodes to promote, demote, or rank anything, this experiment asks a narrower question:
+
+> Can we summarize what happened while keeping every count inspectable and avoiding a universal actionability score?
+
+## Summary v1
+
+The summary compiles one already-validated `BehavioralEpisodeBatch` into:
+
+```text
+total_episodes
+surfaced
+quiet
+consulted
+by_outcome[]
+by_evidence_kind[]
+```
+
+Every grouped count carries:
+
+```text
+key
+count
+episode_ids[]
+```
+
+so a consumer can always inspect exactly which retained episodes produced the number.
+
+No weighting is applied. `changed_next_action=2` and `correct_quiet_negative=1` remain different observed outcomes rather than points in one score.
+
+## Current retained Cultist corpus
+
+`research/behavioral-episodes/cultist-collaboration-v1.json` currently contains three unique episodes:
+
+```text
+2 surfaced
+1 quiet
+2 consulted
+
+2 changed_next_action
+1 correct_quiet_negative
+```
+
+Evidence families remain separate:
+
+```text
+active-work-heads-up
+concurrent-main-head-movement
+project-memory-relation-strengthening
+```
+
+This sample is deliberately tiny. The counts describe these three episodes only.
+
+## Research command
+
+```text
+cargo run --example behavioral_summary \
+  < research/behavioral-episodes/cultist-collaboration-v1.json
+```
+
+The input batch is revalidated through the merged episode/receipt contracts before summarization.
+
+## What this does not justify
+
+The summary does not answer:
+
+- whether one evidence family is globally good or bad;
+- whether an action change improved the final task result;
+- whether a quiet negative is worth the same attention/cost as an action-changing positive;
+- whether a three-episode sample supports product promotion;
+- whether one worker/model population generalizes to another;
+- whether two different tasks are comparable.
+
+Those require additional experimental design and held-out tasks under #137.
+
+## Next discriminator
+
+The useful next step is more raw evidence, especially episodes that fill currently empty outcomes:
+
+```text
+useful_same_action
+ignored
+irrelevant
+stale_or_wrong_coordinate
+needed_stronger_evidence
+prevented_or_reversed_wrong_turn
+```
+
+Only after enough varied episodes exist should Cultist test any higher-level promotion/demotion view. Even then, retain raw episode IDs beside every aggregate.
+
+North star:
+
+> Count observed episodes without letting the count become the explanation.

--- a/src/behavioral_summary.rs
+++ b/src/behavioral_summary.rs
@@ -1,0 +1,96 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::behavioral_episode::{BehavioralEpisodeBatch, validate_behavioral_episode_batch};
+use crate::behavioral_receipt::{BehavioralOutcome, Delivery};
+
+pub const BEHAVIORAL_SUMMARY_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralCount {
+    pub key: String,
+    pub count: usize,
+    pub episode_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralSummary {
+    pub schema_version: u32,
+    pub total_episodes: usize,
+    pub surfaced: usize,
+    pub quiet: usize,
+    pub consulted: usize,
+    pub by_outcome: Vec<BehavioralCount>,
+    pub by_evidence_kind: Vec<BehavioralCount>,
+}
+
+pub fn summarize_behavioral_episodes(
+    batch: &BehavioralEpisodeBatch,
+) -> Result<BehavioralSummary, String> {
+    validate_behavioral_episode_batch(batch).map_err(|error| error.to_string())?;
+
+    let mut surfaced = 0usize;
+    let mut quiet = 0usize;
+    let mut consulted = 0usize;
+    let mut by_outcome = BTreeMap::<String, Vec<String>>::new();
+    let mut by_evidence_kind = BTreeMap::<String, Vec<String>>::new();
+
+    for episode in &batch.episodes {
+        match episode.receipt.delivery {
+            Delivery::Surfaced => surfaced += 1,
+            Delivery::Quiet => quiet += 1,
+        }
+        if episode.receipt.consulted {
+            consulted += 1;
+        }
+
+        by_outcome
+            .entry(outcome_name(episode.receipt.outcome).to_string())
+            .or_default()
+            .push(episode.episode_id.clone());
+        by_evidence_kind
+            .entry(episode.receipt.evidence_kind.clone())
+            .or_default()
+            .push(episode.episode_id.clone());
+    }
+
+    Ok(BehavioralSummary {
+        schema_version: BEHAVIORAL_SUMMARY_SCHEMA_VERSION,
+        total_episodes: batch.episodes.len(),
+        surfaced,
+        quiet,
+        consulted,
+        by_outcome: counts(by_outcome),
+        by_evidence_kind: counts(by_evidence_kind),
+    })
+}
+
+fn counts(values: BTreeMap<String, Vec<String>>) -> Vec<BehavioralCount> {
+    values
+        .into_iter()
+        .map(|(key, mut episode_ids)| {
+            episode_ids.sort();
+            BehavioralCount {
+                key,
+                count: episode_ids.len(),
+                episode_ids,
+            }
+        })
+        .collect()
+}
+
+fn outcome_name(outcome: BehavioralOutcome) -> &'static str {
+    match outcome {
+        BehavioralOutcome::ChangedNextAction => "changed_next_action",
+        BehavioralOutcome::PreventedOrReversedWrongTurn => "prevented_or_reversed_wrong_turn",
+        BehavioralOutcome::UsefulSameAction => "useful_same_action",
+        BehavioralOutcome::Ignored => "ignored",
+        BehavioralOutcome::Irrelevant => "irrelevant",
+        BehavioralOutcome::StaleOrWrongCoordinate => "stale_or_wrong_coordinate",
+        BehavioralOutcome::NeededStrongerEvidence => "needed_stronger_evidence",
+        BehavioralOutcome::CorrectQuietNegative => "correct_quiet_negative",
+    }
+}

--- a/tests/behavioral_summary.rs
+++ b/tests/behavioral_summary.rs
@@ -1,0 +1,92 @@
+#[allow(dead_code)]
+#[path = "../src/behavioral_episode.rs"]
+mod behavioral_episode;
+#[allow(dead_code)]
+#[path = "../src/behavioral_receipt.rs"]
+mod behavioral_receipt;
+#[allow(dead_code)]
+#[path = "../src/behavioral_summary.rs"]
+mod behavioral_summary;
+
+use behavioral_episode::parse_behavioral_episode_batch;
+use behavioral_summary::{BehavioralSummary, summarize_behavioral_episodes};
+
+const CORPUS: &[u8] =
+    include_bytes!("../research/behavioral-episodes/cultist-collaboration-v1.json");
+
+fn retained_summary() -> BehavioralSummary {
+    let batch = parse_behavioral_episode_batch(CORPUS).unwrap();
+    summarize_behavioral_episodes(&batch).unwrap()
+}
+
+#[test]
+fn retained_corpus_has_expected_descriptive_counts() {
+    let summary = retained_summary();
+    assert_eq!(summary.total_episodes, 3);
+    assert_eq!(summary.surfaced, 2);
+    assert_eq!(summary.quiet, 1);
+    assert_eq!(summary.consulted, 2);
+
+    let changed = summary
+        .by_outcome
+        .iter()
+        .find(|count| count.key == "changed_next_action")
+        .unwrap();
+    assert_eq!(changed.count, 2);
+    assert_eq!(changed.episode_ids.len(), 2);
+
+    let quiet = summary
+        .by_outcome
+        .iter()
+        .find(|count| count.key == "correct_quiet_negative")
+        .unwrap();
+    assert_eq!(quiet.count, 1);
+    assert_eq!(
+        quiet.episode_ids,
+        vec!["github-actions:run/32242752523#active-work-heads-up"]
+    );
+}
+
+#[test]
+fn every_count_keeps_the_exact_episode_ids_it_summarizes() {
+    let summary = retained_summary();
+
+    for count in summary
+        .by_outcome
+        .iter()
+        .chain(summary.by_evidence_kind.iter())
+    {
+        assert_eq!(count.count, count.episode_ids.len());
+        assert!(!count.episode_ids.is_empty());
+        let mut sorted = count.episode_ids.clone();
+        sorted.sort();
+        assert_eq!(count.episode_ids, sorted);
+    }
+}
+
+#[test]
+fn evidence_families_remain_separate_instead_of_becoming_one_score() {
+    let summary = retained_summary();
+    let keys = summary
+        .by_evidence_kind
+        .iter()
+        .map(|count| count.key.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        keys,
+        vec![
+            "active-work-heads-up",
+            "concurrent-main-head-movement",
+            "project-memory-relation-strengthening",
+        ]
+    );
+}
+
+#[test]
+fn summary_round_trips_as_plain_descriptive_data() {
+    let summary = retained_summary();
+    let json = serde_json::to_string(&summary).unwrap();
+    let decoded: BehavioralSummary = serde_json::from_str(&json).unwrap();
+    assert_eq!(decoded, summary);
+}


### PR DESCRIPTION
## Goal

Give #137 an inspectable aggregate view over the unique raw episodes landed in #169 without inventing a universal actionability score.

## Summary v1

One already-validated `BehavioralEpisodeBatch` compiles to:

```text
total_episodes
surfaced
quiet
consulted
by_outcome[]
by_evidence_kind[]
```

Each grouped count retains:

```text
key
count
episode_ids[]
```

so every number stays traceable to the exact raw observations it summarizes.

No weighting exists. `changed_next_action=2` and `correct_quiet_negative=1` remain separate outcome counts rather than points in one score.

## Current retained corpus

The three #169 episodes summarize as:

```text
3 total
2 surfaced
1 quiet
2 consulted

2 changed_next_action
1 correct_quiet_negative
```

Evidence families remain distinct:

```text
active-work-heads-up
concurrent-main-head-movement
project-memory-relation-strengthening
```

The tests require every count's `count == episode_ids.len()` and deterministic sorted episode IDs.

## Research command

```text
cargo run --example behavioral_summary \
  < research/behavioral-episodes/cultist-collaboration-v1.json
```

Input is revalidated through the merged behavioral episode/receipt contracts before summarization.

## Boundary

- no actionability/risk/quality score;
- no analyzer promotion/demotion;
- no inference that an action change improved final task outcome;
- no cross-task normalization;
- no worker/model taxonomy;
- no timestamp/causality inference;
- raw episode IDs remain attached to every grouped count.

The useful next input is more varied raw episodes, especially currently empty outcomes such as ignored, irrelevant, stale/wrong-coordinate, needed-stronger-evidence, useful-same-action, and prevented/reversed-wrong-turn.

The branch is one commit ahead / zero behind current main `a551a948db945681195d5d644116090bb9ffc0db` at open time.

Refs #137 #157 #165 #169.