### PR TITLE
research: prove KNOWN can outrun current applicability

### DIFF
--- a/tests/known_stale_observation_frontier.rs
+++ b/tests/known_stale_observation_frontier.rs
@@ -1,0 +1,101 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+
+use applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, evaluate_query,
+};
+use discriminator_observation::{
+    DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation,
+    DiscriminatorObservationBatch, DiscriminatorValueState,
+};
+use observation_frontier::{
+    OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierRequest, ObservationFrontierStatus,
+    ObservationRequirement, evaluate_observation_frontiers,
+};
+
+fn known_observation(applicability_ref: &str) -> DiscriminatorObservation {
+    DiscriminatorObservation {
+        observation_id: "obs:edit-class:subject-a".to_string(),
+        discriminator_id: "edit_class".to_string(),
+        subject_ref: "commit:subject-a".to_string(),
+        source_receipt: "receipt:syntax-cohort:subject-a".to_string(),
+        value_state: DiscriminatorValueState::Known {
+            value_ref: "syntax_changed".to_string(),
+        },
+        applicability_ref: Some(applicability_ref.to_string()),
+    }
+}
+
+fn frontier_for(observation: DiscriminatorObservation) -> ObservationFrontierStatus {
+    let request = ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements: vec![ObservationRequirement {
+            discriminator_id: "edit_class".to_string(),
+            subject_ref: "commit:subject-a".to_string(),
+        }],
+        observations: DiscriminatorObservationBatch {
+            schema_version: DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+            observations: vec![observation],
+        },
+    };
+    evaluate_observation_frontiers(&request).unwrap().frontiers[0].status
+}
+
+#[test]
+fn known_value_can_be_called_current_while_shared_applicability_is_invalid() {
+    let applicability = evaluate_query(&ApplicabilityQuery {
+        schema_version: APPLICABILITY_SCHEMA_VERSION,
+        requirements: EvidenceRequirements {
+            repository: Some("owner/repo".to_string()),
+            revision: Some("old-head".to_string()),
+            work: None,
+            scope: None,
+        },
+        context: EvaluationContext {
+            repository: Some("owner/repo".to_string()),
+            revision: Some("new-head".to_string()),
+            work: None,
+            path: None,
+        },
+    })
+    .unwrap();
+    assert_eq!(applicability.status, ApplicabilityStatus::Invalid);
+
+    let status = frontier_for(known_observation(
+        "applicability:owner/repo:old-head->new-head:invalid",
+    ));
+    assert_eq!(status, ObservationFrontierStatus::Current);
+}
+
+#[test]
+fn known_value_can_be_called_current_while_required_current_revision_is_missing() {
+    let applicability = evaluate_query(&ApplicabilityQuery {
+        schema_version: APPLICABILITY_SCHEMA_VERSION,
+        requirements: EvidenceRequirements {
+            repository: Some("owner/repo".to_string()),
+            revision: Some("exact-head".to_string()),
+            work: None,
+            scope: None,
+        },
+        context: EvaluationContext {
+            repository: Some("owner/repo".to_string()),
+            revision: None,
+            work: None,
+            path: None,
+        },
+    })
+    .unwrap();
+    assert_eq!(applicability.status, ApplicabilityStatus::Unknown);
+
+    let status = frontier_for(known_observation(
+        "applicability:owner/repo:exact-head:current-revision-missing",
+    ));
+    assert_eq!(status, ObservationFrontierStatus::Current);
+}


### PR DESCRIPTION
Closes the #195 discriminator with an explicit negative control over the now-landed #194 frontier.

## Proven incoherent state

The test composes the real modules:

```text
applicability.rs
+ discriminator_observation.rs
+ observation_frontier.rs
```

and shows the v1 types permit a same-subject KNOWN value to outrun current applicability.

### Moved head

```text
required revision = old-head
current revision  = new-head
shared applicability = INVALID
frontier             = CURRENT
```

### Missing current revision

```text
required revision = exact-head
current revision  = missing
shared applicability = UNKNOWN
frontier             = CURRENT
```

The observation's `applicability_ref` is only an opaque receipt pointer in v1, so #194 classifies currentness from `value_state=KNOWN` alone.

This commit deliberately keeps that behavior green. It is the proof artifact #210 must close; no production or research implementation semantics change here.

## Current-main promotion receipt

The exact 101-line counterexample blob was reanchored twice as unrelated main work landed during earlier successful runs. Final current base and head:

```text
main: 79c5c64d2cd17869715c0818e0bf86bdad5b7322
head: 3cf9090dfb474adaac6ab773c357627c37c3f9e6
commits: 1
files: 1
```

Exact-current ordinary CI:

```text
run: 32270569205
job: 96125697857
result: success
```

Generated-provenance review:

```text
run: 32270569233
job: 96125697877
result: success
```

The modern external-reference post-write detector, active-work preflight, full tests, and repository/history/CI-filter/diff dogfood all passed. Main remained at the exact base through the final gate.

## Meaning

The green result proves the forbidden composition exists in v1:

```text
KNOWN old value
+ INVALID | UNKNOWN current applicability
-> Current frontier
```

#210 chooses Model B and separates value knowledge from typed applicability so this state can no longer suppress acquisition.

Files: `tests/known_stale_observation_frontier.rs` only.

Refs #123 #145 #185 #187 #190 #194 #195 #210.