### PR TITLE
research: prove explicit scope history recovers distributed lessons

### DIFF
--- a/.github/workflows/jei-scope-history-pilot.yml
+++ b/.github/workflows/jei-scope-history-pilot.yml
@@ -1,0 +1,154 @@
+name: JEI explicit scope-history pilot
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/jei-scope-history-pilot.yml"
+      - "scripts/jei_scope_history_pilot.py"
+
+permissions:
+  contents: read
+
+jobs:
+  stensibly-explicit-convex-scope:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Cultist
+        uses: actions/checkout@v4
+        with:
+          path: cultist
+
+      - name: Resolve pinned Stensibly case
+        id: target
+        run: |
+          python cultist/scripts/external_dogfood_case.py \
+            --registry cultist/research/external-dogfood-cases.json \
+            --case stensibly-1575-pre-guard-jei \
+            --github-output "$GITHUB_OUTPUT" \
+            > resolved-target.json
+          cat resolved-target.json
+
+      - name: Install stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Build file-local agent context packet
+        run: cargo build --release --example agent_context_packet --manifest-path cultist/Cargo.toml
+
+      - name: Checkout exact pre-guard Stensibly state
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.target.outputs.repository }}
+          ref: ${{ steps.target.outputs.ref }}
+          fetch-depth: ${{ steps.target.outputs.fetch_depth }}
+          persist-credentials: false
+          path: target
+
+      - name: Verify exact historical coordinate
+        env:
+          EXPECTED_HEAD: ${{ steps.target.outputs.ref }}
+          TARGET_FILE: ${{ steps.target.outputs.history_file }}
+        run: |
+          set -euo pipefail
+          test "$(git -C target rev-parse HEAD)" = "$EXPECTED_HEAD"
+          test -f "target/$TARGET_FILE"
+          test -d target/convex
+
+          scope_history="$(git -C target log --no-merges --format='%s' -n 20 -- convex)"
+          printf '%s\n' "$scope_history"
+          grep -F "Keep Gmail semantic-admission indexes deployable (#1571)" <<<"$scope_history"
+          grep -F "Keep Gmail mailbox-disposition indexes deployable (#1573)" <<<"$scope_history"
+
+      - name: Compile explicit scope-history envelopes
+        env:
+          TARGET_FILE: ${{ steps.target.outputs.history_file }}
+          TARGET_REPOSITORY: ${{ steps.target.outputs.repository }}
+          TARGET_SOURCE: ${{ steps.target.outputs.source }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          python cultist/scripts/jei_scope_history_pilot.py \
+            --packet-exe "$PWD/cultist/target/release/examples/agent_context_packet" \
+            --repo "$PWD/target" \
+            --target "$TARGET_FILE" \
+            --scope convex \
+            --repository-label "$TARGET_REPOSITORY" \
+            --source "$TARGET_SOURCE / explicit-scope convex" \
+            --budget 1048576 \
+            --budget 32768 \
+            --control-budget 1048576 \
+            --acceptance-budget 32768 \
+            --history-limit 20 \
+            --required-subject "Keep Gmail semantic-admission indexes deployable (#1571)" \
+            --required-subject "Keep Gmail mailbox-disposition indexes deployable (#1573)" \
+            --output "$PWD/artifacts/stensibly-explicit-convex-scope.json"
+
+      - name: Reject invalid and non-containing scopes
+        env:
+          TARGET_FILE: ${{ steps.target.outputs.history_file }}
+          TARGET_REPOSITORY: ${{ steps.target.outputs.repository }}
+          TARGET_SOURCE: ${{ steps.target.outputs.source }}
+        run: |
+          set -euo pipefail
+          common=(
+            --packet-exe "$PWD/cultist/target/release/examples/agent_context_packet"
+            --repo "$PWD/target"
+            --target "$TARGET_FILE"
+            --repository-label "$TARGET_REPOSITORY"
+            --source "$TARGET_SOURCE / scope-validation"
+            --budget 32768
+            --control-budget 32768
+            --acceptance-budget 32768
+            --required-subject "Keep Gmail semantic-admission indexes deployable (#1571)"
+            --output "$PWD/artifacts/invalid-scope.json"
+          )
+
+          if python cultist/scripts/jei_scope_history_pilot.py "${common[@]}" --scope ../; then
+            echo "traversing scope unexpectedly accepted" >&2
+            exit 1
+          fi
+
+          if python cultist/scripts/jei_scope_history_pilot.py "${common[@]}" --scope src; then
+            echo "non-containing scope unexpectedly accepted" >&2
+            exit 1
+          fi
+
+      - name: Write scope pilot summary
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("artifacts/stensibly-explicit-convex-scope.json")
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as out:
+              out.write("## Stensibly explicit `convex/` scope pilot\n\n")
+              if not path.is_file():
+                  out.write("Scope pilot receipt unavailable.\n")
+                  raise SystemExit(0)
+              receipt = json.loads(path.read_text(encoding="utf-8"))
+              passed = receipt["acceptance"]["passed"]
+              out.write(f"Result: `{'PASS' if passed else 'FAIL'}`  \n")
+              out.write(f"Pinned revision: `{receipt['revision']}`  \n")
+              out.write(f"Target: `{receipt['target']}` · explicit scope: `{receipt['scope']}`\n\n")
+              out.write("| budget | file packet | scope history | combined | fits | lessons |\n")
+              out.write("|---:|---:|---:|---:|---|---|\n")
+              for result in receipt["results"]:
+                  out.write(
+                      f"| {result['budget']} | {result['file_packet_serialized_bytes']} | "
+                      f"{result['scope_history_serialized_bytes']} | {result['combined_serialized_bytes']} | "
+                      f"{'yes' if result['combined_fits_budget'] else 'no'} | "
+                      f"{'yes' if result['preserves_all_required'] else 'no'} |\n"
+                  )
+          PY
+
+      - name: Upload scope-history receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jei-scope-history-stensibly-${{ github.run_id }}
+          path: artifacts/stensibly-explicit-convex-scope.json
+          if-no-files-found: error

--- a/scripts/jei_scope_history_pilot.py
+++ b/scripts/jei_scope_history_pilot.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Compose file-local JEI with one explicitly requested bounded history scope."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path, PurePosixPath
+import subprocess
+import sys
+from typing import Any
+
+MAX_BUDGET = 16 * 1024 * 1024
+MAX_HISTORY_LIMIT = 200
+MAX_REQUIRED_SUBJECTS = 16
+MAX_SUBJECT_BYTES = 1024
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description="Pilot explicit scope history beside a file-local JEI packet")
+    result.add_argument("--packet-exe", required=True, type=Path)
+    result.add_argument("--repo", required=True, type=Path)
+    result.add_argument("--target", required=True)
+    result.add_argument("--scope", required=True)
+    result.add_argument("--budget", required=True, action="append", type=int)
+    result.add_argument("--control-budget", required=True, type=int)
+    result.add_argument("--acceptance-budget", required=True, type=int)
+    result.add_argument("--history-limit", type=int, default=20)
+    result.add_argument("--required-subject", required=True, action="append")
+    result.add_argument("--repository-label", required=True)
+    result.add_argument("--source", required=True)
+    result.add_argument("--output", required=True, type=Path)
+    return result
+
+
+def canonical_relative(value: str, field: str, *, allow_root: bool = False) -> str:
+    if allow_root and value == ".":
+        return value
+    if not value or "\\" in value or value.startswith("./") or value.endswith("/"):
+        raise ValueError(f"{field} must be a canonical repository-relative path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{field} must be a canonical repository-relative path")
+    return path.as_posix()
+
+
+def validate_budget(value: int, field: str) -> int:
+    if value <= 0 or value > MAX_BUDGET:
+        raise ValueError(f"{field} must be between 1 and {MAX_BUDGET}")
+    return value
+
+
+def git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def resolve_inputs(repo: Path, target: str, scope: str) -> tuple[Path, Path, Path]:
+    repo = repo.resolve(strict=True)
+    root = Path(git(repo, "rev-parse", "--show-toplevel")).resolve(strict=True)
+    if repo != root:
+        raise ValueError("--repo must resolve to the Git repository root")
+
+    target_path = (root / target).resolve(strict=True)
+    scope_path = root if scope == "." else (root / scope).resolve(strict=True)
+    if not target_path.is_file():
+        raise ValueError("target must resolve to an existing file")
+    if not scope_path.is_dir():
+        raise ValueError("scope must resolve to an existing directory")
+    try:
+        target_path.relative_to(scope_path)
+    except ValueError as error:
+        raise ValueError("scope must contain the target") from error
+    try:
+        target_path.relative_to(root)
+        scope_path.relative_to(root)
+    except ValueError as error:
+        raise ValueError("target and scope must stay inside the repository") from error
+    return root, target_path, scope_path
+
+
+def parse_history(output: str) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for line in output.splitlines():
+        fields = line.split("\x1f", 2)
+        if len(fields) != 3 or not all(fields):
+            raise ValueError("git history emitted an invalid bounded record")
+        rows.append({"sha": fields[0], "date": fields[1], "subject": fields[2]})
+    return rows
+
+
+def scope_history(repo: Path, scope: str, limit: int) -> tuple[list[dict[str, str]], bool]:
+    output = git(
+        repo,
+        "-c",
+        "core.quotepath=false",
+        "log",
+        "--no-merges",
+        "--format=%H%x1f%cI%x1f%s",
+        "-n",
+        str(limit + 1),
+        "--",
+        scope,
+    )
+    rows = parse_history(output)
+    truncated = len(rows) > limit
+    return rows[:limit], truncated
+
+
+def run_packet(packet_exe: Path, repo: Path, target: Path, budget: int) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["CARGO_CULTIST_PACKET_MAX_BYTES"] = str(budget)
+    completed = subprocess.run(
+        [str(packet_exe), str(target)],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise ValueError(f"file-local packet failed at budget {budget}")
+    packet = json.loads(completed.stdout)
+    if not isinstance(packet, dict):
+        raise ValueError("file-local packet must decode to an object")
+    if not isinstance(packet.get("recent_history"), list):
+        raise ValueError("file-local packet is missing recent_history")
+    return packet
+
+
+def render_with_exact_size(envelope: dict[str, Any]) -> str:
+    envelope["combined_serialized_bytes"] = 0
+    while True:
+        rendered = json.dumps(envelope, indent=2, sort_keys=True) + "\n"
+        size = len(rendered.encode("utf-8"))
+        if envelope["combined_serialized_bytes"] == size:
+            return rendered
+        envelope["combined_serialized_bytes"] = size
+
+
+def compose(
+    packet: dict[str, Any],
+    repository: str,
+    revision: str,
+    target: str,
+    scope: str,
+    raw_scope_history: list[dict[str, str]],
+    scope_truncated: bool,
+    budget: int,
+    history_limit: int,
+    required: list[str],
+    source: str,
+) -> dict[str, Any]:
+    target_shas = {
+        row.get("sha")
+        for row in packet["recent_history"]
+        if isinstance(row, dict) and isinstance(row.get("sha"), str)
+    }
+    additional_scope_history = [row for row in raw_scope_history if row["sha"] not in target_shas]
+    presence = {
+        expected: any(expected in row["subject"] for row in additional_scope_history)
+        for expected in required
+    }
+    scope_history_bytes = len(
+        (json.dumps(additional_scope_history, separators=(",", ":"), sort_keys=True) + "\n").encode("utf-8")
+    )
+    envelope: dict[str, Any] = {
+        "schema_version": 1,
+        "analysis": "jei_explicit_scope_history_pilot",
+        "repository": repository,
+        "revision": revision,
+        "target": target,
+        "scope": scope,
+        "source": source,
+        "budget": {
+            "max_serialized_bytes": budget,
+            "max_scope_history_commits": history_limit,
+        },
+        "file_packet": packet,
+        "scope_recent_history": additional_scope_history,
+        "scope_history_truncated": scope_truncated,
+        "scope_history_serialized_bytes": scope_history_bytes,
+        "combined_serialized_bytes": 0,
+        "lesson_presence": presence,
+        "preserves_all_required": all(presence.values()),
+        "unknowns": [
+            "Explicit scope chronology does not by itself prove that a scope-history commit is semantically relevant to the target."
+        ],
+    }
+    rendered = render_with_exact_size(envelope)
+    envelope["combined_fits_budget"] = len(rendered.encode("utf-8")) <= budget
+    rendered = render_with_exact_size(envelope)
+    envelope["combined_fits_budget"] = len(rendered.encode("utf-8")) <= budget
+    render_with_exact_size(envelope)
+    return envelope
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        packet_exe = args.packet_exe.resolve(strict=True)
+        target = canonical_relative(args.target, "target")
+        scope = canonical_relative(args.scope, "scope", allow_root=True)
+        if args.history_limit <= 0 or args.history_limit > MAX_HISTORY_LIMIT:
+            raise ValueError(f"history-limit must be between 1 and {MAX_HISTORY_LIMIT}")
+        budgets = [validate_budget(value, "budget") for value in args.budget]
+        if len(budgets) != len(set(budgets)):
+            raise ValueError("budgets must be unique")
+        control_budget = validate_budget(args.control_budget, "control-budget")
+        acceptance_budget = validate_budget(args.acceptance_budget, "acceptance-budget")
+        if control_budget not in budgets or acceptance_budget not in budgets:
+            raise ValueError("control and acceptance budgets must also appear in --budget")
+
+        required = args.required_subject
+        if not required or len(required) > MAX_REQUIRED_SUBJECTS:
+            raise ValueError(f"required subjects must contain 1..{MAX_REQUIRED_SUBJECTS} entries")
+        if len(required) != len(set(required)):
+            raise ValueError("required subjects must be unique")
+        if any(not value or len(value.encode("utf-8")) > MAX_SUBJECT_BYTES for value in required):
+            raise ValueError("required subject exceeds the admitted boundary")
+
+        repo, target_path, _scope_path = resolve_inputs(args.repo, target, scope)
+        revision = git(repo, "rev-parse", "HEAD")
+        raw_scope_history, scope_truncated = scope_history(repo, scope, args.history_limit)
+
+        results = []
+        for budget in budgets:
+            packet = run_packet(packet_exe, repo, target_path, budget)
+            envelope = compose(
+                packet,
+                args.repository_label,
+                revision,
+                target,
+                scope,
+                raw_scope_history,
+                scope_truncated,
+                budget,
+                args.history_limit,
+                required,
+                args.source,
+            )
+            results.append(
+                {
+                    "budget": budget,
+                    "file_packet_serialized_bytes": packet.get("serialized_bytes"),
+                    "file_packet_semantic_evictions": packet.get("semantic_evictions", []),
+                    "scope_history_serialized_bytes": envelope["scope_history_serialized_bytes"],
+                    "combined_serialized_bytes": envelope["combined_serialized_bytes"],
+                    "combined_fits_budget": envelope["combined_fits_budget"],
+                    "scope_history_truncated": envelope["scope_history_truncated"],
+                    "scope_recent_history": envelope["scope_recent_history"],
+                    "lesson_presence": envelope["lesson_presence"],
+                    "preserves_all_required": envelope["preserves_all_required"],
+                }
+            )
+
+        by_budget = {row["budget"]: row for row in results}
+        control = by_budget[control_budget]
+        acceptance = by_budget[acceptance_budget]
+        passed = (
+            control["combined_fits_budget"]
+            and control["preserves_all_required"]
+            and acceptance["combined_fits_budget"]
+            and acceptance["preserves_all_required"]
+        )
+        receipt = {
+            "schema_version": 1,
+            "repository": args.repository_label,
+            "revision": revision,
+            "target": target,
+            "scope": scope,
+            "source": args.source,
+            "required_history_subjects": required,
+            "control_budget": control_budget,
+            "acceptance_budget": acceptance_budget,
+            "results": results,
+            "acceptance": {
+                "control_recovers_all_required": control["preserves_all_required"],
+                "control_fits_budget": control["combined_fits_budget"],
+                "acceptance_budget_recovers_all_required": acceptance["preserves_all_required"],
+                "acceptance_budget_fits": acceptance["combined_fits_budget"],
+                "passed": passed,
+            },
+        }
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(json.dumps(receipt, indent=2, sort_keys=True))
+        return 0 if passed else 1
+    except (OSError, ValueError, json.JSONDecodeError, subprocess.CalledProcessError) as error:
+        print(f"JEI scope-history pilot error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Starts #186 from the negative boundary retained in #180/#181.

## Question

Can an **explicitly requested bounded directory scope** recover the Stensibly #1571/#1573 distributed failure family that the file-local `convex/schema.ts` packet misses?

Pinned replay:

```text
repo   teamleaderleo/stensibly
ref    85cecf2608ad9e734a67518577fa85b9a08a550c
target convex/schema.ts
scope  convex
```

The later #1575 generalized guard remains outside the checkout.

## First discriminator

Keep the current Rust `agent_context_packet` untouched.

Add `scripts/jei_scope_history_pilot.py`, which composes:

```text
existing file-local packet
+
explicit bounded scope_recent_history
```

The scope receipt:

- requires a canonical repository-relative existing directory;
- requires the scope to contain the target;
- runs bounded non-merge Git history only under that scope;
- deduplicates commits already present in target-local recent history;
- preserves exact SHA/date/subject;
- records whether scope history was truncated;
- carries an explicit UNKNOWN that chronology alone does not prove semantic relevance;
- measures scope-history bytes and the full combined envelope;
- rejects an over-budget combined envelope instead of byte truncation.

## Executed result

The explicit-scope hypothesis passes on the exact #181 negative control.

Direct `git log -- convex` at the pinned pre-guard revision contains:

```text
Keep Gmail mailbox-disposition indexes deployable (#1573)
Keep Gmail semantic-admission indexes deployable (#1571)
```

while the unchanged file-local `convex/schema.ts` packet still omits both.

### 1 MiB control

```text
file packet        14,087 bytes
scope history       2,687 bytes
combined envelope  19,148 bytes
lessons             both present
fits                yes
```

### 32 KiB acceptance

```text
file packet        14,085 bytes
scope history       2,687 bytes
combined envelope  19,144 bytes
lessons             both present
fits                yes
```

The scope history is bounded to 20 commits and reports `scope_history_truncated=true`; both required lessons remain because they are the two newest entries.

Validation controls also pass:

- `../` traversal rejects;
- existing non-containing `src` scope rejects.

Artifact:

```text
id      9363519274
sha256  117fbc203a9abb11023bbb24edf6477a5439f88ded84cd4c48d75d2f29cf9925
```

## Result

The combined #181/#189 evidence now gives the useful A/B comparison:

```text
same target + file-local history
  -> distributed lessons absent

same target + explicit convex/ scope
  -> distributed lessons recovered
```

So optional explicit scope history is earned for the research packet. Automatic scope inference remains unearned.

## Next promotion boundary

A later Rust integration should preserve:

- absent scope = current behavior;
- one explicit requested scope;
- separately typed scope history;
- target-local history has higher semantic-budget priority;
- scope truncation/eviction remains receipted;
- no semantic-equivalence claim from chronology.

## Boundary

- explicit scope only;
- no whole-repository default;
- no LLM/model grader;
- no external mutation/build/deploy;
- no primary CLI change in this PR.

Refs #62 #67 #74 #106 #139 #180 #181 #186.