### PR TITLE
research: bind GitHub review threads to exact heads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,13 @@ jobs:
             scripts/project_memory_github_lineage.py \
             scripts/project_memory_github_lineage_test.py
           python scripts/project_memory_github_lineage_test.py
+      - name: GitHub review-memory adapter controls
+        run: |
+          python -m py_compile \
+            scripts/project_memory_github.py \
+            scripts/review_memory_github.py \
+            scripts/review_memory_github_test.py
+          python scripts/review_memory_github_test.py
       - name: Active work heads-up
         if: github.event_name == 'pull_request'
         continue-on-error: true

--- a/.github/workflows/review-memory-github.yml
+++ b/.github/workflows/review-memory-github.yml
@@ -1,0 +1,209 @@
+name: GitHub review-memory carrier
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: Public GitHub owner/repository
+        required: true
+        default: The-PR-Agent/pr-agent
+        type: string
+      pull_request:
+        description: Pull request number
+        required: true
+        default: "2424"
+        type: string
+      comment_node_id:
+        description: Root inline-review comment node ID
+        required: true
+        default: PRRC_kwDOJ4EDks7IBoVk
+        type: string
+      resolution_comment_node_id:
+        description: Direct reply node ID for a resolved outcome
+        required: false
+        default: PRRC_kwDOJ4EDks7IB1zX
+        type: string
+      concern_key:
+        description: Caller-supplied semantic concern identity
+        required: true
+        default: pr-agent:persistent-inline-comments:github-fallback-publish-state
+        type: string
+      outcome:
+        description: Caller-supplied review outcome
+        required: true
+        default: patch_changed
+        type: choice
+        options:
+          - open
+          - patch_changed
+          - rejected_with_evidence
+          - dismissed
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  review-memory:
+    if: github.event_name == 'workflow_dispatch' || github.head_ref == 'research/github-review-memory-adapter'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Cultist
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Run adapter regression controls
+        run: |
+          python -m py_compile \
+            scripts/project_memory_github.py \
+            scripts/review_memory_github.py \
+            scripts/review_memory_github_test.py
+          python scripts/review_memory_github_test.py
+
+      - name: Resolve carrier inputs
+        id: carrier
+        env:
+          INPUT_REPOSITORY: ${{ inputs.repository }}
+          INPUT_PULL_REQUEST: ${{ inputs.pull_request }}
+          INPUT_COMMENT_NODE_ID: ${{ inputs.comment_node_id }}
+          INPUT_RESOLUTION_NODE_ID: ${{ inputs.resolution_comment_node_id }}
+          INPUT_CONCERN_KEY: ${{ inputs.concern_key }}
+          INPUT_OUTCOME: ${{ inputs.outcome }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            repository="The-PR-Agent/pr-agent"
+            pull_request="2424"
+            comment_node_id="PRRC_kwDOJ4EDks7IBoVk"
+            resolution_node_id="PRRC_kwDOJ4EDks7IB1zX"
+            concern_key="pr-agent:persistent-inline-comments:github-fallback-publish-state"
+            outcome="patch_changed"
+            carrier="true"
+          else
+            repository="$INPUT_REPOSITORY"
+            pull_request="$INPUT_PULL_REQUEST"
+            comment_node_id="$INPUT_COMMENT_NODE_ID"
+            resolution_node_id="$INPUT_RESOLUTION_NODE_ID"
+            concern_key="$INPUT_CONCERN_KEY"
+            outcome="$INPUT_OUTCOME"
+            carrier="false"
+          fi
+          {
+            echo "repository=$repository"
+            echo "pull_request=$pull_request"
+            echo "comment_node_id=$comment_node_id"
+            echo "resolution_node_id=$resolution_node_id"
+            echo "concern_key=$concern_key"
+            echo "outcome=$outcome"
+            echo "carrier=$carrier"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Collect selected review memory
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TARGET_REPOSITORY: ${{ steps.carrier.outputs.repository }}
+          TARGET_PR: ${{ steps.carrier.outputs.pull_request }}
+          ROOT_NODE: ${{ steps.carrier.outputs.comment_node_id }}
+          RESOLUTION_NODE: ${{ steps.carrier.outputs.resolution_node_id }}
+          CONCERN_KEY: ${{ steps.carrier.outputs.concern_key }}
+          OUTCOME: ${{ steps.carrier.outputs.outcome }}
+        run: |
+          set -euo pipefail
+          resolution=()
+          if [[ -n "$RESOLUTION_NODE" ]]; then
+            resolution=(--resolution-comment-node-id "$RESOLUTION_NODE")
+          fi
+          python scripts/review_memory_github.py \
+            --repository "$TARGET_REPOSITORY" \
+            --pull-request "$TARGET_PR" \
+            --comment-node-id "$ROOT_NODE" \
+            --concern-key "$CONCERN_KEY" \
+            --outcome "$OUTCOME" \
+            "${resolution[@]}" \
+            --output review-memory-query.json \
+            --receipt-output review-memory-github-receipt.json \
+            > /tmp/review-memory-github.stdout
+
+      - name: Validate through independent Rust evaluator
+        run: |
+          cargo run --quiet --example review_memory \
+            < review-memory-query.json \
+            > review-memory-evaluation.json
+
+      - name: Assert PR-Agent review lifecycle carrier
+        if: steps.carrier.outputs.carrier == 'true'
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          query = json.loads(Path("review-memory-query.json").read_text())
+          receipt = json.loads(Path("review-memory-github-receipt.json").read_text())
+          evaluation = json.loads(Path("review-memory-evaluation.json").read_text())
+
+          assert receipt["repository"] == "The-PR-Agent/pr-agent", receipt
+          assert receipt["pull_request"] == 2424, receipt
+          assert receipt["root"]["node_id"] == "PRRC_kwDOJ4EDks7IBoVk", receipt
+          assert receipt["resolution"]["node_id"] == "PRRC_kwDOJ4EDks7IB1zX", receipt
+          assert receipt["resolution"]["in_reply_to_id"] == receipt["root"]["id"], receipt
+          assert receipt["root"]["path"] == "pr_agent/git_providers/github_provider.py", receipt
+          assert "Dedup blocks gh fallback" in receipt["root"]["body"], receipt
+          assert "f699e7ea" in receipt["resolution"]["body"], receipt
+          assert receipt["root"]["commit_id"] != receipt["current_head_sha"], receipt
+
+          record = query["records"][0]
+          assert record["subject"]["revision"] == receipt["root"]["commit_id"], query
+          assert record["outcome"] == "patch_changed", query
+          assert record["resolution_ref"].endswith(
+              f"/{receipt['resolution']['id']}"
+          ), query
+
+          assert evaluation["disposition"] == "refresh_existing_thread", evaluation
+          assert evaluation["matches"][0]["match_kind"] == "prior_head", evaluation
+          assert evaluation["matches"][0]["applicability"]["status"] == "invalid", evaluation
+          assert evaluation["matches"][0]["outcome"] == "patch_changed", evaluation
+          PY
+
+      - name: Write job summary
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          receipt = json.loads(Path("review-memory-github-receipt.json").read_text())
+          evaluation = json.loads(Path("review-memory-evaluation.json").read_text())
+          root = receipt["root"]
+          resolution = receipt["resolution"]
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as out:
+              out.write("## GitHub review memory\n\n")
+              out.write(
+                  f"PR: `{receipt['repository']}#{receipt['pull_request']}` · "
+                  f"comments scanned: **{receipt['review_comment_count']}**\n\n"
+              )
+              out.write(f"Root review comment: `{root['id']}` / `{root['node_id']}`\n\n")
+              out.write(f"Reviewed commit: `{root['commit_id']}`\n\n")
+              out.write(f"Current PR head: `{receipt['current_head_sha']}`\n\n")
+              if resolution:
+                  out.write(
+                      f"Resolution reply: `{resolution['id']}` / `{resolution['node_id']}`\n\n"
+                  )
+              out.write(
+                  f"Evaluation: **{evaluation['disposition']}** · prior applicability: "
+                  f"**{evaluation['matches'][0]['applicability']['status']}**\n"
+              )
+          PY
+
+      - name: Upload provider receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-memory-github-${{ github.run_id }}
+          path: |
+            review-memory-query.json
+            review-memory-github-receipt.json
+            review-memory-evaluation.json
+          if-no-files-found: error

--- a/research/review-memory-github.md
+++ b/research/review-memory-github.md
@@ -184,6 +184,61 @@ outcome        patch_changed (historical evidence)
 
 This is the first real provider replay of #198's central distinction: one review concern can retain thread lineage after the patch moves while its old outcome loses exact-head applicability.
 
+### Executed receipt
+
+PR #206 executed the live carrier successfully.
+
+```text
+workflow run
+  32250963882
+
+artifact
+  9364380361
+
+artifact digest
+  sha256:f4d85deb54ed7c7a5a5b74930800b63974eb423b2bc90524cf76a8203bf9397b
+
+review comments scanned
+  33
+
+root review comment
+  numeric id 3355870564
+  node_id PRRC_kwDOJ4EDks7IBoVk
+  reviewed commit 8fb9e4e86b4794d39afba2d62413571cbc04a744
+  original commit 8fb9e4e86b4794d39afba2d62413571cbc04a744
+  path pr_agent/git_providers/github_provider.py
+  original range 418..436
+
+resolution reply
+  numeric id 3355925719
+  node_id PRRC_kwDOJ4EDks7IB1zX
+  in_reply_to_id 3355870564
+  commit 8fb9e4e86b4794d39afba2d62413571cbc04a744
+
+current PR head
+  f6070fb1a45516565bbb8deeb02a1f66cec13d91
+```
+
+The Rust evaluation retained four independent applicability dimensions:
+
+```text
+repository  matched
+revision    mismatched
+work        matched
+scope       matched
+```
+
+and returned:
+
+```text
+disposition    refresh_existing_thread
+match_kind     prior_head
+applicability  invalid
+outcome        patch_changed
+```
+
+This receipt is useful because the invalidation is narrow: the old outcome is stale specifically because the reviewed head moved. The PR identity and path still match.
+
 ## Standard controls
 
 `scripts/review_memory_github_test.py` covers:

--- a/research/review-memory-github.md
+++ b/research/review-memory-github.md
@@ -1,0 +1,230 @@
+# Exact GitHub review-memory carrier
+
+Issue #202 extends #198's local review-memory contract with one opt-in provider adapter. The adapter's job is deliberately narrow:
+
+```text
+selected GitHub inline-review comment
++ selected direct reply when the caller declares a resolved outcome
++ exact current PR head
+-> existing ReviewMemoryQuery
+-> existing Rust review-memory evaluator
+```
+
+It does not derive semantic concern identity or review outcome from arbitrary comment prose.
+
+## Why provider coordinates belong in the contract
+
+PR-Agent #2424 provides two complementary lessons.
+
+The first is a useful review lifecycle. A resolved/outdated inline thread on `pr_agent/git_providers/github_provider.py` reports that persistent-comment fingerprints were recorded before GitHub accepted the review, so a 422 fallback retry could be skipped even though no comment had been published. The direct maintainer reply says the concern was fixed in commit `f699e7ea`.
+
+The second is an identity counterexample. Another review thread reports that the GitHub path passed `target_line_no=None` into dedup fingerprints. Two same-file comments with the same normalized text/code on different lines could therefore collapse and one real concern could disappear. The review points at a concrete line/range and recommends preserving the already-derived absolute/inline anchor.
+
+Those cases argue for keeping review semantics and provider coordinates separate:
+
+```text
+concern_key
+  caller/producer-owned semantic lineage
+
+provider identity
+  exact comment / reply / PR / reviewed commit
+
+applicability
+  exact repository / work / revision / path
+
+line receipts
+  provider evidence retained for a later richer target dimension
+```
+
+V0 therefore uses exact path scope in `ReviewMemoryQuery` and preserves line/original-line fields in the provider receipt. It does not pretend path-only scope solves inline-comment identity forever.
+
+## Adapter
+
+The opt-in adapter is:
+
+```text
+scripts/review_memory_github.py
+```
+
+Example:
+
+```bash
+python scripts/review_memory_github.py \
+  --repository The-PR-Agent/pr-agent \
+  --pull-request 2424 \
+  --comment-node-id PRRC_kwDOJ4EDks7IBoVk \
+  --resolution-comment-node-id PRRC_kwDOJ4EDks7IB1zX \
+  --concern-key pr-agent:persistent-inline-comments:github-fallback-publish-state \
+  --outcome patch_changed \
+  --output review-memory-query.json \
+  --receipt-output review-memory-github-receipt.json
+
+cargo run --quiet --example review_memory \
+  < review-memory-query.json
+```
+
+The caller supplies `concern_key` and `outcome`. GitHub supplies the exact review coordinates.
+
+## Exact mapping
+
+For one selected root review comment:
+
+```text
+ReviewMemoryRecord.event_id
+  github:pull/<PR>/review-comment/<numeric comment id>
+
+source_ref
+  same exact GitHub review-comment identity
+
+subject.repository
+  selected owner/repository
+
+subject.work
+  github:pull/<PR>
+
+subject.revision
+  root review comment commit_id
+
+subject.scope
+  exact root review comment path
+
+current.revision
+  current PR head SHA
+```
+
+When the caller selects a resolved outcome, the selected resolution comment must be a direct reply to the root. Its exact review-comment identity becomes `resolution_ref`.
+
+This mapping intentionally does not use the comment body to generate `concern_key`, and it does not infer `patch_changed` from the presence of a reply. The body is retained only as bounded source evidence in the provider receipt.
+
+## Provider receipt
+
+The sidecar retains enough exact GitHub evidence to audit or refine the mapping later:
+
+```text
+root / resolution
+  numeric id
+  node_id
+  pull_request_review_id
+  commit_id
+  original_commit_id
+  path
+  line / original_line
+  start_line / original_start_line
+  side / start_side
+  in_reply_to_id
+  created_at / updated_at
+  bounded body
+
+PR
+  repository
+  pull request number
+  exact current head SHA
+```
+
+The line fields stay receipts rather than silently becoming a new applicability dimension in this slice.
+
+## Bounds and failure policy
+
+V0 admits:
+
+```text
+review comments scanned: <= 512
+comment body retained:   <= 16 KiB each selected comment
+review-memory query:     <= 256 KiB
+provider receipt:        <= 256 KiB
+```
+
+Review comments are paginated completely up to the bound. Overflow fails instead of returning a partial inventory.
+
+Validation rejects:
+
+- malformed repository or PR identity;
+- missing/ambiguous root selector;
+- duplicate numeric IDs or node IDs;
+- a root comment that is itself a reply;
+- a selected comment whose `pull_request_url` points elsewhere;
+- malformed current/comment/original Git SHAs;
+- noncanonical repository-relative paths;
+- a resolved outcome without a selected resolution reply;
+- `open` with a resolution reply;
+- a resolution comment that is not a direct reply to the selected root;
+- oversized selected evidence or inventories.
+
+## Live carrier: PR-Agent #2424
+
+The automatic PR carrier selects:
+
+```text
+repository
+  The-PR-Agent/pr-agent
+
+pull request
+  #2424
+
+root node
+  PRRC_kwDOJ4EDks7IBoVk
+  “Dedup blocks gh fallback”
+
+resolution reply node
+  PRRC_kwDOJ4EDks7IB1zX
+  reply names repair commit f699e7ea
+
+caller outcome
+  patch_changed
+```
+
+The carrier requires the root review `commit_id` to differ from the current PR head. The independent Rust evaluator must then return:
+
+```text
+disposition    refresh_existing_thread
+match_kind     prior_head
+applicability  invalid
+outcome        patch_changed (historical evidence)
+```
+
+This is the first real provider replay of #198's central distinction: one review concern can retain thread lineage after the patch moves while its old outcome loses exact-head applicability.
+
+## Standard controls
+
+`scripts/review_memory_github_test.py` covers:
+
+- node-ID and numeric-ID selection;
+- exact query mapping from root/reply/current PR;
+- direct-reply validation;
+- root-is-reply rejection;
+- cross-PR comment rejection;
+- duplicate node-ID rejection;
+- malformed SHAs and paths;
+- outcome/resolution contracts before provider access;
+- fail-closed comment inventory overflow.
+
+The ordinary repository CI runs those controls. `.github/workflows/review-memory-github.yml` additionally runs the live public PR-Agent carrier and validates the emitted query through the independent Rust `review_memory` example.
+
+## What this earns
+
+Cultist can now keep these claims distinct in one real review lifecycle:
+
+```text
+OBSERVED provider fact
+  review comment C was attached to exact PR/head/path
+
+OBSERVED provider fact
+  direct reply R exists on C
+
+caller-supplied review outcome
+  patch_changed
+
+APPLICABILITY
+  old reviewed head != current PR head -> INVALID
+
+THREAD DELIVERY
+  same concern lineage -> refresh existing thread
+```
+
+No step upgrades a resolved comment into project policy.
+
+## Next discriminator
+
+The #2424 line-anchor counterexample makes the next research target concrete: exact inline concern identity needs a stable target below path granularity. The next experiment should compare candidate provider coordinates such as original line/range, diff anchor, and semantic item identity across real head movement and retain the one that survives useful edits without collapsing distinct concerns.
+
+Refs #18 #109 #123 #127 #137 #192 #198 #202.

--- a/scripts/review_memory_github.py
+++ b/scripts/review_memory_github.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Bind one selected GitHub inline-review thread to Cultist review memory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+import project_memory_github as github_memory
+
+MAX_REVIEW_COMMENTS = 512
+MAX_COMMENT_BODY_BYTES = 16 * 1024
+MAX_ID_BYTES = 1024
+MAX_QUERY_BYTES = 256 * 1024
+MAX_RECEIPT_BYTES = 256 * 1024
+OUTCOMES = {"open", "patch_changed", "rejected_with_evidence", "dismissed"}
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description=(
+            "Collect one explicitly selected GitHub inline-review thread and emit "
+            "Cultist's revision-aware review-memory query."
+        )
+    )
+    result.add_argument("--repository", required=True)
+    result.add_argument("--pull-request", required=True, type=int)
+    root = result.add_mutually_exclusive_group(required=True)
+    root.add_argument("--comment-id", type=int)
+    root.add_argument("--comment-node-id")
+    result.add_argument("--concern-key", required=True)
+    result.add_argument("--outcome", required=True, choices=sorted(OUTCOMES))
+    resolution = result.add_mutually_exclusive_group()
+    resolution.add_argument("--resolution-comment-id", type=int)
+    resolution.add_argument("--resolution-comment-node-id")
+    result.add_argument("--output", required=True, type=Path)
+    result.add_argument("--receipt-output", required=True, type=Path)
+    return result
+
+
+def bounded_single_line(value: object, field: str, maximum: int = MAX_ID_BYTES) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value.strip() != value
+        or len(value.encode("utf-8")) > maximum
+        or "\x00" in value
+        or "\n" in value
+        or "\r" in value
+    ):
+        raise github_memory.CollectorError(
+            f"{field} must be a bounded non-empty single-line value"
+        )
+    return value
+
+
+def bounded_body(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise github_memory.CollectorError(f"{field} is empty or malformed")
+    if len(value.encode("utf-8")) > MAX_COMMENT_BODY_BYTES:
+        raise github_memory.CollectorError(
+            f"{field} exceeds the {MAX_COMMENT_BODY_BYTES}-byte bound"
+        )
+    return value
+
+
+def positive_int(value: object, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise github_memory.CollectorError(f"{field} must be a positive integer")
+    return value
+
+
+def optional_positive_int(value: object, field: str) -> int | None:
+    if value is None:
+        return None
+    return positive_int(value, field)
+
+
+def exact_pull_request_url(repository: str, number: int, value: object) -> str:
+    expected = f"https://api.github.com/repos/{repository}/pulls/{number}"
+    actual = bounded_single_line(value, "pull_request_url", 4096)
+    if actual != expected:
+        raise github_memory.CollectorError(
+            f"review comment belongs to a different pull request: {actual}"
+        )
+    return actual
+
+
+def optional_side(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    if value not in {"LEFT", "RIGHT"}:
+        raise github_memory.CollectorError(f"{field} must be LEFT, RIGHT, or null")
+    return str(value)
+
+
+def comment_identity(pull_request: int, comment: dict[str, Any]) -> str:
+    return f"github:pull/{pull_request}/review-comment/{positive_int(comment.get('id'), 'comment id')}"
+
+
+def list_review_comments(
+    client: github_memory.GitHubClient, repository: str, pull_request: int
+) -> list[dict[str, Any]]:
+    comments: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        raw = client.get_json(
+            f"/repos/{repository}/pulls/{pull_request}/comments?per_page=100&page={page}"
+        )
+        if not isinstance(raw, list):
+            raise github_memory.CollectorError("GitHub review-comment list is malformed")
+        if len(raw) > 100:
+            raise github_memory.CollectorError("GitHub review-comment page exceeds per-page bound")
+        for item in raw:
+            if not isinstance(item, dict):
+                raise github_memory.CollectorError("GitHub review-comment entry is malformed")
+            comments.append(item)
+            if len(comments) > MAX_REVIEW_COMMENTS:
+                raise github_memory.CollectorError(
+                    f"review-comment inventory exceeds the {MAX_REVIEW_COMMENTS}-comment bound"
+                )
+        if len(raw) < 100:
+            break
+        page += 1
+    return comments
+
+
+def index_comments(
+    comments: list[dict[str, Any]],
+) -> tuple[dict[int, dict[str, Any]], dict[str, dict[str, Any]]]:
+    by_id: dict[int, dict[str, Any]] = {}
+    by_node: dict[str, dict[str, Any]] = {}
+    for comment in comments:
+        comment_id = positive_int(comment.get("id"), "comment id")
+        node_id = bounded_single_line(comment.get("node_id"), "comment node_id")
+        if comment_id in by_id:
+            raise github_memory.CollectorError(
+                f"duplicate GitHub review-comment id {comment_id}"
+            )
+        if node_id in by_node:
+            raise github_memory.CollectorError(
+                f"duplicate GitHub review-comment node_id {node_id}"
+            )
+        by_id[comment_id] = comment
+        by_node[node_id] = comment
+    return by_id, by_node
+
+
+def select_comment(
+    by_id: dict[int, dict[str, Any]],
+    by_node: dict[str, dict[str, Any]],
+    *,
+    comment_id: int | None,
+    node_id: str | None,
+    label: str,
+) -> dict[str, Any]:
+    if comment_id is not None:
+        if comment_id <= 0:
+            raise github_memory.CollectorError(f"{label} id must be positive")
+        selected = by_id.get(comment_id)
+        selector = str(comment_id)
+    else:
+        if node_id is None:
+            raise github_memory.CollectorError(f"{label} selector is missing")
+        node_id = bounded_single_line(node_id, f"{label} node_id")
+        selected = by_node.get(node_id)
+        selector = node_id
+    if selected is None:
+        raise github_memory.CollectorError(f"selected {label} {selector} was not found")
+    return selected
+
+
+def comment_receipt(
+    repository: str, pull_request: int, comment: dict[str, Any]
+) -> dict[str, Any]:
+    exact_pull_request_url(repository, pull_request, comment.get("pull_request_url"))
+    comment_id = positive_int(comment.get("id"), "comment id")
+    node_id = bounded_single_line(comment.get("node_id"), "comment node_id")
+    review_id = positive_int(comment.get("pull_request_review_id"), "pull_request_review_id")
+    path = github_memory.canonical_path(comment.get("path"))
+    return {
+        "id": comment_id,
+        "node_id": node_id,
+        "pull_request_review_id": review_id,
+        "commit_id": github_memory.exact_sha(comment.get("commit_id"), "comment commit_id"),
+        "original_commit_id": github_memory.exact_sha(
+            comment.get("original_commit_id"), "comment original_commit_id"
+        ),
+        "path": path,
+        "line": optional_positive_int(comment.get("line"), "comment line"),
+        "original_line": optional_positive_int(
+            comment.get("original_line"), "comment original_line"
+        ),
+        "start_line": optional_positive_int(comment.get("start_line"), "comment start_line"),
+        "original_start_line": optional_positive_int(
+            comment.get("original_start_line"), "comment original_start_line"
+        ),
+        "side": optional_side(comment.get("side"), "comment side"),
+        "start_side": optional_side(comment.get("start_side"), "comment start_side"),
+        "in_reply_to_id": optional_positive_int(
+            comment.get("in_reply_to_id"), "comment in_reply_to_id"
+        ),
+        "created_at": github_memory.timestamp(comment.get("created_at"), "comment created_at"),
+        "updated_at": github_memory.timestamp(comment.get("updated_at"), "comment updated_at"),
+        "body": bounded_body(comment.get("body"), "comment body"),
+    }
+
+
+def collect(
+    repository: str,
+    pull_request: int,
+    concern_key: str,
+    outcome: str,
+    *,
+    comment_id: int | None = None,
+    comment_node_id: str | None = None,
+    resolution_comment_id: int | None = None,
+    resolution_comment_node_id: str | None = None,
+    client: github_memory.GitHubClient | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if github_memory.REPOSITORY_RE.fullmatch(repository) is None:
+        raise github_memory.CollectorError("repository must be canonical owner/name")
+    if pull_request <= 0:
+        raise github_memory.CollectorError("pull request number must be positive")
+    concern_key = bounded_single_line(concern_key, "concern_key")
+    if outcome not in OUTCOMES:
+        raise github_memory.CollectorError(f"unsupported review outcome: {outcome}")
+
+    has_resolution = (
+        resolution_comment_id is not None or resolution_comment_node_id is not None
+    )
+    if outcome == "open" and has_resolution:
+        raise github_memory.CollectorError("open outcome forbids a resolution comment")
+    if outcome != "open" and not has_resolution:
+        raise github_memory.CollectorError(
+            f"outcome={outcome} requires a selected resolution comment"
+        )
+    if comment_id is None and comment_node_id is None:
+        raise github_memory.CollectorError("root review-comment selector is missing")
+    if comment_id is not None and comment_node_id is not None:
+        raise github_memory.CollectorError("root review-comment selector is ambiguous")
+    if resolution_comment_id is not None and resolution_comment_node_id is not None:
+        raise github_memory.CollectorError("resolution review-comment selector is ambiguous")
+
+    if client is None:
+        token = os.environ.get("GITHUB_TOKEN")
+        client = github_memory.GitHubClient(token if token else None)
+
+    raw_pr = client.get_json(f"/repos/{repository}/pulls/{pull_request}")
+    if not isinstance(raw_pr, dict) or raw_pr.get("number") != pull_request:
+        raise github_memory.CollectorError(
+            f"GitHub PR #{pull_request} payload is malformed"
+        )
+    head = raw_pr.get("head")
+    if not isinstance(head, dict):
+        raise github_memory.CollectorError(
+            f"GitHub PR #{pull_request} head payload is malformed"
+        )
+    current_head = github_memory.exact_sha(head.get("sha"), "current PR head_sha")
+
+    comments = list_review_comments(client, repository, pull_request)
+    by_id, by_node = index_comments(comments)
+    root = select_comment(
+        by_id,
+        by_node,
+        comment_id=comment_id,
+        node_id=comment_node_id,
+        label="root review comment",
+    )
+    root_receipt = comment_receipt(repository, pull_request, root)
+    if root_receipt["in_reply_to_id"] is not None:
+        raise github_memory.CollectorError(
+            "selected root review comment is itself a reply"
+        )
+
+    resolution_receipt: dict[str, Any] | None = None
+    if has_resolution:
+        resolution = select_comment(
+            by_id,
+            by_node,
+            comment_id=resolution_comment_id,
+            node_id=resolution_comment_node_id,
+            label="resolution review comment",
+        )
+        resolution_receipt = comment_receipt(repository, pull_request, resolution)
+        if resolution_receipt["in_reply_to_id"] != root_receipt["id"]:
+            raise github_memory.CollectorError(
+                "selected resolution comment is not a direct reply to the root review comment"
+            )
+
+    work = f"github:pull/{pull_request}"
+    root_identity = comment_identity(pull_request, root)
+    resolution_identity = (
+        comment_identity(pull_request, resolution)
+        if has_resolution and resolution_receipt is not None
+        else None
+    )
+
+    record: dict[str, Any] = {
+        "event_id": root_identity,
+        "concern_key": concern_key,
+        "source_ref": root_identity,
+        "subject": {
+            "repository": repository,
+            "work": work,
+            "revision": root_receipt["commit_id"],
+            "scope": {"mode": "exact", "path": root_receipt["path"]},
+        },
+        "outcome": outcome,
+    }
+    if resolution_identity is not None:
+        record["resolution_ref"] = resolution_identity
+
+    query = {
+        "schema_version": 1,
+        "current": {
+            "concern_key": concern_key,
+            "context": {
+                "repository": repository,
+                "revision": current_head,
+                "work": work,
+                "path": root_receipt["path"],
+            },
+        },
+        "records": [record],
+    }
+    receipt = {
+        "schema_version": 1,
+        "provider": "github_review_comment",
+        "repository": repository,
+        "pull_request": pull_request,
+        "current_head_sha": current_head,
+        "concern_key": concern_key,
+        "selected_outcome": outcome,
+        "review_comment_count": len(comments),
+        "pagination_complete": True,
+        "root": root_receipt,
+        "resolution": resolution_receipt,
+    }
+
+    query_bytes = (json.dumps(query, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    if len(query_bytes) > MAX_QUERY_BYTES:
+        raise github_memory.CollectorError(
+            f"review-memory query exceeds the {MAX_QUERY_BYTES}-byte bound"
+        )
+    receipt_bytes = (json.dumps(receipt, indent=2, sort_keys=True) + "\n").encode(
+        "utf-8"
+    )
+    if len(receipt_bytes) > MAX_RECEIPT_BYTES:
+        raise github_memory.CollectorError(
+            f"GitHub review-memory receipt exceeds the {MAX_RECEIPT_BYTES}-byte bound"
+        )
+    return query, receipt
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        query, receipt = collect(
+            args.repository,
+            args.pull_request,
+            args.concern_key,
+            args.outcome,
+            comment_id=args.comment_id,
+            comment_node_id=args.comment_node_id,
+            resolution_comment_id=args.resolution_comment_id,
+            resolution_comment_node_id=args.resolution_comment_node_id,
+        )
+        encoded_query = json.dumps(query, indent=2, sort_keys=True) + "\n"
+        encoded_receipt = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.receipt_output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded_query, encoding="utf-8")
+        args.receipt_output.write_text(encoded_receipt, encoding="utf-8")
+    except (github_memory.CollectorError, OSError) as error:
+        print(f"review-memory-github: {error}", file=sys.stderr)
+        return 1
+
+    print(encoded_query, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/review_memory_github_test.py
+++ b/scripts/review_memory_github_test.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Regression controls for the selected GitHub review-memory adapter."""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+import project_memory_github as github_memory
+import review_memory_github as adapter
+
+REPOSITORY = "owner/repo"
+PR = 7
+HEAD_A = "a" * 40
+HEAD_B = "b" * 40
+
+
+class FakeGitHubClient:
+    def __init__(self, responses: dict[str, Any]) -> None:
+        self.responses = responses
+        self.calls: list[str] = []
+
+    def get_json(self, path: str) -> Any:
+        self.calls.append(path)
+        if path not in self.responses:
+            raise AssertionError(f"unexpected GitHub request: {path}")
+        return self.responses[path]
+
+
+def pr_payload(head: str = HEAD_B) -> dict[str, Any]:
+    return {"number": PR, "head": {"sha": head}}
+
+
+def comment_payload(
+    comment_id: int,
+    node_id: str,
+    *,
+    commit_id: str = HEAD_A,
+    original_commit_id: str = HEAD_A,
+    path: str = "src/lib.rs",
+    in_reply_to_id: int | None = None,
+    pull_request: int = PR,
+    body: str = "review concern",
+) -> dict[str, Any]:
+    return {
+        "id": comment_id,
+        "node_id": node_id,
+        "pull_request_review_id": 42,
+        "commit_id": commit_id,
+        "original_commit_id": original_commit_id,
+        "path": path,
+        "line": 12,
+        "original_line": 10,
+        "start_line": None,
+        "original_start_line": None,
+        "side": "RIGHT",
+        "start_side": None,
+        "in_reply_to_id": in_reply_to_id,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:01:00Z",
+        "body": body,
+        "pull_request_url": f"https://api.github.com/repos/{REPOSITORY}/pulls/{pull_request}",
+    }
+
+
+def responses(comments: list[dict[str, Any]], *, head: str = HEAD_B) -> dict[str, Any]:
+    return {
+        f"/repos/{REPOSITORY}/pulls/{PR}": pr_payload(head),
+        f"/repos/{REPOSITORY}/pulls/{PR}/comments?per_page=100&page=1": comments,
+    }
+
+
+class ReviewMemoryGitHubAdapterTests(unittest.TestCase):
+    def test_emits_exact_review_memory_query_from_selected_thread(self) -> None:
+        root = comment_payload(10, "ROOT")
+        reply = comment_payload(
+            11,
+            "REPLY",
+            commit_id=HEAD_B,
+            in_reply_to_id=10,
+            body="Fixed in `deadbeef`.",
+        )
+        client = FakeGitHubClient(responses([root, reply]))
+
+        query, receipt = adapter.collect(
+            REPOSITORY,
+            PR,
+            "review:github-fallback-publish-state",
+            "patch_changed",
+            comment_node_id="ROOT",
+            resolution_comment_node_id="REPLY",
+            client=client,
+        )
+
+        record = query["records"][0]
+        self.assertEqual(query["current"]["context"]["revision"], HEAD_B)
+        self.assertEqual(query["current"]["context"]["work"], "github:pull/7")
+        self.assertEqual(record["subject"]["revision"], HEAD_A)
+        self.assertEqual(record["subject"]["scope"], {"mode": "exact", "path": "src/lib.rs"})
+        self.assertEqual(record["outcome"], "patch_changed")
+        self.assertEqual(
+            record["resolution_ref"], "github:pull/7/review-comment/11"
+        )
+        self.assertEqual(receipt["root"]["node_id"], "ROOT")
+        self.assertEqual(receipt["root"]["original_line"], 10)
+        self.assertEqual(receipt["resolution"]["in_reply_to_id"], 10)
+        self.assertTrue(receipt["pagination_complete"])
+
+    def test_numeric_comment_selectors_are_supported(self) -> None:
+        root = comment_payload(10, "ROOT")
+        reply = comment_payload(11, "REPLY", in_reply_to_id=10)
+        client = FakeGitHubClient(responses([root, reply]))
+
+        query, _ = adapter.collect(
+            REPOSITORY,
+            PR,
+            "review:fixture",
+            "dismissed",
+            comment_id=10,
+            resolution_comment_id=11,
+            client=client,
+        )
+
+        self.assertEqual(
+            query["records"][0]["event_id"], "github:pull/7/review-comment/10"
+        )
+
+    def test_selected_root_may_not_be_a_reply(self) -> None:
+        reply = comment_payload(11, "REPLY", in_reply_to_id=10)
+        client = FakeGitHubClient(responses([reply]))
+
+        with self.assertRaisesRegex(
+            github_memory.CollectorError, "root review comment is itself a reply"
+        ):
+            adapter.collect(
+                REPOSITORY,
+                PR,
+                "review:fixture",
+                "open",
+                comment_node_id="REPLY",
+                client=client,
+            )
+
+    def test_resolution_must_reply_directly_to_selected_root(self) -> None:
+        root = comment_payload(10, "ROOT")
+        wrong_reply = comment_payload(11, "REPLY", in_reply_to_id=9)
+        client = FakeGitHubClient(responses([root, wrong_reply]))
+
+        with self.assertRaisesRegex(
+            github_memory.CollectorError, "not a direct reply"
+        ):
+            adapter.collect(
+                REPOSITORY,
+                PR,
+                "review:fixture",
+                "patch_changed",
+                comment_node_id="ROOT",
+                resolution_comment_node_id="REPLY",
+                client=client,
+            )
+
+    def test_selected_comment_must_belong_to_selected_pull_request(self) -> None:
+        root = comment_payload(10, "ROOT", pull_request=8)
+        client = FakeGitHubClient(responses([root]))
+
+        with self.assertRaisesRegex(
+            github_memory.CollectorError, "different pull request"
+        ):
+            adapter.collect(
+                REPOSITORY,
+                PR,
+                "review:fixture",
+                "open",
+                comment_node_id="ROOT",
+                client=client,
+            )
+
+    def test_duplicate_node_ids_fail_closed(self) -> None:
+        comments = [comment_payload(10, "DUP"), comment_payload(11, "DUP")]
+        client = FakeGitHubClient(responses(comments))
+
+        with self.assertRaisesRegex(
+            github_memory.CollectorError, "duplicate GitHub review-comment node_id"
+        ):
+            adapter.collect(
+                REPOSITORY,
+                PR,
+                "review:fixture",
+                "open",
+                comment_node_id="DUP",
+                client=client,
+            )
+
+    def test_noncanonical_path_rejects(self) -> None:
+        root = comment_payload(10, "ROOT", path="../src/lib.rs")
+        client = FakeGitHubClient(responses([root]))
+
+        with self.assertRaisesRegex(github_memory.CollectorError, "non-canonical"):
+            adapter.collect(
+                REPOSITORY,
+                PR,
+                "review:fixture",
+                "open",
+                comment_node_id="ROOT",
+                client=client,
+            )
+
+    def test_invalid_comment_and_current_head_shas_reject(self) -> None:
+        root = comment_payload(10, "ROOT", commit_id="HEAD")
+        client = FakeGitHubClient(responses([root]))
+        with self.assertRaisesRegex(github_memory.CollectorError, "comment commit_id"):
+            adapter.collect(
+                REPOSITORY,
+                PR,
+                "review:fixture",
+                "open",
+                comment_node_id="ROOT",
+                client=client,
+            )
+
+        root = comment_payload(10, "ROOT")
+        client = FakeGitHubClient(responses([root], head="HEAD"))
+        with self.assertRaisesRegex(github_memory.CollectorError, "current PR head_sha"):
+            adapter.collect(
+                REPOSITORY,
+                PR,
+                "review:fixture",
+                "open",
+                comment_node_id="ROOT",
+                client=client,
+            )
+
+    def test_outcome_resolution_contract_rejects_before_provider_work(self) -> None:
+        client = FakeGitHubClient({})
+
+        with self.assertRaisesRegex(
+            github_memory.CollectorError, "open outcome forbids"
+        ):
+            adapter.collect(
+                REPOSITORY,
+                PR,
+                "review:fixture",
+                "open",
+                comment_node_id="ROOT",
+                resolution_comment_node_id="REPLY",
+                client=client,
+            )
+        with self.assertRaisesRegex(
+            github_memory.CollectorError, "requires a selected resolution comment"
+        ):
+            adapter.collect(
+                REPOSITORY,
+                PR,
+                "review:fixture",
+                "patch_changed",
+                comment_node_id="ROOT",
+                client=client,
+            )
+        self.assertEqual(client.calls, [])
+
+    def test_inventory_overflow_fails_instead_of_truncating(self) -> None:
+        all_comments = [
+            comment_payload(index + 1, f"NODE-{index + 1}")
+            for index in range(adapter.MAX_REVIEW_COMMENTS + 1)
+        ]
+        paged: dict[str, Any] = {f"/repos/{REPOSITORY}/pulls/{PR}": pr_payload()}
+        for page in range(1, 7):
+            start = (page - 1) * 100
+            paged[
+                f"/repos/{REPOSITORY}/pulls/{PR}/comments?per_page=100&page={page}"
+            ] = all_comments[start : start + 100]
+        client = FakeGitHubClient(paged)
+
+        with self.assertRaisesRegex(
+            github_memory.CollectorError, "exceeds the 512-comment bound"
+        ):
+            adapter.collect(
+                REPOSITORY,
+                PR,
+                "review:fixture",
+                "open",
+                comment_node_id="NODE-1",
+                client=client,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Progress #109 through #202 by adding an opt-in GitHub adapter for the revision-aware review-memory contract merged in #198.

The adapter starts from one explicitly selected inline-review root comment, an optional selected direct reply, a caller-supplied `concern_key`, and a caller-supplied review outcome. GitHub supplies the exact provider coordinates:

```text
PR current head
root comment id / node_id
root commit_id / original_commit_id
path + line/original-line receipts
reply linkage
```

It then emits the existing `ReviewMemoryQuery` and validates it through the independent Rust `review_memory` example.

## Semantic boundary

The provider never hashes review prose into semantic concern identity and never infers `patch_changed`/dismissal from sentiment, reactions, timestamps, or thread resolution.

```text
concern_key + outcome
  caller/producer supplied

repository / work / reviewed head / path
  exact provider evidence

resolution_ref
  exact selected direct reply identity
```

Line/range fields are retained in the provider receipt for the next target-identity experiment; v0 does not silently add a new applicability dimension.

## Live carrier

[PR-Agent PR #2424](https://redirect.github.com/The-PR-Agent/pr-agent/pull/2424) has a resolved/outdated review thread on `pr_agent/git_providers/github_provider.py`:

- root `PRRC_kwDOJ4EDks7IBoVk`: “Dedup blocks gh fallback”;
- direct reply `PRRC_kwDOJ4EDks7IB1zX`: maintainer says the concern was fixed in commit `f699e7ea`.

The PR workflow selects that exact pair, labels the retained research outcome `patch_changed`, and requires:

```text
root reviewed commit != current PR head
-> old outcome applicability INVALID
-> same concern lineage refresh_existing_thread
```

This is a real-provider replay of #198's core distinction.

## Counterexample carried forward

The same external PR contains a review finding that GitHub dedup used `target_line_no=None`, allowing distinct same-file/same-text comments at different anchors to collide. That is why this adapter preserves provider line receipts and keeps semantic concern identity caller-owned instead of implementing generic text-hash dedup.

## Verification

- bounded/paginated review-comment inventory, complete-or-fail through 512 comments;
- duplicate comment IDs/node IDs reject;
- selected root must belong to the selected PR and must not itself be a reply;
- selected resolution must be a direct reply;
- exact current/comment/original Git SHAs required;
- canonical path validation;
- outcome/resolution contract checked before provider access;
- ordinary CI runs the Python adapter suite;
- dedicated workflow runs the live PR-Agent carrier and pipes the result through Rust review-memory evaluation.

Remote collection stays outside ordinary `cargo-cultist` commands.

Closes #202.

Refs #18 #109 #123 #127 #137 #192 #198.