### PR TITLE
research: protect selected scope evidence from budget eviction

### DIFF
--- a/.github/workflows/scoped-selected-evidence-floor.yml
+++ b/.github/workflows/scoped-selected-evidence-floor.yml
@@ -1,0 +1,119 @@
+name: Stensibly selected evidence floor
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/scoped-selected-evidence-floor.yml"
+      - "examples/scoped_selected_evidence_protection.rs"
+      - "examples/agent_context_packet.rs"
+      - "examples/support/scoped_agent_context_packet_impl.rs"
+
+permissions:
+  contents: read
+
+jobs:
+  floor:
+    if: github.head_ref == 'research/scoped-selected-evidence-protection'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: cultist
+          fetch-depth: 1
+
+      - name: Install stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Build protected scoped example
+        run: cargo build --release --example scoped_selected_evidence_protection --manifest-path cultist/Cargo.toml
+
+      - uses: actions/checkout@v4
+        with:
+          repository: teamleaderleo/stensibly
+          ref: 85cecf2608ad9e734a67518577fa85b9a08a550c
+          fetch-depth: 256
+          persist-credentials: false
+          path: target
+
+      - name: Find lower protected-core boundary
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          exe="$PWD/cultist/target/release/examples/scoped_selected_evidence_protection"
+          target="$PWD/target/convex/schema.ts"
+          python - "$exe" "$target" <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import subprocess
+          import sys
+
+          exe, target = sys.argv[1:]
+          budgets = [4096, 3900, 3800, 3700, 3600, 3500, 3400, 3300, 3200, 3100, 3000, 2900, 2800, 2700, 2600, 2500, 2400, 2300, 2200, 2100, 2000, 1800, 1600, 1400, 1200, 1000]
+          selected_shas = [
+              "85cecf2608ad9e734a67518577fa85b9a08a550c",
+              "ca5d2c7fdf89666e523972ab6e81610d17b9611b",
+          ]
+          required = [
+              "Keep Gmail mailbox-disposition indexes deployable (#1573)",
+              "Keep Gmail semantic-admission indexes deployable (#1571)",
+          ]
+          rows = []
+
+          for budget in budgets:
+              env = os.environ.copy()
+              env["CARGO_CULTIST_PACKET_MAX_BYTES"] = str(budget)
+              args = [exe, target, "--scope", "convex"]
+              for sha in selected_shas:
+                  args.extend(["--protect-scope-sha", sha])
+              completed = subprocess.run(args, env=env, capture_output=True, text=True)
+              if completed.returncode != 0:
+                  stderr = completed.stderr.strip()
+                  if "protected scoped packet evidence requires" not in stderr:
+                      raise SystemExit(f"unexpected failure at {budget}: {stderr}")
+                  rows.append({"budget": budget, "status": "protected_core_too_large", "stderr": stderr})
+                  continue
+
+              envelope = json.loads(completed.stdout)
+              subjects = [item["subject"] for item in envelope["scope_recent_history"]]
+              presence = {subject: any(subject in observed for observed in subjects) for subject in required}
+              if not all(presence.values()):
+                  raise SystemExit(f"protected selected evidence disappeared at successful budget {budget}")
+              rows.append({
+                  "budget": budget,
+                  "status": "selected",
+                  "serialized_bytes": envelope["serialized_bytes"],
+                  "scope_history_count": len(envelope["scope_recent_history"]),
+                  "target_recent_history_count": len(envelope["file_packet"]["recent_history"]),
+                  "scope_semantic_evictions": envelope["semantic_evictions"],
+                  "file_packet_semantic_evictions": envelope["file_packet"]["semantic_evictions"],
+              })
+
+          successful = [row["budget"] for row in rows if row["status"] == "selected"]
+          failed = [row["budget"] for row in rows if row["status"] != "selected"]
+          receipt = {
+              "schema_version": 1,
+              "selected_scope_shas": selected_shas,
+              "rows": rows,
+              "summary": {
+                  "minimum_tested_successful_budget": min(successful) if successful else None,
+                  "first_failure_descending": next((row["budget"] for row in rows if row["status"] != "selected"), None),
+                  "maximum_tested_failed_budget": max(failed) if failed else None,
+              },
+          }
+          Path("artifacts/stensibly-selected-evidence-floor.json").write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          print(json.dumps(receipt["summary"], indent=2, sort_keys=True))
+          PY
+
+      - name: Upload floor receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stensibly-selected-evidence-floor-${{ github.run_id }}
+          path: artifacts/stensibly-selected-evidence-floor.json
+          if-no-files-found: error

