### PR TITLE
research: collect bounded explicit project-memory lineage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
         run: cargo fmt --check
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
+      - name: Project-memory lineage controls
+        run: |
+          python -m py_compile \
+            scripts/project_memory_github.py \
+            scripts/project_memory_github_issue.py \
+            scripts/project_memory_github_lineage.py \
+            scripts/project_memory_github_lineage_test.py
+          python scripts/project_memory_github_lineage_test.py
       - name: Active work heads-up
         if: github.event_name == 'pull_request'
         continue-on-error: true

--- a/.github/workflows/project-memory-lineage.yml
+++ b/.github/workflows/project-memory-lineage.yml
@@ -1,0 +1,218 @@
+name: GitHub project-memory lineage
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: Public GitHub owner/repository
+        required: true
+        default: The-PR-Agent/pr-agent
+        type: string
+      anchor_kind:
+        description: GitHub artifact kind
+        required: true
+        default: issue
+        type: choice
+        options:
+          - issue
+          - pull_request
+      anchor_number:
+        description: Issue or pull-request number to use as the lineage anchor
+        required: true
+        default: "2627"
+        type: string
+      max_depth:
+        description: Maximum explicit relationship depth, 0 through 3
+        required: true
+        default: "2"
+        type: string
+      max_artifacts:
+        description: Maximum admitted artifacts including anchor, 1 through 32
+        required: true
+        default: "8"
+        type: string
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lineage:
+    if: github.event_name == 'workflow_dispatch' || github.head_ref == 'research/project-memory-lineage'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Cultist
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Run collector regression controls
+        run: |
+          python -m py_compile \
+            scripts/project_memory_github.py \
+            scripts/project_memory_github_issue.py \
+            scripts/project_memory_github_lineage.py \
+            scripts/project_memory_github_lineage_test.py
+          python scripts/project_memory_github_lineage_test.py
+
+      - name: Resolve carrier inputs
+        id: carrier
+        env:
+          INPUT_REPOSITORY: ${{ inputs.repository }}
+          INPUT_ANCHOR_KIND: ${{ inputs.anchor_kind }}
+          INPUT_ANCHOR_NUMBER: ${{ inputs.anchor_number }}
+          INPUT_MAX_DEPTH: ${{ inputs.max_depth }}
+          INPUT_MAX_ARTIFACTS: ${{ inputs.max_artifacts }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            repository="The-PR-Agent/pr-agent"
+            anchor_kind="issue"
+            anchor_number="2627"
+            max_depth="2"
+            max_artifacts="8"
+            carrier="true"
+          else
+            repository="$INPUT_REPOSITORY"
+            anchor_kind="$INPUT_ANCHOR_KIND"
+            anchor_number="$INPUT_ANCHOR_NUMBER"
+            max_depth="$INPUT_MAX_DEPTH"
+            max_artifacts="$INPUT_MAX_ARTIFACTS"
+            carrier="false"
+          fi
+          {
+            echo "repository=$repository"
+            echo "anchor_kind=$anchor_kind"
+            echo "anchor_number=$anchor_number"
+            echo "max_depth=$max_depth"
+            echo "max_artifacts=$max_artifacts"
+            echo "carrier=$carrier"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Collect bounded explicit lineage
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TARGET_REPOSITORY: ${{ steps.carrier.outputs.repository }}
+          TARGET_KIND: ${{ steps.carrier.outputs.anchor_kind }}
+          TARGET_NUMBER: ${{ steps.carrier.outputs.anchor_number }}
+          MAX_DEPTH: ${{ steps.carrier.outputs.max_depth }}
+          MAX_ARTIFACTS: ${{ steps.carrier.outputs.max_artifacts }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET_KIND" == "pull_request" ]]; then
+            anchor=(--anchor-pr "$TARGET_NUMBER")
+          elif [[ "$TARGET_KIND" == "issue" ]]; then
+            anchor=(--anchor-issue "$TARGET_NUMBER")
+          else
+            echo "unsupported anchor kind: $TARGET_KIND" >&2
+            exit 1
+          fi
+          python scripts/project_memory_github_lineage.py \
+            --repository "$TARGET_REPOSITORY" \
+            "${anchor[@]}" \
+            --max-depth "$MAX_DEPTH" \
+            --max-artifacts "$MAX_ARTIFACTS" \
+            --output project-memory-lineage.json \
+            --receipt-output project-memory-lineage-receipt.json \
+            > /tmp/project-memory-lineage.stdout
+
+      - name: Validate with offline packet reader
+        run: |
+          cargo run --quiet --example project_memory_packet \
+            < project-memory-lineage.json \
+            > project-memory-lineage-summary.json
+
+      - name: Assert PR-Agent closed-issue carrier
+        if: steps.carrier.outputs.carrier == 'true'
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          packet = json.loads(Path("project-memory-lineage.json").read_text())
+          receipt = json.loads(Path("project-memory-lineage-receipt.json").read_text())
+
+          assert packet["repository"] == "The-PR-Agent/pr-agent", packet
+          assert packet["anchor"] == {"kind": "issue", "number": 2627}, packet
+          assert [a["reference"] for a in packet["artifacts"]] == [
+              {"kind": "issue", "number": 2627},
+              {"kind": "issue", "number": 2573},
+          ], packet
+          assert [a["state"] for a in packet["artifacts"]] == ["closed", "closed"], packet
+          assert packet["edges"] == [
+              {
+                  "from": {"kind": "issue", "number": 2627},
+                  "relation": "follow_up_to",
+                  "to": {"kind": "issue", "number": 2573},
+                  "evidence": (
+                      "Follow-up to #2573: releases since 0.39.0 (v0.40.0 through v0.42.0) "
+                      "are still not on PyPI, so `pip install pr-agent` succeeds but silently "
+                      "installs 0.39.0, now three releases behind."
+                  ),
+              }
+          ], packet
+          assert receipt["artifact_count"] == 2, receipt
+          assert receipt["edge_count"] == 1, receipt
+          assert receipt["depth_frontier"] == [], receipt
+          PY
+
+      - name: Write job summary
+        env:
+          TARGET_REPOSITORY: ${{ steps.carrier.outputs.repository }}
+          TARGET_KIND: ${{ steps.carrier.outputs.anchor_kind }}
+          TARGET_NUMBER: ${{ steps.carrier.outputs.anchor_number }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          packet_path = Path("project-memory-lineage.json")
+          packet = json.loads(packet_path.read_text())
+          receipt = json.loads(Path("project-memory-lineage-receipt.json").read_text())
+          digest = hashlib.sha256(packet_path.read_bytes()).hexdigest()
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as out:
+              out.write("## GitHub project-memory lineage\n\n")
+              out.write(
+                  f"Anchor: `{os.environ['TARGET_REPOSITORY']} "
+                  f"{os.environ['TARGET_KIND']} #{os.environ['TARGET_NUMBER']}`\n\n"
+              )
+              out.write(
+                  f"Artifacts: **{receipt['artifact_count']}** · "
+                  f"explicit edges: **{receipt['edge_count']}** · "
+                  f"max depth: **{receipt['requested_max_depth']}**\n\n"
+              )
+              out.write(f"Packet SHA-256: `{digest}`\n\n")
+              out.write("| source | relation | target |\n|---|---|---|\n")
+              for edge in packet["edges"]:
+                  source = edge["from"]
+                  target = edge["to"]
+                  out.write(
+                      f"| {source['kind']} #{source['number']} | {edge['relation']} | "
+                      f"{target['kind']} #{target['number']} |\n"
+                  )
+              out.write("\nUnexpanded depth frontier:\n\n")
+              if receipt["depth_frontier"]:
+                  for artifact in receipt["depth_frontier"]:
+                      out.write(f"- `{artifact['kind']} #{artifact['number']}`\n")
+              else:
+                  out.write("- empty\n")
+              out.write(
+                  "\nOnly explicitly admitted same-repository relationships create edges. "
+                  "Chronology and title similarity create none.\n"
+              )
+          PY
+
+      - name: Upload lineage receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: project-memory-lineage-${{ github.run_id }}
+          path: |
+            project-memory-lineage.json
+            project-memory-lineage-receipt.json
+            project-memory-lineage-summary.json
+          if-no-files-found: error

--- a/research/project-memory-lineage.md
+++ b/research/project-memory-lineage.md
@@ -76,7 +76,15 @@ depth_frontier
 
 so a consumer cannot mistake the bounded packet for evidence that deeper explicit lineage does not exist.
 
-An anchor with no admitted explicit relationship yields an anchor-only packet and an empty edge list. That is a useful quiet result.
+Provider source completeness is independent. The existing GitHub adapter can fall back to an artifact title when its body is absent; such an artifact carries `evidence_complete=false`. If lineage expansion reaches one of those artifacts, the sidecar records it under:
+
+```text
+incomplete_evidence_artifacts
+```
+
+and sets `complete_within_requested_depth=false`. An empty relation set over incomplete retained text therefore remains visibly incomplete evidence rather than a false claim that the source artifact contains no relationship.
+
+An anchor with complete evidence and no admitted explicit relationship yields an anchor-only packet and an empty edge list. That is a useful quiet result.
 
 ## External discriminator: PR-Agent #2627 -> #2573
 
@@ -96,6 +104,33 @@ issue #2627 explicitly says follow_up_to issue #2573
 
 The collector does not infer that both issues are the same bug, that #2573's closure was incorrect, or that one artifact caused another. Those interpretations remain separate work.
 
+### Executed live carrier
+
+The first PR carrier executed the public pair through the provider collector and independent Rust packet validator:
+
+```text
+workflow run: 32248397421
+job:          96053824984
+artifact:     9363465840
+artifact digest:
+  sha256:e3333d14d004a11f4130aceda10b2366d46fb2707f7dd66461e1896c9da882e5
+```
+
+The workflow asserted:
+
+```text
+artifacts: 2
+  issue #2627 closed
+  issue #2573 closed
+
+edges: 1
+  #2627 follow_up_to #2573
+
+depth frontier: empty
+```
+
+The collector regression controls, live collection, Rust validation, exact carrier assertion, summary generation, and artifact upload all completed successfully in that run.
+
 The product value to test under #137/#109 is whether seeing the closed predecessor before editing release/install behavior changes the next justified inspection or prevents repeated archaeology.
 
 ## Regression controls
@@ -110,6 +145,7 @@ The product value to test under #137/#109 is whether seeing the closed predecess
 - duplicate reference deduplication;
 - fail-closed artifact overflow;
 - anchor-only quiet output;
+- incomplete source-evidence receipts;
 - self-reference rejection;
 - invalid bounds before provider access.
 

--- a/research/project-memory-lineage.md
+++ b/research/project-memory-lineage.md
@@ -1,0 +1,124 @@
+# Explicit project-memory lineage
+
+Issue #183 extends the existing #18 project-memory experiment in one narrow direction: follow already-admitted explicit GitHub relationships for a small bounded number of hops so a current task can retain the earlier issue/PR episode it explicitly points back to.
+
+The carrier reuses `ProjectMemoryPacket` schema v1. No new relation kind or semantic classification is introduced.
+
+## Why one hop is sometimes insufficient
+
+The current GitHub collector starts from one selected PR and collects only the artifacts explicitly named by that anchor. That is a useful boundary, but it stops before a referenced artifact's own explicit predecessor/follow-up evidence.
+
+For longitudinal work the useful chain can be:
+
+```text
+current follow-up
+-> earlier repair/failure
+-> still earlier explicit predecessor
+```
+
+A later worker should be able to recover that small chain without turning chronology or title similarity into causal evidence.
+
+## Collector
+
+The opt-in adapter is:
+
+```text
+scripts/project_memory_github_lineage.py
+```
+
+Example:
+
+```bash
+python scripts/project_memory_github_lineage.py \
+  --repository The-PR-Agent/pr-agent \
+  --anchor-issue 2627 \
+  --max-depth 2 \
+  --max-artifacts 8 \
+  --output project-memory-lineage.json \
+  --receipt-output project-memory-lineage-receipt.json
+
+cargo run --quiet --example project_memory_packet \
+  < project-memory-lineage.json
+```
+
+The adapter performs breadth-first traversal over only the relationship forms already admitted by the offline packet validator:
+
+```text
+closes / fixes / resolves
+follow-up to
+continuation from / deployment continuation
+parent:
+related:
+Primary case: <same-repository issue URL>
+```
+
+Every `#N` target is resolved through GitHub before its artifact kind is recorded. PRs retain exact head/base coordinates and bounded changed paths through the existing collector helpers.
+
+## Bounds and omission receipt
+
+V0 admits:
+
+```text
+max depth:      0..3
+max artifacts:  1..32
+max edges:      256
+packet:         <= 256 KiB
+receipt:        <= 64 KiB
+```
+
+Artifact or edge overflow fails instead of returning a partial packet.
+
+A depth limit is different: artifacts reached exactly at the requested maximum depth are retained, but their outgoing relationships are deliberately uninspected. The sidecar receipt records them under:
+
+```text
+depth_frontier
+```
+
+so a consumer cannot mistake the bounded packet for evidence that deeper explicit lineage does not exist.
+
+An anchor with no admitted explicit relationship yields an anchor-only packet and an empty edge list. That is a useful quiet result.
+
+## External discriminator: PR-Agent #2627 -> #2573
+
+Public issue `The-PR-Agent/pr-agent#2627` begins with:
+
+```text
+Follow-up to #2573: releases since 0.39.0 ... are still not on PyPI
+```
+
+Issue #2573 had already documented the failed PyPI publication path and remediation options, then closed. #2627 later records a residual user-facing consequence: installation documentation still directed users to a stale PyPI release while publishing remained unavailable.
+
+The relationship Cultist is allowed to retain is deliberately small:
+
+```text
+issue #2627 explicitly says follow_up_to issue #2573
+```
+
+The collector does not infer that both issues are the same bug, that #2573's closure was incorrect, or that one artifact caused another. Those interpretations remain separate work.
+
+The product value to test under #137/#109 is whether seeing the closed predecessor before editing release/install behavior changes the next justified inspection or prevents repeated archaeology.
+
+## Regression controls
+
+`scripts/project_memory_github_lineage_test.py` covers:
+
+- two-hop explicit lineage;
+- visible depth frontier;
+- cycle termination;
+- issue-vs-PR target resolution;
+- `Primary case:` composition;
+- duplicate reference deduplication;
+- fail-closed artifact overflow;
+- anchor-only quiet output;
+- self-reference rejection;
+- invalid bounds before provider access.
+
+Chronology, nearby artifact numbers, shared labels, title similarity, and changed-path overlap remain unable to create a lineage edge.
+
+## Promotion boundary
+
+This is provider-side research. Ordinary `cargo-cultist` commands remain local and make no GitHub requests.
+
+A lineage earns a prominent JEI/review projection only through behavioral evidence that it changes a useful next action. Closed artifacts remain inspectable historical evidence; closed state by itself neither suppresses nor strengthens the retained claim.
+
+Refs #16 #18 #62 #74 #109 #137 #160 #162 #166 #167 #174 #183.

--- a/scripts/project_memory_github_lineage.py
+++ b/scripts/project_memory_github_lineage.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Collect bounded explicit GitHub project-memory lineage into Cultist's offline packet."""
+
+from __future__ import annotations
+
+import argparse
+from collections import deque
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+import project_memory_github as github_memory
+import project_memory_github_issue as issue_memory
+
+MAX_DEPTH_HARD = 3
+MAX_ARTIFACTS_HARD = 32
+MAX_EDGES = 256
+MAX_PACKET_BYTES = 256 * 1024
+MAX_RECEIPT_BYTES = 64 * 1024
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description=(
+            "Collect an explicitly linked same-repository GitHub issue/PR lineage into "
+            "Cultist's existing bounded project-memory packet."
+        )
+    )
+    result.add_argument("--repository", required=True)
+    anchor = result.add_mutually_exclusive_group(required=True)
+    anchor.add_argument("--anchor-pr", type=int)
+    anchor.add_argument("--anchor-issue", type=int)
+    result.add_argument("--output", required=True, type=Path)
+    result.add_argument("--receipt-output", required=True, type=Path)
+    result.add_argument(
+        "--max-depth",
+        type=int,
+        default=2,
+        help=f"maximum explicit-link traversal depth (0..{MAX_DEPTH_HARD})",
+    )
+    result.add_argument(
+        "--max-artifacts",
+        type=int,
+        default=16,
+        help=f"maximum admitted artifacts including anchor (1..{MAX_ARTIFACTS_HARD})",
+    )
+    return result
+
+
+def admitted_edges(repository: str, artifact: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return only relationship species already admitted by ProjectMemoryPacket v1."""
+    edges = list(github_memory.explicit_anchor_edges(artifact))
+    edges.extend(issue_memory.primary_case_edges(repository, artifact))
+    return edges
+
+
+def artifact_key(reference: dict[str, Any]) -> tuple[str, int]:
+    kind = reference.get("kind")
+    number = reference.get("number")
+    if (
+        kind not in {"issue", "pull_request"}
+        or not isinstance(number, int)
+        or isinstance(number, bool)
+    ):
+        raise github_memory.CollectorError("project-memory artifact reference is malformed")
+    return kind, number
+
+
+def edge_key(
+    edge: dict[str, Any],
+) -> tuple[tuple[str, int], str, tuple[str, int], str]:
+    relation = edge.get("relation")
+    evidence = edge.get("evidence")
+    if not isinstance(relation, str) or not isinstance(evidence, str):
+        raise github_memory.CollectorError("project-memory edge is malformed")
+    return artifact_key(edge["from"]), relation, artifact_key(edge["to"]), evidence
+
+
+def _anchor_artifact(
+    client: github_memory.GitHubClient,
+    repository: str,
+    anchor_kind: str,
+    anchor_number: int,
+) -> dict[str, Any]:
+    if anchor_number <= 0:
+        raise github_memory.CollectorError("anchor number must be positive")
+    if anchor_kind == "pull_request":
+        return github_memory.pull_request_artifact(client, repository, anchor_number)
+    if anchor_kind == "issue":
+        return issue_memory.issue_anchor(client, repository, anchor_number)
+    raise github_memory.CollectorError(f"unsupported anchor kind: {anchor_kind}")
+
+
+def collect(
+    repository: str,
+    anchor_kind: str,
+    anchor_number: int,
+    max_depth: int,
+    max_artifacts: int,
+    *,
+    client: github_memory.GitHubClient | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if github_memory.REPOSITORY_RE.fullmatch(repository) is None:
+        raise github_memory.CollectorError("repository must be canonical owner/name")
+    if max_depth < 0 or max_depth > MAX_DEPTH_HARD:
+        raise github_memory.CollectorError(
+            f"max depth must be between 0 and {MAX_DEPTH_HARD}"
+        )
+    if max_artifacts < 1 or max_artifacts > MAX_ARTIFACTS_HARD:
+        raise github_memory.CollectorError(
+            f"max artifacts must be between 1 and {MAX_ARTIFACTS_HARD}"
+        )
+
+    if client is None:
+        token = os.environ.get("GITHUB_TOKEN")
+        client = github_memory.GitHubClient(token if token else None)
+
+    anchor = _anchor_artifact(client, repository, anchor_kind, anchor_number)
+    anchor_reference = anchor["reference"]
+    anchor_identity = artifact_key(anchor_reference)
+
+    artifacts = [anchor]
+    artifacts_by_number: dict[int, dict[str, Any]] = {anchor_number: anchor}
+    depth_by_number: dict[int, int] = {anchor_number: 0}
+    queue: deque[int] = deque([anchor_number])
+    edges: list[dict[str, Any]] = []
+    seen_edges: set[
+        tuple[tuple[str, int], str, tuple[str, int], str]
+    ] = set()
+    depth_frontier: list[dict[str, Any]] = []
+
+    while queue:
+        source_number = queue.popleft()
+        source = artifacts_by_number[source_number]
+        source_depth = depth_by_number[source_number]
+        if source_depth == max_depth:
+            # We retain the artifact but deliberately do not inspect it for deeper links.
+            # The sidecar receipt makes that omission observable.
+            depth_frontier.append(source["reference"].copy())
+            continue
+
+        for edge in admitted_edges(repository, source):
+            if edge.get("from") != source["reference"]:
+                raise github_memory.CollectorError(
+                    "collector edge source disagrees with expanded artifact"
+                )
+            raw_target = edge.get("to")
+            if not isinstance(raw_target, dict):
+                raise github_memory.CollectorError("collector edge target is malformed")
+            target_number = raw_target.get("number")
+            if (
+                not isinstance(target_number, int)
+                or isinstance(target_number, bool)
+                or target_number <= 0
+            ):
+                raise github_memory.CollectorError(
+                    "collector edge target number is malformed"
+                )
+            if target_number == source_number:
+                raise github_memory.CollectorError(
+                    "explicit project-memory lineage may not self-reference"
+                )
+
+            target = artifacts_by_number.get(target_number)
+            if target is None:
+                if len(artifacts) >= max_artifacts:
+                    raise github_memory.CollectorError(
+                        f"explicit lineage exceeds max-artifacts={max_artifacts}; "
+                        f"next target is #{target_number}"
+                    )
+                target = github_memory.referenced_artifact(
+                    client, repository, target_number
+                )
+                artifacts_by_number[target_number] = target
+                artifacts.append(target)
+                depth_by_number[target_number] = source_depth + 1
+                queue.append(target_number)
+
+            # `#N` is syntactically ambiguous until GitHub resolves it. Preserve the
+            # same relation/evidence while correcting the target artifact species.
+            edge["to"]["kind"] = target["reference"]["kind"]
+            key = edge_key(edge)
+            if key in seen_edges:
+                continue
+            if len(edges) >= MAX_EDGES:
+                raise github_memory.CollectorError(
+                    f"explicit lineage exceeds the {MAX_EDGES}-edge packet bound"
+                )
+            seen_edges.add(key)
+            edges.append(edge)
+
+    packet = {
+        "schema_version": 1,
+        "repository": repository,
+        "anchor": anchor_reference,
+        "artifacts": artifacts,
+        "edges": edges,
+    }
+    receipt = {
+        "schema_version": 1,
+        "collector": "github_explicit_lineage",
+        "repository": repository,
+        "anchor": anchor_reference,
+        "requested_max_depth": max_depth,
+        "max_artifacts": max_artifacts,
+        "artifact_count": len(artifacts),
+        "edge_count": len(edges),
+        "depth_frontier": depth_frontier,
+        "complete_within_requested_depth": True,
+    }
+
+    if artifact_key(packet["anchor"]) != anchor_identity:
+        raise github_memory.CollectorError(
+            "project-memory anchor identity changed during collection"
+        )
+
+    packet_bytes = (json.dumps(packet, indent=2, sort_keys=True) + "\n").encode(
+        "utf-8"
+    )
+    if len(packet_bytes) > MAX_PACKET_BYTES:
+        raise github_memory.CollectorError(
+            f"collected lineage packet exceeds the {MAX_PACKET_BYTES}-byte offline bound"
+        )
+    receipt_bytes = (
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+    ).encode("utf-8")
+    if len(receipt_bytes) > MAX_RECEIPT_BYTES:
+        raise github_memory.CollectorError(
+            f"lineage collection receipt exceeds the {MAX_RECEIPT_BYTES}-byte bound"
+        )
+
+    return packet, receipt
+
+
+def main() -> int:
+    args = parser().parse_args()
+    anchor_kind = "pull_request" if args.anchor_pr is not None else "issue"
+    anchor_number = args.anchor_pr if args.anchor_pr is not None else args.anchor_issue
+    assert anchor_number is not None
+
+    try:
+        packet, receipt = collect(
+            args.repository,
+            anchor_kind,
+            anchor_number,
+            args.max_depth,
+            args.max_artifacts,
+        )
+        encoded_packet = json.dumps(packet, indent=2, sort_keys=True) + "\n"
+        encoded_receipt = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.receipt_output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded_packet, encoding="utf-8")
+        args.receipt_output.write_text(encoded_receipt, encoding="utf-8")
+    except (github_memory.CollectorError, OSError) as error:
+        print(f"project-memory-github-lineage: {error}", file=sys.stderr)
+        return 1
+
+    print(encoded_packet, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/project_memory_github_lineage.py
+++ b/scripts/project_memory_github_lineage.py
@@ -130,6 +130,7 @@ def collect(
         tuple[tuple[str, int], str, tuple[str, int], str]
     ] = set()
     depth_frontier: list[dict[str, Any]] = []
+    incomplete_evidence_artifacts: list[dict[str, Any]] = []
 
     while queue:
         source_number = queue.popleft()
@@ -140,6 +141,12 @@ def collect(
             # The sidecar receipt makes that omission observable.
             depth_frontier.append(source["reference"].copy())
             continue
+
+        if source.get("evidence_complete") is not True:
+            # Existing GitHub packet adapters may fall back to a title when an artifact
+            # body is absent. We can still inspect the admitted text, but absence of a
+            # relation in that fallback cannot certify absence from the source artifact.
+            incomplete_evidence_artifacts.append(source["reference"].copy())
 
         for edge in admitted_edges(repository, source):
             if edge.get("from") != source["reference"]:
@@ -208,7 +215,8 @@ def collect(
         "artifact_count": len(artifacts),
         "edge_count": len(edges),
         "depth_frontier": depth_frontier,
-        "complete_within_requested_depth": True,
+        "incomplete_evidence_artifacts": incomplete_evidence_artifacts,
+        "complete_within_requested_depth": not incomplete_evidence_artifacts,
     }
 
     if artifact_key(packet["anchor"]) != anchor_identity:

--- a/scripts/project_memory_github_lineage_test.py
+++ b/scripts/project_memory_github_lineage_test.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Regression controls for the bounded GitHub project-memory lineage collector."""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+import project_memory_github as github_memory
+import project_memory_github_lineage as lineage
+
+REPOSITORY = "owner/repo"
+
+
+def issue_payload(number: int, body: str, *, state: str = "closed") -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": f"issue {number}",
+        "body": body,
+        "state": state,
+        "created_at": "2026-01-01T00:00:00Z",
+        "closed_at": "2026-01-02T00:00:00Z" if state == "closed" else None,
+    }
+
+
+def pr_issue_payload(number: int, body: str) -> dict[str, Any]:
+    payload = issue_payload(number, body)
+    payload["pull_request"] = {"url": f"https://api.github.com/repos/{REPOSITORY}/pulls/{number}"}
+    return payload
+
+
+def pr_payload(number: int, body: str) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": f"pull request {number}",
+        "body": body,
+        "state": "closed",
+        "created_at": "2026-01-01T00:00:00Z",
+        "closed_at": "2026-01-02T00:00:00Z",
+        "merged_at": "2026-01-02T00:00:00Z",
+        "changed_files": 0,
+        "base": {"sha": "1" * 40},
+        "head": {"sha": "2" * 40},
+    }
+
+
+class FakeGitHubClient:
+    def __init__(self, responses: dict[str, Any]) -> None:
+        self.responses = responses
+        self.calls: list[str] = []
+
+    def get_json(self, path: str) -> Any:
+        self.calls.append(path)
+        if path not in self.responses:
+            raise AssertionError(f"unexpected GitHub request: {path}")
+        return self.responses[path]
+
+
+def issue_responses(items: dict[int, str]) -> dict[str, Any]:
+    return {
+        f"/repos/{REPOSITORY}/issues/{number}": issue_payload(number, body)
+        for number, body in items.items()
+    }
+
+
+class ProjectMemoryGithubLineageTests(unittest.TestCase):
+    def test_collects_two_hop_explicit_lineage(self) -> None:
+        client = FakeGitHubClient(
+            issue_responses(
+                {
+                    3: "Follow-up to #2",
+                    2: "Continuation from #1",
+                    1: "Earlier evidence",
+                }
+            )
+        )
+
+        packet, receipt = lineage.collect(
+            REPOSITORY, "issue", 3, 2, 8, client=client
+        )
+
+        self.assertEqual(
+            [artifact["reference"]["number"] for artifact in packet["artifacts"]],
+            [3, 2, 1],
+        )
+        self.assertEqual(
+            [edge["relation"] for edge in packet["edges"]],
+            ["follow_up_to", "continuation_from"],
+        )
+        self.assertEqual(
+            receipt["depth_frontier"], [{"kind": "issue", "number": 1}]
+        )
+
+    def test_depth_limit_keeps_unexpanded_frontier_visible(self) -> None:
+        client = FakeGitHubClient(
+            issue_responses(
+                {
+                    3: "Follow-up to #2",
+                    2: "Continuation from #1",
+                    1: "Earlier evidence",
+                }
+            )
+        )
+
+        packet, receipt = lineage.collect(
+            REPOSITORY, "issue", 3, 1, 8, client=client
+        )
+
+        self.assertEqual(
+            [artifact["reference"]["number"] for artifact in packet["artifacts"]],
+            [3, 2],
+        )
+        self.assertEqual(
+            receipt["depth_frontier"], [{"kind": "issue", "number": 2}]
+        )
+        self.assertNotIn(f"/repos/{REPOSITORY}/issues/1", client.calls)
+
+    def test_cycle_terminates_without_duplicate_artifacts(self) -> None:
+        client = FakeGitHubClient(
+            issue_responses(
+                {
+                    3: "Follow-up to #2",
+                    2: "Follow-up to #3",
+                }
+            )
+        )
+
+        packet, _ = lineage.collect(REPOSITORY, "issue", 3, 3, 8, client=client)
+
+        self.assertEqual(len(packet["artifacts"]), 2)
+        self.assertEqual(len(packet["edges"]), 2)
+        self.assertEqual(
+            [artifact["reference"]["number"] for artifact in packet["artifacts"]],
+            [3, 2],
+        )
+
+    def test_resolves_hash_reference_to_pull_request_kind(self) -> None:
+        responses = issue_responses({3: "Related: #4"})
+        responses[f"/repos/{REPOSITORY}/issues/4"] = pr_issue_payload(4, "PR body")
+        responses[f"/repos/{REPOSITORY}/pulls/4"] = pr_payload(4, "PR body")
+        client = FakeGitHubClient(responses)
+
+        packet, _ = lineage.collect(REPOSITORY, "issue", 3, 1, 8, client=client)
+
+        self.assertEqual(
+            packet["artifacts"][1]["reference"],
+            {"kind": "pull_request", "number": 4},
+        )
+        self.assertEqual(
+            packet["edges"][0]["to"],
+            {"kind": "pull_request", "number": 4},
+        )
+
+    def test_primary_case_block_composes_with_lineage(self) -> None:
+        client = FakeGitHubClient(
+            issue_responses(
+                {
+                    3: f"Primary case:\nhttps://github.com/{REPOSITORY}/issues/2",
+                    2: "Follow-up to #1",
+                    1: "Earlier evidence",
+                }
+            )
+        )
+
+        packet, _ = lineage.collect(REPOSITORY, "issue", 3, 2, 8, client=client)
+
+        self.assertEqual(
+            [edge["relation"] for edge in packet["edges"]],
+            ["related", "follow_up_to"],
+        )
+        self.assertIn("Primary case:", packet["edges"][0]["evidence"])
+
+    def test_duplicate_textual_reference_does_not_duplicate_artifact(self) -> None:
+        client = FakeGitHubClient(
+            issue_responses(
+                {
+                    3: "Follow-up to #2/#2",
+                    2: "Earlier evidence",
+                }
+            )
+        )
+
+        packet, _ = lineage.collect(REPOSITORY, "issue", 3, 1, 8, client=client)
+
+        self.assertEqual(len(packet["artifacts"]), 2)
+        self.assertEqual(len(packet["edges"]), 1)
+
+    def test_artifact_overflow_fails_instead_of_truncating(self) -> None:
+        client = FakeGitHubClient(
+            issue_responses(
+                {
+                    3: "Follow-up to #2",
+                    2: "Continuation from #1",
+                    1: "Earlier evidence",
+                }
+            )
+        )
+
+        with self.assertRaisesRegex(
+            github_memory.CollectorError, "exceeds max-artifacts=2"
+        ):
+            lineage.collect(REPOSITORY, "issue", 3, 2, 2, client=client)
+
+    def test_unrelated_anchor_stays_anchor_only(self) -> None:
+        client = FakeGitHubClient(issue_responses({3: "Observed failure without an explicit relationship."}))
+
+        packet, receipt = lineage.collect(
+            REPOSITORY, "issue", 3, 2, 8, client=client
+        )
+
+        self.assertEqual(len(packet["artifacts"]), 1)
+        self.assertEqual(packet["edges"], [])
+        self.assertEqual(receipt["depth_frontier"], [])
+
+    def test_self_reference_fails_closed(self) -> None:
+        client = FakeGitHubClient(issue_responses({3: "Follow-up to #3"}))
+
+        with self.assertRaisesRegex(github_memory.CollectorError, "self-reference"):
+            lineage.collect(REPOSITORY, "issue", 3, 1, 8, client=client)
+
+    def test_invalid_bounds_reject_before_provider_work(self) -> None:
+        client = FakeGitHubClient({})
+
+        with self.assertRaisesRegex(github_memory.CollectorError, "max depth"):
+            lineage.collect(REPOSITORY, "issue", 3, 4, 8, client=client)
+        with self.assertRaisesRegex(github_memory.CollectorError, "max artifacts"):
+            lineage.collect(REPOSITORY, "issue", 3, 1, 0, client=client)
+        with self.assertRaisesRegex(github_memory.CollectorError, "owner/name"):
+            lineage.collect("bad/repo/name", "issue", 3, 1, 8, client=client)
+        self.assertEqual(client.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/project_memory_github_lineage_test.py
+++ b/scripts/project_memory_github_lineage_test.py
@@ -25,7 +25,9 @@ def issue_payload(number: int, body: str, *, state: str = "closed") -> dict[str,
 
 def pr_issue_payload(number: int, body: str) -> dict[str, Any]:
     payload = issue_payload(number, body)
-    payload["pull_request"] = {"url": f"https://api.github.com/repos/{REPOSITORY}/pulls/{number}"}
+    payload["pull_request"] = {
+        "url": f"https://api.github.com/repos/{REPOSITORY}/pulls/{number}"
+    }
     return payload
 
 
@@ -90,6 +92,8 @@ class ProjectMemoryGithubLineageTests(unittest.TestCase):
         self.assertEqual(
             receipt["depth_frontier"], [{"kind": "issue", "number": 1}]
         )
+        self.assertEqual(receipt["incomplete_evidence_artifacts"], [])
+        self.assertTrue(receipt["complete_within_requested_depth"])
 
     def test_depth_limit_keeps_unexpanded_frontier_visible(self) -> None:
         client = FakeGitHubClient(
@@ -202,7 +206,9 @@ class ProjectMemoryGithubLineageTests(unittest.TestCase):
             lineage.collect(REPOSITORY, "issue", 3, 2, 2, client=client)
 
     def test_unrelated_anchor_stays_anchor_only(self) -> None:
-        client = FakeGitHubClient(issue_responses({3: "Observed failure without an explicit relationship."}))
+        client = FakeGitHubClient(
+            issue_responses({3: "Observed failure without an explicit relationship."})
+        )
 
         packet, receipt = lineage.collect(
             REPOSITORY, "issue", 3, 2, 8, client=client
@@ -211,6 +217,23 @@ class ProjectMemoryGithubLineageTests(unittest.TestCase):
         self.assertEqual(len(packet["artifacts"]), 1)
         self.assertEqual(packet["edges"], [])
         self.assertEqual(receipt["depth_frontier"], [])
+        self.assertEqual(receipt["incomplete_evidence_artifacts"], [])
+        self.assertTrue(receipt["complete_within_requested_depth"])
+
+    def test_missing_body_marks_lineage_evidence_incomplete(self) -> None:
+        client = FakeGitHubClient(issue_responses({3: ""}))
+
+        packet, receipt = lineage.collect(
+            REPOSITORY, "issue", 3, 2, 8, client=client
+        )
+
+        self.assertEqual(packet["edges"], [])
+        self.assertFalse(packet["artifacts"][0]["evidence_complete"])
+        self.assertEqual(
+            receipt["incomplete_evidence_artifacts"],
+            [{"kind": "issue", "number": 3}],
+        )
+        self.assertFalse(receipt["complete_within_requested_depth"])
 
     def test_self_reference_fails_closed(self) -> None:
         client = FakeGitHubClient(issue_responses({3: "Follow-up to #3"}))


### PR DESCRIPTION
## What

Add a bounded opt-in GitHub lineage collector for #183 that reuses the existing `ProjectMemoryPacket` v1 contract.

The collector starts from one selected issue or PR and follows only already-admitted same-repository relationship evidence (`closes`, `follow_up_to`, `continuation_from`, `parent`, `related`, and the exact `Primary case:` form) breadth-first to an explicit depth.

## Why

One-hop project memory can lose the earlier episode named by a referenced closed issue/PR. The public carrier is `The-PR-Agent/pr-agent#2627 -> #2573`: #2627 explicitly says it is a follow-up to the earlier closed PyPI publication failure, preserving context a later worker may otherwise reconstruct manually.

## Safety boundary

- no edges from chronology, title similarity, labels, nearby numbers, or path overlap;
- every `#N` is resolved through GitHub before issue/PR kind is recorded;
- cycles terminate without duplicate artifacts;
- artifact/edge/packet overflow fails closed;
- exact-depth artifacts are retained in a sidecar `depth_frontier` so bounded traversal does not imply deeper lineage absence;
- anchor-only output remains a valid quiet result;
- remote collection stays outside ordinary `cargo-cultist` commands.

## Verification

- dedicated Python regression controls run in normal CI;
- manual GitHub lineage workflow validates every collected packet through the independent Rust `project_memory_packet` reader;
- this PR also runs a live PR-Agent #2627/#2573 carrier and asserts both closed artifacts plus the exact explicit `follow_up_to` edge.

Closes #183.

Refs #16 #18 #62 #74 #109 #137 #160 #162 #166 #167 #174.