### PR TITLE
research: expose missing discriminator observation frontiers

### DIFF
--- a/examples/observation_frontiers.rs
+++ b/examples/observation_frontiers.rs
@@ -1,0 +1,39 @@
+#![allow(dead_code)]
+
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+
+use observation_frontier::{
+    MAX_OBSERVATION_FRONTIER_REQUEST_BYTES, evaluate_observation_frontiers,
+    parse_observation_frontier_request,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("observation-frontiers: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_OBSERVATION_FRONTIER_REQUEST_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_OBSERVATION_FRONTIER_REQUEST_BYTES {
+        return Err(format!(
+            "observation frontier request exceeds the {MAX_OBSERVATION_FRONTIER_REQUEST_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let request = parse_observation_frontier_request(&bytes)?;
+    let evaluation = evaluate_observation_frontiers(&request)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}

--- a/research/observation-frontiers.md
+++ b/research/observation-frontiers.md
@@ -1,0 +1,171 @@
+# Missing discriminator observation frontiers
+
+Tracking: #190 Phase A. Stacked on #187/#185 and #179/#148.
+
+## Question
+
+When a selected refinement requires discriminator `D` for exact subject `S`, can Cultist state whether a usable source-owned observation currently exists without running the source analyzer or guessing from another subject?
+
+Phase A adds only the read-only frontier.
+
+## Exact requirement identity
+
+```text
+ObservationRequirement
+  discriminator_id
+  subject_ref
+```
+
+A requirement is satisfied only by observations with the exact same pair.
+
+This deliberately prevents a source observation such as:
+
+```text
+edit_class = syntax_changed
+subject = file A
+```
+
+from satisfying the same discriminator for file B.
+
+Observations with the same discriminator and another subject stay visible under `other_subject`; they never satisfy the requested frontier.
+
+## Frontier states
+
+```text
+current
+  >= 1 matching KNOWN observation
+
+unknown
+  zero matching KNOWN
+  >= 1 matching UNKNOWN
+
+invalid
+  zero matching KNOWN/UNKNOWN
+  >= 1 matching INVALID
+
+missing
+  zero matching observations
+```
+
+All matching receipts remain visible even when a higher-precedence state wins. For example:
+
+```text
+KNOWN + UNKNOWN
+  -> current
+  -> preserve both current and unknown receipts
+
+UNKNOWN + INVALID
+  -> unknown
+  -> preserve both unknown and invalid receipts
+```
+
+The precedence represents current usability, not evidence strength:
+
+```text
+current > unknown > invalid > missing
+```
+
+## Composition controls
+
+The first standard-suite control derives exact requirements from the retained #179 selected transitions plus #187 observation corpus. All four selected discriminator requirements resolve `current`.
+
+Then adversarial controls mutate the same supplied observations:
+
+- remove one selected observation -> explicit `missing`;
+- keep the discriminator but move it to another subject -> `missing` + `other_subject` receipt;
+- change matching observation to UNKNOWN -> `unknown`;
+- change matching observation to INVALID -> `invalid`;
+- add UNKNOWN beside KNOWN -> `current`, preserving both;
+- add INVALID beside UNKNOWN -> `unknown`, preserving both;
+- duplicate exact requirements reject;
+- frontier order is deterministic;
+- request JSON round trip revalidates the embedded observation batch;
+- input above 512 KiB rejects before JSON parsing.
+
+## Bounded research reader
+
+```text
+cargo run --example observation_frontiers < request.json
+```
+
+The request embeds the bounded #185 observation batch and a bounded requirement list. The reader validates and prints only frontier receipts.
+
+## Executed GitHub receipt
+
+Draft PR #194 was compacted to one semantic commit on #187's exact green receipt head.
+
+Exact semantic head:
+
+```text
+b54ed3213994c96ec818ef36bb9728b0dc1f7eb6
+```
+
+GitHub Actions CI run `32249440070` / run number `1293` completed successfully. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work preflight;
+- full `cargo test`, including current coverage for all four selected #179/#187 requirements, explicit missing after observation removal, wrong-subject isolation, UNKNOWN/INVALID states, mixed-state receipt preservation and precedence, duplicate requirement rejection, deterministic ordering, bounded request parsing, and JSON round trip;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The first CI attempt stopped at rustfmt before Clippy or tests. The exact formatter delta was applied, then the branch was compacted back to the single semantic commit above before the successful run.
+
+The central Phase A result is now executable:
+
+```text
+same discriminator + wrong subject
+  -> other_subject receipt remains visible
+  -> exact required frontier stays missing
+```
+
+and mixed source states preserve their receipts while current usability follows:
+
+```text
+current > unknown > invalid > missing
+```
+
+## Boundary
+
+Phase A performs zero acquisition work:
+
+- no source analyzer execution;
+- no probe capability lookup;
+- no mapping from `discriminator_id` to #145 `{kind,target}`;
+- no evidence-strength or authority inference;
+- no action/disposition decision;
+- no duplicate applicability evaluator.
+
+UNKNOWN/INVALID reason and applicability references remain source-owned strings. The frontier carries them; it does not interpret them.
+
+## Phase B discriminator
+
+Phase A survived CI. The next experiment can test one explicit source-owned adapter mapping:
+
+```text
+missing observation D@S
+-> adapter receipt
+   observation discriminator D
+   observation subject S
+   #145 probe discriminator {kind,target}
+   clearing requirements
+-> existing #145 planner
+```
+
+Negative control:
+
+```text
+similarly named probe
++ no explicit adapter mapping
+-> frontier remains unresolved for acquisition
+```
+
+Effect authorization remains #145's existing responsibility.
+
+The bridge should be a separate carrier because #190 currently spans two independent research stacks: #179/#187 frontier semantics and #159/#164 probe planning. Phase A now gives that bridge a precise input without copying #145 types into the read-only frontier layer.
+
+North star:
+
+> Name the exact missing analyzer observation before deciding which evidence work, if any, can produce it.

--- a/src/observation_frontier.rs
+++ b/src/observation_frontier.rs
@@ -1,0 +1,295 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::discriminator_observation::{
+    DiscriminatorObservation, DiscriminatorObservationBatch, DiscriminatorValueState,
+    validate_discriminator_observation_batch,
+};
+
+pub const OBSERVATION_FRONTIER_SCHEMA_VERSION: u32 = 1;
+pub const MAX_OBSERVATION_FRONTIER_REQUEST_BYTES: usize = 512 * 1024;
+const MAX_REQUIREMENTS: usize = 256;
+const MAX_ID_BYTES: usize = 512;
+const MAX_REFERENCE_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationFrontierRequest {
+    pub schema_version: u32,
+    pub requirements: Vec<ObservationRequirement>,
+    pub observations: DiscriminatorObservationBatch,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationRequirement {
+    pub discriminator_id: String,
+    pub subject_ref: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationFrontierStatus {
+    Current,
+    Unknown,
+    Invalid,
+    Missing,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationFrontierEvaluation {
+    pub schema_version: u32,
+    pub frontiers: Vec<ObservationFrontierReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationFrontierReceipt {
+    pub discriminator_id: String,
+    pub subject_ref: String,
+    pub status: ObservationFrontierStatus,
+    pub current: Vec<CurrentObservationReceipt>,
+    pub unknown: Vec<NonCurrentObservationReceipt>,
+    pub invalid: Vec<NonCurrentObservationReceipt>,
+    pub other_subject: Vec<OtherSubjectObservationReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CurrentObservationReceipt {
+    pub observation_id: String,
+    pub source_receipt: String,
+    pub value_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct NonCurrentObservationReceipt {
+    pub observation_id: String,
+    pub source_receipt: String,
+    pub reason_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationValueStateKind {
+    Known,
+    Unknown,
+    Invalid,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OtherSubjectObservationReceipt {
+    pub observation_id: String,
+    pub subject_ref: String,
+    pub source_receipt: String,
+    pub state: ObservationValueStateKind,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ObservationFrontierError {
+    message: String,
+}
+
+impl ObservationFrontierError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ObservationFrontierError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for ObservationFrontierError {}
+
+pub fn parse_observation_frontier_request(
+    bytes: &[u8],
+) -> Result<ObservationFrontierRequest, ObservationFrontierError> {
+    if bytes.len() > MAX_OBSERVATION_FRONTIER_REQUEST_BYTES {
+        return Err(ObservationFrontierError::new(format!(
+            "observation frontier request exceeds the {MAX_OBSERVATION_FRONTIER_REQUEST_BYTES}-byte limit"
+        )));
+    }
+    let request: ObservationFrontierRequest = serde_json::from_slice(bytes).map_err(|error| {
+        ObservationFrontierError::new(format!("invalid observation frontier JSON: {error}"))
+    })?;
+    validate_request(&request)?;
+    Ok(request)
+}
+
+pub fn evaluate_observation_frontiers(
+    request: &ObservationFrontierRequest,
+) -> Result<ObservationFrontierEvaluation, ObservationFrontierError> {
+    validate_request(request)?;
+
+    let mut frontiers = request
+        .requirements
+        .iter()
+        .map(|requirement| evaluate_requirement(requirement, &request.observations.observations))
+        .collect::<Vec<_>>();
+    frontiers.sort_by(|left, right| {
+        left.discriminator_id
+            .cmp(&right.discriminator_id)
+            .then_with(|| left.subject_ref.cmp(&right.subject_ref))
+    });
+
+    Ok(ObservationFrontierEvaluation {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        frontiers,
+    })
+}
+
+fn evaluate_requirement(
+    requirement: &ObservationRequirement,
+    observations: &[DiscriminatorObservation],
+) -> ObservationFrontierReceipt {
+    let mut current = Vec::new();
+    let mut unknown = Vec::new();
+    let mut invalid = Vec::new();
+    let mut other_subject = Vec::new();
+
+    for observation in observations
+        .iter()
+        .filter(|observation| observation.discriminator_id == requirement.discriminator_id)
+    {
+        if observation.subject_ref != requirement.subject_ref {
+            other_subject.push(OtherSubjectObservationReceipt {
+                observation_id: observation.observation_id.clone(),
+                subject_ref: observation.subject_ref.clone(),
+                source_receipt: observation.source_receipt.clone(),
+                state: value_state_kind(&observation.value_state),
+            });
+            continue;
+        }
+
+        match &observation.value_state {
+            DiscriminatorValueState::Known { value_ref } => {
+                current.push(CurrentObservationReceipt {
+                    observation_id: observation.observation_id.clone(),
+                    source_receipt: observation.source_receipt.clone(),
+                    value_ref: value_ref.clone(),
+                    applicability_ref: observation.applicability_ref.clone(),
+                });
+            }
+            DiscriminatorValueState::Unknown { reason_ref } => {
+                unknown.push(NonCurrentObservationReceipt {
+                    observation_id: observation.observation_id.clone(),
+                    source_receipt: observation.source_receipt.clone(),
+                    reason_ref: reason_ref.clone(),
+                    applicability_ref: observation.applicability_ref.clone(),
+                });
+            }
+            DiscriminatorValueState::Invalid { reason_ref } => {
+                invalid.push(NonCurrentObservationReceipt {
+                    observation_id: observation.observation_id.clone(),
+                    source_receipt: observation.source_receipt.clone(),
+                    reason_ref: reason_ref.clone(),
+                    applicability_ref: observation.applicability_ref.clone(),
+                });
+            }
+        }
+    }
+
+    current.sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+    unknown.sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+    invalid.sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+    other_subject.sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+
+    let status = if !current.is_empty() {
+        ObservationFrontierStatus::Current
+    } else if !unknown.is_empty() {
+        ObservationFrontierStatus::Unknown
+    } else if !invalid.is_empty() {
+        ObservationFrontierStatus::Invalid
+    } else {
+        ObservationFrontierStatus::Missing
+    };
+
+    ObservationFrontierReceipt {
+        discriminator_id: requirement.discriminator_id.clone(),
+        subject_ref: requirement.subject_ref.clone(),
+        status,
+        current,
+        unknown,
+        invalid,
+        other_subject,
+    }
+}
+
+fn value_state_kind(value_state: &DiscriminatorValueState) -> ObservationValueStateKind {
+    match value_state {
+        DiscriminatorValueState::Known { .. } => ObservationValueStateKind::Known,
+        DiscriminatorValueState::Unknown { .. } => ObservationValueStateKind::Unknown,
+        DiscriminatorValueState::Invalid { .. } => ObservationValueStateKind::Invalid,
+    }
+}
+
+fn validate_request(request: &ObservationFrontierRequest) -> Result<(), ObservationFrontierError> {
+    if request.schema_version != OBSERVATION_FRONTIER_SCHEMA_VERSION {
+        return Err(ObservationFrontierError::new(format!(
+            "unsupported observation frontier schema {}; expected {OBSERVATION_FRONTIER_SCHEMA_VERSION}",
+            request.schema_version
+        )));
+    }
+    if request.requirements.is_empty() || request.requirements.len() > MAX_REQUIREMENTS {
+        return Err(ObservationFrontierError::new(
+            "observation frontier requirements must be bounded and non-empty",
+        ));
+    }
+    validate_discriminator_observation_batch(&request.observations).map_err(|error| {
+        ObservationFrontierError::new(format!("observation batch validation failed: {error}"))
+    })?;
+
+    let mut seen = BTreeSet::new();
+    for requirement in &request.requirements {
+        validate_atom(
+            &requirement.discriminator_id,
+            "requirement discriminator_id",
+            MAX_ID_BYTES,
+        )?;
+        validate_atom(
+            &requirement.subject_ref,
+            "requirement subject_ref",
+            MAX_REFERENCE_BYTES,
+        )?;
+        if !seen.insert(requirement.clone()) {
+            return Err(ObservationFrontierError::new(format!(
+                "duplicate observation requirement {} @ {}",
+                requirement.discriminator_id, requirement.subject_ref
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_atom(
+    value: &str,
+    field: &str,
+    max_bytes: usize,
+) -> Result<(), ObservationFrontierError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > max_bytes
+        || value.contains('\0')
+        || value.contains(['\n', '\r'])
+    {
+        return Err(ObservationFrontierError::new(format!(
+            "{field} must be bounded canonical single-line text"
+        )));
+    }
+    Ok(())
+}

--- a/tests/observation_frontier.rs
+++ b/tests/observation_frontier.rs
@@ -1,0 +1,283 @@
+#![allow(dead_code)]
+
+use std::collections::BTreeSet;
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+
+use discriminator_observation::{
+    DiscriminatorObservationBatch, DiscriminatorValueState, parse_discriminator_observation_batch,
+};
+use observation_frontier::{
+    MAX_OBSERVATION_FRONTIER_REQUEST_BYTES, OBSERVATION_FRONTIER_SCHEMA_VERSION,
+    ObservationFrontierRequest, ObservationFrontierStatus, ObservationRequirement,
+    evaluate_observation_frontiers, parse_observation_frontier_request,
+};
+use refinement_episode::parse_refinement_episode_batch;
+
+const OBSERVATIONS: &[u8] =
+    include_bytes!("../research/discriminator-observations/cultist-v1.json");
+const REFINEMENTS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+
+fn observation_batch() -> DiscriminatorObservationBatch {
+    parse_discriminator_observation_batch(OBSERVATIONS).unwrap()
+}
+
+fn requirement(discriminator_id: &str, subject_ref: &str) -> ObservationRequirement {
+    ObservationRequirement {
+        discriminator_id: discriminator_id.to_string(),
+        subject_ref: subject_ref.to_string(),
+    }
+}
+
+fn request(
+    requirements: Vec<ObservationRequirement>,
+    observations: DiscriminatorObservationBatch,
+) -> ObservationFrontierRequest {
+    ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements,
+        observations,
+    }
+}
+
+#[test]
+fn retained_selected_refinement_discriminators_resolve_current() {
+    let observations = observation_batch();
+    let refinements = parse_refinement_episode_batch(REFINEMENTS).unwrap();
+    let mut requirements = Vec::new();
+
+    for episode in &refinements.episodes {
+        let selected = episode.selected_transition.as_ref().unwrap();
+        let candidate = episode
+            .candidate_refinements
+            .iter()
+            .find(|candidate| candidate.id == *selected)
+            .unwrap();
+        for discriminator_id in &candidate.discriminator_refs {
+            let matches = observations
+                .observations
+                .iter()
+                .filter(|observation| {
+                    observation.discriminator_id == *discriminator_id
+                        && matches!(
+                            &observation.value_state,
+                            DiscriminatorValueState::Known { .. }
+                        )
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(
+                matches.len(),
+                1,
+                "retained fixture requires one current subject for {discriminator_id}"
+            );
+            requirements.push(requirement(discriminator_id, &matches[0].subject_ref));
+        }
+    }
+
+    let evaluation = evaluate_observation_frontiers(&request(requirements, observations)).unwrap();
+    assert_eq!(evaluation.frontiers.len(), 4);
+    assert!(
+        evaluation
+            .frontiers
+            .iter()
+            .all(|frontier| frontier.status == ObservationFrontierStatus::Current)
+    );
+}
+
+#[test]
+fn removing_one_selected_observation_creates_explicit_missing_frontier() {
+    let mut observations = observation_batch();
+    let removed = observations.observations.remove(0);
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&removed.discriminator_id, &removed.subject_ref)],
+        observations,
+    ))
+    .unwrap();
+
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Missing);
+    assert!(frontier.current.is_empty());
+    assert!(frontier.unknown.is_empty());
+    assert!(frontier.invalid.is_empty());
+}
+
+#[test]
+fn same_discriminator_on_wrong_subject_does_not_satisfy_requirement() {
+    let mut observations = observation_batch();
+    let mut wrong_subject = observations.observations.remove(0);
+    let discriminator_id = wrong_subject.discriminator_id.clone();
+    let required_subject = wrong_subject.subject_ref.clone();
+    wrong_subject.observation_id = "justification/wrong-subject:clearing-presence".to_string();
+    wrong_subject.subject_ref = "refinement:justification/another-obligation".to_string();
+    observations.observations.push(wrong_subject);
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &required_subject)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Missing);
+    assert_eq!(frontier.other_subject.len(), 1);
+}
+
+#[test]
+fn unknown_matching_observation_produces_unknown_frontier() {
+    let mut observations = observation_batch();
+    let discriminator_id = observations.observations[0].discriminator_id.clone();
+    let subject_ref = observations.observations[0].subject_ref.clone();
+    observations.observations[0].value_state = DiscriminatorValueState::Unknown {
+        reason_ref: "applicability:missing-current-revision".to_string(),
+    };
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
+    assert_eq!(frontier.unknown.len(), 1);
+    assert!(frontier.current.is_empty());
+}
+
+#[test]
+fn invalid_matching_observation_produces_invalid_frontier() {
+    let mut observations = observation_batch();
+    let discriminator_id = observations.observations[1].discriminator_id.clone();
+    let subject_ref = observations.observations[1].subject_ref.clone();
+    observations.observations[1].value_state = DiscriminatorValueState::Invalid {
+        reason_ref: "applicability:revision-moved".to_string(),
+    };
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Invalid);
+    assert_eq!(frontier.invalid.len(), 1);
+    assert!(frontier.current.is_empty());
+}
+
+#[test]
+fn current_precedes_unknown_while_preserving_both_receipts() {
+    let mut observations = observation_batch();
+    let mut unknown = observations.observations[1].clone();
+    unknown.observation_id = "history/oxc-edit-class-v1:unknown-second-source".to_string();
+    unknown.source_receipt = "research:cohort-refinement.md#unknown-edit-class".to_string();
+    unknown.value_state = DiscriminatorValueState::Unknown {
+        reason_ref: "classifier:missing-source-version".to_string(),
+    };
+    let discriminator_id = unknown.discriminator_id.clone();
+    let subject_ref = unknown.subject_ref.clone();
+    observations.observations.push(unknown);
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Current);
+    assert_eq!(frontier.current.len(), 1);
+    assert_eq!(frontier.unknown.len(), 1);
+}
+
+#[test]
+fn unknown_precedes_invalid_when_no_current_observation_exists() {
+    let mut observations = observation_batch();
+    let mut invalid = observations.observations[0].clone();
+    invalid.observation_id = "justification/open-obligation-v1:invalid-second-source".to_string();
+    invalid.source_receipt = "research:durable-unknown-obligation.md#stale".to_string();
+    invalid.value_state = DiscriminatorValueState::Invalid {
+        reason_ref: "applicability:head-moved".to_string(),
+    };
+    let discriminator_id = invalid.discriminator_id.clone();
+    let subject_ref = invalid.subject_ref.clone();
+    observations.observations[0].value_state = DiscriminatorValueState::Unknown {
+        reason_ref: "applicability:missing-head".to_string(),
+    };
+    observations.observations.push(invalid);
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
+    assert_eq!(frontier.unknown.len(), 1);
+    assert_eq!(frontier.invalid.len(), 1);
+}
+
+#[test]
+fn duplicate_exact_requirement_rejects() {
+    let observations = observation_batch();
+    let requirement = requirement(
+        &observations.observations[0].discriminator_id,
+        &observations.observations[0].subject_ref,
+    );
+    let error = evaluate_observation_frontiers(&request(
+        vec![requirement.clone(), requirement],
+        observations,
+    ))
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate observation requirement")
+    );
+}
+
+#[test]
+fn frontier_output_order_is_deterministic() {
+    let observations = observation_batch();
+    let requirements = observations
+        .observations
+        .iter()
+        .rev()
+        .map(|observation| requirement(&observation.discriminator_id, &observation.subject_ref))
+        .collect::<Vec<_>>();
+    let evaluation = evaluate_observation_frontiers(&request(requirements, observations)).unwrap();
+    let keys = evaluation
+        .frontiers
+        .iter()
+        .map(|frontier| {
+            (
+                frontier.discriminator_id.as_str(),
+                frontier.subject_ref.as_str(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let sorted = keys.iter().copied().collect::<BTreeSet<_>>();
+    assert_eq!(keys, sorted.into_iter().collect::<Vec<_>>());
+}
+
+#[test]
+fn request_json_round_trip_revalidates_the_frontier_input() {
+    let observations = observation_batch();
+    let request = request(
+        vec![requirement(
+            &observations.observations[0].discriminator_id,
+            &observations.observations[0].subject_ref,
+        )],
+        observations,
+    );
+    let encoded = serde_json::to_vec(&request).unwrap();
+    let decoded = parse_observation_frontier_request(&encoded).unwrap();
+    assert_eq!(decoded, request);
+}
+
+#[test]
+fn oversized_request_rejects_before_json_parsing() {
+    let bytes = vec![b' '; MAX_OBSERVATION_FRONTIER_REQUEST_BYTES + 1];
+    let error = parse_observation_frontier_request(&bytes).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}


### PR DESCRIPTION
Starts #190 Phase A as the exact-frontier child of the now-landed #187 observation layer.

Adds a read-only frontier over exact observation requirements `(discriminator_id, subject_ref)` and the source-owned observation batch.

## Frontier semantics

States are `current`, `unknown`, `invalid`, and `missing`. Current usability follows:

```text
current -> unknown -> invalid -> missing
```

while all matching receipts remain inspectable. Same-discriminator observations for another subject are retained under `other_subject` and never satisfy the exact requirement.

The standard harness derives the four selected #179/#187 requirements and verifies they are current, then covers removal -> missing, wrong subject -> missing, UNKNOWN/INVALID states, mixed-state receipt preservation/precedence, duplicate requirements, deterministic ordering, JSON round trip, and a 512 KiB request bound.

## Current-main promotion receipt

The four #194 semantic blobs were rebuilt on the current repository after #187 landed. Main advanced once during the first successful run, so that first pass was deliberately discarded as the final promotion authority. The same four blobs were then reanchored again onto:

```text
main: 0c7da4f3ad148c4d14bce127c75cfe4b03b658c8
head: 6706755e434a9bb533d77655587b01cbdd3fa1e8
commits: 1
files: 4
```

Exact-current ordinary CI:

```text
run: 32269578803
job: 96122443251
result: success
```

Generated-provenance review:

```text
run: 32269578744
job: 96122443145
result: success
```

Formatter, strict Clippy, modern project/review/closure/external-reference guards, active-work preflight, full tests, and repository/history/CI-filter/diff dogfood all passed. Main remained at the exact reanchor base through the gate.

The earlier executed receipt remains in `research/observation-frontiers.md`; this current-main pass proves the same frontier bytes compose with the present repository.

## Boundary / next

Phase A performs zero source acquisition, probe lookup, evidence-strength inference, or mapping from discriminator ID to #145 `{kind,target}`.

The next commit is intentionally the #201 negative control proving that a KNOWN value can still be labeled `Current` while shared applicability says INVALID or UNKNOWN. #210 then repairs that type contract.

Files: `src/observation_frontier.rs`, `tests/observation_frontier.rs`, `examples/observation_frontiers.rs`, `research/observation-frontiers.md`.

Refs #145 #148 #179 #185 #187 #190 #201 #210.