--- a/.github/workflows/scoped-selected-evidence-protection.yml
+++ b/.github/workflows/scoped-selected-evidence-protection.yml
@@ -1,0 +1,200 @@
+name: Stensibly selected evidence protection
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/scoped-selected-evidence-protection.yml"
+      - "examples/scoped_selected_evidence_protection.rs"
+      - "examples/agent_context_packet.rs"
+      - "examples/scoped_agent_context_packet.rs"
+      - "examples/support/scoped_agent_context_packet_impl.rs"
+
+permissions:
+  contents: read
+
+jobs:
+  compare:
+    if: github.head_ref == 'research/scoped-selected-evidence-protection'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Cultist
+        uses: actions/checkout@v4
+        with:
+          path: cultist
+          fetch-depth: 1
+
+      - name: Install stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Build current and protected scoped examples
+        run: |
+          cargo build --release --example scoped_agent_context_packet --manifest-path cultist/Cargo.toml
+          cargo build --release --example scoped_selected_evidence_protection --manifest-path cultist/Cargo.toml
+
+      - name: Checkout exact pre-guard Stensibly state
+        uses: actions/checkout@v4
+        with:
+          repository: teamleaderleo/stensibly
+          ref: 85cecf2608ad9e734a67518577fa85b9a08a550c
+          fetch-depth: 256
+          persist-credentials: false
+          path: target
+
+      - name: Compare budget policies
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          current="$PWD/cultist/target/release/examples/scoped_agent_context_packet"
+          protected="$PWD/cultist/target/release/examples/scoped_selected_evidence_protection"
+          target="$PWD/target/convex/schema.ts"
+
+          python - "$current" "$protected" "$target" <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import subprocess
+          import sys
+
+          current, protected, target = sys.argv[1:]
+          budgets = [32768, 16000, 15750, 15500, 15000, 14000, 12000, 10000, 8000, 6000, 4096]
+          selected_shas = [
+              "85cecf2608ad9e734a67518577fa85b9a08a550c",
+              "ca5d2c7fdf89666e523972ab6e81610d17b9611b",
+          ]
+          required_subjects = [
+              "Keep Gmail mailbox-disposition indexes deployable (#1573)",
+              "Keep Gmail semantic-admission indexes deployable (#1571)",
+          ]
+
+          def run(exe, budget, protect=False):
+              env = os.environ.copy()
+              env["CARGO_CULTIST_PACKET_MAX_BYTES"] = str(budget)
+              args = [exe, target, "--scope", "convex"]
+              if protect:
+                  for sha in selected_shas:
+                      args.extend(["--protect-scope-sha", sha])
+              completed = subprocess.run(args, env=env, capture_output=True, text=True)
+              if completed.returncode != 0:
+                  stderr = completed.stderr.strip()
+                  if "protected scoped packet evidence requires" not in stderr:
+                      raise SystemExit(f"unexpected failure at {budget}: {stderr}")
+                  return {"status": "protected_core_too_large", "stderr": stderr}
+
+              envelope = json.loads(completed.stdout)
+              scope_subjects = [row["subject"] for row in envelope["scope_recent_history"]]
+              presence = {
+                  subject: any(subject in observed for observed in scope_subjects)
+                  for subject in required_subjects
+              }
+              return {
+                  "status": "selected",
+                  "candidate_serialized_bytes": envelope["candidate_serialized_bytes"],
+                  "serialized_bytes": envelope["serialized_bytes"],
+                  "scope_history_count": len(envelope["scope_recent_history"]),
+                  "scope_semantic_evictions": envelope["semantic_evictions"],
+                  "file_packet_semantic_evictions": envelope["file_packet"]["semantic_evictions"],
+                  "target_recent_history_count": len(envelope["file_packet"]["recent_history"]),
+                  "lesson_presence": presence,
+                  "preserves_all_required": all(presence.values()),
+              }
+
+          rows = []
+          for budget in budgets:
+              rows.append({
+                  "budget": budget,
+                  "current": run(current, budget),
+                  "protected": run(protected, budget, protect=True),
+              })
+
+          baseline_16000 = next(row for row in rows if row["budget"] == 16000)["current"]
+          baseline_15750 = next(row for row in rows if row["budget"] == 15750)["current"]
+          if not baseline_16000.get("preserves_all_required"):
+              raise SystemExit("landed 16,000-byte baseline no longer preserves both lessons")
+          if baseline_15750.get("preserves_all_required"):
+              raise SystemExit("landed 15,750-byte baseline no longer reproduces lesson loss")
+
+          protected_selected = [
+              row for row in rows
+              if row["protected"]["status"] == "selected"
+          ]
+          protected_preserving = [
+              row["budget"] for row in protected_selected
+              if row["protected"]["preserves_all_required"]
+          ]
+          protected_failures = [
+              row["budget"] for row in rows
+              if row["protected"]["status"] != "selected"
+          ]
+
+          receipt = {
+              "schema_version": 1,
+              "repository": "teamleaderleo/stensibly",
+              "revision": "85cecf2608ad9e734a67518577fa85b9a08a550c",
+              "target": "convex/schema.ts",
+              "scope": "convex",
+              "selected_scope_shas": selected_shas,
+              "required_history_subjects": required_subjects,
+              "rows": rows,
+              "summary": {
+                  "protected_15750_preserves_all_required": next(row for row in rows if row["budget"] == 15750)["protected"].get("preserves_all_required", False),
+                  "minimum_tested_protected_budget_preserving_all_required": min(protected_preserving) if protected_preserving else None,
+                  "first_protected_failure_descending": next((row["budget"] for row in rows if row["protected"]["status"] != "selected"), None),
+                  "tested_protected_failure": bool(protected_failures),
+              },
+          }
+          Path("artifacts/stensibly-selected-evidence-protection.json").write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(receipt["summary"], indent=2, sort_keys=True))
+          PY
+
+      - name: Write comparison summary
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("artifacts/stensibly-selected-evidence-protection.json")
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as out:
+              out.write("## Selected-evidence protection comparison\n\n")
+              if not path.is_file():
+                  out.write("Comparison receipt unavailable.\n")
+                  raise SystemExit(0)
+              receipt = json.loads(path.read_text(encoding="utf-8"))
+              summary = receipt["summary"]
+              out.write(f"Protected policy keeps both lessons at 15,750: `{summary['protected_15750_preserves_all_required']}`  \n")
+              out.write(f"Minimum tested protected budget preserving both: `{summary['minimum_tested_protected_budget_preserving_all_required']}`  \n")
+              out.write(f"First protected-core failure descending: `{summary['first_protected_failure_descending']}`\n\n")
+              out.write("| budget | current lessons | protected lessons | current scope rows | protected scope rows | protected file evictions |\n")
+              out.write("|---:|---|---|---:|---:|---|\n")
+              for row in receipt["rows"]:
+                  current = row["current"]
+                  protected = row["protected"]
+                  current_lessons = "both" if current.get("preserves_all_required") else "lost"
+                  if protected["status"] != "selected":
+                      protected_lessons = "protected-core fail"
+                      protected_rows = "—"
+                      protected_file = "—"
+                  else:
+                      protected_lessons = "both" if protected["preserves_all_required"] else "lost"
+                      protected_rows = protected["scope_history_count"]
+                      protected_file = f"`{protected['file_packet_semantic_evictions']}`"
+                  out.write(
+                      f"| {row['budget']} | {current_lessons} | {protected_lessons} | "
+                      f"{current.get('scope_history_count', '—')} | {protected_rows} | {protected_file} |\n"
+                  )
+          PY
+
+      - name: Upload comparison receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stensibly-selected-evidence-protection-${{ github.run_id }}
+          path: artifacts/stensibly-selected-evidence-protection.json
+          if-no-files-found: error

