### PR TITLE
research: select scope probes from durable obligations

### DIFF
--- a/examples/durable_unknown.rs
+++ b/examples/durable_unknown.rs
@@ -1,0 +1,45 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+use serde::Deserialize;
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/justification.rs"]
+mod justification;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+
+use applicability::EvaluationContext;
+use durable_obligation::{ClearingEvidenceReceipt, DurableObligation, evaluate_obligation};
+
+const MAX_INPUT_BYTES: u64 = 1024 * 1024;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvaluationInput {
+    obligation: DurableObligation,
+    #[serde(default)]
+    receipts: Vec<ClearingEvidenceReceipt>,
+    context: EvaluationContext,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut input = Vec::new();
+    io::stdin()
+        .take(MAX_INPUT_BYTES + 1)
+        .read_to_end(&mut input)?;
+    if input.len() as u64 > MAX_INPUT_BYTES {
+        return Err("durable unknown input exceeds 1 MiB".into());
+    }
+
+    let request: EvaluationInput = serde_json::from_slice(&input)?;
+    let evaluation = evaluate_obligation(
+        &request.obligation,
+        &request.receipts,
+        &request.context,
+    )?;
+    serde_json::to_writer_pretty(io::stdout().lock(), &evaluation)?;
+    println!();
+    Ok(())
+}

--- a/examples/durable_unknown.rs
+++ b/examples/durable_unknown.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::error::Error;
 use std::io::{self, Read};
 
@@ -5,10 +7,10 @@ use serde::Deserialize;
 
 #[path = "../src/applicability.rs"]
 mod applicability;
-#[path = "../src/justification.rs"]
-mod justification;
 #[path = "../src/durable_obligation.rs"]
 mod durable_obligation;
+#[path = "../src/justification.rs"]
+mod justification;
 
 use applicability::EvaluationContext;
 use durable_obligation::{ClearingEvidenceReceipt, DurableObligation, evaluate_obligation};
@@ -34,11 +36,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let request: EvaluationInput = serde_json::from_slice(&input)?;
-    let evaluation = evaluate_obligation(
-        &request.obligation,
-        &request.receipts,
-        &request.context,
-    )?;
+    let evaluation = evaluate_obligation(&request.obligation, &request.receipts, &request.context)?;
     serde_json::to_writer_pretty(io::stdout().lock(), &evaluation)?;
     println!();
     Ok(())

--- a/examples/evidence_plan.rs
+++ b/examples/evidence_plan.rs
@@ -1,0 +1,33 @@
+#![allow(dead_code)]
+
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[path = "../src/justification.rs"]
+mod justification;
+
+use evidence_planner::{ProbePlanRequest, plan_evidence};
+
+const MAX_INPUT_BYTES: u64 = 1024 * 1024;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut input = Vec::new();
+    io::stdin()
+        .take(MAX_INPUT_BYTES + 1)
+        .read_to_end(&mut input)?;
+    if input.len() as u64 > MAX_INPUT_BYTES {
+        return Err("evidence planner input exceeds 1 MiB".into());
+    }
+
+    let request: ProbePlanRequest = serde_json::from_slice(&input)?;
+    let plan = plan_evidence(&request)?;
+    serde_json::to_writer_pretty(io::stdout().lock(), &plan)?;
+    println!();
+    Ok(())
+}

