### PR TITLE
research: preserve analyzer refinement episodes

### DIFF
--- a/examples/refinement_episodes.rs
+++ b/examples/refinement_episodes.rs
@@ -1,0 +1,33 @@
+#![allow(dead_code)]
+
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+
+use refinement_episode::{MAX_REFINEMENT_EPISODE_BATCH_BYTES, parse_refinement_episode_batch};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("refinement-episodes: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_REFINEMENT_EPISODE_BATCH_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_REFINEMENT_EPISODE_BATCH_BYTES {
+        return Err(format!(
+            "refinement episode batch exceeds the {MAX_REFINEMENT_EPISODE_BATCH_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let batch = parse_refinement_episode_batch(&bytes)?;
+    println!("{}", serde_json::to_string_pretty(&batch)?);
+    Ok(())
+}

--- a/research/refinement-episodes.md
+++ b/research/refinement-episodes.md
@@ -1,0 +1,260 @@
+# Counterexample-guided analyzer refinement episodes
+
+Tracking: #148. Built after #141/#144, #142/#168, project-memory contract refinement #174, and the behavioral episode work in #137/#175/#178.
+
+## Question
+
+Can Cultist preserve analyzer-research transitions as bounded, replayable records while leaving domain facts and predicates with the analyzers that produced them?
+
+V0 answers only the bookkeeping layer.
+
+## Episode contract
+
+```text
+RefinementEpisode
+  id
+  family
+  hypothesis_before
+  counterexample_refs[]
+  admitted_discriminators[]
+  candidate_refinements[]
+  selected_transition?
+  source_receipts[]
+  behavioral_episode_ids[]
+```
+
+Each candidate carries:
+
+```text
+hypothesis_after
+admitted discriminator refs
+source replay receipts
+replay_result
+  expected_cases_retained
+  counterexamples_resolved
+  expected_cases_lost
+  counterexamples_remaining
+  held_out_status
+status
+  retained
+  weakened
+  split
+  rejected_no_improvement
+  rejected_overfit
+  rejected_lost_expected_case
+```
+
+The replay counts are supplied by exact source receipts. This layer does zero Rust edit classification, obligation applicability, historical co-change analysis, project-memory relation parsing, or domain predicate evaluation.
+
+## Meta-level invariants
+
+The validator checks only properties the refinement ledger itself owns:
+
+- episode, candidate, discriminator, and reference identities are bounded and unique where required;
+- every candidate discriminator reference names one discriminator admitted by the episode;
+- a selected transition names an existing `retained`, `weakened`, or `split` candidate;
+- kept candidates retain every expected replay case, resolve at least one counterexample, and cannot carry a failed held-out result;
+- `rejected_no_improvement` resolves zero counterexamples and loses zero expected cases;
+- `rejected_lost_expected_case` records at least one lost expected case;
+- rejected-overfit status stays a supplied source conclusion because overfit criteria belong to the source experiment;
+- behavioral episode IDs remain optional explicit links to already-observed #165 episodes.
+
+The last point composes with #175: a research transition can link to observed receiver episodes and descriptive summaries while deterministic replay remains independently inspectable.
+
+## Retained episode A: justification / open obligation
+
+The first episode records the refinement discovered by stacking #144 on #141.
+
+```text
+H0
+  every obligation requires >= 1 observed clearing edge
+
+counterexample
+  a durable material UNKNOWN can exist before clearing evidence arrives
+
+selected transition
+  allow zero-edge OPEN obligations
+  keep typed clearing receipts when evidence later arrives
+```
+
+Source receipts point at the #156/#159 research heads and CI. The meta replay records expected cases retained, the counterexample resolved, and zero expected cases lost.
+
+No behavioral episode is attached because this was a deterministic semantic refinement rather than an observed receiver episode.
+
+## Retained episode B: Oxc edit-class cohort
+
+The second episode records the already-executed Oxc result:
+
+```text
+raw forward cohort
+  99 support / 1 counterexample
+
+edit_class = syntax_changed
+  99 support / 0 counterexamples
+```
+
+The selected `edit_class` refinement is `weakened` because it narrows the original file-change hypothesis.
+
+Two rejected candidates remain beside it:
+
+```text
+reverse edit-class control
+  94 support / 6 counterexamples
+  -> rejected_no_improvement
+
+exact commit identity partition
+  one-current-observation cohort
+  -> rejected_overfit
+```
+
+The source receipts preserve the full Rust syntax cohort replay, #168's generic refinement evaluator, its green CI run, and the earlier held-out generated-companion product proof.
+
+## Retained episode C: project-memory Primary case contract
+
+The third episode came from a real producer/consumer collision between merged #166 and #167.
+
+```text
+H0
+  current project-memory relation admission composes with collector evidence
+
+#166 consumer
+  strict single-line relation admission + exact target mention
+
+#167 producer
+  Primary case:\nURL issue evidence block
+
+counterexample
+  both landed with zero path overlap
+  current-main packet no longer passed the consumer contract
+```
+
+#174 split the admission rule instead of weakening every relation edge:
+
+```text
+ordinary relationship prose
+  -> existing strict single-line classifier
+
+exact Primary case block
+  -> separate validated path
+     exact label
+     admitted GitHub origin
+     packet repository match
+     canonical positive issue number
+     relation = related
+     declared target match
+```
+
+The source replay admits the two intended Primary case forms, resolves the integration counterexample, loses zero expected cases, and passed #174 CI/provenance on head `e1196c553ab496df13a230535de997f30c2d63ca`.
+
+This episode also carries the real #178 behavioral episode:
+
+```text
+project-memory:primary-case-contract-collision:9792bfe->df5ae59
+```
+
+The standard refinement test resolves that ID against the retained #165 behavioral batch and requires its observed outcome to be `changed_next_action`.
+
+## Why rejected candidates stay in the object
+
+Keeping only the winner would erase the research path. The durable episode instead records:
+
+```text
+what broad claim existed
+which counterexample challenged it
+which discriminators were admitted
+which candidate survived
+which tempting candidates failed
+which exact receipts justify those statuses
+```
+
+That gives a future worker enough information to resume the research question without reconstructing the discarded alternatives from prose or chronology.
+
+## Behavioral boundary
+
+`behavioral_episode_ids[]` is an explicit optional join to merged #165 observation identity.
+
+Episodes A and B stay empty because no observed worker episode has been collected for those exact research transitions. Episode C links one already-retained #178 observation and verifies that the ID exists in the behavioral corpus.
+
+A deterministic replay result never manufactures a behavioral receipt. Behavioral identity and deterministic refinement identity remain separate records joined by explicit ID only when an observation exists.
+
+## Research reader
+
+```text
+cargo run --example refinement_episodes \
+  < research/refinement-episodes/cultist-v1.json
+```
+
+The reader validates the bounded batch and reprints the typed records.
+
+## Executed GitHub receipts
+
+The first two-family version of draft PR #179 passed on exact head:
+
+```text
+f4d92b05e061a99e262a1ef1eb2f2be424686359
+```
+
+CI run `32247329835` / run number `1222` and generated provenance review run `32247329697` / run number `219` completed successfully. The first CI attempt had failed only at rustfmt before Clippy or tests; the formatter delta was applied verbatim and the standalone reader received fixture-local dead-code containment.
+
+The three-family carrier was then rebuilt as one commit on merged #178 main so its behavioral join resolves against the current retained observation corpus.
+
+Exact three-family semantic head:
+
+```text
+dbb39fb729df762ffefcf97d024e52fd647832cf
+```
+
+GitHub Actions CI run `32247721374` / run number `1235` completed successfully. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work preflight;
+- full `cargo test`, including the three retained refinement episodes, rejected-candidate controls, and the cross-corpus #178 behavioral ID/outcome assertion;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+Generated provenance review dogfood run `32247721348` / run number `223` also completed successfully on the same three-family head.
+
+## Boundary
+
+- research-only ledger;
+- no analyzer predicate language;
+- no automatic discriminator enumeration;
+- no scalar research score;
+- no automatic promotion/demotion;
+- no chronology-derived causality;
+- no fabricated behavioral evidence;
+- exact source receipts remain the authority for domain replay claims.
+
+## Next discriminator
+
+Three independent families now fit the ledger, but they expose different fact-production mechanisms:
+
+```text
+justification
+  typed clearing-evidence presence
+
+historical companion
+  supplied Rust edit class
+
+project memory
+  exact evidence-form + target/repository contract
+```
+
+That diversity argues for one more restraint: episode count alone does not earn automatic candidate enumeration. The next useful question is whether these source analyzers can expose a common **discriminator reference interface** without moving their domain logic into #148.
+
+A small future experiment can ask each source family for only:
+
+```text
+discriminator id
+source receipt
+current supplied value / applicability
+```
+
+and then test whether the refinement ledger can enumerate candidates over those references while still delegating semantics to the source evaluator. If the adapters need family-specific execution logic, keep enumeration outside the meta-layer.
+
+North star:
+
+> Preserve every analyzer refinement as an inspectable transition from broad hypothesis through counterexample and replay, including the rejected alternatives that explain why the surviving rule earned its narrower claim.

--- a/research/refinement-episodes/cultist-v1.json
+++ b/research/refinement-episodes/cultist-v1.json
@@ -1,0 +1,209 @@
+{
+  "schema_version": 1,
+  "episodes": [
+    {
+      "id": "justification/open-obligation-v1",
+      "family": "justification",
+      "hypothesis_before": {
+        "id": "requires-clearing-edge",
+        "statement": "Every obligation node requires at least one observed clearing edge."
+      },
+      "counterexample_refs": [
+        "github:issue/144#open-before-clearing-evidence"
+      ],
+      "admitted_discriminators": [
+        {
+          "id": "clearing_evidence_presence",
+          "source_ref": "github:pull/159@1c1a0086a199168fd0e21445d103936183063dc7"
+        }
+      ],
+      "candidate_refinements": [
+        {
+          "id": "allow-open-zero-edge",
+          "hypothesis_after": {
+            "id": "observed-clearing-edge-is-optional",
+            "statement": "An obligation may remain open before clearing evidence arrives; observed clearing edges remain typed receipts when present."
+          },
+          "discriminator_refs": [
+            "clearing_evidence_presence"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 7,
+            "counterexamples_resolved": 1,
+            "expected_cases_lost": 0,
+            "counterexamples_remaining": 0,
+            "held_out_status": "not_run"
+          },
+          "status": "weakened",
+          "source_receipts": [
+            "github:pull/156@9beaeaab2bece20a4e0bb9c880f510f740bf8cfb",
+            "github:pull/159@1c1a0086a199168fd0e21445d103936183063dc7",
+            "github-actions:run/32243719268"
+          ]
+        }
+      ],
+      "selected_transition": "allow-open-zero-edge",
+      "source_receipts": [
+        "research:justification-graph.md",
+        "research:durable-unknown-obligation.md"
+      ],
+      "behavioral_episode_ids": []
+    },
+    {
+      "id": "history/oxc-edit-class-v1",
+      "family": "historical_companion",
+      "hypothesis_before": {
+        "id": "raw-source-change-cohort",
+        "statement": "Every source-file change belongs to one historical companion cohort for evaluating the generated-file expectation."
+      },
+      "counterexample_refs": [
+        "oxc:5e113baf716b9f3781331b268b4142d23cac0541#docs-license-notices"
+      ],
+      "admitted_discriminators": [
+        {
+          "id": "edit_class",
+          "source_ref": "research:rust-syntax-cohort-replay.md"
+        },
+        {
+          "id": "commit_identity",
+          "source_ref": "github:pull/168@b8c6457de8d05a38a662289962fc11a124d32861"
+        }
+      ],
+      "candidate_refinements": [
+        {
+          "id": "syntax-changing-current-cohort",
+          "hypothesis_after": {
+            "id": "syntax-changing-source-cohort",
+            "statement": "Evaluate the forward generated-companion expectation inside the supplied Rust syntax-changing edit cohort."
+          },
+          "discriminator_refs": [
+            "edit_class"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 99,
+            "counterexamples_resolved": 1,
+            "expected_cases_lost": 0,
+            "counterexamples_remaining": 0,
+            "held_out_status": "passed"
+          },
+          "status": "weakened",
+          "source_receipts": [
+            "research:rust-syntax-cohort-replay.md",
+            "github:pull/168@b8c6457de8d05a38a662289962fc11a124d32861",
+            "github-actions:run/32245110401",
+            "github:pull/72"
+          ]
+        },
+        {
+          "id": "reverse-edit-class-control",
+          "hypothesis_after": {
+            "id": "reverse-syntax-cohort-improves",
+            "statement": "Applying the same edit-class discriminator to generated-to-source history should remove reverse-direction counterexamples."
+          },
+          "discriminator_refs": [
+            "edit_class"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 94,
+            "counterexamples_resolved": 0,
+            "expected_cases_lost": 0,
+            "counterexamples_remaining": 6,
+            "held_out_status": "passed"
+          },
+          "status": "rejected_no_improvement",
+          "source_receipts": [
+            "research:rust-syntax-cohort-replay.md",
+            "github:pull/168@b8c6457de8d05a38a662289962fc11a124d32861"
+          ]
+        },
+        {
+          "id": "singleton-commit-partition",
+          "hypothesis_after": {
+            "id": "exact-commit-is-cohort",
+            "statement": "Use exact commit identity as the discriminator so the current observation defines its own cohort."
+          },
+          "discriminator_refs": [
+            "commit_identity"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 1,
+            "counterexamples_resolved": 1,
+            "expected_cases_lost": 98,
+            "counterexamples_remaining": 0,
+            "held_out_status": "not_run"
+          },
+          "status": "rejected_overfit",
+          "source_receipts": [
+            "github:pull/168@b8c6457de8d05a38a662289962fc11a124d32861"
+          ]
+        }
+      ],
+      "selected_transition": "syntax-changing-current-cohort",
+      "source_receipts": [
+        "research:history-companion-replay.md",
+        "research:rust-syntax-cohort-replay.md",
+        "research:cohort-refinement.md"
+      ],
+      "behavioral_episode_ids": []
+    },
+    {
+      "id": "project-memory/primary-case-contract-collision-v1",
+      "family": "project_memory",
+      "hypothesis_before": {
+        "id": "single-line-admission-covers-collector-evidence",
+        "statement": "The existing project-memory relation admission contract composes with every explicit relationship evidence form emitted by current collectors."
+      },
+      "counterexample_refs": [
+        "github:issue/172#primary-case-multiline-contract-collision"
+      ],
+      "admitted_discriminators": [
+        {
+          "id": "primary_case_evidence_form",
+          "source_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca"
+        },
+        {
+          "id": "same_repository_issue_target",
+          "source_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca"
+        }
+      ],
+      "candidate_refinements": [
+        {
+          "id": "split-primary-case-admission",
+          "hypothesis_after": {
+            "id": "typed-primary-case-admission",
+            "statement": "Keep ordinary relation evidence on the strict single-line grammar and admit only the exact same-repository Primary case issue block through a separate validated path."
+          },
+          "discriminator_refs": [
+            "primary_case_evidence_form",
+            "same_repository_issue_target"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 2,
+            "counterexamples_resolved": 1,
+            "expected_cases_lost": 0,
+            "counterexamples_remaining": 0,
+            "held_out_status": "passed"
+          },
+          "status": "split",
+          "source_receipts": [
+            "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca",
+            "github-actions:run/32246042100",
+            "github-actions:run/32246042091"
+          ]
+        }
+      ],
+      "selected_transition": "split-primary-case-admission",
+      "source_receipts": [
+        "github:pull/166",
+        "github:pull/167",
+        "github:issue/172",
+        "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca",
+        "github:pull/178@22fa1d9405737ae6868d9b1f6643b4107c6f058a",
+        "research:behavioral-receipts/project-memory-primary-case-collision-174.json"
+      ],
+      "behavioral_episode_ids": [
+        "project-memory:primary-case-contract-collision:9792bfe->df5ae59"
+      ]
+    }
+  ]
+}

--- a/src/refinement_episode.rs
+++ b/src/refinement_episode.rs
@@ -1,0 +1,362 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+pub const REFINEMENT_EPISODE_SCHEMA_VERSION: u32 = 1;
+pub const MAX_REFINEMENT_EPISODE_BATCH_BYTES: usize = 256 * 1024;
+const MAX_EPISODES: usize = 128;
+const MAX_CANDIDATES: usize = 64;
+const MAX_REFERENCES: usize = 256;
+const MAX_ID_BYTES: usize = 512;
+const MAX_TEXT_BYTES: usize = 8 * 1024;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementEpisodeBatch {
+    pub schema_version: u32,
+    pub episodes: Vec<RefinementEpisode>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementEpisode {
+    pub id: String,
+    pub family: String,
+    pub hypothesis_before: ResearchHypothesis,
+    pub counterexample_refs: Vec<String>,
+    pub admitted_discriminators: Vec<DiscriminatorRef>,
+    pub candidate_refinements: Vec<CandidateRefinement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_transition: Option<String>,
+    pub source_receipts: Vec<String>,
+    #[serde(default)]
+    pub behavioral_episode_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResearchHypothesis {
+    pub id: String,
+    pub statement: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorRef {
+    pub id: String,
+    pub source_ref: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CandidateRefinement {
+    pub id: String,
+    pub hypothesis_after: ResearchHypothesis,
+    pub discriminator_refs: Vec<String>,
+    pub replay_result: ReplayResult,
+    pub status: RefinementStatus,
+    pub source_receipts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReplayResult {
+    pub expected_cases_retained: usize,
+    pub counterexamples_resolved: usize,
+    pub expected_cases_lost: usize,
+    pub counterexamples_remaining: usize,
+    pub held_out_status: HeldOutStatus,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HeldOutStatus {
+    NotRun,
+    Passed,
+    Failed,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefinementStatus {
+    Retained,
+    Weakened,
+    Split,
+    RejectedNoImprovement,
+    RejectedOverfit,
+    RejectedLostExpectedCase,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RefinementEpisodeError {
+    message: String,
+}
+
+impl RefinementEpisodeError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for RefinementEpisodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for RefinementEpisodeError {}
+
+pub fn parse_refinement_episode_batch(
+    bytes: &[u8],
+) -> Result<RefinementEpisodeBatch, RefinementEpisodeError> {
+    if bytes.len() > MAX_REFINEMENT_EPISODE_BATCH_BYTES {
+        return Err(RefinementEpisodeError::new(format!(
+            "refinement episode batch exceeds the {MAX_REFINEMENT_EPISODE_BATCH_BYTES}-byte limit"
+        )));
+    }
+    let batch: RefinementEpisodeBatch = serde_json::from_slice(bytes).map_err(|error| {
+        RefinementEpisodeError::new(format!("invalid refinement episode JSON: {error}"))
+    })?;
+    validate_refinement_episode_batch(&batch)?;
+    Ok(batch)
+}
+
+pub fn validate_refinement_episode_batch(
+    batch: &RefinementEpisodeBatch,
+) -> Result<(), RefinementEpisodeError> {
+    if batch.schema_version != REFINEMENT_EPISODE_SCHEMA_VERSION {
+        return Err(RefinementEpisodeError::new(format!(
+            "unsupported refinement episode schema {}; expected {REFINEMENT_EPISODE_SCHEMA_VERSION}",
+            batch.schema_version
+        )));
+    }
+    if batch.episodes.is_empty() || batch.episodes.len() > MAX_EPISODES {
+        return Err(RefinementEpisodeError::new(
+            "refinement episode batch must contain a bounded non-empty episode set",
+        ));
+    }
+
+    let mut episode_ids = BTreeSet::new();
+    for episode in &batch.episodes {
+        validate_episode(episode)?;
+        if !episode_ids.insert(episode.id.clone()) {
+            return Err(RefinementEpisodeError::new(format!(
+                "duplicate refinement episode id {}",
+                episode.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_episode(episode: &RefinementEpisode) -> Result<(), RefinementEpisodeError> {
+    validate_atom(&episode.id, "episode id", MAX_ID_BYTES)?;
+    validate_atom(&episode.family, "episode family", MAX_ID_BYTES)?;
+    validate_hypothesis(&episode.hypothesis_before, "hypothesis_before")?;
+    validate_reference_set(&episode.counterexample_refs, "counterexample_refs", false)?;
+    validate_reference_set(&episode.source_receipts, "source_receipts", false)?;
+    validate_reference_set(
+        &episode.behavioral_episode_ids,
+        "behavioral_episode_ids",
+        true,
+    )?;
+
+    if episode.admitted_discriminators.is_empty()
+        || episode.admitted_discriminators.len() > MAX_REFERENCES
+    {
+        return Err(RefinementEpisodeError::new(
+            "admitted_discriminators must be bounded and non-empty",
+        ));
+    }
+    let mut discriminator_ids = BTreeSet::new();
+    for discriminator in &episode.admitted_discriminators {
+        validate_atom(&discriminator.id, "discriminator id", MAX_ID_BYTES)?;
+        validate_atom(
+            &discriminator.source_ref,
+            "discriminator source_ref",
+            MAX_TEXT_BYTES,
+        )?;
+        if !discriminator_ids.insert(discriminator.id.clone()) {
+            return Err(RefinementEpisodeError::new(format!(
+                "duplicate admitted discriminator {}",
+                discriminator.id
+            )));
+        }
+    }
+
+    if episode.candidate_refinements.is_empty()
+        || episode.candidate_refinements.len() > MAX_CANDIDATES
+    {
+        return Err(RefinementEpisodeError::new(
+            "candidate_refinements must be bounded and non-empty",
+        ));
+    }
+    let mut candidate_ids = BTreeSet::new();
+    for candidate in &episode.candidate_refinements {
+        validate_candidate(candidate, &discriminator_ids)?;
+        if !candidate_ids.insert(candidate.id.clone()) {
+            return Err(RefinementEpisodeError::new(format!(
+                "duplicate candidate refinement id {}",
+                candidate.id
+            )));
+        }
+    }
+
+    if let Some(selected) = &episode.selected_transition {
+        validate_atom(selected, "selected_transition", MAX_ID_BYTES)?;
+        let candidate = episode
+            .candidate_refinements
+            .iter()
+            .find(|candidate| candidate.id == *selected)
+            .ok_or_else(|| {
+                RefinementEpisodeError::new(format!(
+                    "selected transition {selected} is absent from candidate_refinements"
+                ))
+            })?;
+        if !matches!(
+            candidate.status,
+            RefinementStatus::Retained | RefinementStatus::Weakened | RefinementStatus::Split
+        ) {
+            return Err(RefinementEpisodeError::new(format!(
+                "selected transition {selected} has rejected status {:?}",
+                candidate.status
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_candidate(
+    candidate: &CandidateRefinement,
+    admitted_discriminators: &BTreeSet<String>,
+) -> Result<(), RefinementEpisodeError> {
+    validate_atom(&candidate.id, "candidate id", MAX_ID_BYTES)?;
+    validate_hypothesis(&candidate.hypothesis_after, "hypothesis_after")?;
+    validate_reference_set(
+        &candidate.discriminator_refs,
+        "candidate discriminator_refs",
+        false,
+    )?;
+    validate_reference_set(
+        &candidate.source_receipts,
+        "candidate source_receipts",
+        false,
+    )?;
+
+    for discriminator in &candidate.discriminator_refs {
+        if !admitted_discriminators.contains(discriminator) {
+            return Err(RefinementEpisodeError::new(format!(
+                "candidate {} references unadmitted discriminator {discriminator}",
+                candidate.id
+            )));
+        }
+    }
+
+    match candidate.status {
+        RefinementStatus::Retained | RefinementStatus::Weakened | RefinementStatus::Split => {
+            if candidate.replay_result.expected_cases_lost != 0 {
+                return Err(RefinementEpisodeError::new(format!(
+                    "kept candidate {} loses expected replay cases",
+                    candidate.id
+                )));
+            }
+            if candidate.replay_result.counterexamples_resolved == 0 {
+                return Err(RefinementEpisodeError::new(format!(
+                    "kept candidate {} resolves no counterexample",
+                    candidate.id
+                )));
+            }
+            if candidate.replay_result.held_out_status == HeldOutStatus::Failed {
+                return Err(RefinementEpisodeError::new(format!(
+                    "kept candidate {} has failed held-out replay",
+                    candidate.id
+                )));
+            }
+        }
+        RefinementStatus::RejectedNoImprovement => {
+            if candidate.replay_result.counterexamples_resolved != 0
+                || candidate.replay_result.expected_cases_lost != 0
+            {
+                return Err(RefinementEpisodeError::new(format!(
+                    "rejected_no_improvement candidate {} must preserve the baseline replay",
+                    candidate.id
+                )));
+            }
+        }
+        RefinementStatus::RejectedLostExpectedCase => {
+            if candidate.replay_result.expected_cases_lost == 0 {
+                return Err(RefinementEpisodeError::new(format!(
+                    "rejected_lost_expected_case candidate {} must lose at least one expected case",
+                    candidate.id
+                )));
+            }
+        }
+        RefinementStatus::RejectedOverfit => {}
+    }
+
+    Ok(())
+}
+
+fn validate_hypothesis(
+    hypothesis: &ResearchHypothesis,
+    field: &str,
+) -> Result<(), RefinementEpisodeError> {
+    validate_atom(&hypothesis.id, &format!("{field} id"), MAX_ID_BYTES)?;
+    validate_text(
+        &hypothesis.statement,
+        &format!("{field} statement"),
+        MAX_TEXT_BYTES,
+    )
+}
+
+fn validate_reference_set(
+    values: &[String],
+    field: &str,
+    allow_empty: bool,
+) -> Result<(), RefinementEpisodeError> {
+    if (!allow_empty && values.is_empty()) || values.len() > MAX_REFERENCES {
+        return Err(RefinementEpisodeError::new(format!(
+            "{field} must be within the admitted reference bound"
+        )));
+    }
+    let mut seen = BTreeSet::new();
+    for value in values {
+        validate_atom(value, field, MAX_TEXT_BYTES)?;
+        if !seen.insert(value.clone()) {
+            return Err(RefinementEpisodeError::new(format!(
+                "{field} contains duplicate reference {value}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_atom(value: &str, field: &str, max_bytes: usize) -> Result<(), RefinementEpisodeError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > max_bytes
+        || value.contains('\0')
+        || value.contains(['\n', '\r'])
+    {
+        return Err(RefinementEpisodeError::new(format!(
+            "{field} must be bounded canonical single-line text"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, field: &str, max_bytes: usize) -> Result<(), RefinementEpisodeError> {
+    if value.is_empty() || value.trim() != value || value.len() > max_bytes || value.contains('\0')
+    {
+        return Err(RefinementEpisodeError::new(format!(
+            "{field} must be bounded non-empty text"
+        )));
+    }
+    Ok(())
+}

--- a/tests/refinement_episode.rs
+++ b/tests/refinement_episode.rs
@@ -1,0 +1,177 @@
+#![allow(dead_code)]
+
+use std::collections::BTreeSet;
+
+#[path = "../src/behavioral_episode.rs"]
+mod behavioral_episode;
+#[path = "../src/behavioral_receipt.rs"]
+mod behavioral_receipt;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+
+use behavioral_episode::parse_behavioral_episode_batch;
+use behavioral_receipt::BehavioralOutcome;
+use refinement_episode::{
+    HeldOutStatus, MAX_REFINEMENT_EPISODE_BATCH_BYTES, RefinementStatus,
+    parse_refinement_episode_batch, validate_refinement_episode_batch,
+};
+
+const CORPUS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+const BEHAVIORAL_CORPUS: &[u8] =
+    include_bytes!("../research/behavioral-episodes/cultist-collaboration-v1.json");
+
+#[test]
+fn retained_cultist_refinement_corpus_preserves_selected_and_rejected_candidates() {
+    let batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    assert_eq!(batch.episodes.len(), 3);
+
+    let justification = &batch.episodes[0];
+    assert_eq!(justification.id, "justification/open-obligation-v1");
+    assert_eq!(
+        justification.selected_transition.as_deref(),
+        Some("allow-open-zero-edge")
+    );
+    assert!(justification.behavioral_episode_ids.is_empty());
+    assert_eq!(
+        justification.candidate_refinements[0].status,
+        RefinementStatus::Weakened
+    );
+
+    let history = &batch.episodes[1];
+    assert_eq!(history.id, "history/oxc-edit-class-v1");
+    assert_eq!(history.candidate_refinements.len(), 3);
+    assert_eq!(
+        history.candidate_refinements[0]
+            .replay_result
+            .held_out_status,
+        HeldOutStatus::Passed
+    );
+    assert!(
+        history
+            .candidate_refinements
+            .iter()
+            .any(|candidate| { candidate.status == RefinementStatus::RejectedNoImprovement })
+    );
+    assert!(
+        history
+            .candidate_refinements
+            .iter()
+            .any(|candidate| { candidate.status == RefinementStatus::RejectedOverfit })
+    );
+
+    let project_memory = &batch.episodes[2];
+    assert_eq!(
+        project_memory.id,
+        "project-memory/primary-case-contract-collision-v1"
+    );
+    assert_eq!(
+        project_memory.candidate_refinements[0].status,
+        RefinementStatus::Split
+    );
+    assert_eq!(
+        project_memory.behavioral_episode_ids,
+        vec!["project-memory:primary-case-contract-collision:9792bfe->df5ae59"]
+    );
+}
+
+#[test]
+fn selected_transition_must_name_a_kept_candidate() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[1].selected_transition = Some("singleton-commit-partition".to_string());
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("rejected status"));
+}
+
+#[test]
+fn kept_candidate_cannot_lose_expected_replay_cases() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[0].candidate_refinements[0]
+        .replay_result
+        .expected_cases_lost = 1;
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("loses expected replay cases"));
+}
+
+#[test]
+fn no_improvement_candidate_cannot_claim_a_resolved_counterexample() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    let candidate = batch.episodes[1]
+        .candidate_refinements
+        .iter_mut()
+        .find(|candidate| candidate.status == RefinementStatus::RejectedNoImprovement)
+        .unwrap();
+    candidate.replay_result.counterexamples_resolved = 1;
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("preserve the baseline replay"));
+}
+
+#[test]
+fn candidate_discriminator_must_be_admitted_by_the_episode() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[0].candidate_refinements[0].discriminator_refs =
+        vec!["invented_discriminator".to_string()];
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("unadmitted discriminator"));
+}
+
+#[test]
+fn behavioral_episode_links_resolve_against_retained_observation_corpus() {
+    let refinement_batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    let behavioral_batch = parse_behavioral_episode_batch(BEHAVIORAL_CORPUS).unwrap();
+    let behavioral_ids = behavioral_batch
+        .episodes
+        .iter()
+        .map(|episode| episode.episode_id.as_str())
+        .collect::<BTreeSet<_>>();
+
+    let linked_ids = refinement_batch
+        .episodes
+        .iter()
+        .flat_map(|episode| episode.behavioral_episode_ids.iter())
+        .collect::<Vec<_>>();
+    assert_eq!(linked_ids.len(), 1);
+    assert!(behavioral_ids.contains(linked_ids[0].as_str()));
+
+    let linked_episode = behavioral_batch
+        .episodes
+        .iter()
+        .find(|episode| episode.episode_id == *linked_ids[0])
+        .unwrap();
+    assert_eq!(
+        linked_episode.receipt.outcome,
+        BehavioralOutcome::ChangedNextAction
+    );
+}
+
+#[test]
+fn behavioral_episode_links_are_optional_and_explicit() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[0].behavioral_episode_ids = vec!["observed:episode-1".to_string()];
+    validate_refinement_episode_batch(&batch).unwrap();
+
+    let encoded = serde_json::to_vec(&batch).unwrap();
+    let decoded = parse_refinement_episode_batch(&encoded).unwrap();
+    assert_eq!(
+        decoded.episodes[0].behavioral_episode_ids,
+        vec!["observed:episode-1"]
+    );
+}
+
+#[test]
+fn duplicate_episode_ids_fail_before_any_aggregate_can_count_them() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[1].id = batch.episodes[0].id.clone();
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate refinement episode id")
+    );
+}
+
+#[test]
+fn oversized_batch_rejects_before_json_parsing() {
+    let bytes = vec![b' '; MAX_REFINEMENT_EPISODE_BATCH_BYTES + 1];
+    let error = parse_refinement_episode_batch(&bytes).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}


### PR DESCRIPTION
Progresses #148 with a bounded research ledger for counterexample-guided analyzer refinement.

V0 records supplied source receipts and replay outcomes rather than reimplementing domain analyzers. Each episode preserves the broad hypothesis, counterexamples, admitted discriminators, competing candidate refinements, rejected alternatives, one optional selected transition, source receipts, and optional links to already-observed behavioral episode IDs.

## Retained families

1. **#141 -> #144 justification/open obligation** — mandatory observed clearing-edge hypothesis -> durable open-before-evidence counterexample -> weakened zero-edge OPEN semantics.
2. **#142/#168 Oxc edit-class cohort** — raw 99/100 forward cohort -> supplied `edit_class` yields 99/99; reverse 94/100 remains `rejected_no_improvement`; singleton commit identity remains `rejected_overfit`.
3. **#166/#167 -> #174 project-memory contract** — zero-path-overlap producer/consumer collision -> split admission preserving strict ordinary relation grammar while admitting only exact same-repository `Primary case:` issue blocks.

The third family exercises the real behavioral join: its `behavioral_episode_ids[]` points at merged #178 episode `project-memory:primary-case-contract-collision:9792bfe->df5ae59`, and the standard test resolves that ID in the retained behavioral corpus and requires outcome `changed_next_action`.

## Meta contract

Validation owns bookkeeping only:

- bounded unique episode/candidate/discriminator identities;
- candidate discriminator refs must be admitted by the episode;
- selected transitions must name kept candidates;
- kept candidates retain expected replay cases, resolve a counterexample, and cannot have a failed held-out result;
- no-improvement/lost-case statuses must agree with supplied replay counts;
- rejected overfit remains a source-experiment conclusion;
- behavioral links are explicit and never fabricated.

Domain replay truth stays in the exact source receipts.

## Current-main promotion receipt

The original five semantic blobs were transplanted byte-for-byte onto current `main@51affea6c645780652e6af9c80d79e4763eb609b`, erasing stale branch ancestry without changing the ledger:

```text
head: f0accb7832c6f8509affe3d64e5789d1d11265cb
commits: 1
files: 5
```

Exact-head ordinary CI:

```text
run: 32268251362
job: 96117991420
result: success
```

That run passed formatter, strict Clippy, project-memory lineage controls, GitHub review-memory and issue-closure adapter controls, external GitHub reference guards, active-work preflight, full tests, and repository/history/CI-filter/diff dogfood.

Generated-provenance review also passed:

```text
run: 32268251406
job: 96117992037
result: success
```

`main` remained at the exact reanchor base through both gates.

The earlier executed research receipt remains in `research/refinement-episodes.md`; this current-main run proves the same bytes compose with the modern repository surface.

Files: `src/refinement_episode.rs`, `tests/refinement_episode.rs`, `examples/refinement_episodes.rs`, `research/refinement-episodes/cultist-v1.json`, `research/refinement-episodes.md`.

## Boundary / next discriminator

Research only; no analyzer predicate language, scalar score, automatic promotion, or product CLI/report-schema change.

Three families expose three different discriminator-production mechanisms. The next earned child is the source-owned discriminator observation layer in #187.

Refs #137 #141 #142 #144 #148 #166 #167 #168 #174 #175 #178 #187.