--- a/examples/scoped_selected_evidence_protection.rs
+++ b/examples/scoped_selected_evidence_protection.rs
@@ -115,7 +115,9 @@ mod packet {
                 .bytes()
                 .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
         {
-            return Err("protected scope evidence refs must be exact lowercase 40-hex Git SHAs".into());
+            return Err(
+                "protected scope evidence refs must be exact lowercase 40-hex Git SHAs".into(),
+            );
         }
         Ok(())
     }

--- a/examples/scoped_selected_evidence_protection.rs
+++ b/examples/scoped_selected_evidence_protection.rs
@@ -1,0 +1,232 @@
+#[allow(dead_code)]
+mod packet {
+    include!("agent_context_packet.rs");
+    include!("support/scoped_agent_context_packet_impl.rs");
+
+    use std::collections::BTreeSet as ProtectedBTreeSet;
+
+    pub fn run_protected_scoped() -> Result<(), Box<dyn Error>> {
+        let (target_arg, scope_arg, protected_scope_shas) =
+            parse_protected_args(env::args().skip(1))?;
+
+        let requested = PathBuf::from(target_arg);
+        let requested = if requested.is_absolute() {
+            requested
+        } else {
+            env::current_dir()?.join(requested)
+        };
+        let target = requested.canonicalize()?;
+        if !target.is_file() {
+            return Err(format!("target must be an existing file: {}", target.display()).into());
+        }
+
+        let probe = target
+            .parent()
+            .ok_or("could not determine target parent directory")?;
+        let root = git_repo_root(probe)?;
+        let relative_target = target
+            .strip_prefix(&root)
+            .map_err(|_| "target is outside the resolved Git repository")?
+            .to_path_buf();
+
+        let scope = resolve_explicit_scope(&root, &target, &scope_arg)?;
+        let relative_scope = scope.strip_prefix(&root)?.to_path_buf();
+        let budget = packet_budget_from_env()?;
+        let mut file_packet = build_file_packet(&root, &target, &relative_target, budget)?;
+        stabilize_candidate_size(&mut file_packet)?;
+
+        let (scope_history, scope_history_truncated) =
+            scoped_recent_commits(&root, &relative_scope, DEFAULT_MAX_SCOPE_HISTORY)?;
+        let scope_recent_history = dedupe_scope_history(scope_history, &file_packet.recent_history);
+        let available = scope_recent_history
+            .iter()
+            .map(|commit| commit.sha.as_str())
+            .collect::<ProtectedBTreeSet<_>>();
+        for protected in &protected_scope_shas {
+            if !available.contains(protected.as_str()) {
+                return Err(format!(
+                    "selected scope evidence `{protected}` is absent from the admitted scope-history window"
+                )
+                .into());
+            }
+        }
+
+        let mut envelope = ScopedAgentContextEnvelope {
+            schema_version: SCOPED_SCHEMA_VERSION,
+            analysis: "scoped_agent_context",
+            repository: root.display().to_string(),
+            target: relative_target.display().to_string(),
+            scope: relative_scope.display().to_string(),
+            budget: ScopedEnvelopeBudget {
+                max_serialized_bytes: budget.max_serialized_bytes,
+                max_scope_history_commits: DEFAULT_MAX_SCOPE_HISTORY,
+            },
+            candidate_serialized_bytes: 0,
+            serialized_bytes: 0,
+            semantic_evictions: Vec::new(),
+            file_packet,
+            scope_recent_history,
+            scope_history_truncated,
+            unknowns: vec![
+                "Explicit scope chronology does not by itself prove that a scope-history commit is semantically relevant to the target.".to_string(),
+                "This research compiler protects only exact scope evidence refs selected upstream; the byte budget does not infer semantic importance.".to_string(),
+            ],
+        };
+
+        println!(
+            "{}",
+            compile_scoped_to_budget_protecting(&mut envelope, &protected_scope_shas)?
+        );
+        Ok(())
+    }
+
+    fn parse_protected_args<I>(mut args: I) -> Result<(String, String, ProtectedBTreeSet<String>), Box<dyn Error>>
+    where
+        I: Iterator<Item = String>,
+    {
+        let usage = "usage: cargo run --example scoped_selected_evidence_protection -- FILE --scope DIR --protect-scope-sha SHA [--protect-scope-sha SHA ...]";
+        let target = args.next().ok_or(usage)?;
+        if args.next().as_deref() != Some("--scope") {
+            return Err(usage.into());
+        }
+        let scope = args.next().ok_or(usage)?;
+        validate_scope_text(&scope)?;
+
+        let mut protected = ProtectedBTreeSet::new();
+        while let Some(flag) = args.next() {
+            if flag != "--protect-scope-sha" {
+                return Err(usage.into());
+            }
+            let sha = args.next().ok_or(usage)?;
+            validate_exact_sha(&sha)?;
+            protected.insert(sha);
+        }
+        if protected.is_empty() {
+            return Err("at least one --protect-scope-sha is required".into());
+        }
+        Ok((target, scope, protected))
+    }
+
+    fn validate_exact_sha(sha: &str) -> Result<(), Box<dyn Error>> {
+        if sha.len() != 40
+            || !sha
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err("protected scope evidence refs must be exact lowercase 40-hex Git SHAs".into());
+        }
+        Ok(())
+    }
+
+    fn compile_scoped_to_budget_protecting(
+        envelope: &mut ScopedAgentContextEnvelope,
+        protected_scope_shas: &ProtectedBTreeSet<String>,
+    ) -> Result<String, ScopedBudgetError> {
+        envelope.semantic_evictions.clear();
+        envelope.candidate_serialized_bytes = 0;
+        envelope.serialized_bytes = 0;
+        stabilize_scoped_candidate_size(envelope)?;
+
+        loop {
+            let rendered = render_scoped_with_exact_size(envelope)?;
+            if rendered.len() <= envelope.budget.max_serialized_bytes {
+                return Ok(rendered);
+            }
+
+            if let Some(index) = envelope
+                .scope_recent_history
+                .iter()
+                .rposition(|commit| !protected_scope_shas.contains(&commit.sha))
+            {
+                envelope.scope_recent_history.remove(index);
+                record_scoped_eviction(envelope, "scope_recent_history_summary");
+                envelope.serialized_bytes = 0;
+                continue;
+            }
+
+            if let Some(class) = evict_one_semantic_detail(&mut envelope.file_packet) {
+                record_semantic_eviction(&mut envelope.file_packet, class);
+                envelope.file_packet.serialized_bytes = 0;
+                let _ = render_packet_with_exact_size(&mut envelope.file_packet)?;
+                envelope.serialized_bytes = 0;
+                continue;
+            }
+
+            return Err(ScopedBudgetError::ProtectedCoreTooLarge {
+                max_serialized_bytes: envelope.budget.max_serialized_bytes,
+                required_serialized_bytes: rendered.len(),
+            });
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn exact_sha_validation_rejects_short_uppercase_and_non_hex() {
+            assert!(validate_exact_sha("abcd").is_err());
+            assert!(validate_exact_sha(&"A".repeat(40)).is_err());
+            assert!(validate_exact_sha(&format!("{}g", "0".repeat(39))).is_err());
+            assert!(validate_exact_sha(&"a".repeat(40)).is_ok());
+        }
+
+        #[test]
+        fn protected_scope_refs_are_not_candidates_for_scope_eviction() {
+            let mut file_packet = scoped_tests::minimal_file_packet(usize::MAX);
+            file_packet.recent_history[0].subject = "x".repeat(800);
+            stabilize_candidate_size(&mut file_packet).unwrap();
+
+            let protected_sha = "a".repeat(40);
+            let expendable_sha = "b".repeat(40);
+            let mut envelope = ScopedAgentContextEnvelope {
+                schema_version: SCOPED_SCHEMA_VERSION,
+                analysis: "scoped_agent_context",
+                repository: "/repo".to_string(),
+                target: "src/target.rs".to_string(),
+                scope: "src".to_string(),
+                budget: ScopedEnvelopeBudget {
+                    max_serialized_bytes: usize::MAX,
+                    max_scope_history_commits: DEFAULT_MAX_SCOPE_HISTORY,
+                },
+                candidate_serialized_bytes: 0,
+                serialized_bytes: 0,
+                semantic_evictions: Vec::new(),
+                file_packet,
+                scope_recent_history: vec![
+                    scoped_tests::summary(&protected_sha, "selected scope lesson"),
+                    scoped_tests::summary(&expendable_sha, &"unselected ".repeat(80)),
+                ],
+                scope_history_truncated: false,
+                unknowns: Vec::new(),
+            };
+            stabilize_scoped_candidate_size(&mut envelope).unwrap();
+            envelope.budget.max_serialized_bytes = envelope.candidate_serialized_bytes - 200;
+            envelope.file_packet.budget.max_serialized_bytes = envelope.budget.max_serialized_bytes;
+
+            let protected = ProtectedBTreeSet::from([protected_sha.clone()]);
+            let rendered = compile_scoped_to_budget_protecting(&mut envelope, &protected).unwrap();
+
+            assert!(rendered.len() <= envelope.budget.max_serialized_bytes);
+            assert!(
+                envelope
+                    .scope_recent_history
+                    .iter()
+                    .any(|commit| commit.sha == protected_sha)
+            );
+            assert!(
+                envelope
+                    .scope_recent_history
+                    .iter()
+                    .all(|commit| commit.sha != expendable_sha)
+            );
+        }
+    }
+}
+
+fn main() {
+    if let Err(error) = packet::run_protected_scoped() {
+        eprintln!("scoped-selected-evidence-protection: {error}");
+        std::process::exit(1);
+    }
+}