--- a/examples/justification_graph.rs
+++ b/examples/justification_graph.rs
@@ -1,0 +1,63 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+use serde::Deserialize;
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/justification.rs"]
+mod justification;
+
+use applicability::EvaluationContext;
+use justification::{JustificationGraph, evaluate_graph, reevaluate_graph};
+
+const MAX_INPUT_BYTES: u64 = 1024 * 1024;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvaluationInput {
+    graph: JustificationGraph,
+    context: EvaluationContext,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReevaluationInput {
+    graph: JustificationGraph,
+    before_context: EvaluationContext,
+    after_context: EvaluationContext,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    let mut input = Vec::new();
+    io::stdin()
+        .take(MAX_INPUT_BYTES + 1)
+        .read_to_end(&mut input)?;
+    if input.len() as u64 > MAX_INPUT_BYTES {
+        return Err("justification input exceeds 1 MiB".into());
+    }
+
+    match args.as_slice() {
+        [] => {
+            let request: EvaluationInput = serde_json::from_slice(&input)?;
+            let evaluation = evaluate_graph(&request.graph, &request.context)?;
+            serde_json::to_writer_pretty(io::stdout().lock(), &evaluation)?;
+        }
+        [flag] if flag == "--reevaluate" => {
+            let request: ReevaluationInput = serde_json::from_slice(&input)?;
+            let receipt = reevaluate_graph(
+                &request.graph,
+                &request.before_context,
+                &request.after_context,
+            )?;
+            serde_json::to_writer_pretty(io::stdout().lock(), &receipt)?;
+        }
+        _ => {
+            return Err("usage: cultist_justification [--reevaluate] < request.json".into());
+        }
+    }
+
+    println!();
+    Ok(())
+}

--- a/examples/justification_graph.rs
+++ b/examples/justification_graph.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::error::Error;
 use std::io::{self, Read};
 

--- a/research/durable-unknown-obligation.md
+++ b/research/durable-unknown-obligation.md
@@ -17,6 +17,8 @@ Encoding a prospective clearing edge as if evidence already existed would confus
 
 This carrier therefore treats **the open durable record** and **arrived clearing receipts** as separate things.
 
+That counterexample was fed back into #141/#156 as well: an obligation node may now remain open with zero clearing edges instead of requiring a fabricated future evidence object.
+
 ## v0 record
 
 ```text
@@ -77,6 +79,30 @@ The stacked carrier tests:
 - record round-trips with completed evidence references for fresh-worker handoff;
 - a clearing condition must actually answer the declared missing discriminator.
 
+## Executed GitHub receipt
+
+Draft stacked PR #159 ran against exact parent #156 head:
+
+```text
+parent  9beaeaab2bece20a4e0bb9c880f510f740bf8cfb
+child   fd37861d73e966ed64538c60cc00bf32f8f928b2
+```
+
+GitHub Actions CI run `32243607858` / run number `1045` completed successfully on the stacked PR merge ref. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work heads-up;
+- full `cargo test` including the durable-obligation harness;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The PR-only push-diff step remained skipped by workflow context.
+
+The first current-stack CI attempt was a useful mechanical control: rustfmt rejected handwritten formatting in the new research files. Applying the exact formatter diff plus a fixture-local dead-code allowance for the standalone example allowed the next run to reach and pass Clippy/tests.
+
 ## Boundary
 
 - discriminator `{kind,target}` is a research key, not a final universal evidence ontology;
@@ -89,3 +115,5 @@ The stacked carrier tests:
 ## Next discriminator
 
 The next useful experiment is #145: given this typed missing discriminator and a bounded set of available probe capabilities, select the cheapest admitted probe capable of producing a matching receipt. That experiment should consume this object rather than restating the missing question in prose.
+
+Keep planning forecasts separate from observed performance receipts. Current `PerfCounters` measure work after execution; a planner cost is an admitted forecast before execution and can later be calibrated against measured counters where the dimensions overlap.

--- a/research/durable-unknown-obligation.md
+++ b/research/durable-unknown-obligation.md
@@ -1,0 +1,91 @@
+# Durable UNKNOWN obligation research receipt
+
+Tracking: #144. Stacked on the #141 justification-graph carrier.
+
+## Dogfood discriminator from #141
+
+The first justification graph required every obligation node to have a clearing edge. That is convenient for evaluating a graph containing known candidate evidence, but it fails the central durable-handoff case:
+
+```text
+worker finishes bounded investigation
+-> material discriminator remains missing
+-> clearing evidence does not exist yet
+-> preserve the open obligation for the next worker
+```
+
+Encoding a prospective clearing edge as if evidence already existed would confuse an expected future observation with an observed evidence object.
+
+This carrier therefore treats **the open durable record** and **arrived clearing receipts** as separate things.
+
+## v0 record
+
+```text
+DurableObligation
+  id
+  question
+  exact subject applicability requirements
+  established_evidence[]
+  missing_discriminator { kind, target }
+  clearing_conditions[]
+```
+
+A clearing condition names an exact typed discriminator plus exact applicability requirements. A supplied receipt must match both before it can participate in clearing.
+
+`established_evidence` is intentionally a bounded list of evidence IDs in this experiment. It preserves completed investigation for handoff without granting those strings authority or semantic lineage.
+
+## Evaluation
+
+The record and every candidate receipt reuse the shared applicability evaluator.
+
+```text
+subject APPLIES
+  + matching clearing receipt APPLIES
+    -> CLEARED
+
+subject APPLIES
+  + no matching/current clearing receipt
+    -> OPEN
+
+subject APPLIES
+  + matching receipt applicability UNKNOWN
+    -> UNKNOWN
+
+subject applicability UNKNOWN
+    -> UNKNOWN
+
+subject INVALID because the exact coordinate moved
+    -> REOPEN_REQUIRED
+```
+
+A semantically adjacent receipt with another discriminator kind remains unmatched even when it names the same target/revision.
+
+## Why `REOPEN_REQUIRED` exists
+
+An obligation captured for exact head A cannot silently become the obligation for head B. Head movement invalidates the old subject coordinate. The next worker/orchestrator can compile a fresh obligation for B while preserving the old record as a historical handoff receipt.
+
+This keeps reopening distinct from pretending the stale obligation is still current.
+
+## Standard-suite controls
+
+The stacked carrier tests:
+
+- open obligation with zero clearing evidence;
+- exact matching receipt clears;
+- exact subject head movement produces `reopen_required`;
+- missing current coordinate remains `unknown`;
+- semantically adjacent receipt does not clear;
+- record round-trips with completed evidence references for fresh-worker handoff;
+- a clearing condition must actually answer the declared missing discriminator.
+
+## Boundary
+
+- discriminator `{kind,target}` is a research key, not a final universal evidence ontology;
+- receipt requirements use exact v1 matching against the clearing condition before applicability evaluation;
+- richer subject/predicate envelopes belong to #147;
+- probe discovery/cost belongs to #145;
+- this record grants no mutation, review, merge, or deployment authority;
+- solved records can remain as history, while current use always rechecks applicability.
+
+## Next discriminator
+
+The next useful experiment is #145: given this typed missing discriminator and a bounded set of available probe capabilities, select the cheapest admitted probe capable of producing a matching receipt. That experiment should consume this object rather than restating the missing question in prose.

--- a/research/evidence-acquisition-planner.md
+++ b/research/evidence-acquisition-planner.md
@@ -1,0 +1,133 @@
+# Evidence acquisition planner research receipt
+
+Tracking: #145. Stacked on #144/#159 and #141/#156.
+
+## Question
+
+Given one material durable `UNKNOWN`, can Cultist select the smallest admitted evidence probe capable of changing that exact answer without confusing cheap evidence with sufficient evidence or granting permission to perform effects?
+
+## Earned input from #144
+
+The planner consumes the durable record directly:
+
+```text
+DurableObligation
+  subject applicability
+  missing_discriminator { kind, target }
+  clearing_conditions[]
+```
+
+It does not reparse the question prose to decide what evidence is needed.
+
+A candidate probe declares:
+
+```text
+id
+produces { kind, target }
+requirements
+probe effect class
+forecast cost
+```
+
+A probe is capable only when its produced discriminator exactly matches the obligation's missing discriminator and its exact output requirements match an admitted clearing condition.
+
+This is deliberately stronger than vocabulary overlap. A historical companion probe can be cheap and useful while remaining incapable of clearing an `exact-head target_test_result` obligation.
+
+## Candidate states
+
+Each probe receives one inspectable status:
+
+```text
+eligible
+incapable
+incompatible_clearing_condition
+invalid_coordinate
+missing_context
+effect_authority_required
+```
+
+The whole plan is:
+
+```text
+selected
+blocked
+unresolved
+stale_obligation
+```
+
+`unresolved` means no admitted probe can currently answer the obligation. It is a valid research-frontier result.
+
+`stale_obligation` means the durable obligation's own subject coordinate moved; the planner refuses to select new work against an obsolete question and requires a fresh obligation first.
+
+## Effect boundary
+
+Probe effect class is explicit:
+
+```text
+read_only
+external_read
+effectful
+```
+
+An effectful probe may be the only capable next discriminator. The planner can identify that fact while returning `blocked / effect_authority_required` when the caller has not admitted effectful work.
+
+Selection therefore answers:
+
+> Which admitted probe would be appropriate if its effect class is allowed?
+
+It does not itself execute the probe or mint execution authority.
+
+## Forecast cost versus measured performance
+
+V0 `ProbeCost` is a pre-execution forecast:
+
+```text
+git_subprocesses
+rust_files_parsed
+remote_requests
+effectful_executions
+```
+
+Current `PerfCounters` on main are post-execution observations. Keep those concepts separate. A later calibration experiment can compare forecast and measured dimensions where they overlap.
+
+The first explicit policy is `conservative`:
+
+1. prefer read-only over external-read over effectful probes;
+2. then fewer remote requests;
+3. then fewer Git subprocesses;
+4. then fewer Rust files parsed;
+5. then fewer effectful executions;
+6. stable probe ID breaks exact ties.
+
+No hidden scalar cost score is produced.
+
+## Initial controls
+
+The carrier tests:
+
+- a cheaper historical probe is skipped when it cannot produce the required discriminator;
+- a stale exact-test probe cannot satisfy a current-head clearing condition;
+- the exact-head target execution probe is selected when effectful work is admitted;
+- the same capable probe returns `blocked` when effect authority is absent;
+- conservative policy prefers an eligible external read before an eligible effectful alternative;
+- no capable probe produces explicit `unresolved`;
+- missing current obligation context produces `blocked` instead of guessing;
+- moved obligation subject produces `stale_obligation` before probe selection;
+- simulated execution of the selected probe can emit the exact typed receipt that #144 evaluates from `open -> cleared`;
+- malformed effect/cost declarations fail explicitly.
+
+## Boundary
+
+- candidate capability comes from typed probe declarations, never prose keyword inference;
+- planning does not strengthen the epistemic kind of the evidence produced;
+- historical co-change remains association evidence even when it is the cheapest probe;
+- selection is deterministic under the declared policy;
+- a selected effectful probe remains unexecuted until an external caller/orchestrator grants that action;
+- no model, network request, test command, or repository mutation occurs inside the planner;
+- planner output is research-only and does not change the product CLI/report schema.
+
+## Next discriminator
+
+If this carrier survives CI, replay one real Cultist research frontier where two probes can answer the same typed discriminator at different costs. Then compare forecast work with existing performance receipts after execution.
+
+A second follow-up should test whether probe prerequisites need their own typed relation beyond output applicability. Keep v0 small until a real probe requires a prerequisite that cannot be represented by the current obligation/context coordinates.

--- a/research/evidence-acquisition-planner.md
+++ b/research/evidence-acquisition-planner.md
@@ -77,6 +77,8 @@ Selection therefore answers:
 
 It does not itself execute the probe or mint execution authority.
 
+A `SelectedProbe` remains an **expected evidence contract** until the probe actually runs and produces a separate observed receipt. The planner cannot clear its own obligation merely by selecting a capable probe.
+
 ## Forecast cost versus measured performance
 
 V0 `ProbeCost` is a pre-execution forecast:
@@ -116,6 +118,35 @@ The carrier tests:
 - simulated execution of the selected probe can emit the exact typed receipt that #144 evaluates from `open -> cleared`;
 - malformed effect/cost declarations fail explicitly.
 
+## Executed GitHub receipt
+
+Draft stacked PR #164 ran against exact parent #159 head:
+
+```text
+parent  1c1a0086a199168fd0e21445d103936183063dc7
+child   179a2b45267b36d9dfd92eddca93f70aac1744d4
+```
+
+GitHub Actions CI run `32244269156` / run number `1083` completed successfully on the stacked PR merge ref. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work heads-up;
+- full `cargo test` including the evidence-planner harness;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The PR-only push-diff step remained skipped by workflow context.
+
+Two preceding runs were useful controls:
+
+1. run `32243927421` exposed handwritten rustfmt differences before semantic validation;
+2. run `32244049236` passed format/Clippy and all planner semantics except one test assertion that expected the plural phrase `effectful executions` while the intentional validation error used singular `effectful execution`.
+
+The second failure changed only the test's string expectation. The planner contract stayed unchanged, and the next full run passed.
+
 ## Boundary
 
 - candidate capability comes from typed probe declarations, never prose keyword inference;
@@ -123,11 +154,12 @@ The carrier tests:
 - historical co-change remains association evidence even when it is the cheapest probe;
 - selection is deterministic under the declared policy;
 - a selected effectful probe remains unexecuted until an external caller/orchestrator grants that action;
+- selection produces an expected receipt contract, not observed clearing evidence;
 - no model, network request, test command, or repository mutation occurs inside the planner;
 - planner output is research-only and does not change the product CLI/report schema.
 
 ## Next discriminator
 
-If this carrier survives CI, replay one real Cultist research frontier where two probes can answer the same typed discriminator at different costs. Then compare forecast work with existing performance receipts after execution.
+Replay one real Cultist research frontier where two probes can answer the same typed discriminator at different costs. Then compare forecast work with existing performance receipts after execution.
 
 A second follow-up should test whether probe prerequisites need their own typed relation beyond output applicability. Keep v0 small until a real probe requires a prerequisite that cannot be represented by the current obligation/context coordinates.

--- a/research/justification-graph.md
+++ b/research/justification-graph.md
@@ -62,6 +62,8 @@ cleared
   at least one clearing evidence object applies
 ```
 
+An open obligation is valid with **zero clearing edges**. The immediately stacked #144 experiment exposed this as a necessary case: a durable missing discriminator can exist before any clearing evidence object has arrived. Requiring a clearing edge would manufacture prospective evidence as if it had already been observed.
+
 When exact-head clearing evidence later becomes INVALID after revision movement, the obligation reopens.
 
 ## Reevaluation receipt
@@ -84,10 +86,38 @@ The carrier includes controls for:
 - one invalidated support + one independent support -> claim remains supported;
 - sole invalidated support -> claim becomes unknown;
 - counterexample and limit receipts remain visible;
+- an obligation can remain open before any clearing evidence exists;
 - exact-head clearing evidence clears an obligation and head movement reopens it;
 - reevaluation names only targets downstream of changed evidence;
 - UNKNOWN dependency prevents a supported projection;
 - relation/target mismatch rejects rather than inventing cyclic/general graph semantics.
+
+## Executed GitHub receipt
+
+Draft PR #156 ran the ordinary repository gates after the open-obligation correction and fixture-only Clippy containment.
+
+Exact head under test:
+
+```text
+9399f29ebcb96e5b306e88b6ad12c0189f0e6f62
+```
+
+GitHub Actions CI run `32243151354` / run number `1018` completed successfully on the PR merge ref. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work heads-up;
+- full `cargo test` including the justification integration harness;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The PR-only push-diff step remained skipped by workflow context.
+
+Generated provenance review dogfood run `32243151304` / run number `160` also completed successfully for the same head.
+
+Two earlier CI attempts were useful mechanical controls rather than semantic failures: the first exposed rustfmt differences; the second reached Clippy and exposed one fixture-only unused applicability constant through the standalone example. Both were repaired before this executed receipt.
 
 ## Boundary
 
@@ -101,12 +131,12 @@ The carrier includes controls for:
 
 ## Next discriminator after this carrier
 
-If the controls hold, the next useful question is whether real Cultist evidence needs **alternative derivation groups** such as:
+The first follow-up is already concrete through #144: preserve open obligations and their future clearing conditions without pretending expected evidence is observed evidence.
+
+Beyond that, the next useful truth-maintenance question is whether real Cultist evidence needs **alternative derivation groups** such as:
 
 ```text
 (E1 AND E2) OR E3 -> C1
 ```
 
 before justification edges deserve canonical IR representation. Keep the v0 bipartite model until a real replay demonstrates that richer derivation semantics change the justified next action.
-
-CI/executed-run details should be appended after the carrier runs on GitHub.

--- a/research/justification-graph.md
+++ b/research/justification-graph.md
@@ -1,0 +1,112 @@
+# Justification graph research receipt
+
+Tracking: #141.
+
+## Question
+
+When one evidence object becomes invalid or unknown at a new repository/work/revision coordinate, can Cultist identify exactly which conclusions need reconsideration while preserving independent support, counterexamples, limits, and explicit clearing conditions?
+
+## v0 model
+
+The first carrier deliberately uses a typed bipartite graph:
+
+```text
+EvidenceNode
+  -> ClaimNode
+  -> relation: support | counterexample | limit | dependency
+
+EvidenceNode
+  -> ObligationNode
+  -> relation: clearing
+```
+
+Evidence nodes carry the existing `EvidenceRequirements` coordinate contract. Evaluation delegates applicability to the shared evaluator from #123/#124/#130.
+
+This means v0 has no claim-to-claim or obligation-to-claim edges. Cycles are excluded by representation instead of being accepted and then interpreted heuristically.
+
+## Semantics under test
+
+### Independent support
+
+```text
+E1 --support--> C1
+E2 --support--> C1
+```
+
+If `E1` becomes INVALID while `E2` still APPLIES, `C1` remains `supported` and both receipts stay visible.
+
+If the sole support becomes INVALID or UNKNOWN, the claim returns to `unknown`. The graph never turns missing applicable justification into a false claim.
+
+### Dependencies
+
+A dependency is a hard prerequisite in this v0 experiment. Any INVALID or UNKNOWN dependency keeps the claim justification `unknown` even when an ordinary support receipt still applies.
+
+This is intentionally narrower than a general logical justification language. Alternative dependency sets / AND-OR derivations remain future research.
+
+### Counterexamples and limits
+
+Applicable `counterexample` and `limit` edges remain explicit receipts. They do not automatically negate a supported claim or grant a stronger disposition. A downstream JEI/review/projection consumer can decide how those roles affect the current action while preserving the evidence that changes what may be concluded.
+
+### Clearing obligations
+
+An obligation is:
+
+```text
+open
+  no clearing evidence currently applies
+
+unknown
+  candidate clearing evidence has UNKNOWN applicability
+
+cleared
+  at least one clearing evidence object applies
+```
+
+When exact-head clearing evidence later becomes INVALID after revision movement, the obligation reopens.
+
+## Reevaluation receipt
+
+`reevaluate_graph(before_context, after_context)` evaluates evidence applicability at both coordinates and emits only:
+
+```text
+changed evidence applicability
+-> affected claim/obligation targets
+```
+
+An unrelated claim whose evidence coordinate did not change is absent from the affected-target receipt.
+
+This is the first discriminator for a future truth-maintenance engine: invalidate/reconsider downstream conclusions instead of treating the entire packet as one stale blob.
+
+## Adversarial controls in the standard test suite
+
+The carrier includes controls for:
+
+- one invalidated support + one independent support -> claim remains supported;
+- sole invalidated support -> claim becomes unknown;
+- counterexample and limit receipts remain visible;
+- exact-head clearing evidence clears an obligation and head movement reopens it;
+- reevaluation names only targets downstream of changed evidence;
+- UNKNOWN dependency prevents a supported projection;
+- relation/target mismatch rejects rather than inventing cyclic/general graph semantics.
+
+## Boundary
+
+- claim provenance remains separate from justification relation;
+- applicability remains separate from epistemic strength and authority;
+- v0 graph identity is local to the exact research object;
+- no stable semantic lineage is inferred from IDs;
+- no mutation, merge, deployment, or review authority is granted;
+- no model is required;
+- no `AnalysisReport` schema change is proposed by this carrier.
+
+## Next discriminator after this carrier
+
+If the controls hold, the next useful question is whether real Cultist evidence needs **alternative derivation groups** such as:
+
+```text
+(E1 AND E2) OR E3 -> C1
+```
+
+before justification edges deserve canonical IR representation. Keep the v0 bipartite model until a real replay demonstrates that richer derivation semantics change the justified next action.
+
+CI/executed-run details should be appended after the carrier runs on GitHub.

--- a/src/durable_obligation.rs
+++ b/src/durable_obligation.rs
@@ -1,0 +1,428 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, evaluate_query,
+};
+use crate::justification::RelationReceipt;
+
+pub const DURABLE_OBLIGATION_SCHEMA_VERSION: u32 = 1;
+const MAX_ID_BYTES: usize = 256;
+const MAX_TEXT_BYTES: usize = 4096;
+const MAX_ESTABLISHED_EVIDENCE: usize = 256;
+const MAX_CLEARING_CONDITIONS: usize = 64;
+const MAX_RECEIPTS: usize = 512;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DurableObligation {
+    pub schema_version: u32,
+    pub id: String,
+    pub question: String,
+    pub subject: EvidenceRequirements,
+    pub established_evidence: Vec<String>,
+    pub missing_discriminator: DiscriminatorKey,
+    pub clearing_conditions: Vec<ClearingCondition>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorKey {
+    pub kind: String,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClearingCondition {
+    pub discriminator: DiscriminatorKey,
+    pub requirements: EvidenceRequirements,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClearingEvidenceReceipt {
+    pub id: String,
+    pub discriminator: DiscriminatorKey,
+    pub requirements: EvidenceRequirements,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DurableObligationStatus {
+    Open,
+    Cleared,
+    Unknown,
+    ReopenRequired,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DurableObligationEvaluation {
+    pub schema_version: u32,
+    pub id: String,
+    pub status: DurableObligationStatus,
+    pub subject_applicability: ApplicabilityStatus,
+    pub clearing: RelationReceipt,
+    pub unmatched_receipts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DurableObligationError {
+    message: String,
+}
+
+impl DurableObligationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for DurableObligationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for DurableObligationError {}
+
+pub fn evaluate_obligation(
+    obligation: &DurableObligation,
+    receipts: &[ClearingEvidenceReceipt],
+    context: &EvaluationContext,
+) -> Result<DurableObligationEvaluation, DurableObligationError> {
+    validate_obligation(obligation)?;
+    validate_receipts(receipts)?;
+
+    let subject_applicability = evaluate_requirements(&obligation.subject, context, "subject")?;
+    let mut clearing = RelationReceipt::default();
+    let mut unmatched_receipts = Vec::new();
+
+    for receipt in receipts {
+        let Some(condition) = obligation.clearing_conditions.iter().find(|condition| {
+            condition.discriminator == receipt.discriminator
+                && condition.requirements == receipt.requirements
+        }) else {
+            unmatched_receipts.push(receipt.id.clone());
+            continue;
+        };
+
+        debug_assert_eq!(condition.requirements, receipt.requirements);
+        let applicability = evaluate_requirements(
+            &receipt.requirements,
+            context,
+            &format!("clearing receipt {}", receipt.id),
+        )?;
+        push_receipt(&mut clearing, receipt.id.clone(), applicability);
+    }
+
+    clearing.applies.sort();
+    clearing.invalid.sort();
+    clearing.unknown.sort();
+    unmatched_receipts.sort();
+
+    let status = match subject_applicability {
+        ApplicabilityStatus::Invalid => DurableObligationStatus::ReopenRequired,
+        ApplicabilityStatus::Unknown => DurableObligationStatus::Unknown,
+        ApplicabilityStatus::Applies if !clearing.applies.is_empty() => {
+            DurableObligationStatus::Cleared
+        }
+        ApplicabilityStatus::Applies if !clearing.unknown.is_empty() => {
+            DurableObligationStatus::Unknown
+        }
+        ApplicabilityStatus::Applies => DurableObligationStatus::Open,
+    };
+
+    Ok(DurableObligationEvaluation {
+        schema_version: DURABLE_OBLIGATION_SCHEMA_VERSION,
+        id: obligation.id.clone(),
+        status,
+        subject_applicability,
+        clearing,
+        unmatched_receipts,
+    })
+}
+
+fn evaluate_requirements(
+    requirements: &EvidenceRequirements,
+    context: &EvaluationContext,
+    label: &str,
+) -> Result<ApplicabilityStatus, DurableObligationError> {
+    let evaluation = evaluate_query(&ApplicabilityQuery {
+        schema_version: APPLICABILITY_SCHEMA_VERSION,
+        requirements: requirements.clone(),
+        context: context.clone(),
+    })
+    .map_err(|error| {
+        DurableObligationError::new(format!("{label} applicability failed: {error}"))
+    })?;
+    Ok(evaluation.status)
+}
+
+fn validate_obligation(obligation: &DurableObligation) -> Result<(), DurableObligationError> {
+    if obligation.schema_version != DURABLE_OBLIGATION_SCHEMA_VERSION {
+        return Err(DurableObligationError::new(format!(
+            "unsupported durable obligation schema {}; expected {DURABLE_OBLIGATION_SCHEMA_VERSION}",
+            obligation.schema_version
+        )));
+    }
+
+    validate_id(&obligation.id, "obligation id")?;
+    validate_text(&obligation.question, "obligation question")?;
+    validate_discriminator(&obligation.missing_discriminator)?;
+    require_coordinates(&obligation.subject, "obligation subject")?;
+
+    if obligation.established_evidence.len() > MAX_ESTABLISHED_EVIDENCE {
+        return Err(DurableObligationError::new(
+            "established evidence exceeds the admitted boundary",
+        ));
+    }
+    let mut established = BTreeSet::new();
+    for id in &obligation.established_evidence {
+        validate_id(id, "established evidence id")?;
+        if !established.insert(id.clone()) {
+            return Err(DurableObligationError::new(format!(
+                "duplicate established evidence id {id}"
+            )));
+        }
+    }
+
+    if obligation.clearing_conditions.is_empty()
+        || obligation.clearing_conditions.len() > MAX_CLEARING_CONDITIONS
+    {
+        return Err(DurableObligationError::new(
+            "durable obligation must declare a bounded non-empty clearing condition set",
+        ));
+    }
+
+    let mut conditions = BTreeSet::new();
+    for condition in &obligation.clearing_conditions {
+        validate_discriminator(&condition.discriminator)?;
+        require_coordinates(&condition.requirements, "clearing condition requirements")?;
+        let key = (
+            condition.discriminator.clone(),
+            serde_json::to_string(&condition.requirements).map_err(|error| {
+                DurableObligationError::new(format!(
+                    "failed to canonicalize clearing requirements: {error}"
+                ))
+            })?,
+        );
+        if !conditions.insert(key) {
+            return Err(DurableObligationError::new(
+                "duplicate durable obligation clearing condition",
+            ));
+        }
+    }
+
+    if !obligation
+        .clearing_conditions
+        .iter()
+        .any(|condition| condition.discriminator == obligation.missing_discriminator)
+    {
+        return Err(DurableObligationError::new(
+            "at least one clearing condition must answer the missing discriminator",
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_receipts(receipts: &[ClearingEvidenceReceipt]) -> Result<(), DurableObligationError> {
+    if receipts.len() > MAX_RECEIPTS {
+        return Err(DurableObligationError::new(
+            "clearing receipts exceed the admitted boundary",
+        ));
+    }
+
+    let mut ids = BTreeSet::new();
+    for receipt in receipts {
+        validate_id(&receipt.id, "clearing receipt id")?;
+        validate_discriminator(&receipt.discriminator)?;
+        require_coordinates(&receipt.requirements, "clearing receipt requirements")?;
+        if !ids.insert(receipt.id.clone()) {
+            return Err(DurableObligationError::new(format!(
+                "duplicate clearing receipt id {}",
+                receipt.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn require_coordinates(
+    requirements: &EvidenceRequirements,
+    label: &str,
+) -> Result<(), DurableObligationError> {
+    if requirements.repository.is_none()
+        && requirements.revision.is_none()
+        && requirements.work.is_none()
+        && requirements.scope.is_none()
+    {
+        return Err(DurableObligationError::new(format!(
+            "{label} must carry at least one applicability coordinate"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_discriminator(discriminator: &DiscriminatorKey) -> Result<(), DurableObligationError> {
+    validate_id(&discriminator.kind, "discriminator kind")?;
+    validate_text(&discriminator.target, "discriminator target")
+}
+
+fn validate_id(value: &str, field: &str) -> Result<(), DurableObligationError> {
+    if value.is_empty() || value.trim() != value || value.len() > MAX_ID_BYTES || value.contains('\0') {
+        return Err(DurableObligationError::new(format!(
+            "{field} must be a bounded canonical identifier"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, field: &str) -> Result<(), DurableObligationError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_TEXT_BYTES
+        || value.contains('\0')
+    {
+        return Err(DurableObligationError::new(format!(
+            "{field} must be bounded non-empty text"
+        )));
+    }
+    Ok(())
+}
+
+fn push_receipt(receipt: &mut RelationReceipt, id: String, status: ApplicabilityStatus) {
+    match status {
+        ApplicabilityStatus::Applies => receipt.applies.push(id),
+        ApplicabilityStatus::Invalid => receipt.invalid.push(id),
+        ApplicabilityStatus::Unknown => receipt.unknown.push(id),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn requirements(repository: &str, revision: Option<&str>) -> EvidenceRequirements {
+        EvidenceRequirements {
+            repository: Some(repository.to_string()),
+            revision: revision.map(str::to_string),
+            work: None,
+            scope: None,
+        }
+    }
+
+    fn discriminator() -> DiscriminatorKey {
+        DiscriminatorKey {
+            kind: "target_test_result".to_string(),
+            target: "cargo test target_t".to_string(),
+        }
+    }
+
+    fn obligation() -> DurableObligation {
+        DurableObligation {
+            schema_version: DURABLE_OBLIGATION_SCHEMA_VERSION,
+            id: "U17".to_string(),
+            question: "Does target T pass at this exact head?".to_string(),
+            subject: requirements("owner/repo", Some("head-a")),
+            established_evidence: vec!["E-history".to_string(), "E-guidance".to_string()],
+            missing_discriminator: discriminator(),
+            clearing_conditions: vec![ClearingCondition {
+                discriminator: discriminator(),
+                requirements: requirements("owner/repo", Some("head-a")),
+            }],
+        }
+    }
+
+    fn context(revision: Option<&str>) -> EvaluationContext {
+        EvaluationContext {
+            repository: Some("owner/repo".to_string()),
+            revision: revision.map(str::to_string),
+            work: None,
+            path: None,
+        }
+    }
+
+    fn receipt(revision: &str) -> ClearingEvidenceReceipt {
+        ClearingEvidenceReceipt {
+            id: format!("test-{revision}"),
+            discriminator: discriminator(),
+            requirements: requirements("owner/repo", Some(revision)),
+        }
+    }
+
+    #[test]
+    fn durable_unknown_can_exist_before_any_clearing_evidence_arrives() {
+        let evaluation = evaluate_obligation(&obligation(), &[], &context(Some("head-a"))).unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Open);
+        assert!(evaluation.clearing.applies.is_empty());
+    }
+
+    #[test]
+    fn exact_matching_receipt_clears_the_obligation() {
+        let evaluation = evaluate_obligation(
+            &obligation(),
+            &[receipt("head-a")],
+            &context(Some("head-a")),
+        )
+        .unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Cleared);
+        assert_eq!(evaluation.clearing.applies, vec!["test-head-a"]);
+    }
+
+    #[test]
+    fn moved_subject_coordinate_requires_reopen() {
+        let evaluation = evaluate_obligation(
+            &obligation(),
+            &[receipt("head-a")],
+            &context(Some("head-b")),
+        )
+        .unwrap();
+        assert_eq!(
+            evaluation.status,
+            DurableObligationStatus::ReopenRequired
+        );
+        assert_eq!(evaluation.subject_applicability, ApplicabilityStatus::Invalid);
+        assert_eq!(evaluation.clearing.invalid, vec!["test-head-a"]);
+    }
+
+    #[test]
+    fn missing_current_coordinate_remains_unknown() {
+        let evaluation = evaluate_obligation(&obligation(), &[], &context(None)).unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Unknown);
+        assert_eq!(evaluation.subject_applicability, ApplicabilityStatus::Unknown);
+    }
+
+    #[test]
+    fn semantically_adjacent_receipt_does_not_clear() {
+        let mut wrong = receipt("head-a");
+        wrong.discriminator.kind = "target_test_listing".to_string();
+        let evaluation = evaluate_obligation(&obligation(), &[wrong], &context(Some("head-a"))).unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Open);
+        assert_eq!(evaluation.unmatched_receipts, vec!["test-head-a"]);
+    }
+
+    #[test]
+    fn durable_record_round_trips_for_fresh_worker_handoff() {
+        let record = obligation();
+        let encoded = serde_json::to_string(&record).unwrap();
+        let decoded: DurableObligation = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, record);
+        assert_eq!(decoded.established_evidence, vec!["E-history", "E-guidance"]);
+    }
+
+    #[test]
+    fn clearing_condition_must_answer_declared_missing_discriminator() {
+        let mut record = obligation();
+        record.clearing_conditions[0].discriminator.kind = "provider_current".to_string();
+        let error = evaluate_obligation(&record, &[], &context(Some("head-a"))).unwrap_err();
+        assert!(error.to_string().contains("answer the missing discriminator"));
+    }
+}

--- a/src/durable_obligation.rs
+++ b/src/durable_obligation.rs
@@ -277,7 +277,11 @@ fn validate_discriminator(discriminator: &DiscriminatorKey) -> Result<(), Durabl
 }
 
 fn validate_id(value: &str, field: &str) -> Result<(), DurableObligationError> {
-    if value.is_empty() || value.trim() != value || value.len() > MAX_ID_BYTES || value.contains('\0') {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_ID_BYTES
+        || value.contains('\0')
+    {
         return Err(DurableObligationError::new(format!(
             "{field} must be a bounded canonical identifier"
         )));
@@ -385,11 +389,11 @@ mod tests {
             &context(Some("head-b")),
         )
         .unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::ReopenRequired);
         assert_eq!(
-            evaluation.status,
-            DurableObligationStatus::ReopenRequired
+            evaluation.subject_applicability,
+            ApplicabilityStatus::Invalid
         );
-        assert_eq!(evaluation.subject_applicability, ApplicabilityStatus::Invalid);
         assert_eq!(evaluation.clearing.invalid, vec!["test-head-a"]);
     }
 
@@ -397,14 +401,18 @@ mod tests {
     fn missing_current_coordinate_remains_unknown() {
         let evaluation = evaluate_obligation(&obligation(), &[], &context(None)).unwrap();
         assert_eq!(evaluation.status, DurableObligationStatus::Unknown);
-        assert_eq!(evaluation.subject_applicability, ApplicabilityStatus::Unknown);
+        assert_eq!(
+            evaluation.subject_applicability,
+            ApplicabilityStatus::Unknown
+        );
     }
 
     #[test]
     fn semantically_adjacent_receipt_does_not_clear() {
         let mut wrong = receipt("head-a");
         wrong.discriminator.kind = "target_test_listing".to_string();
-        let evaluation = evaluate_obligation(&obligation(), &[wrong], &context(Some("head-a"))).unwrap();
+        let evaluation =
+            evaluate_obligation(&obligation(), &[wrong], &context(Some("head-a"))).unwrap();
         assert_eq!(evaluation.status, DurableObligationStatus::Open);
         assert_eq!(evaluation.unmatched_receipts, vec!["test-head-a"]);
     }
@@ -415,7 +423,10 @@ mod tests {
         let encoded = serde_json::to_string(&record).unwrap();
         let decoded: DurableObligation = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded, record);
-        assert_eq!(decoded.established_evidence, vec!["E-history", "E-guidance"]);
+        assert_eq!(
+            decoded.established_evidence,
+            vec!["E-history", "E-guidance"]
+        );
     }
 
     #[test]
@@ -423,6 +434,10 @@ mod tests {
         let mut record = obligation();
         record.clearing_conditions[0].discriminator.kind = "provider_current".to_string();
         let error = evaluate_obligation(&record, &[], &context(Some("head-a"))).unwrap_err();
-        assert!(error.to_string().contains("answer the missing discriminator"));
+        assert!(
+            error
+                .to_string()
+                .contains("answer the missing discriminator")
+        );
     }
 }

--- a/src/evidence_planner.rs
+++ b/src/evidence_planner.rs
@@ -683,6 +683,6 @@ mod tests {
         ))
         .unwrap_err();
 
-        assert!(error.to_string().contains("effectful executions"));
+        assert!(error.to_string().contains("effectful execution"));
     }
 }

--- a/src/evidence_planner.rs
+++ b/src/evidence_planner.rs
@@ -1,0 +1,687 @@
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, evaluate_query,
+};
+use crate::durable_obligation::{
+    DiscriminatorKey, DurableObligation, DurableObligationStatus, evaluate_obligation,
+};
+
+pub const EVIDENCE_PLANNER_SCHEMA_VERSION: u32 = 1;
+const MAX_PROBES: usize = 128;
+const MAX_ID_BYTES: usize = 256;
+const MAX_TEXT_BYTES: usize = 4096;
+const MAX_COST_UNIT: u32 = 1_000_000;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProbePlanRequest {
+    pub schema_version: u32,
+    pub obligation: DurableObligation,
+    pub context: EvaluationContext,
+    pub probes: Vec<EvidenceProbe>,
+    pub allow_effectful: bool,
+    pub policy: ProbeSelectionPolicy,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceProbe {
+    pub id: String,
+    pub produces: DiscriminatorKey,
+    pub requirements: EvidenceRequirements,
+    pub effect: ProbeEffect,
+    pub cost: ProbeCost,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeEffect {
+    ReadOnly,
+    ExternalRead,
+    Effectful,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProbeCost {
+    pub git_subprocesses: u32,
+    pub rust_files_parsed: u32,
+    pub remote_requests: u32,
+    pub effectful_executions: u32,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeSelectionPolicy {
+    Conservative,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeCandidateStatus {
+    Eligible,
+    Incapable,
+    IncompatibleClearingCondition,
+    InvalidCoordinate,
+    MissingContext,
+    EffectAuthorityRequired,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProbeCandidateReceipt {
+    pub id: String,
+    pub status: ProbeCandidateStatus,
+    pub effect: ProbeEffect,
+    pub cost: ProbeCost,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidencePlanStatus {
+    Selected,
+    Blocked,
+    Unresolved,
+    StaleObligation,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SelectedProbe {
+    pub id: String,
+    pub produces: DiscriminatorKey,
+    pub requirements: EvidenceRequirements,
+    pub effect: ProbeEffect,
+    pub cost: ProbeCost,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidencePlan {
+    pub schema_version: u32,
+    pub obligation_id: String,
+    pub obligation_status: DurableObligationStatus,
+    pub status: EvidencePlanStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected: Option<SelectedProbe>,
+    pub candidates: Vec<ProbeCandidateReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct EvidencePlannerError {
+    message: String,
+}
+
+impl EvidencePlannerError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for EvidencePlannerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for EvidencePlannerError {}
+
+pub fn plan_evidence(request: &ProbePlanRequest) -> Result<EvidencePlan, EvidencePlannerError> {
+    validate_request(request)?;
+
+    let obligation_evaluation = evaluate_obligation(&request.obligation, &[], &request.context)
+        .map_err(|error| {
+            EvidencePlannerError::new(format!("obligation evaluation failed: {error}"))
+        })?;
+
+    if obligation_evaluation.status == DurableObligationStatus::ReopenRequired {
+        return Ok(EvidencePlan {
+            schema_version: EVIDENCE_PLANNER_SCHEMA_VERSION,
+            obligation_id: request.obligation.id.clone(),
+            obligation_status: obligation_evaluation.status,
+            status: EvidencePlanStatus::StaleObligation,
+            selected: None,
+            candidates: Vec::new(),
+        });
+    }
+
+    let mut candidates = request
+        .probes
+        .iter()
+        .map(|probe| {
+            evaluate_candidate(
+                &request.obligation,
+                &request.context,
+                request.allow_effectful,
+                probe,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    candidates.sort_by(|left, right| left.receipt.id.cmp(&right.receipt.id));
+
+    let selected_probe = candidates
+        .iter()
+        .filter(|candidate| candidate.receipt.status == ProbeCandidateStatus::Eligible)
+        .map(|candidate| candidate.probe)
+        .min_by(|left, right| compare_probe_cost(left, right, request.policy));
+
+    let status = if selected_probe.is_some() {
+        EvidencePlanStatus::Selected
+    } else if obligation_evaluation.status == DurableObligationStatus::Unknown
+        || candidates.iter().any(|candidate| {
+            matches!(
+                candidate.receipt.status,
+                ProbeCandidateStatus::MissingContext
+                    | ProbeCandidateStatus::EffectAuthorityRequired
+            )
+        })
+    {
+        EvidencePlanStatus::Blocked
+    } else {
+        EvidencePlanStatus::Unresolved
+    };
+
+    let selected = selected_probe.map(|probe| SelectedProbe {
+        id: probe.id.clone(),
+        produces: probe.produces.clone(),
+        requirements: probe.requirements.clone(),
+        effect: probe.effect,
+        cost: probe.cost,
+    });
+
+    Ok(EvidencePlan {
+        schema_version: EVIDENCE_PLANNER_SCHEMA_VERSION,
+        obligation_id: request.obligation.id.clone(),
+        obligation_status: obligation_evaluation.status,
+        status,
+        selected,
+        candidates: candidates
+            .into_iter()
+            .map(|candidate| candidate.receipt)
+            .collect(),
+    })
+}
+
+struct CandidateEvaluation<'a> {
+    probe: &'a EvidenceProbe,
+    receipt: ProbeCandidateReceipt,
+}
+
+fn evaluate_candidate<'a>(
+    obligation: &DurableObligation,
+    context: &EvaluationContext,
+    allow_effectful: bool,
+    probe: &'a EvidenceProbe,
+) -> Result<CandidateEvaluation<'a>, EvidencePlannerError> {
+    let status = if probe.produces != obligation.missing_discriminator {
+        ProbeCandidateStatus::Incapable
+    } else if !obligation.clearing_conditions.iter().any(|condition| {
+        condition.discriminator == probe.produces && condition.requirements == probe.requirements
+    }) {
+        ProbeCandidateStatus::IncompatibleClearingCondition
+    } else {
+        let applicability = evaluate_query(&ApplicabilityQuery {
+            schema_version: APPLICABILITY_SCHEMA_VERSION,
+            requirements: probe.requirements.clone(),
+            context: context.clone(),
+        })
+        .map_err(|error| {
+            EvidencePlannerError::new(format!(
+                "probe {} applicability failed: {error}",
+                probe.id
+            ))
+        })?;
+
+        match applicability.status {
+            ApplicabilityStatus::Invalid => ProbeCandidateStatus::InvalidCoordinate,
+            ApplicabilityStatus::Unknown => ProbeCandidateStatus::MissingContext,
+            ApplicabilityStatus::Applies
+                if probe.effect == ProbeEffect::Effectful && !allow_effectful =>
+            {
+                ProbeCandidateStatus::EffectAuthorityRequired
+            }
+            ApplicabilityStatus::Applies => ProbeCandidateStatus::Eligible,
+        }
+    };
+
+    Ok(CandidateEvaluation {
+        probe,
+        receipt: ProbeCandidateReceipt {
+            id: probe.id.clone(),
+            status,
+            effect: probe.effect,
+            cost: probe.cost,
+        },
+    })
+}
+
+fn compare_probe_cost(
+    left: &EvidenceProbe,
+    right: &EvidenceProbe,
+    policy: ProbeSelectionPolicy,
+) -> Ordering {
+    match policy {
+        ProbeSelectionPolicy::Conservative => conservative_cost_key(left)
+            .cmp(&conservative_cost_key(right))
+            .then_with(|| left.id.cmp(&right.id)),
+    }
+}
+
+fn conservative_cost_key(probe: &EvidenceProbe) -> (u8, u32, u32, u32, u32) {
+    (
+        effect_rank(probe.effect),
+        probe.cost.remote_requests,
+        probe.cost.git_subprocesses,
+        probe.cost.rust_files_parsed,
+        probe.cost.effectful_executions,
+    )
+}
+
+fn effect_rank(effect: ProbeEffect) -> u8 {
+    match effect {
+        ProbeEffect::ReadOnly => 0,
+        ProbeEffect::ExternalRead => 1,
+        ProbeEffect::Effectful => 2,
+    }
+}
+
+fn validate_request(request: &ProbePlanRequest) -> Result<(), EvidencePlannerError> {
+    if request.schema_version != EVIDENCE_PLANNER_SCHEMA_VERSION {
+        return Err(EvidencePlannerError::new(format!(
+            "unsupported evidence planner schema {}; expected {EVIDENCE_PLANNER_SCHEMA_VERSION}",
+            request.schema_version
+        )));
+    }
+    if request.probes.len() > MAX_PROBES {
+        return Err(EvidencePlannerError::new(
+            "probe inventory exceeds the admitted boundary",
+        ));
+    }
+
+    let mut ids = BTreeSet::new();
+    for probe in &request.probes {
+        validate_probe(probe)?;
+        if !ids.insert(probe.id.clone()) {
+            return Err(EvidencePlannerError::new(format!(
+                "duplicate probe id {}",
+                probe.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_probe(probe: &EvidenceProbe) -> Result<(), EvidencePlannerError> {
+    validate_id(&probe.id, "probe id")?;
+    validate_id(&probe.produces.kind, "probe discriminator kind")?;
+    validate_text(&probe.produces.target, "probe discriminator target")?;
+    require_coordinates(&probe.requirements)?;
+    validate_cost(probe)?;
+    Ok(())
+}
+
+fn validate_cost(probe: &EvidenceProbe) -> Result<(), EvidencePlannerError> {
+    let costs = [
+        probe.cost.git_subprocesses,
+        probe.cost.rust_files_parsed,
+        probe.cost.remote_requests,
+        probe.cost.effectful_executions,
+    ];
+    if costs.into_iter().any(|cost| cost > MAX_COST_UNIT) {
+        return Err(EvidencePlannerError::new(format!(
+            "probe {} cost exceeds the admitted boundary",
+            probe.id
+        )));
+    }
+
+    match probe.effect {
+        ProbeEffect::ReadOnly
+            if probe.cost.remote_requests != 0 || probe.cost.effectful_executions != 0 =>
+        {
+            Err(EvidencePlannerError::new(format!(
+                "read-only probe {} cannot forecast remote requests or effectful executions",
+                probe.id
+            )))
+        }
+        ProbeEffect::ExternalRead if probe.cost.remote_requests == 0 => {
+            Err(EvidencePlannerError::new(format!(
+                "external-read probe {} must forecast at least one remote request",
+                probe.id
+            )))
+        }
+        ProbeEffect::ExternalRead if probe.cost.effectful_executions != 0 => {
+            Err(EvidencePlannerError::new(format!(
+                "external-read probe {} cannot forecast effectful executions",
+                probe.id
+            )))
+        }
+        ProbeEffect::Effectful if probe.cost.effectful_executions == 0 => {
+            Err(EvidencePlannerError::new(format!(
+                "effectful probe {} must forecast at least one effectful execution",
+                probe.id
+            )))
+        }
+        _ => Ok(()),
+    }
+}
+
+fn require_coordinates(requirements: &EvidenceRequirements) -> Result<(), EvidencePlannerError> {
+    if requirements.repository.is_none()
+        && requirements.revision.is_none()
+        && requirements.work.is_none()
+        && requirements.scope.is_none()
+    {
+        return Err(EvidencePlannerError::new(
+            "probe requirements must carry at least one applicability coordinate",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_id(value: &str, field: &str) -> Result<(), EvidencePlannerError> {
+    if value.is_empty() || value.trim() != value || value.len() > MAX_ID_BYTES || value.contains('\0') {
+        return Err(EvidencePlannerError::new(format!(
+            "{field} must be a bounded canonical identifier"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, field: &str) -> Result<(), EvidencePlannerError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_TEXT_BYTES
+        || value.contains('\0')
+    {
+        return Err(EvidencePlannerError::new(format!(
+            "{field} must be bounded non-empty text"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::durable_obligation::{
+        ClearingCondition, ClearingEvidenceReceipt, DURABLE_OBLIGATION_SCHEMA_VERSION,
+    };
+
+    fn requirements(revision: Option<&str>) -> EvidenceRequirements {
+        EvidenceRequirements {
+            repository: Some("owner/repo".to_string()),
+            revision: revision.map(str::to_string),
+            work: None,
+            scope: None,
+        }
+    }
+
+    fn discriminator(kind: &str) -> DiscriminatorKey {
+        DiscriminatorKey {
+            kind: kind.to_string(),
+            target: "cargo test target_t".to_string(),
+        }
+    }
+
+    fn obligation() -> DurableObligation {
+        DurableObligation {
+            schema_version: DURABLE_OBLIGATION_SCHEMA_VERSION,
+            id: "U17".to_string(),
+            question: "Does target T pass at this exact head?".to_string(),
+            subject: requirements(Some("head-a")),
+            established_evidence: vec!["E-history".to_string()],
+            missing_discriminator: discriminator("target_test_result"),
+            clearing_conditions: vec![ClearingCondition {
+                discriminator: discriminator("target_test_result"),
+                requirements: requirements(Some("head-a")),
+            }],
+        }
+    }
+
+    fn context(revision: Option<&str>) -> EvaluationContext {
+        EvaluationContext {
+            repository: Some("owner/repo".to_string()),
+            revision: revision.map(str::to_string),
+            work: None,
+            path: None,
+        }
+    }
+
+    fn probe(
+        id: &str,
+        kind: &str,
+        revision: Option<&str>,
+        effect: ProbeEffect,
+        cost: ProbeCost,
+    ) -> EvidenceProbe {
+        EvidenceProbe {
+            id: id.to_string(),
+            produces: discriminator(kind),
+            requirements: requirements(revision),
+            effect,
+            cost,
+        }
+    }
+
+    fn request(probes: Vec<EvidenceProbe>, allow_effectful: bool) -> ProbePlanRequest {
+        ProbePlanRequest {
+            schema_version: EVIDENCE_PLANNER_SCHEMA_VERSION,
+            obligation: obligation(),
+            context: context(Some("head-a")),
+            probes,
+            allow_effectful,
+            policy: ProbeSelectionPolicy::Conservative,
+        }
+    }
+
+    #[test]
+    fn selects_capable_exact_head_probe_and_skips_cheaper_incapable_work() {
+        let plan = plan_evidence(&request(
+            vec![
+                probe(
+                    "history",
+                    "historical_companion",
+                    Some("head-a"),
+                    ProbeEffect::ReadOnly,
+                    ProbeCost {
+                        git_subprocesses: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+                probe(
+                    "stale-test",
+                    "target_test_result",
+                    Some("old-head"),
+                    ProbeEffect::Effectful,
+                    ProbeCost {
+                        effectful_executions: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+                probe(
+                    "exact-test",
+                    "target_test_result",
+                    Some("head-a"),
+                    ProbeEffect::Effectful,
+                    ProbeCost {
+                        effectful_executions: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+            ],
+            true,
+        ))
+        .unwrap();
+
+        assert_eq!(plan.status, EvidencePlanStatus::Selected);
+        assert_eq!(plan.selected.as_ref().unwrap().id, "exact-test");
+        assert_eq!(plan.candidates[0].id, "exact-test");
+        assert_eq!(plan.candidates[0].status, ProbeCandidateStatus::Eligible);
+        assert_eq!(plan.candidates[1].status, ProbeCandidateStatus::Incapable);
+        assert_eq!(
+            plan.candidates[2].status,
+            ProbeCandidateStatus::IncompatibleClearingCondition
+        );
+    }
+
+    #[test]
+    fn effectful_capability_can_be_selected_without_granting_execution_authority() {
+        let plan = plan_evidence(&request(
+            vec![probe(
+                "exact-test",
+                "target_test_result",
+                Some("head-a"),
+                ProbeEffect::Effectful,
+                ProbeCost {
+                    effectful_executions: 1,
+                    ..ProbeCost::default()
+                },
+            )],
+            false,
+        ))
+        .unwrap();
+
+        assert_eq!(plan.status, EvidencePlanStatus::Blocked);
+        assert!(plan.selected.is_none());
+        assert_eq!(
+            plan.candidates[0].status,
+            ProbeCandidateStatus::EffectAuthorityRequired
+        );
+    }
+
+    #[test]
+    fn conservative_policy_prefers_read_only_capability_before_effectful_probe() {
+        let mut record = obligation();
+        record.missing_discriminator = discriminator("provider_current");
+        record.clearing_conditions[0].discriminator = discriminator("provider_current");
+
+        let mut request = request(
+            vec![
+                probe(
+                    "remote-current",
+                    "provider_current",
+                    Some("head-a"),
+                    ProbeEffect::ExternalRead,
+                    ProbeCost {
+                        remote_requests: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+                probe(
+                    "effectful-current",
+                    "provider_current",
+                    Some("head-a"),
+                    ProbeEffect::Effectful,
+                    ProbeCost {
+                        effectful_executions: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+            ],
+            true,
+        );
+        request.obligation = record;
+
+        let plan = plan_evidence(&request).unwrap();
+        assert_eq!(plan.selected.as_ref().unwrap().id, "remote-current");
+    }
+
+    #[test]
+    fn no_capable_probe_leaves_an_explicit_unresolved_frontier() {
+        let plan = plan_evidence(&request(
+            vec![probe(
+                "history",
+                "historical_companion",
+                Some("head-a"),
+                ProbeEffect::ReadOnly,
+                ProbeCost {
+                    git_subprocesses: 1,
+                    ..ProbeCost::default()
+                },
+            )],
+            true,
+        ))
+        .unwrap();
+
+        assert_eq!(plan.status, EvidencePlanStatus::Unresolved);
+        assert!(plan.selected.is_none());
+        assert_eq!(plan.candidates[0].status, ProbeCandidateStatus::Incapable);
+    }
+
+    #[test]
+    fn missing_current_coordinate_blocks_planning_instead_of_guessing() {
+        let mut request = request(Vec::new(), true);
+        request.context = context(None);
+
+        let plan = plan_evidence(&request).unwrap();
+        assert_eq!(plan.status, EvidencePlanStatus::Blocked);
+        assert_eq!(plan.obligation_status, DurableObligationStatus::Unknown);
+    }
+
+    #[test]
+    fn moved_obligation_subject_requires_reopen_before_new_probe_selection() {
+        let mut request = request(Vec::new(), true);
+        request.context = context(Some("head-b"));
+
+        let plan = plan_evidence(&request).unwrap();
+        assert_eq!(plan.status, EvidencePlanStatus::StaleObligation);
+        assert_eq!(
+            plan.obligation_status,
+            DurableObligationStatus::ReopenRequired
+        );
+    }
+
+    #[test]
+    fn selected_probe_can_produce_a_receipt_that_clears_the_same_obligation() {
+        let request = request(
+            vec![probe(
+                "exact-test",
+                "target_test_result",
+                Some("head-a"),
+                ProbeEffect::Effectful,
+                ProbeCost {
+                    effectful_executions: 1,
+                    ..ProbeCost::default()
+                },
+            )],
+            true,
+        );
+        let plan = plan_evidence(&request).unwrap();
+        let selected = plan.selected.unwrap();
+
+        let receipt = ClearingEvidenceReceipt {
+            id: "executed-test-receipt".to_string(),
+            discriminator: selected.produces,
+            requirements: selected.requirements,
+        };
+        let evaluation = evaluate_obligation(&request.obligation, &[receipt], &request.context)
+            .unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Cleared);
+    }
+
+    #[test]
+    fn malformed_effect_forecast_fails_explicitly() {
+        let error = plan_evidence(&request(
+            vec![probe(
+                "bad-test",
+                "target_test_result",
+                Some("head-a"),
+                ProbeEffect::Effectful,
+                ProbeCost::default(),
+            )],
+            true,
+        ))
+        .unwrap_err();
+
+        assert!(error.to_string().contains("effectful executions"));
+    }
+}

--- a/src/evidence_planner.rs
+++ b/src/evidence_planner.rs
@@ -235,10 +235,7 @@ fn evaluate_candidate<'a>(
             context: context.clone(),
         })
         .map_err(|error| {
-            EvidencePlannerError::new(format!(
-                "probe {} applicability failed: {error}",
-                probe.id
-            ))
+            EvidencePlannerError::new(format!("probe {} applicability failed: {error}", probe.id))
         })?;
 
         match applicability.status {
@@ -388,7 +385,11 @@ fn require_coordinates(requirements: &EvidenceRequirements) -> Result<(), Eviden
 }
 
 fn validate_id(value: &str, field: &str) -> Result<(), EvidencePlannerError> {
-    if value.is_empty() || value.trim() != value || value.len() > MAX_ID_BYTES || value.contains('\0') {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_ID_BYTES
+        || value.contains('\0')
+    {
         return Err(EvidencePlannerError::new(format!(
             "{field} must be a bounded canonical identifier"
         )));
@@ -663,8 +664,8 @@ mod tests {
             discriminator: selected.produces,
             requirements: selected.requirements,
         };
-        let evaluation = evaluate_obligation(&request.obligation, &[receipt], &request.context)
-            .unwrap();
+        let evaluation =
+            evaluate_obligation(&request.obligation, &[receipt], &request.context).unwrap();
         assert_eq!(evaluation.status, DurableObligationStatus::Cleared);
     }
 

--- a/src/justification.rs
+++ b/src/justification.rs
@@ -414,7 +414,6 @@ fn validate_graph(graph: &JustificationGraph) -> Result<(), JustificationError> 
 
     let mut edge_keys = BTreeSet::new();
     let mut supported_claims = BTreeSet::new();
-    let mut clearable_obligations = BTreeSet::new();
     for edge in &graph.edges {
         if !evidence_ids.contains(&edge.evidence_id) {
             return Err(JustificationError::new(format!(
@@ -445,7 +444,6 @@ fn validate_graph(graph: &JustificationGraph) -> Result<(), JustificationError> 
                         "edge references unknown obligation {id}"
                     )));
                 }
-                clearable_obligations.insert(id.clone());
             }
             (JustificationTarget::Obligation(id), relation) => {
                 return Err(JustificationError::new(format!(
@@ -454,11 +452,7 @@ fn validate_graph(graph: &JustificationGraph) -> Result<(), JustificationError> 
             }
         }
 
-        let key = (
-            edge.evidence_id.clone(),
-            edge.target.clone(),
-            edge.relation,
-        );
+        let key = (edge.evidence_id.clone(), edge.target.clone(), edge.relation);
         if !edge_keys.insert(key) {
             return Err(JustificationError::new("duplicate justification edge"));
         }
@@ -467,11 +461,6 @@ fn validate_graph(graph: &JustificationGraph) -> Result<(), JustificationError> 
     if let Some(id) = claim_ids.difference(&supported_claims).next() {
         return Err(JustificationError::new(format!(
             "claim {id} has no support edge"
-        )));
-    }
-    if let Some(id) = obligation_ids.difference(&clearable_obligations).next() {
-        return Err(JustificationError::new(format!(
-            "obligation {id} has no clearing edge"
         )));
     }
 
@@ -598,7 +587,10 @@ mod tests {
         };
 
         let evaluation = evaluate_graph(&graph, &context("owner/repo", Some("new-head"))).unwrap();
-        assert_eq!(evaluation.claims[0].status, ClaimJustificationStatus::Supported);
+        assert_eq!(
+            evaluation.claims[0].status,
+            ClaimJustificationStatus::Supported
+        );
         assert_eq!(evaluation.claims[0].support.applies, vec!["E2"]);
         assert_eq!(evaluation.claims[0].support.invalid, vec!["E1"]);
     }
@@ -614,7 +606,10 @@ mod tests {
         };
 
         let evaluation = evaluate_graph(&graph, &context("owner/repo", Some("new-head"))).unwrap();
-        assert_eq!(evaluation.claims[0].status, ClaimJustificationStatus::Unknown);
+        assert_eq!(
+            evaluation.claims[0].status,
+            ClaimJustificationStatus::Unknown
+        );
         assert_eq!(evaluation.claims[0].support.invalid, vec!["E1"]);
     }
 
@@ -649,6 +644,24 @@ mod tests {
         assert_eq!(claim.status, ClaimJustificationStatus::Supported);
         assert_eq!(claim.counterexamples.applies, vec!["E2"]);
         assert_eq!(claim.limits.applies, vec!["E3"]);
+    }
+
+    #[test]
+    fn open_obligation_can_exist_before_clearing_evidence_arrives() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: Vec::new(),
+            claims: Vec::new(),
+            obligations: vec![ObligationNode {
+                id: "U0".to_string(),
+                question: "which exact evidence clears this?".to_string(),
+            }],
+            edges: Vec::new(),
+        };
+
+        let evaluation = evaluate_graph(&graph, &context("owner/repo", Some("head"))).unwrap();
+        assert_eq!(evaluation.obligations[0].status, ObligationStatus::Open);
+        assert!(evaluation.obligations[0].clearing.applies.is_empty());
     }
 
     #[test]
@@ -725,7 +738,10 @@ mod tests {
         };
 
         let evaluation = evaluate_graph(&graph, &context("owner/repo", None)).unwrap();
-        assert_eq!(evaluation.claims[0].status, ClaimJustificationStatus::Unknown);
+        assert_eq!(
+            evaluation.claims[0].status,
+            ClaimJustificationStatus::Unknown
+        );
         assert_eq!(evaluation.claims[0].dependencies.unknown, vec!["E2"]);
     }
 

--- a/src/justification.rs
+++ b/src/justification.rs
@@ -1,0 +1,752 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, evaluate_query,
+};
+
+pub const JUSTIFICATION_SCHEMA_VERSION: u32 = 1;
+const MAX_NODES: usize = 1024;
+const MAX_EDGES: usize = 4096;
+const MAX_ID_BYTES: usize = 256;
+const MAX_TEXT_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct JustificationGraph {
+    pub schema_version: u32,
+    pub evidence: Vec<EvidenceNode>,
+    pub claims: Vec<ClaimNode>,
+    pub obligations: Vec<ObligationNode>,
+    pub edges: Vec<JustificationEdge>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceNode {
+    pub id: String,
+    pub requirements: EvidenceRequirements,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClaimNode {
+    pub id: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObligationNode {
+    pub id: String,
+    pub question: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
+#[serde(tag = "kind", content = "id", rename_all = "snake_case")]
+pub enum JustificationTarget {
+    Claim(String),
+    Obligation(String),
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JustificationRelation {
+    Support,
+    Counterexample,
+    Limit,
+    Dependency,
+    Clearing,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct JustificationEdge {
+    pub evidence_id: String,
+    pub target: JustificationTarget,
+    pub relation: JustificationRelation,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct JustificationEvaluation {
+    pub schema_version: u32,
+    pub evidence: Vec<EvidenceEvaluation>,
+    pub claims: Vec<ClaimEvaluation>,
+    pub obligations: Vec<ObligationEvaluation>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceEvaluation {
+    pub id: String,
+    pub applicability: ApplicabilityStatus,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimJustificationStatus {
+    Supported,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RelationReceipt {
+    pub applies: Vec<String>,
+    pub invalid: Vec<String>,
+    pub unknown: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClaimEvaluation {
+    pub id: String,
+    pub status: ClaimJustificationStatus,
+    pub support: RelationReceipt,
+    pub counterexamples: RelationReceipt,
+    pub limits: RelationReceipt,
+    pub dependencies: RelationReceipt,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObligationStatus {
+    Open,
+    Cleared,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObligationEvaluation {
+    pub id: String,
+    pub status: ObligationStatus,
+    pub clearing: RelationReceipt,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceTransition {
+    pub id: String,
+    pub before: ApplicabilityStatus,
+    pub after: ApplicabilityStatus,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReevaluationReceipt {
+    pub schema_version: u32,
+    pub evidence_transitions: Vec<EvidenceTransition>,
+    pub affected_targets: Vec<JustificationTarget>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct JustificationError {
+    message: String,
+}
+
+impl JustificationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for JustificationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for JustificationError {}
+
+pub fn evaluate_graph(
+    graph: &JustificationGraph,
+    context: &EvaluationContext,
+) -> Result<JustificationEvaluation, JustificationError> {
+    validate_graph(graph)?;
+    let evidence_status = evaluate_evidence(graph, context)?;
+
+    let mut claim_receipts: BTreeMap<String, ClaimReceipts> = graph
+        .claims
+        .iter()
+        .map(|claim| (claim.id.clone(), ClaimReceipts::default()))
+        .collect();
+    let mut obligation_receipts: BTreeMap<String, RelationReceipt> = graph
+        .obligations
+        .iter()
+        .map(|obligation| (obligation.id.clone(), RelationReceipt::default()))
+        .collect();
+
+    for edge in &graph.edges {
+        let status = evidence_status[&edge.evidence_id];
+        match (&edge.target, edge.relation) {
+            (JustificationTarget::Claim(id), JustificationRelation::Support) => {
+                claim_receipts
+                    .get_mut(id)
+                    .expect("validated claim target")
+                    .support
+                    .push(edge.evidence_id.clone(), status);
+            }
+            (JustificationTarget::Claim(id), JustificationRelation::Counterexample) => {
+                claim_receipts
+                    .get_mut(id)
+                    .expect("validated claim target")
+                    .counterexamples
+                    .push(edge.evidence_id.clone(), status);
+            }
+            (JustificationTarget::Claim(id), JustificationRelation::Limit) => {
+                claim_receipts
+                    .get_mut(id)
+                    .expect("validated claim target")
+                    .limits
+                    .push(edge.evidence_id.clone(), status);
+            }
+            (JustificationTarget::Claim(id), JustificationRelation::Dependency) => {
+                claim_receipts
+                    .get_mut(id)
+                    .expect("validated claim target")
+                    .dependencies
+                    .push(edge.evidence_id.clone(), status);
+            }
+            (JustificationTarget::Obligation(id), JustificationRelation::Clearing) => {
+                obligation_receipts
+                    .get_mut(id)
+                    .expect("validated obligation target")
+                    .push(edge.evidence_id.clone(), status);
+            }
+            _ => unreachable!("validated relation/target pairing"),
+        }
+    }
+
+    let evidence = evidence_status
+        .iter()
+        .map(|(id, applicability)| EvidenceEvaluation {
+            id: id.clone(),
+            applicability: *applicability,
+        })
+        .collect();
+
+    let claims = graph
+        .claims
+        .iter()
+        .map(|claim| {
+            let mut receipts = claim_receipts
+                .remove(&claim.id)
+                .expect("claim accumulator exists");
+            receipts.sort();
+
+            let dependencies_block = !receipts.dependencies.invalid.is_empty()
+                || !receipts.dependencies.unknown.is_empty();
+            let status = if !dependencies_block && !receipts.support.applies.is_empty() {
+                ClaimJustificationStatus::Supported
+            } else {
+                ClaimJustificationStatus::Unknown
+            };
+
+            ClaimEvaluation {
+                id: claim.id.clone(),
+                status,
+                support: receipts.support,
+                counterexamples: receipts.counterexamples,
+                limits: receipts.limits,
+                dependencies: receipts.dependencies,
+            }
+        })
+        .collect();
+
+    let obligations = graph
+        .obligations
+        .iter()
+        .map(|obligation| {
+            let mut clearing = obligation_receipts
+                .remove(&obligation.id)
+                .expect("obligation accumulator exists");
+            clearing.sort();
+            let status = if !clearing.applies.is_empty() {
+                ObligationStatus::Cleared
+            } else if !clearing.unknown.is_empty() {
+                ObligationStatus::Unknown
+            } else {
+                ObligationStatus::Open
+            };
+
+            ObligationEvaluation {
+                id: obligation.id.clone(),
+                status,
+                clearing,
+            }
+        })
+        .collect();
+
+    Ok(JustificationEvaluation {
+        schema_version: JUSTIFICATION_SCHEMA_VERSION,
+        evidence,
+        claims,
+        obligations,
+    })
+}
+
+pub fn reevaluate_graph(
+    graph: &JustificationGraph,
+    before: &EvaluationContext,
+    after: &EvaluationContext,
+) -> Result<ReevaluationReceipt, JustificationError> {
+    validate_graph(graph)?;
+    let before_status = evaluate_evidence(graph, before)?;
+    let after_status = evaluate_evidence(graph, after)?;
+
+    let mut changed = BTreeSet::new();
+    let mut evidence_transitions = Vec::new();
+    for (id, before) in &before_status {
+        let after = after_status[id];
+        if *before != after {
+            changed.insert(id.clone());
+            evidence_transitions.push(EvidenceTransition {
+                id: id.clone(),
+                before: *before,
+                after,
+            });
+        }
+    }
+
+    let affected_targets = graph
+        .edges
+        .iter()
+        .filter(|edge| changed.contains(&edge.evidence_id))
+        .map(|edge| edge.target.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    Ok(ReevaluationReceipt {
+        schema_version: JUSTIFICATION_SCHEMA_VERSION,
+        evidence_transitions,
+        affected_targets,
+    })
+}
+
+fn evaluate_evidence(
+    graph: &JustificationGraph,
+    context: &EvaluationContext,
+) -> Result<BTreeMap<String, ApplicabilityStatus>, JustificationError> {
+    graph
+        .evidence
+        .iter()
+        .map(|evidence| {
+            let query = ApplicabilityQuery {
+                schema_version: APPLICABILITY_SCHEMA_VERSION,
+                requirements: evidence.requirements.clone(),
+                context: context.clone(),
+            };
+            let evaluation = evaluate_query(&query).map_err(|error| {
+                JustificationError::new(format!(
+                    "evidence {} applicability failed: {error}",
+                    evidence.id
+                ))
+            })?;
+            Ok((evidence.id.clone(), evaluation.status))
+        })
+        .collect()
+}
+
+fn validate_graph(graph: &JustificationGraph) -> Result<(), JustificationError> {
+    if graph.schema_version != JUSTIFICATION_SCHEMA_VERSION {
+        return Err(JustificationError::new(format!(
+            "unsupported justification schema {}; expected {JUSTIFICATION_SCHEMA_VERSION}",
+            graph.schema_version
+        )));
+    }
+
+    let total_nodes = graph.evidence.len() + graph.claims.len() + graph.obligations.len();
+    if total_nodes > MAX_NODES || graph.edges.len() > MAX_EDGES {
+        return Err(JustificationError::new(
+            "justification graph exceeds the admitted node/edge boundary",
+        ));
+    }
+
+    let mut evidence_ids = BTreeSet::new();
+    for evidence in &graph.evidence {
+        validate_id(&evidence.id, "evidence id")?;
+        if !evidence_ids.insert(evidence.id.clone()) {
+            return Err(JustificationError::new(format!(
+                "duplicate evidence id {}",
+                evidence.id
+            )));
+        }
+        if requirements_are_empty(&evidence.requirements) {
+            return Err(JustificationError::new(format!(
+                "evidence {} must carry at least one applicability requirement",
+                evidence.id
+            )));
+        }
+    }
+
+    let mut claim_ids = BTreeSet::new();
+    for claim in &graph.claims {
+        validate_id(&claim.id, "claim id")?;
+        validate_text(&claim.message, "claim message")?;
+        if !claim_ids.insert(claim.id.clone()) {
+            return Err(JustificationError::new(format!(
+                "duplicate claim id {}",
+                claim.id
+            )));
+        }
+    }
+
+    let mut obligation_ids = BTreeSet::new();
+    for obligation in &graph.obligations {
+        validate_id(&obligation.id, "obligation id")?;
+        validate_text(&obligation.question, "obligation question")?;
+        if !obligation_ids.insert(obligation.id.clone()) {
+            return Err(JustificationError::new(format!(
+                "duplicate obligation id {}",
+                obligation.id
+            )));
+        }
+    }
+
+    let mut edge_keys = BTreeSet::new();
+    let mut supported_claims = BTreeSet::new();
+    let mut clearable_obligations = BTreeSet::new();
+    for edge in &graph.edges {
+        if !evidence_ids.contains(&edge.evidence_id) {
+            return Err(JustificationError::new(format!(
+                "edge references unknown evidence {}",
+                edge.evidence_id
+            )));
+        }
+
+        match (&edge.target, edge.relation) {
+            (JustificationTarget::Claim(id), JustificationRelation::Clearing) => {
+                return Err(JustificationError::new(format!(
+                    "clearing relation cannot target claim {id}"
+                )));
+            }
+            (JustificationTarget::Claim(id), relation) => {
+                if !claim_ids.contains(id) {
+                    return Err(JustificationError::new(format!(
+                        "edge references unknown claim {id}"
+                    )));
+                }
+                if relation == JustificationRelation::Support {
+                    supported_claims.insert(id.clone());
+                }
+            }
+            (JustificationTarget::Obligation(id), JustificationRelation::Clearing) => {
+                if !obligation_ids.contains(id) {
+                    return Err(JustificationError::new(format!(
+                        "edge references unknown obligation {id}"
+                    )));
+                }
+                clearable_obligations.insert(id.clone());
+            }
+            (JustificationTarget::Obligation(id), relation) => {
+                return Err(JustificationError::new(format!(
+                    "{relation:?} relation cannot target obligation {id}"
+                )));
+            }
+        }
+
+        let key = (
+            edge.evidence_id.clone(),
+            edge.target.clone(),
+            edge.relation,
+        );
+        if !edge_keys.insert(key) {
+            return Err(JustificationError::new("duplicate justification edge"));
+        }
+    }
+
+    if let Some(id) = claim_ids.difference(&supported_claims).next() {
+        return Err(JustificationError::new(format!(
+            "claim {id} has no support edge"
+        )));
+    }
+    if let Some(id) = obligation_ids.difference(&clearable_obligations).next() {
+        return Err(JustificationError::new(format!(
+            "obligation {id} has no clearing edge"
+        )));
+    }
+
+    Ok(())
+}
+
+fn requirements_are_empty(requirements: &EvidenceRequirements) -> bool {
+    requirements.repository.is_none()
+        && requirements.revision.is_none()
+        && requirements.work.is_none()
+        && requirements.scope.is_none()
+}
+
+fn validate_id(id: &str, field: &str) -> Result<(), JustificationError> {
+    if id.is_empty() || id.trim() != id || id.len() > MAX_ID_BYTES || id.contains('\0') {
+        return Err(JustificationError::new(format!(
+            "{field} must be a bounded canonical identifier"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, field: &str) -> Result<(), JustificationError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_TEXT_BYTES
+        || value.contains('\0')
+    {
+        return Err(JustificationError::new(format!(
+            "{field} must be bounded non-empty text"
+        )));
+    }
+    Ok(())
+}
+
+impl RelationReceipt {
+    fn push(&mut self, evidence_id: String, status: ApplicabilityStatus) {
+        match status {
+            ApplicabilityStatus::Applies => self.applies.push(evidence_id),
+            ApplicabilityStatus::Invalid => self.invalid.push(evidence_id),
+            ApplicabilityStatus::Unknown => self.unknown.push(evidence_id),
+        }
+    }
+
+    fn sort(&mut self) {
+        self.applies.sort();
+        self.invalid.sort();
+        self.unknown.sort();
+    }
+}
+
+#[derive(Debug, Default)]
+struct ClaimReceipts {
+    support: RelationReceipt,
+    counterexamples: RelationReceipt,
+    limits: RelationReceipt,
+    dependencies: RelationReceipt,
+}
+
+impl ClaimReceipts {
+    fn sort(&mut self) {
+        self.support.sort();
+        self.counterexamples.sort();
+        self.limits.sort();
+        self.dependencies.sort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn requirements(repository: Option<&str>, revision: Option<&str>) -> EvidenceRequirements {
+        EvidenceRequirements {
+            repository: repository.map(str::to_string),
+            revision: revision.map(str::to_string),
+            work: None,
+            scope: None,
+        }
+    }
+
+    fn evidence(id: &str, requirements: EvidenceRequirements) -> EvidenceNode {
+        EvidenceNode {
+            id: id.to_string(),
+            requirements,
+        }
+    }
+
+    fn claim(id: &str) -> ClaimNode {
+        ClaimNode {
+            id: id.to_string(),
+            message: format!("claim {id}"),
+        }
+    }
+
+    fn support(evidence_id: &str, claim_id: &str) -> JustificationEdge {
+        JustificationEdge {
+            evidence_id: evidence_id.to_string(),
+            target: JustificationTarget::Claim(claim_id.to_string()),
+            relation: JustificationRelation::Support,
+        }
+    }
+
+    fn context(repository: &str, revision: Option<&str>) -> EvaluationContext {
+        EvaluationContext {
+            repository: Some(repository.to_string()),
+            revision: revision.map(str::to_string),
+            work: None,
+            path: None,
+        }
+    }
+
+    #[test]
+    fn independent_support_survives_one_invalidated_receipt() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: vec![
+                evidence("E1", requirements(None, Some("old-head"))),
+                evidence("E2", requirements(Some("owner/repo"), None)),
+            ],
+            claims: vec![claim("C1")],
+            obligations: Vec::new(),
+            edges: vec![support("E1", "C1"), support("E2", "C1")],
+        };
+
+        let evaluation = evaluate_graph(&graph, &context("owner/repo", Some("new-head"))).unwrap();
+        assert_eq!(evaluation.claims[0].status, ClaimJustificationStatus::Supported);
+        assert_eq!(evaluation.claims[0].support.applies, vec!["E2"]);
+        assert_eq!(evaluation.claims[0].support.invalid, vec!["E1"]);
+    }
+
+    #[test]
+    fn sole_invalidated_support_returns_claim_to_unknown() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: vec![evidence("E1", requirements(None, Some("old-head")))],
+            claims: vec![claim("C1")],
+            obligations: Vec::new(),
+            edges: vec![support("E1", "C1")],
+        };
+
+        let evaluation = evaluate_graph(&graph, &context("owner/repo", Some("new-head"))).unwrap();
+        assert_eq!(evaluation.claims[0].status, ClaimJustificationStatus::Unknown);
+        assert_eq!(evaluation.claims[0].support.invalid, vec!["E1"]);
+    }
+
+    #[test]
+    fn counterexamples_and_limits_remain_visible_without_collapsing_support() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: vec![
+                evidence("E1", requirements(Some("owner/repo"), None)),
+                evidence("E2", requirements(Some("owner/repo"), None)),
+                evidence("E3", requirements(Some("owner/repo"), None)),
+            ],
+            claims: vec![claim("C1")],
+            obligations: Vec::new(),
+            edges: vec![
+                support("E1", "C1"),
+                JustificationEdge {
+                    evidence_id: "E2".to_string(),
+                    target: JustificationTarget::Claim("C1".to_string()),
+                    relation: JustificationRelation::Counterexample,
+                },
+                JustificationEdge {
+                    evidence_id: "E3".to_string(),
+                    target: JustificationTarget::Claim("C1".to_string()),
+                    relation: JustificationRelation::Limit,
+                },
+            ],
+        };
+
+        let evaluation = evaluate_graph(&graph, &context("owner/repo", Some("head"))).unwrap();
+        let claim = &evaluation.claims[0];
+        assert_eq!(claim.status, ClaimJustificationStatus::Supported);
+        assert_eq!(claim.counterexamples.applies, vec!["E2"]);
+        assert_eq!(claim.limits.applies, vec!["E3"]);
+    }
+
+    #[test]
+    fn exact_clearing_evidence_resolves_obligation_and_reopens_after_head_moves() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: vec![evidence("E1", requirements(None, Some("exact-head")))],
+            claims: Vec::new(),
+            obligations: vec![ObligationNode {
+                id: "U1".to_string(),
+                question: "run exact target execution?".to_string(),
+            }],
+            edges: vec![JustificationEdge {
+                evidence_id: "E1".to_string(),
+                target: JustificationTarget::Obligation("U1".to_string()),
+                relation: JustificationRelation::Clearing,
+            }],
+        };
+
+        let cleared = evaluate_graph(&graph, &context("owner/repo", Some("exact-head"))).unwrap();
+        assert_eq!(cleared.obligations[0].status, ObligationStatus::Cleared);
+
+        let reopened = evaluate_graph(&graph, &context("owner/repo", Some("new-head"))).unwrap();
+        assert_eq!(reopened.obligations[0].status, ObligationStatus::Open);
+        assert_eq!(reopened.obligations[0].clearing.invalid, vec!["E1"]);
+    }
+
+    #[test]
+    fn reevaluation_names_only_targets_downstream_of_changed_evidence() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: vec![
+                evidence("E1", requirements(None, Some("old-head"))),
+                evidence("E2", requirements(Some("owner/repo"), None)),
+            ],
+            claims: vec![claim("C1"), claim("C2")],
+            obligations: Vec::new(),
+            edges: vec![support("E1", "C1"), support("E2", "C2")],
+        };
+
+        let receipt = reevaluate_graph(
+            &graph,
+            &context("owner/repo", Some("old-head")),
+            &context("owner/repo", Some("new-head")),
+        )
+        .unwrap();
+
+        assert_eq!(receipt.evidence_transitions.len(), 1);
+        assert_eq!(receipt.evidence_transitions[0].id, "E1");
+        assert_eq!(
+            receipt.affected_targets,
+            vec![JustificationTarget::Claim("C1".to_string())]
+        );
+    }
+
+    #[test]
+    fn dependency_unknown_prevents_supported_projection() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: vec![
+                evidence("E1", requirements(Some("owner/repo"), None)),
+                evidence("E2", requirements(None, Some("exact-head"))),
+            ],
+            claims: vec![claim("C1")],
+            obligations: Vec::new(),
+            edges: vec![
+                support("E1", "C1"),
+                JustificationEdge {
+                    evidence_id: "E2".to_string(),
+                    target: JustificationTarget::Claim("C1".to_string()),
+                    relation: JustificationRelation::Dependency,
+                },
+            ],
+        };
+
+        let evaluation = evaluate_graph(&graph, &context("owner/repo", None)).unwrap();
+        assert_eq!(evaluation.claims[0].status, ClaimJustificationStatus::Unknown);
+        assert_eq!(evaluation.claims[0].dependencies.unknown, vec!["E2"]);
+    }
+
+    #[test]
+    fn typed_targets_keep_v0_graph_acyclic_and_reject_relation_mismatch() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: vec![evidence("E1", requirements(Some("owner/repo"), None))],
+            claims: Vec::new(),
+            obligations: vec![ObligationNode {
+                id: "U1".to_string(),
+                question: "resolve?".to_string(),
+            }],
+            edges: vec![JustificationEdge {
+                evidence_id: "E1".to_string(),
+                target: JustificationTarget::Obligation("U1".to_string()),
+                relation: JustificationRelation::Support,
+            }],
+        };
+
+        let error = evaluate_graph(&graph, &context("owner/repo", Some("head"))).unwrap_err();
+        assert!(error.to_string().contains("cannot target obligation"));
+    }
+}

--- a/tests/durable_obligation.rs
+++ b/tests/durable_obligation.rs
@@ -1,0 +1,8 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/justification.rs"]
+mod justification;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;

--- a/tests/durable_obligation.rs
+++ b/tests/durable_obligation.rs
@@ -2,7 +2,7 @@
 
 #[path = "../src/applicability.rs"]
 mod applicability;
-#[path = "../src/justification.rs"]
-mod justification;
 #[path = "../src/durable_obligation.rs"]
 mod durable_obligation;
+#[path = "../src/justification.rs"]
+mod justification;

--- a/tests/evidence_planner.rs
+++ b/tests/evidence_planner.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[path = "../src/justification.rs"]
+mod justification;

--- a/tests/justification.rs
+++ b/tests/justification.rs
@@ -1,0 +1,6 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/justification.rs"]
+mod justification;

--- a/tests/obligation_selected_scope_probe.rs
+++ b/tests/obligation_selected_scope_probe.rs
@@ -1,0 +1,202 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/justification.rs"]
+mod justification;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+
+use applicability::{
+    EvaluationContext, EvidenceRequirements, PathScope, PathScopeMode,
+};
+use durable_obligation::{
+    ClearingCondition, DiscriminatorKey, DurableObligation,
+    DURABLE_OBLIGATION_SCHEMA_VERSION,
+};
+use evidence_planner::{
+    plan_evidence, EvidencePlanStatus, EvidenceProbe, EVIDENCE_PLANNER_SCHEMA_VERSION,
+    ProbeCandidateStatus, ProbeCost, ProbeEffect, ProbePlanRequest, ProbeSelectionPolicy,
+};
+
+const REPOSITORY: &str = "owner/repo";
+const REVISION: &str = "exact-head";
+const TARGET: &str = "convex/schema.ts";
+
+fn discriminator() -> DiscriminatorKey {
+    DiscriminatorKey {
+        kind: "distributed_failure_history".to_string(),
+        target: TARGET.to_string(),
+    }
+}
+
+fn scope_requirements(mode: PathScopeMode, path: &str) -> EvidenceRequirements {
+    EvidenceRequirements {
+        repository: Some(REPOSITORY.to_string()),
+        revision: Some(REVISION.to_string()),
+        work: None,
+        scope: Some(PathScope {
+            mode,
+            path: path.to_string(),
+        }),
+    }
+}
+
+fn current_context() -> EvaluationContext {
+    EvaluationContext {
+        repository: Some(REPOSITORY.to_string()),
+        revision: Some(REVISION.to_string()),
+        work: None,
+        path: Some(TARGET.to_string()),
+    }
+}
+
+fn obligation(required: EvidenceRequirements) -> DurableObligation {
+    let missing = discriminator();
+    DurableObligation {
+        schema_version: DURABLE_OBLIGATION_SCHEMA_VERSION,
+        id: "obligation:distributed-failure-history".to_string(),
+        question: "What repository history is required to evaluate the distributed failure family?"
+            .to_string(),
+        subject: scope_requirements(PathScopeMode::Exact, TARGET),
+        established_evidence: vec!["evidence:file-local-history-insufficient".to_string()],
+        missing_discriminator: missing.clone(),
+        clearing_conditions: vec![ClearingCondition {
+            discriminator: missing,
+            requirements: required,
+        }],
+    }
+}
+
+fn probe(id: &str, requirements: EvidenceRequirements, git_subprocesses: u32) -> EvidenceProbe {
+    EvidenceProbe {
+        id: id.to_string(),
+        produces: discriminator(),
+        requirements,
+        effect: ProbeEffect::ReadOnly,
+        cost: ProbeCost {
+            git_subprocesses,
+            ..ProbeCost::default()
+        },
+    }
+}
+
+fn request(obligation: DurableObligation, probes: Vec<EvidenceProbe>) -> ProbePlanRequest {
+    ProbePlanRequest {
+        schema_version: EVIDENCE_PLANNER_SCHEMA_VERSION,
+        obligation,
+        context: current_context(),
+        probes,
+        allow_effectful: false,
+        policy: ProbeSelectionPolicy::Conservative,
+    }
+}
+
+fn candidate_status(plan: &evidence_planner::EvidencePlan, id: &str) -> ProbeCandidateStatus {
+    plan.candidates
+        .iter()
+        .find(|candidate| candidate.id == id)
+        .unwrap_or_else(|| panic!("missing candidate {id}"))
+        .status
+}
+
+#[test]
+fn obligation_can_select_exact_bounded_scope_even_when_wrong_scope_probes_are_cheaper() {
+    let plan = plan_evidence(&request(
+        obligation(scope_requirements(PathScopeMode::Prefix, "convex")),
+        vec![
+            probe(
+                "file-history-cheapest",
+                scope_requirements(PathScopeMode::Exact, TARGET),
+                0,
+            ),
+            probe(
+                "convex-history-required",
+                scope_requirements(PathScopeMode::Prefix, "convex"),
+                4,
+            ),
+            probe(
+                "repo-history-cheaper",
+                scope_requirements(PathScopeMode::Prefix, "."),
+                0,
+            ),
+        ],
+    ))
+    .unwrap();
+
+    assert_eq!(plan.status, EvidencePlanStatus::Selected);
+    assert_eq!(
+        plan.selected.as_ref().map(|selected| selected.id.as_str()),
+        Some("convex-history-required")
+    );
+    assert_eq!(
+        candidate_status(&plan, "convex-history-required"),
+        ProbeCandidateStatus::Eligible
+    );
+    assert_eq!(
+        candidate_status(&plan, "file-history-cheapest"),
+        ProbeCandidateStatus::IncompatibleClearingCondition
+    );
+    assert_eq!(
+        candidate_status(&plan, "repo-history-cheaper"),
+        ProbeCandidateStatus::IncompatibleClearingCondition
+    );
+}
+
+#[test]
+fn file_local_clearing_condition_keeps_parent_scope_quiet_even_when_parent_is_cheaper() {
+    let plan = plan_evidence(&request(
+        obligation(scope_requirements(PathScopeMode::Exact, TARGET)),
+        vec![
+            probe(
+                "file-history-required",
+                scope_requirements(PathScopeMode::Exact, TARGET),
+                3,
+            ),
+            probe(
+                "convex-history-cheaper",
+                scope_requirements(PathScopeMode::Prefix, "convex"),
+                0,
+            ),
+        ],
+    ))
+    .unwrap();
+
+    assert_eq!(plan.status, EvidencePlanStatus::Selected);
+    assert_eq!(
+        plan.selected.as_ref().map(|selected| selected.id.as_str()),
+        Some("file-history-required")
+    );
+    assert_eq!(
+        candidate_status(&plan, "file-history-required"),
+        ProbeCandidateStatus::Eligible
+    );
+    assert_eq!(
+        candidate_status(&plan, "convex-history-cheaper"),
+        ProbeCandidateStatus::IncompatibleClearingCondition
+    );
+}
+
+#[test]
+fn required_scope_probe_blocks_when_current_path_context_is_missing_instead_of_guessing() {
+    let mut request = request(
+        obligation(scope_requirements(PathScopeMode::Prefix, "convex")),
+        vec![probe(
+            "convex-history-required",
+            scope_requirements(PathScopeMode::Prefix, "convex"),
+            1,
+        )],
+    );
+    request.context.path = None;
+
+    let plan = plan_evidence(&request).unwrap();
+
+    assert_eq!(plan.status, EvidencePlanStatus::Blocked);
+    assert!(plan.selected.is_none());
+    assert_eq!(
+        candidate_status(&plan, "convex-history-required"),
+        ProbeCandidateStatus::MissingContext
+    );
+}

--- a/tests/obligation_selected_scope_probe.rs
+++ b/tests/obligation_selected_scope_probe.rs
@@ -2,23 +2,20 @@
 
 #[path = "../src/applicability.rs"]
 mod applicability;
-#[path = "../src/justification.rs"]
-mod justification;
 #[path = "../src/durable_obligation.rs"]
 mod durable_obligation;
 #[path = "../src/evidence_planner.rs"]
 mod evidence_planner;
+#[path = "../src/justification.rs"]
+mod justification;
 
-use applicability::{
-    EvaluationContext, EvidenceRequirements, PathScope, PathScopeMode,
-};
+use applicability::{EvaluationContext, EvidenceRequirements, PathScope, PathScopeMode};
 use durable_obligation::{
-    ClearingCondition, DiscriminatorKey, DurableObligation,
-    DURABLE_OBLIGATION_SCHEMA_VERSION,
+    ClearingCondition, DURABLE_OBLIGATION_SCHEMA_VERSION, DiscriminatorKey, DurableObligation,
 };
 use evidence_planner::{
-    plan_evidence, EvidencePlanStatus, EvidenceProbe, EVIDENCE_PLANNER_SCHEMA_VERSION,
-    ProbeCandidateStatus, ProbeCost, ProbeEffect, ProbePlanRequest, ProbeSelectionPolicy,
+    EVIDENCE_PLANNER_SCHEMA_VERSION, EvidencePlanStatus, EvidenceProbe, ProbeCandidateStatus,
+    ProbeCost, ProbeEffect, ProbePlanRequest, ProbeSelectionPolicy, plan_evidence,
 };
 
 const REPOSITORY: &str = "owner/repo";


### PR DESCRIPTION
Superseded by current-main #276.

The original #209 branch carried the entire historical #156/#159/#164 stack because those parents had not landed yet. Those primitives are now on `main`, and #276 replays the exact earned child delta as a one-file test:

```text
tests/obligation_selected_scope_probe.rs
```

No semantics from this stacked branch need separate integration.