### PR TITLE
research: add source-owned discriminator observation refs

### DIFF
--- a/examples/discriminator_observations.rs
+++ b/examples/discriminator_observations.rs
@@ -1,0 +1,37 @@
+#![allow(dead_code)]
+
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+
+use discriminator_observation::{
+    MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES, enumerate_discriminator_partitions,
+    parse_discriminator_observation_batch,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("discriminator-observations: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES {
+        return Err(format!(
+            "discriminator observation batch exceeds the {MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let batch = parse_discriminator_observation_batch(&bytes)?;
+    let enumeration = enumerate_discriminator_partitions(&batch)?;
+    println!("{}", serde_json::to_string_pretty(&enumeration)?);
+    Ok(())
+}

--- a/research/discriminator-observations.md
+++ b/research/discriminator-observations.md
@@ -1,0 +1,195 @@
+# Source-owned discriminator observation references
+
+Tracking: #185. Stacked on the green #179 / #148 refinement-episode carrier.
+
+## Question
+
+Can three very different analyzer families expose one tiny typed reference seam for already-earned discriminator observations without moving their domain evaluators into the analyzer-refinement layer?
+
+V0 deliberately models **references to observations**, not the logic that produces them.
+
+## Observation contract
+
+```text
+DiscriminatorObservation
+  observation_id
+  discriminator_id
+  subject_ref
+  source_receipt
+  value_state
+    known { value_ref }
+    unknown { reason_ref }
+    invalid { reason_ref }
+  applicability_ref?
+```
+
+The fields mean:
+
+- `observation_id` — identity of this supplied observation event/object;
+- `discriminator_id` — which distinction the source analyzer says this observation answers;
+- `subject_ref` — exact source-owned subject identity;
+- `source_receipt` — where the value/status came from;
+- `value_ref` — opaque supplied partition value when current;
+- `reason_ref` — source-owned explanation reference for UNKNOWN/INVALID;
+- `applicability_ref` — optional exact reference to the source applicability/coordinate receipt.
+
+The generic layer parses none of those reference strings for semantic meaning.
+
+## Enumeration contract
+
+`enumerate_discriminator_partitions` groups only KNOWN observations by:
+
+```text
+discriminator_id
+  -> value_ref
+     -> current observation receipts[]
+```
+
+UNKNOWN and INVALID observations remain separate inspectable lists under the same discriminator and never enter current partitions.
+
+Each current partition keeps every observation identity, subject, source receipt, and applicability reference. Equal values from two source receipts therefore remain two observations rather than being silently deduplicated into one evidence event.
+
+## Retained three-family corpus
+
+`research/discriminator-observations/cultist-v1.json` supplies one current observation for every discriminator used by the selected transitions in #179.
+
+### A. Justification / durable UNKNOWN
+
+```text
+discriminator_id = clearing_evidence_presence
+value_ref        = absent
+source           = #159 exact durable-obligation head
+```
+
+The reference layer does not decide whether `absent` means OPEN or whether the subject remains applicable. #159/#123 own those semantics.
+
+### B. Historical companion refinement
+
+```text
+discriminator_id = edit_class
+value_ref        = syntax_changed
+source           = retained Oxc syntax-cohort replay
+```
+
+The reference layer does not tokenize Rust or decide that exact commit identity is overfit. Those results remain in the source research and #168.
+
+### C. Project-memory contract refinement
+
+```text
+discriminator_id = primary_case_evidence_form
+value_ref        = primary_case_issue_block
+
+discriminator_id = same_repository_issue_target
+value_ref        = same_repository_issue
+
+source           = #174 exact repair head
+```
+
+The reference layer does not parse `Primary case:`, GitHub URLs, repositories, issue numbers, or relation types. #174/project-memory validation owns those checks.
+
+## Composition with #179
+
+The strongest first control is cross-object rather than family-specific:
+
+```text
+for every selected transition in the retained #179 corpus:
+  for every discriminator_ref used by that selected candidate:
+    a current KNOWN discriminator observation must exist
+```
+
+The test uses only exact discriminator IDs and supplied observation state. It does not execute the source analyzers.
+
+This proves the narrow seam #185 is asking for: #179 can consume current source-owned discriminator references without learning how those discriminators were produced.
+
+## Adversarial controls
+
+The standard test harness requires:
+
+- KNOWN observations enumerate deterministically by discriminator/value;
+- UNKNOWN stays visible and out of current partitions;
+- INVALID stays visible and out of current partitions;
+- exact duplicate observation identity rejects;
+- same observation identity with changed semantics rejects as a conflict;
+- missing source receipt rejects;
+- same value from distinct source receipts preserves both observation identities;
+- batch/enum JSON round trips and ordering remain deterministic;
+- oversized input rejects before JSON parsing;
+- an alarming value spelling such as `approve_and_merge_everything` remains an opaque value reference and grants no authority/disposition.
+
+## What V0 intentionally cannot do
+
+This module does not decide:
+
+```text
+which discriminator to acquire
+whether a partition is causal
+whether a partition is overfit
+whether a candidate improves replay
+whether evidence is strong enough
+whether a source observation is authorized
+what action/disposition follows
+```
+
+Those questions remain in #145, #168, #179, applicability, or the originating analyzer.
+
+## Research reader
+
+```text
+cargo run --example discriminator_observations \
+  < research/discriminator-observations/cultist-v1.json
+```
+
+The reader validates the supplied observation batch and prints generic current/unknown/invalid partition receipts.
+
+## Executed GitHub receipt
+
+Draft PR #187 was compacted to one semantic commit on #179's exact green receipt head.
+
+Exact semantic head:
+
+```text
+bea8b42be1d372096c64e41c7dce37cb363b8f1a
+```
+
+GitHub Actions CI run `32248518562` / run number `1266` completed successfully. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work preflight;
+- full `cargo test`, including selected #179 discriminator coverage, KNOWN/UNKNOWN/INVALID partition behavior, duplicate/conflict identity controls, distinct-source identity preservation, deterministic round trip, and opaque value semantics;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The first CI attempt failed only at rustfmt before Clippy or tests. The exact formatter delta was applied, then the branch was compacted back to the single semantic commit above before the successful run.
+
+Because #187 is stacked on #179 rather than `main`, the PR executes the ordinary CI workflow; the generated-provenance PR workflow is not part of this stacked carrier's gate.
+
+## Boundary
+
+- research-only reference seam;
+- no universal fact ontology;
+- no source analyzer duplication;
+- no string parsing for semantic authority;
+- no behavioral identity conflation;
+- no automatic analyzer refinement/promotion;
+- no product CLI/report-schema change.
+
+## Next discriminator
+
+The three-family reference seam survived CI. The next useful experiment is deliberately tiny:
+
+```text
+#179 candidate needs discriminator D
+#185 has zero current KNOWN observations for D
+-> return explicit missing-observation frontier
+```
+
+Compare that frontier with #145's probe-capability planning while keeping their vocabularies separate. #185 identifies the missing generic observation reference; a source adapter must map that need to #145's `{kind,target}` clearing/probe contract. The generic layer must not assume that a matching string means a probe can produce the observation.
+
+A useful composition would let #145 select a source-owned probe capable of producing observation D while #185 remains a read-only reference/partition layer. If the bridge requires family-specific probe semantics inside #185, keep the bridge in adapters and preserve the reference module as the narrow boundary earned here.
+
+North star:
+
+> Exchange references to analyzer-earned distinctions; keep the knowledge of how those distinctions are proved with the analyzer that owns them.

--- a/research/discriminator-observations/cultist-v1.json
+++ b/research/discriminator-observations/cultist-v1.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "observations": [
+    {
+      "observation_id": "justification/open-obligation-v1:clearing-evidence-presence",
+      "discriminator_id": "clearing_evidence_presence",
+      "subject_ref": "refinement:justification/open-obligation-v1",
+      "source_receipt": "github:pull/159@1c1a0086a199168fd0e21445d103936183063dc7",
+      "value_state": {
+        "state": "known",
+        "value_ref": "absent"
+      },
+      "applicability_ref": "research:durable-unknown-obligation.md#evaluation"
+    },
+    {
+      "observation_id": "history/oxc-edit-class-v1:current-edit-class",
+      "discriminator_id": "edit_class",
+      "subject_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588:crates/oxc_linter/src/rules.rs",
+      "source_receipt": "research:rust-syntax-cohort-replay.md",
+      "value_state": {
+        "state": "known",
+        "value_ref": "syntax_changed"
+      },
+      "applicability_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588"
+    },
+    {
+      "observation_id": "project-memory/primary-case-contract-collision-v1:evidence-form",
+      "discriminator_id": "primary_case_evidence_form",
+      "subject_ref": "refinement:project-memory/primary-case-contract-collision-v1",
+      "source_receipt": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca",
+      "value_state": {
+        "state": "known",
+        "value_ref": "primary_case_issue_block"
+      },
+      "applicability_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+    },
+    {
+      "observation_id": "project-memory/primary-case-contract-collision-v1:target-relation",
+      "discriminator_id": "same_repository_issue_target",
+      "subject_ref": "refinement:project-memory/primary-case-contract-collision-v1",
+      "source_receipt": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca",
+      "value_state": {
+        "state": "known",
+        "value_ref": "same_repository_issue"
+      },
+      "applicability_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+    }
+  ]
+}

--- a/src/discriminator_observation.rs
+++ b/src/discriminator_observation.rs
@@ -1,0 +1,300 @@
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+pub const DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION: u32 = 1;
+pub const MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES: usize = 256 * 1024;
+const MAX_OBSERVATIONS: usize = 1024;
+const MAX_ID_BYTES: usize = 512;
+const MAX_REFERENCE_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorObservationBatch {
+    pub schema_version: u32,
+    pub observations: Vec<DiscriminatorObservation>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorObservation {
+    pub observation_id: String,
+    pub discriminator_id: String,
+    pub subject_ref: String,
+    pub source_receipt: String,
+    pub value_state: DiscriminatorValueState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DiscriminatorValueState {
+    Known { value_ref: String },
+    Unknown { reason_ref: String },
+    Invalid { reason_ref: String },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorEnumeration {
+    pub schema_version: u32,
+    pub discriminators: Vec<EnumeratedDiscriminator>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EnumeratedDiscriminator {
+    pub discriminator_id: String,
+    pub known_partitions: Vec<KnownPartition>,
+    pub unknown: Vec<NonCurrentObservationReceipt>,
+    pub invalid: Vec<NonCurrentObservationReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct KnownPartition {
+    pub value_ref: String,
+    pub observations: Vec<CurrentObservationReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CurrentObservationReceipt {
+    pub observation_id: String,
+    pub subject_ref: String,
+    pub source_receipt: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct NonCurrentObservationReceipt {
+    pub observation_id: String,
+    pub subject_ref: String,
+    pub source_receipt: String,
+    pub reason_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DiscriminatorObservationError {
+    message: String,
+}
+
+impl DiscriminatorObservationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for DiscriminatorObservationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for DiscriminatorObservationError {}
+
+pub fn parse_discriminator_observation_batch(
+    bytes: &[u8],
+) -> Result<DiscriminatorObservationBatch, DiscriminatorObservationError> {
+    if bytes.len() > MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES {
+        return Err(DiscriminatorObservationError::new(format!(
+            "discriminator observation batch exceeds the {MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES}-byte limit"
+        )));
+    }
+    let batch: DiscriminatorObservationBatch = serde_json::from_slice(bytes).map_err(|error| {
+        DiscriminatorObservationError::new(format!(
+            "invalid discriminator observation JSON: {error}"
+        ))
+    })?;
+    validate_discriminator_observation_batch(&batch)?;
+    Ok(batch)
+}
+
+pub fn validate_discriminator_observation_batch(
+    batch: &DiscriminatorObservationBatch,
+) -> Result<(), DiscriminatorObservationError> {
+    if batch.schema_version != DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION {
+        return Err(DiscriminatorObservationError::new(format!(
+            "unsupported discriminator observation schema {}; expected {DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION}",
+            batch.schema_version
+        )));
+    }
+    if batch.observations.is_empty() || batch.observations.len() > MAX_OBSERVATIONS {
+        return Err(DiscriminatorObservationError::new(
+            "discriminator observation batch must contain a bounded non-empty observation set",
+        ));
+    }
+
+    let mut seen = BTreeMap::<String, DiscriminatorObservation>::new();
+    for observation in &batch.observations {
+        validate_observation(observation)?;
+        if let Some(existing) = seen.get(&observation.observation_id) {
+            let message = if existing == observation {
+                format!(
+                    "duplicate discriminator observation id {}",
+                    observation.observation_id
+                )
+            } else {
+                format!(
+                    "conflicting discriminator observation id {}",
+                    observation.observation_id
+                )
+            };
+            return Err(DiscriminatorObservationError::new(message));
+        }
+        seen.insert(observation.observation_id.clone(), observation.clone());
+    }
+    Ok(())
+}
+
+pub fn enumerate_discriminator_partitions(
+    batch: &DiscriminatorObservationBatch,
+) -> Result<DiscriminatorEnumeration, DiscriminatorObservationError> {
+    validate_discriminator_observation_batch(batch)?;
+
+    #[derive(Default)]
+    struct Builder {
+        known: BTreeMap<String, Vec<CurrentObservationReceipt>>,
+        unknown: Vec<NonCurrentObservationReceipt>,
+        invalid: Vec<NonCurrentObservationReceipt>,
+    }
+
+    let mut builders = BTreeMap::<String, Builder>::new();
+    for observation in &batch.observations {
+        let builder = builders
+            .entry(observation.discriminator_id.clone())
+            .or_default();
+        match &observation.value_state {
+            DiscriminatorValueState::Known { value_ref } => {
+                builder
+                    .known
+                    .entry(value_ref.clone())
+                    .or_default()
+                    .push(current_receipt(observation));
+            }
+            DiscriminatorValueState::Unknown { reason_ref } => {
+                builder
+                    .unknown
+                    .push(non_current_receipt(observation, reason_ref));
+            }
+            DiscriminatorValueState::Invalid { reason_ref } => {
+                builder
+                    .invalid
+                    .push(non_current_receipt(observation, reason_ref));
+            }
+        }
+    }
+
+    let discriminators = builders
+        .into_iter()
+        .map(|(discriminator_id, mut builder)| {
+            let known_partitions = builder
+                .known
+                .into_iter()
+                .map(|(value_ref, mut observations)| {
+                    observations
+                        .sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+                    KnownPartition {
+                        value_ref,
+                        observations,
+                    }
+                })
+                .collect();
+            builder
+                .unknown
+                .sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+            builder
+                .invalid
+                .sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+            EnumeratedDiscriminator {
+                discriminator_id,
+                known_partitions,
+                unknown: builder.unknown,
+                invalid: builder.invalid,
+            }
+        })
+        .collect();
+
+    Ok(DiscriminatorEnumeration {
+        schema_version: DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+        discriminators,
+    })
+}
+
+fn current_receipt(observation: &DiscriminatorObservation) -> CurrentObservationReceipt {
+    CurrentObservationReceipt {
+        observation_id: observation.observation_id.clone(),
+        subject_ref: observation.subject_ref.clone(),
+        source_receipt: observation.source_receipt.clone(),
+        applicability_ref: observation.applicability_ref.clone(),
+    }
+}
+
+fn non_current_receipt(
+    observation: &DiscriminatorObservation,
+    reason_ref: &str,
+) -> NonCurrentObservationReceipt {
+    NonCurrentObservationReceipt {
+        observation_id: observation.observation_id.clone(),
+        subject_ref: observation.subject_ref.clone(),
+        source_receipt: observation.source_receipt.clone(),
+        reason_ref: reason_ref.to_string(),
+        applicability_ref: observation.applicability_ref.clone(),
+    }
+}
+
+fn validate_observation(
+    observation: &DiscriminatorObservation,
+) -> Result<(), DiscriminatorObservationError> {
+    validate_atom(&observation.observation_id, "observation_id", MAX_ID_BYTES)?;
+    validate_atom(
+        &observation.discriminator_id,
+        "discriminator_id",
+        MAX_ID_BYTES,
+    )?;
+    validate_atom(&observation.subject_ref, "subject_ref", MAX_REFERENCE_BYTES)?;
+    validate_atom(
+        &observation.source_receipt,
+        "source_receipt",
+        MAX_REFERENCE_BYTES,
+    )?;
+    if let Some(applicability_ref) = &observation.applicability_ref {
+        validate_atom(applicability_ref, "applicability_ref", MAX_REFERENCE_BYTES)?;
+    }
+    match &observation.value_state {
+        DiscriminatorValueState::Known { value_ref } => {
+            validate_atom(value_ref, "value_ref", MAX_REFERENCE_BYTES)
+        }
+        DiscriminatorValueState::Unknown { reason_ref }
+        | DiscriminatorValueState::Invalid { reason_ref } => {
+            validate_atom(reason_ref, "reason_ref", MAX_REFERENCE_BYTES)
+        }
+    }
+}
+
+fn validate_atom(
+    value: &str,
+    field: &str,
+    max_bytes: usize,
+) -> Result<(), DiscriminatorObservationError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > max_bytes
+        || value.contains('\0')
+        || value.contains(['\n', '\r'])
+    {
+        return Err(DiscriminatorObservationError::new(format!(
+            "{field} must be bounded canonical single-line text"
+        )));
+    }
+    Ok(())
+}

--- a/tests/discriminator_observation.rs
+++ b/tests/discriminator_observation.rs
@@ -1,0 +1,210 @@
+#![allow(dead_code)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+
+use discriminator_observation::{
+    DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation, DiscriminatorValueState,
+    MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES, enumerate_discriminator_partitions,
+    parse_discriminator_observation_batch, validate_discriminator_observation_batch,
+};
+use refinement_episode::parse_refinement_episode_batch;
+
+const OBSERVATIONS: &[u8] =
+    include_bytes!("../research/discriminator-observations/cultist-v1.json");
+const REFINEMENTS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+
+#[test]
+fn retained_observations_cover_every_selected_refinement_discriminator() {
+    let observations = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let enumeration = enumerate_discriminator_partitions(&observations).unwrap();
+    let refinements = parse_refinement_episode_batch(REFINEMENTS).unwrap();
+
+    let current = enumeration
+        .discriminators
+        .iter()
+        .map(|discriminator| {
+            (
+                discriminator.discriminator_id.as_str(),
+                !discriminator.known_partitions.is_empty(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    for episode in &refinements.episodes {
+        let selected = episode
+            .selected_transition
+            .as_ref()
+            .expect("retained fixture has selected transition");
+        let candidate = episode
+            .candidate_refinements
+            .iter()
+            .find(|candidate| candidate.id == *selected)
+            .expect("selected candidate exists");
+        for discriminator in &candidate.discriminator_refs {
+            assert_eq!(
+                current.get(discriminator.as_str()),
+                Some(&true),
+                "selected discriminator {discriminator} lacks a current KNOWN observation"
+            );
+        }
+    }
+}
+
+#[test]
+fn known_observations_enumerate_by_discriminator_and_value() {
+    let batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    assert_eq!(
+        enumeration.schema_version,
+        DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION
+    );
+    assert_eq!(enumeration.discriminators.len(), 4);
+    assert!(enumeration.discriminators.iter().all(|discriminator| {
+        discriminator.known_partitions.len() == 1
+            && discriminator.unknown.is_empty()
+            && discriminator.invalid.is_empty()
+    }));
+}
+
+#[test]
+fn unknown_observation_stays_visible_and_out_of_current_partitions() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[0].value_state = DiscriminatorValueState::Unknown {
+        reason_ref: "applicability:missing-current-revision".to_string(),
+    };
+
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let discriminator = enumeration
+        .discriminators
+        .iter()
+        .find(|item| item.discriminator_id == "clearing_evidence_presence")
+        .unwrap();
+    assert!(discriminator.known_partitions.is_empty());
+    assert_eq!(discriminator.unknown.len(), 1);
+    assert!(discriminator.invalid.is_empty());
+}
+
+#[test]
+fn invalid_observation_stays_visible_and_out_of_current_partitions() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[1].value_state = DiscriminatorValueState::Invalid {
+        reason_ref: "applicability:revision-moved".to_string(),
+    };
+
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let discriminator = enumeration
+        .discriminators
+        .iter()
+        .find(|item| item.discriminator_id == "edit_class")
+        .unwrap();
+    assert!(discriminator.known_partitions.is_empty());
+    assert!(discriminator.unknown.is_empty());
+    assert_eq!(discriminator.invalid.len(), 1);
+}
+
+#[test]
+fn exact_duplicate_observation_identity_rejects() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations.push(batch.observations[0].clone());
+    let error = validate_discriminator_observation_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate discriminator observation id")
+    );
+}
+
+#[test]
+fn conflicting_duplicate_observation_identity_rejects() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let mut conflicting = batch.observations[0].clone();
+    conflicting.value_state = DiscriminatorValueState::Known {
+        value_ref: "observed".to_string(),
+    };
+    batch.observations.push(conflicting);
+    let error = validate_discriminator_observation_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("conflicting discriminator observation id")
+    );
+}
+
+#[test]
+fn missing_source_receipt_rejects() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[0].source_receipt.clear();
+    let error = validate_discriminator_observation_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("source_receipt"));
+}
+
+#[test]
+fn same_value_from_distinct_sources_preserves_each_observation_identity() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let mut repeated = batch.observations[1].clone();
+    repeated.observation_id = "history/oxc-edit-class-v1:second-source".to_string();
+    repeated.source_receipt = "research:cohort-refinement.md#supplied-edit-class".to_string();
+    batch.observations.push(repeated);
+
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let edit_class = enumeration
+        .discriminators
+        .iter()
+        .find(|item| item.discriminator_id == "edit_class")
+        .unwrap();
+    assert_eq!(edit_class.known_partitions.len(), 1);
+    let observations = &edit_class.known_partitions[0].observations;
+    assert_eq!(observations.len(), 2);
+    assert_ne!(
+        observations[0].observation_id,
+        observations[1].observation_id
+    );
+    assert_ne!(
+        observations[0].source_receipt,
+        observations[1].source_receipt
+    );
+}
+
+#[test]
+fn enumeration_order_and_json_round_trip_are_deterministic() {
+    let batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let first = enumerate_discriminator_partitions(&batch).unwrap();
+    let second = enumerate_discriminator_partitions(&batch).unwrap();
+    assert_eq!(first, second);
+
+    let ids = first
+        .discriminators
+        .iter()
+        .map(|item| item.discriminator_id.as_str())
+        .collect::<Vec<_>>();
+    let sorted = ids.iter().copied().collect::<BTreeSet<_>>();
+    assert_eq!(ids, sorted.into_iter().collect::<Vec<_>>());
+
+    let encoded = serde_json::to_vec(&batch).unwrap();
+    let decoded = parse_discriminator_observation_batch(&encoded).unwrap();
+    assert_eq!(decoded, batch);
+}
+
+#[test]
+fn oversized_batch_rejects_before_json_parsing() {
+    let bytes = vec![b' '; MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES + 1];
+    let error = parse_discriminator_observation_batch(&bytes).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}
+
+#[test]
+fn value_spelling_remains_an_opaque_reference() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let DiscriminatorObservation { value_state, .. } = &mut batch.observations[0];
+    *value_state = DiscriminatorValueState::Known {
+        value_ref: "approve_and_merge_everything".to_string(),
+    };
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let partition = &enumeration.discriminators[0].known_partitions[0];
+    assert_eq!(partition.observations.len(), 1);
+}


### PR DESCRIPTION
Starts #185 as the first landed child of #179.

Adds a research-only typed reference seam for discriminator observations already produced by source analyzers. One observation carries bounded identity, discriminator ID, subject ref, source receipt, KNOWN/UNKNOWN/INVALID value state, and an optional applicability receipt reference.

Generic enumeration groups only KNOWN observations by discriminator/value reference while preserving every observation/source identity. UNKNOWN and INVALID observations remain explicit and never enter current partitions.

## Three-family composition

The retained corpus supplies current observations for every discriminator used by #179's selected transitions:

- `clearing_evidence_presence` from #159;
- `edit_class` from the retained Oxc syntax-cohort replay;
- `primary_case_evidence_form` and `same_repository_issue_target` from #174.

A cross-object test parses the now-landed #179 refinement corpus and requires every selected candidate discriminator ref to have at least one current KNOWN observation, without executing any source analyzer.

## Controls

- KNOWN values enumerate deterministically;
- UNKNOWN/INVALID stay visible and out of current partitions;
- duplicate and conflicting observation identities reject separately;
- missing source receipt rejects;
- equal values from distinct source receipts preserve both observation identities;
- JSON round trip/order and byte bounds are explicit;
- value spelling remains opaque and grants zero evidence strength/authority/disposition.

The module deliberately cannot decide overfit, replay improvement, applicability meaning, probe capability, or action.

## Current-main promotion receipt

The five #187 semantic blobs were rebuilt as one commit after #179 landed:

```text
head: 5e98b403229e76a7b0e7a5ce46cf75c5f0f8b60d
commits: 1
files: 5
```

The PR was retargeted to `main`. Its successful merge-view gate included current `main@0eabd231a23dfc243c167d336b7ad9836aff2bcc`, including the newer frozen first-action trial work.

Ordinary CI:

```text
run: 32268881806
job: 96120117040
result: success
```

Generated-provenance review:

```text
run: 32268881627
job: 96120116433
result: success
```

The full current CI surface passed: formatter, strict Clippy, project-memory lineage, GitHub review-memory and issue-closure controls, external-reference guards, active-work preflight, full tests, and repository/history/CI-filter/diff dogfood.

The earlier semantic receipt remains in `research/discriminator-observations.md`; this run proves the same observation layer composes with the current repository.

Files: `src/discriminator_observation.rs`, `tests/discriminator_observation.rs`, `examples/discriminator_observations.rs`, `research/discriminator-observations/cultist-v1.json`, `research/discriminator-observations.md`.

## Boundary / next

Research only; no universal fact ontology, analyzer predicate language, automatic promotion, or product CLI/report-schema change.

The next earned child is #194: exact `(discriminator_id, subject_ref)` currentness frontiers.

Refs #123 #141 #142 #144 #145 #148 #159 #168 #174 #179 #185 #194.