--- a/examples/scoped_selected_evidence_protection.rs
+++ b/examples/scoped_selected_evidence_protection.rs
@@ -80,7 +80,9 @@ mod packet {
         Ok(())
     }
 
-    fn parse_protected_args<I>(mut args: I) -> Result<(String, String, ProtectedBTreeSet<String>), Box<dyn Error>>
+    fn parse_protected_args<I>(
+        mut args: I,
+    ) -> Result<(String, String, ProtectedBTreeSet<String>), Box<dyn Error>>
     where
         I: Iterator<Item = String>,
     {
@@ -156,70 +158,6 @@ mod packet {
                 max_serialized_bytes: envelope.budget.max_serialized_bytes,
                 required_serialized_bytes: rendered.len(),
             });
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        #[test]
-        fn exact_sha_validation_rejects_short_uppercase_and_non_hex() {
-            assert!(validate_exact_sha("abcd").is_err());
-            assert!(validate_exact_sha(&"A".repeat(40)).is_err());
-            assert!(validate_exact_sha(&format!("{}g", "0".repeat(39))).is_err());
-            assert!(validate_exact_sha(&"a".repeat(40)).is_ok());
-        }
-
-        #[test]
-        fn protected_scope_refs_are_not_candidates_for_scope_eviction() {
-            let mut file_packet = scoped_tests::minimal_file_packet(usize::MAX);
-            file_packet.recent_history[0].subject = "x".repeat(800);
-            stabilize_candidate_size(&mut file_packet).unwrap();
-
-            let protected_sha = "a".repeat(40);
-            let expendable_sha = "b".repeat(40);
-            let mut envelope = ScopedAgentContextEnvelope {
-                schema_version: SCOPED_SCHEMA_VERSION,
-                analysis: "scoped_agent_context",
-                repository: "/repo".to_string(),
-                target: "src/target.rs".to_string(),
-                scope: "src".to_string(),
-                budget: ScopedEnvelopeBudget {
-                    max_serialized_bytes: usize::MAX,
-                    max_scope_history_commits: DEFAULT_MAX_SCOPE_HISTORY,
-                },
-                candidate_serialized_bytes: 0,
-                serialized_bytes: 0,
-                semantic_evictions: Vec::new(),
-                file_packet,
-                scope_recent_history: vec![
-                    scoped_tests::summary(&protected_sha, "selected scope lesson"),
-                    scoped_tests::summary(&expendable_sha, &"unselected ".repeat(80)),
-                ],
-                scope_history_truncated: false,
-                unknowns: Vec::new(),
-            };
-            stabilize_scoped_candidate_size(&mut envelope).unwrap();
-            envelope.budget.max_serialized_bytes = envelope.candidate_serialized_bytes - 200;
-            envelope.file_packet.budget.max_serialized_bytes = envelope.budget.max_serialized_bytes;
-
-            let protected = ProtectedBTreeSet::from([protected_sha.clone()]);
-            let rendered = compile_scoped_to_budget_protecting(&mut envelope, &protected).unwrap();
-
-            assert!(rendered.len() <= envelope.budget.max_serialized_bytes);
-            assert!(
-                envelope
-                    .scope_recent_history
-                    .iter()
-                    .any(|commit| commit.sha == protected_sha)
-            );
-            assert!(
-                envelope
-                    .scope_recent_history
-                    .iter()
-                    .all(|commit| commit.sha != expendable_sha)
-            );
         }
     }
 }


### PR DESCRIPTION
Historical comparator superseded by merged promotion #282.

#205 earned the exact-ref protection seam on the Stensibly budget cliff. #282 promoted that seam into the existing scoped compiler, kept ordinary calls on the original #191 path, added an explicit selected-SHA receipt, and passed both merge-view CI and the pinned public replay.

Landed behavior:

```text
unprotected 15750 -> both selected lessons lost
protected   15750 -> both selected lessons preserved, 15721 bytes
protected    4096 -> both selected lessons preserved, 3911 bytes
protected    3900 -> fail closed at required floor 3911
```

Executed promotion receipt:

```text
run       32280602283
result    success
merge     ef94b1ec9e9b20335599ffcdec47b377f65acf50
```

This older PR remains useful historical evidence for the research comparator and the earlier 3,953-byte floor. The promoted wrapper measured a smaller 3,911-byte floor while retaining the exact SHA audit receipt.

Refs #196 #197 #281 #282.