### PR TITLE
research: separate discriminator knowledge from applicability

### DIFF
--- a/research/discriminator-observations/cultist-v1.json
+++ b/research/discriminator-observations/cultist-v1.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "observations": [
     {
       "observation_id": "justification/open-obligation-v1:clearing-evidence-presence",
@@ -10,7 +10,10 @@
         "state": "known",
         "value_ref": "absent"
       },
-      "applicability_ref": "research:durable-unknown-obligation.md#evaluation"
+      "applicability": {
+        "status": "applies",
+        "receipt_ref": "research:durable-unknown-obligation.md#evaluation"
+      }
     },
     {
       "observation_id": "history/oxc-edit-class-v1:current-edit-class",
@@ -21,7 +24,10 @@
         "state": "known",
         "value_ref": "syntax_changed"
       },
-      "applicability_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588"
+      "applicability": {
+        "status": "applies",
+        "receipt_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588"
+      }
     },
     {
       "observation_id": "project-memory/primary-case-contract-collision-v1:evidence-form",
@@ -32,7 +38,10 @@
         "state": "known",
         "value_ref": "primary_case_issue_block"
       },
-      "applicability_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+      "applicability": {
+        "status": "applies",
+        "receipt_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+      }
     },
     {
       "observation_id": "project-memory/primary-case-contract-collision-v1:target-relation",
@@ -43,7 +52,10 @@
         "state": "known",
         "value_ref": "same_repository_issue"
       },
-      "applicability_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+      "applicability": {
+        "status": "applies",
+        "receipt_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+      }
     }
   ]
 }

--- a/research/typed-observation-applicability.md
+++ b/research/typed-observation-applicability.md
@@ -1,0 +1,161 @@
+# Typed discriminator applicability repair
+
+Tracking: #195. Stacked on the green #201 negative control over #194/#187.
+
+## Counterexample that earned the repair
+
+#201 composes the real shared applicability evaluator with the v1 discriminator observation and observation frontier types.
+
+It proves both of these states were admitted:
+
+```text
+value_state = KNOWN(syntax_changed)
+shared applicability = INVALID after exact-head movement
+frontier = CURRENT
+```
+
+and:
+
+```text
+value_state = KNOWN(syntax_changed)
+shared applicability = UNKNOWN because current revision is missing
+frontier = CURRENT
+```
+
+#201 head `1614cc2ae82df50ec3c8b5c4a9e428ad01c1d50f` passed CI run `32250242114` / #1341, so the ambiguity was executable.
+
+The cause is precise: v1 carries only an opaque `applicability_ref`, while generic currentness is decided entirely from `value_state=KNOWN`.
+
+## Disposition: separate axes
+
+The repair chooses #195 Model B.
+
+V2 discriminator observations carry two independent supplied facts:
+
+```text
+value_state
+  known { value_ref }
+  unknown { reason_ref }
+
+applicability
+  status = applies | unknown | invalid
+  receipt_ref
+```
+
+`INVALID` leaves the value-knowledge axis. Stale/coordinate invalidity belongs to applicability.
+
+The generic module still performs no Git/repository/source-domain applicability evaluation. A source adapter supplies the typed applicability state plus the exact receipt that earned it.
+
+## Shared combination rule
+
+One source-owned helper combines the two axes for both generic consumers:
+
+```text
+applicability INVALID
+  -> INVALID
+  preserve known old value when present
+
+applicability UNKNOWN
+  -> UNKNOWN
+  preserve known old value when present
+
+applicability APPLIES + value UNKNOWN
+  -> UNKNOWN
+
+applicability APPLIES + value KNOWN
+  -> CURRENT
+```
+
+Both discriminator partition enumeration and observation frontier evaluation call this same classifier. The rule therefore cannot drift between #187 and #194.
+
+## Wire/version change
+
+Because the v1 observation meaning allowed KNOWN to outrun applicability, this is an incompatible research wire change:
+
+```text
+DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION: 1 -> 2
+OBSERVATION_FRONTIER_SCHEMA_VERSION:        1 -> 2
+```
+
+The retained three-family observation corpus is rewritten to v2 and gives every current observation an explicit `applicability.status = applies` plus its source receipt.
+
+## Adversarial controls
+
+The repaired standard harness requires:
+
+- retained selected #179 discriminators are current only through `KNOWN + APPLIES`;
+- value UNKNOWN with APPLIES remains unknown;
+- known value + applicability UNKNOWN remains unknown and preserves the known value;
+- known value + applicability INVALID remains invalid and preserves the known value;
+- missing applicability receipt rejects;
+- duplicate/conflicting observation identity controls remain intact;
+- equal values from different source receipts remain distinct observations;
+- opaque value spelling still grants zero authority/disposition;
+- #194 wrong-subject isolation and mixed-state precedence remain intact;
+- the exact #201 moved-head and missing-current-revision cases now produce INVALID/UNKNOWN frontiers instead of CURRENT.
+
+## Executed GitHub receipt
+
+The v2 repair was compacted to one semantic commit directly on #201's exact green counterexample head.
+
+Exact semantic head:
+
+```text
+5c84155eb1616b6774f0c5ac764f17ac5d61fa9b
+```
+
+GitHub Actions CI run `32251969947` / run number `1417` completed successfully. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work preflight;
+- full `cargo test`, including the v2 discriminator enumeration controls, exact-subject frontier controls, and the two #201 closure tests using the real shared applicability evaluator;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The first repair attempt stopped only at rustfmt before Clippy or tests. The exact formatter deltas touched the three v2 test files only. After those mechanical edits, the intermediate head passed the full gate; the branch was then compacted back to the one semantic commit above and revalidated through CI #1417.
+
+Because #210 is a stacked research PR, the ordinary CI workflow is its authoritative gate; generated-provenance PR dogfood is not part of this stack's trigger set.
+
+The central closure is now executable:
+
+```text
+KNOWN old value + applicability INVALID
+  -> frontier INVALID
+  -> known old value preserved
+
+KNOWN old value + applicability UNKNOWN
+  -> frontier UNKNOWN
+  -> known old value preserved
+```
+
+Stale knowledge can no longer suppress a current observation frontier.
+
+## Phase B consequence
+
+#190 probe planning must consume the repaired frontier semantics.
+
+A historical known value can remain useful as a receipt while current acquisition still proceeds:
+
+```text
+KNOWN old value
++ applicability INVALID
+-> frontier INVALID
+-> source adapter may propose current evidence acquisition
+```
+
+The known value is preserved in the noncurrent receipt; it simply cannot suppress current work.
+
+## Boundary
+
+- source adapters supply applicability state; generic modules do not execute the shared evaluator;
+- applicability receipt strings remain opaque references after the typed state is supplied;
+- no implicit mapping to #145 probe capability;
+- no evidence strength, authority, or disposition is inferred from either axis;
+- v1 receipts remain retained as the historical counterexample/earlier experiment.
+
+North star:
+
+> Preserve what was learned from stale evidence while making current usability an explicit typed fact that stale knowledge cannot silently override.

--- a/src/discriminator_observation.rs
+++ b/src/discriminator_observation.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-pub const DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION: u32 = 1;
+pub const DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION: u32 = 2;
 pub const MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES: usize = 256 * 1024;
 const MAX_OBSERVATIONS: usize = 1024;
 const MAX_ID_BYTES: usize = 512;
@@ -25,8 +25,7 @@ pub struct DiscriminatorObservation {
     pub subject_ref: String,
     pub source_receipt: String,
     pub value_state: DiscriminatorValueState,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub applicability: ObservationApplicability,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -34,7 +33,21 @@ pub struct DiscriminatorObservation {
 pub enum DiscriminatorValueState {
     Known { value_ref: String },
     Unknown { reason_ref: String },
-    Invalid { reason_ref: String },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationApplicability {
+    pub status: ObservationApplicabilityStatus,
+    pub receipt_ref: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationApplicabilityStatus {
+    Applies,
+    Unknown,
+    Invalid,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -66,8 +79,7 @@ pub struct CurrentObservationReceipt {
     pub observation_id: String,
     pub subject_ref: String,
     pub source_receipt: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub applicability_ref: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -76,9 +88,29 @@ pub struct NonCurrentObservationReceipt {
     pub observation_id: String,
     pub subject_ref: String,
     pub source_receipt: String,
-    pub reason_ref: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub known_value_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_unknown_reason_ref: Option<String>,
+    pub applicability_ref: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ObservationCurrentness<'a> {
+    Current {
+        value_ref: &'a str,
+        applicability_ref: &'a str,
+    },
+    Unknown {
+        known_value_ref: Option<&'a str>,
+        value_unknown_reason_ref: Option<&'a str>,
+        applicability_ref: &'a str,
+    },
+    Invalid {
+        known_value_ref: Option<&'a str>,
+        value_unknown_reason_ref: Option<&'a str>,
+        applicability_ref: &'a str,
+    },
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -156,6 +188,39 @@ pub fn validate_discriminator_observation_batch(
     Ok(())
 }
 
+pub fn classify_observation_currentness(
+    observation: &DiscriminatorObservation,
+) -> ObservationCurrentness<'_> {
+    let (known_value_ref, value_unknown_reason_ref) = match &observation.value_state {
+        DiscriminatorValueState::Known { value_ref } => (Some(value_ref.as_str()), None),
+        DiscriminatorValueState::Unknown { reason_ref } => (None, Some(reason_ref.as_str())),
+    };
+
+    match observation.applicability.status {
+        ObservationApplicabilityStatus::Invalid => ObservationCurrentness::Invalid {
+            known_value_ref,
+            value_unknown_reason_ref,
+            applicability_ref: &observation.applicability.receipt_ref,
+        },
+        ObservationApplicabilityStatus::Unknown => ObservationCurrentness::Unknown {
+            known_value_ref,
+            value_unknown_reason_ref,
+            applicability_ref: &observation.applicability.receipt_ref,
+        },
+        ObservationApplicabilityStatus::Applies => match known_value_ref {
+            Some(value_ref) => ObservationCurrentness::Current {
+                value_ref,
+                applicability_ref: &observation.applicability.receipt_ref,
+            },
+            None => ObservationCurrentness::Unknown {
+                known_value_ref: None,
+                value_unknown_reason_ref,
+                applicability_ref: &observation.applicability.receipt_ref,
+            },
+        },
+    }
+}
+
 pub fn enumerate_discriminator_partitions(
     batch: &DiscriminatorObservationBatch,
 ) -> Result<DiscriminatorEnumeration, DiscriminatorObservationError> {
@@ -173,24 +238,42 @@ pub fn enumerate_discriminator_partitions(
         let builder = builders
             .entry(observation.discriminator_id.clone())
             .or_default();
-        match &observation.value_state {
-            DiscriminatorValueState::Known { value_ref } => {
+        match classify_observation_currentness(observation) {
+            ObservationCurrentness::Current {
+                value_ref,
+                applicability_ref,
+            } => {
                 builder
                     .known
-                    .entry(value_ref.clone())
+                    .entry(value_ref.to_string())
                     .or_default()
-                    .push(current_receipt(observation));
+                    .push(CurrentObservationReceipt {
+                        observation_id: observation.observation_id.clone(),
+                        subject_ref: observation.subject_ref.clone(),
+                        source_receipt: observation.source_receipt.clone(),
+                        applicability_ref: applicability_ref.to_string(),
+                    });
             }
-            DiscriminatorValueState::Unknown { reason_ref } => {
-                builder
-                    .unknown
-                    .push(non_current_receipt(observation, reason_ref));
-            }
-            DiscriminatorValueState::Invalid { reason_ref } => {
-                builder
-                    .invalid
-                    .push(non_current_receipt(observation, reason_ref));
-            }
+            ObservationCurrentness::Unknown {
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            } => builder.unknown.push(non_current_receipt(
+                observation,
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            )),
+            ObservationCurrentness::Invalid {
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            } => builder.invalid.push(non_current_receipt(
+                observation,
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            )),
         }
     }
 
@@ -230,25 +313,19 @@ pub fn enumerate_discriminator_partitions(
     })
 }
 
-fn current_receipt(observation: &DiscriminatorObservation) -> CurrentObservationReceipt {
-    CurrentObservationReceipt {
-        observation_id: observation.observation_id.clone(),
-        subject_ref: observation.subject_ref.clone(),
-        source_receipt: observation.source_receipt.clone(),
-        applicability_ref: observation.applicability_ref.clone(),
-    }
-}
-
 fn non_current_receipt(
     observation: &DiscriminatorObservation,
-    reason_ref: &str,
+    known_value_ref: Option<&str>,
+    value_unknown_reason_ref: Option<&str>,
+    applicability_ref: &str,
 ) -> NonCurrentObservationReceipt {
     NonCurrentObservationReceipt {
         observation_id: observation.observation_id.clone(),
         subject_ref: observation.subject_ref.clone(),
         source_receipt: observation.source_receipt.clone(),
-        reason_ref: reason_ref.to_string(),
-        applicability_ref: observation.applicability_ref.clone(),
+        known_value_ref: known_value_ref.map(str::to_string),
+        value_unknown_reason_ref: value_unknown_reason_ref.map(str::to_string),
+        applicability_ref: applicability_ref.to_string(),
     }
 }
 
@@ -267,18 +344,19 @@ fn validate_observation(
         "source_receipt",
         MAX_REFERENCE_BYTES,
     )?;
-    if let Some(applicability_ref) = &observation.applicability_ref {
-        validate_atom(applicability_ref, "applicability_ref", MAX_REFERENCE_BYTES)?;
-    }
     match &observation.value_state {
         DiscriminatorValueState::Known { value_ref } => {
-            validate_atom(value_ref, "value_ref", MAX_REFERENCE_BYTES)
+            validate_atom(value_ref, "value_ref", MAX_REFERENCE_BYTES)?;
         }
-        DiscriminatorValueState::Unknown { reason_ref }
-        | DiscriminatorValueState::Invalid { reason_ref } => {
-            validate_atom(reason_ref, "reason_ref", MAX_REFERENCE_BYTES)
+        DiscriminatorValueState::Unknown { reason_ref } => {
+            validate_atom(reason_ref, "value reason_ref", MAX_REFERENCE_BYTES)?;
         }
     }
+    validate_atom(
+        &observation.applicability.receipt_ref,
+        "applicability receipt_ref",
+        MAX_REFERENCE_BYTES,
+    )
 }
 
 fn validate_atom(

--- a/src/observation_frontier.rs
+++ b/src/observation_frontier.rs
@@ -5,11 +5,11 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 use crate::discriminator_observation::{
-    DiscriminatorObservation, DiscriminatorObservationBatch, DiscriminatorValueState,
-    validate_discriminator_observation_batch,
+    DiscriminatorObservation, DiscriminatorObservationBatch, ObservationCurrentness,
+    classify_observation_currentness, validate_discriminator_observation_batch,
 };
 
-pub const OBSERVATION_FRONTIER_SCHEMA_VERSION: u32 = 1;
+pub const OBSERVATION_FRONTIER_SCHEMA_VERSION: u32 = 2;
 pub const MAX_OBSERVATION_FRONTIER_REQUEST_BYTES: usize = 512 * 1024;
 const MAX_REQUIREMENTS: usize = 256;
 const MAX_ID_BYTES: usize = 512;
@@ -64,8 +64,7 @@ pub struct CurrentObservationReceipt {
     pub observation_id: String,
     pub source_receipt: String,
     pub value_ref: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub applicability_ref: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -73,15 +72,17 @@ pub struct CurrentObservationReceipt {
 pub struct NonCurrentObservationReceipt {
     pub observation_id: String,
     pub source_receipt: String,
-    pub reason_ref: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub known_value_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_unknown_reason_ref: Option<String>,
+    pub applicability_ref: String,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ObservationValueStateKind {
-    Known,
+pub enum ObservationCurrentnessKind {
+    Current,
     Unknown,
     Invalid,
 }
@@ -92,7 +93,7 @@ pub struct OtherSubjectObservationReceipt {
     pub observation_id: String,
     pub subject_ref: String,
     pub source_receipt: String,
-    pub state: ObservationValueStateKind,
+    pub state: ObservationCurrentnessKind,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -166,41 +167,47 @@ fn evaluate_requirement(
         .iter()
         .filter(|observation| observation.discriminator_id == requirement.discriminator_id)
     {
+        let currentness = classify_observation_currentness(observation);
         if observation.subject_ref != requirement.subject_ref {
             other_subject.push(OtherSubjectObservationReceipt {
                 observation_id: observation.observation_id.clone(),
                 subject_ref: observation.subject_ref.clone(),
                 source_receipt: observation.source_receipt.clone(),
-                state: value_state_kind(&observation.value_state),
+                state: currentness_kind(currentness),
             });
             continue;
         }
 
-        match &observation.value_state {
-            DiscriminatorValueState::Known { value_ref } => {
-                current.push(CurrentObservationReceipt {
-                    observation_id: observation.observation_id.clone(),
-                    source_receipt: observation.source_receipt.clone(),
-                    value_ref: value_ref.clone(),
-                    applicability_ref: observation.applicability_ref.clone(),
-                });
-            }
-            DiscriminatorValueState::Unknown { reason_ref } => {
-                unknown.push(NonCurrentObservationReceipt {
-                    observation_id: observation.observation_id.clone(),
-                    source_receipt: observation.source_receipt.clone(),
-                    reason_ref: reason_ref.clone(),
-                    applicability_ref: observation.applicability_ref.clone(),
-                });
-            }
-            DiscriminatorValueState::Invalid { reason_ref } => {
-                invalid.push(NonCurrentObservationReceipt {
-                    observation_id: observation.observation_id.clone(),
-                    source_receipt: observation.source_receipt.clone(),
-                    reason_ref: reason_ref.clone(),
-                    applicability_ref: observation.applicability_ref.clone(),
-                });
-            }
+        match currentness {
+            ObservationCurrentness::Current {
+                value_ref,
+                applicability_ref,
+            } => current.push(CurrentObservationReceipt {
+                observation_id: observation.observation_id.clone(),
+                source_receipt: observation.source_receipt.clone(),
+                value_ref: value_ref.to_string(),
+                applicability_ref: applicability_ref.to_string(),
+            }),
+            ObservationCurrentness::Unknown {
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            } => unknown.push(non_current_receipt(
+                observation,
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            )),
+            ObservationCurrentness::Invalid {
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            } => invalid.push(non_current_receipt(
+                observation,
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            )),
         }
     }
 
@@ -230,11 +237,26 @@ fn evaluate_requirement(
     }
 }
 
-fn value_state_kind(value_state: &DiscriminatorValueState) -> ObservationValueStateKind {
-    match value_state {
-        DiscriminatorValueState::Known { .. } => ObservationValueStateKind::Known,
-        DiscriminatorValueState::Unknown { .. } => ObservationValueStateKind::Unknown,
-        DiscriminatorValueState::Invalid { .. } => ObservationValueStateKind::Invalid,
+fn currentness_kind(currentness: ObservationCurrentness<'_>) -> ObservationCurrentnessKind {
+    match currentness {
+        ObservationCurrentness::Current { .. } => ObservationCurrentnessKind::Current,
+        ObservationCurrentness::Unknown { .. } => ObservationCurrentnessKind::Unknown,
+        ObservationCurrentness::Invalid { .. } => ObservationCurrentnessKind::Invalid,
+    }
+}
+
+fn non_current_receipt(
+    observation: &DiscriminatorObservation,
+    known_value_ref: Option<&str>,
+    value_unknown_reason_ref: Option<&str>,
+    applicability_ref: &str,
+) -> NonCurrentObservationReceipt {
+    NonCurrentObservationReceipt {
+        observation_id: observation.observation_id.clone(),
+        source_receipt: observation.source_receipt.clone(),
+        known_value_ref: known_value_ref.map(str::to_string),
+        value_unknown_reason_ref: value_unknown_reason_ref.map(str::to_string),
+        applicability_ref: applicability_ref.to_string(),
     }
 }
 

--- a/tests/discriminator_observation.rs
+++ b/tests/discriminator_observation.rs
@@ -9,8 +9,9 @@ mod refinement_episode;
 
 use discriminator_observation::{
     DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation, DiscriminatorValueState,
-    MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES, enumerate_discriminator_partitions,
-    parse_discriminator_observation_batch, validate_discriminator_observation_batch,
+    MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES, ObservationApplicabilityStatus,
+    enumerate_discriminator_partitions, parse_discriminator_observation_batch,
+    validate_discriminator_observation_batch,
 };
 use refinement_episode::parse_refinement_episode_batch;
 
@@ -49,14 +50,14 @@ fn retained_observations_cover_every_selected_refinement_discriminator() {
             assert_eq!(
                 current.get(discriminator.as_str()),
                 Some(&true),
-                "selected discriminator {discriminator} lacks a current KNOWN observation"
+                "selected discriminator {discriminator} lacks a current KNOWN+APPLIES observation"
             );
         }
     }
 }
 
 #[test]
-fn known_observations_enumerate_by_discriminator_and_value() {
+fn known_applicable_observations_enumerate_by_discriminator_and_value() {
     let batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
     let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
     assert_eq!(
@@ -72,10 +73,10 @@ fn known_observations_enumerate_by_discriminator_and_value() {
 }
 
 #[test]
-fn unknown_observation_stays_visible_and_out_of_current_partitions() {
+fn unknown_value_with_applicable_source_stays_unknown() {
     let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
     batch.observations[0].value_state = DiscriminatorValueState::Unknown {
-        reason_ref: "applicability:missing-current-revision".to_string(),
+        reason_ref: "classifier:missing-value".to_string(),
     };
 
     let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
@@ -86,15 +87,38 @@ fn unknown_observation_stays_visible_and_out_of_current_partitions() {
         .unwrap();
     assert!(discriminator.known_partitions.is_empty());
     assert_eq!(discriminator.unknown.len(), 1);
-    assert!(discriminator.invalid.is_empty());
+    assert_eq!(
+        discriminator.unknown[0].value_unknown_reason_ref.as_deref(),
+        Some("classifier:missing-value")
+    );
 }
 
 #[test]
-fn invalid_observation_stays_visible_and_out_of_current_partitions() {
+fn known_value_with_unknown_applicability_stays_unknown_and_preserves_value() {
     let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
-    batch.observations[1].value_state = DiscriminatorValueState::Invalid {
-        reason_ref: "applicability:revision-moved".to_string(),
-    };
+    batch.observations[0].applicability.status = ObservationApplicabilityStatus::Unknown;
+    batch.observations[0].applicability.receipt_ref =
+        "applicability:missing-current-revision".to_string();
+
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let discriminator = enumeration
+        .discriminators
+        .iter()
+        .find(|item| item.discriminator_id == "clearing_evidence_presence")
+        .unwrap();
+    assert!(discriminator.known_partitions.is_empty());
+    assert_eq!(discriminator.unknown.len(), 1);
+    assert_eq!(
+        discriminator.unknown[0].known_value_ref.as_deref(),
+        Some("absent")
+    );
+}
+
+#[test]
+fn known_value_with_invalid_applicability_stays_invalid_and_preserves_value() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[1].applicability.status = ObservationApplicabilityStatus::Invalid;
+    batch.observations[1].applicability.receipt_ref = "applicability:revision-moved".to_string();
 
     let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
     let discriminator = enumeration
@@ -103,8 +127,11 @@ fn invalid_observation_stays_visible_and_out_of_current_partitions() {
         .find(|item| item.discriminator_id == "edit_class")
         .unwrap();
     assert!(discriminator.known_partitions.is_empty());
-    assert!(discriminator.unknown.is_empty());
     assert_eq!(discriminator.invalid.len(), 1);
+    assert_eq!(
+        discriminator.invalid[0].known_value_ref.as_deref(),
+        Some("syntax_changed")
+    );
 }
 
 #[test]
@@ -141,6 +168,14 @@ fn missing_source_receipt_rejects() {
     batch.observations[0].source_receipt.clear();
     let error = validate_discriminator_observation_batch(&batch).unwrap_err();
     assert!(error.to_string().contains("source_receipt"));
+}
+
+#[test]
+fn missing_applicability_receipt_rejects() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[0].applicability.receipt_ref.clear();
+    let error = validate_discriminator_observation_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("applicability receipt_ref"));
 }
 
 #[test]

--- a/tests/known_stale_observation_frontier.rs
+++ b/tests/known_stale_observation_frontier.rs
@@ -13,14 +13,18 @@ use applicability::{
 };
 use discriminator_observation::{
     DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation,
-    DiscriminatorObservationBatch, DiscriminatorValueState,
+    DiscriminatorObservationBatch, DiscriminatorValueState, ObservationApplicability,
+    ObservationApplicabilityStatus,
 };
 use observation_frontier::{
     OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierRequest, ObservationFrontierStatus,
     ObservationRequirement, evaluate_observation_frontiers,
 };
 
-fn known_observation(applicability_ref: &str) -> DiscriminatorObservation {
+fn known_observation(
+    applicability_status: ObservationApplicabilityStatus,
+    applicability_ref: &str,
+) -> DiscriminatorObservation {
     DiscriminatorObservation {
         observation_id: "obs:edit-class:subject-a".to_string(),
         discriminator_id: "edit_class".to_string(),
@@ -29,11 +33,16 @@ fn known_observation(applicability_ref: &str) -> DiscriminatorObservation {
         value_state: DiscriminatorValueState::Known {
             value_ref: "syntax_changed".to_string(),
         },
-        applicability_ref: Some(applicability_ref.to_string()),
+        applicability: ObservationApplicability {
+            status: applicability_status,
+            receipt_ref: applicability_ref.to_string(),
+        },
     }
 }
 
-fn frontier_for(observation: DiscriminatorObservation) -> ObservationFrontierStatus {
+fn frontier_for(
+    observation: DiscriminatorObservation,
+) -> observation_frontier::ObservationFrontierReceipt {
     let request = ObservationFrontierRequest {
         schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
         requirements: vec![ObservationRequirement {
@@ -45,11 +54,14 @@ fn frontier_for(observation: DiscriminatorObservation) -> ObservationFrontierSta
             observations: vec![observation],
         },
     };
-    evaluate_observation_frontiers(&request).unwrap().frontiers[0].status
+    evaluate_observation_frontiers(&request)
+        .unwrap()
+        .frontiers
+        .remove(0)
 }
 
 #[test]
-fn known_value_can_be_called_current_while_shared_applicability_is_invalid() {
+fn known_value_with_invalid_shared_applicability_is_not_current() {
     let applicability = evaluate_query(&ApplicabilityQuery {
         schema_version: APPLICABILITY_SCHEMA_VERSION,
         requirements: EvidenceRequirements {
@@ -68,14 +80,21 @@ fn known_value_can_be_called_current_while_shared_applicability_is_invalid() {
     .unwrap();
     assert_eq!(applicability.status, ApplicabilityStatus::Invalid);
 
-    let status = frontier_for(known_observation(
+    let frontier = frontier_for(known_observation(
+        ObservationApplicabilityStatus::Invalid,
         "applicability:owner/repo:old-head->new-head:invalid",
     ));
-    assert_eq!(status, ObservationFrontierStatus::Current);
+    assert_eq!(frontier.status, ObservationFrontierStatus::Invalid);
+    assert!(frontier.current.is_empty());
+    assert_eq!(frontier.invalid.len(), 1);
+    assert_eq!(
+        frontier.invalid[0].known_value_ref.as_deref(),
+        Some("syntax_changed")
+    );
 }
 
 #[test]
-fn known_value_can_be_called_current_while_required_current_revision_is_missing() {
+fn known_value_with_unknown_shared_applicability_is_not_current() {
     let applicability = evaluate_query(&ApplicabilityQuery {
         schema_version: APPLICABILITY_SCHEMA_VERSION,
         requirements: EvidenceRequirements {
@@ -94,8 +113,15 @@ fn known_value_can_be_called_current_while_required_current_revision_is_missing(
     .unwrap();
     assert_eq!(applicability.status, ApplicabilityStatus::Unknown);
 
-    let status = frontier_for(known_observation(
+    let frontier = frontier_for(known_observation(
+        ObservationApplicabilityStatus::Unknown,
         "applicability:owner/repo:exact-head:current-revision-missing",
     ));
-    assert_eq!(status, ObservationFrontierStatus::Current);
+    assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
+    assert!(frontier.current.is_empty());
+    assert_eq!(frontier.unknown.len(), 1);
+    assert_eq!(
+        frontier.unknown[0].known_value_ref.as_deref(),
+        Some("syntax_changed")
+    );
 }

--- a/tests/observation_frontier.rs
+++ b/tests/observation_frontier.rs
@@ -10,7 +10,8 @@ mod observation_frontier;
 mod refinement_episode;
 
 use discriminator_observation::{
-    DiscriminatorObservationBatch, DiscriminatorValueState, parse_discriminator_observation_batch,
+    DiscriminatorObservationBatch, DiscriminatorValueState, ObservationApplicabilityStatus,
+    parse_discriminator_observation_batch,
 };
 use observation_frontier::{
     MAX_OBSERVATION_FRONTIER_REQUEST_BYTES, OBSERVATION_FRONTIER_SCHEMA_VERSION,
@@ -68,12 +69,14 @@ fn retained_selected_refinement_discriminators_resolve_current() {
                             &observation.value_state,
                             DiscriminatorValueState::Known { .. }
                         )
+                        && observation.applicability.status
+                            == ObservationApplicabilityStatus::Applies
                 })
                 .collect::<Vec<_>>();
             assert_eq!(
                 matches.len(),
                 1,
-                "retained fixture requires one current subject for {discriminator_id}"
+                "retained fixture requires one current KNOWN+APPLIES subject for {discriminator_id}"
             );
             requirements.push(requirement(discriminator_id, &matches[0].subject_ref));
         }
@@ -127,12 +130,12 @@ fn same_discriminator_on_wrong_subject_does_not_satisfy_requirement() {
 }
 
 #[test]
-fn unknown_matching_observation_produces_unknown_frontier() {
+fn unknown_value_with_applicable_source_produces_unknown_frontier() {
     let mut observations = observation_batch();
     let discriminator_id = observations.observations[0].discriminator_id.clone();
     let subject_ref = observations.observations[0].subject_ref.clone();
     observations.observations[0].value_state = DiscriminatorValueState::Unknown {
-        reason_ref: "applicability:missing-current-revision".to_string(),
+        reason_ref: "classifier:missing-value".to_string(),
     };
 
     let evaluation = evaluate_observation_frontiers(&request(
@@ -143,17 +146,42 @@ fn unknown_matching_observation_produces_unknown_frontier() {
     let frontier = &evaluation.frontiers[0];
     assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
     assert_eq!(frontier.unknown.len(), 1);
-    assert!(frontier.current.is_empty());
+    assert_eq!(
+        frontier.unknown[0].value_unknown_reason_ref.as_deref(),
+        Some("classifier:missing-value")
+    );
 }
 
 #[test]
-fn invalid_matching_observation_produces_invalid_frontier() {
+fn known_value_with_unknown_applicability_produces_unknown_frontier() {
+    let mut observations = observation_batch();
+    let discriminator_id = observations.observations[0].discriminator_id.clone();
+    let subject_ref = observations.observations[0].subject_ref.clone();
+    observations.observations[0].applicability.status = ObservationApplicabilityStatus::Unknown;
+    observations.observations[0].applicability.receipt_ref =
+        "applicability:missing-current-revision".to_string();
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
+    assert_eq!(
+        frontier.unknown[0].known_value_ref.as_deref(),
+        Some("absent")
+    );
+}
+
+#[test]
+fn known_value_with_invalid_applicability_produces_invalid_frontier() {
     let mut observations = observation_batch();
     let discriminator_id = observations.observations[1].discriminator_id.clone();
     let subject_ref = observations.observations[1].subject_ref.clone();
-    observations.observations[1].value_state = DiscriminatorValueState::Invalid {
-        reason_ref: "applicability:revision-moved".to_string(),
-    };
+    observations.observations[1].applicability.status = ObservationApplicabilityStatus::Invalid;
+    observations.observations[1].applicability.receipt_ref =
+        "applicability:revision-moved".to_string();
 
     let evaluation = evaluate_observation_frontiers(&request(
         vec![requirement(&discriminator_id, &subject_ref)],
@@ -162,8 +190,10 @@ fn invalid_matching_observation_produces_invalid_frontier() {
     .unwrap();
     let frontier = &evaluation.frontiers[0];
     assert_eq!(frontier.status, ObservationFrontierStatus::Invalid);
-    assert_eq!(frontier.invalid.len(), 1);
-    assert!(frontier.current.is_empty());
+    assert_eq!(
+        frontier.invalid[0].known_value_ref.as_deref(),
+        Some("syntax_changed")
+    );
 }
 
 #[test]
@@ -172,9 +202,8 @@ fn current_precedes_unknown_while_preserving_both_receipts() {
     let mut unknown = observations.observations[1].clone();
     unknown.observation_id = "history/oxc-edit-class-v1:unknown-second-source".to_string();
     unknown.source_receipt = "research:cohort-refinement.md#unknown-edit-class".to_string();
-    unknown.value_state = DiscriminatorValueState::Unknown {
-        reason_ref: "classifier:missing-source-version".to_string(),
-    };
+    unknown.applicability.status = ObservationApplicabilityStatus::Unknown;
+    unknown.applicability.receipt_ref = "applicability:missing-source-version".to_string();
     let discriminator_id = unknown.discriminator_id.clone();
     let subject_ref = unknown.subject_ref.clone();
     observations.observations.push(unknown);
@@ -196,14 +225,13 @@ fn unknown_precedes_invalid_when_no_current_observation_exists() {
     let mut invalid = observations.observations[0].clone();
     invalid.observation_id = "justification/open-obligation-v1:invalid-second-source".to_string();
     invalid.source_receipt = "research:durable-unknown-obligation.md#stale".to_string();
-    invalid.value_state = DiscriminatorValueState::Invalid {
-        reason_ref: "applicability:head-moved".to_string(),
-    };
+    invalid.applicability.status = ObservationApplicabilityStatus::Invalid;
+    invalid.applicability.receipt_ref = "applicability:head-moved".to_string();
     let discriminator_id = invalid.discriminator_id.clone();
     let subject_ref = invalid.subject_ref.clone();
-    observations.observations[0].value_state = DiscriminatorValueState::Unknown {
-        reason_ref: "applicability:missing-head".to_string(),
-    };
+    observations.observations[0].applicability.status = ObservationApplicabilityStatus::Unknown;
+    observations.observations[0].applicability.receipt_ref =
+        "applicability:missing-head".to_string();
     observations.observations.push(invalid);
 
     let evaluation = evaluate_observation_frontiers(&request(


### PR DESCRIPTION
Closes #195 by replacing the v1 frontier contract demonstrated by #201 with separate typed value-knowledge and current-applicability axes.

## Before / after

#201 is now on `main` and proves v1 can represent:

```text
KNOWN old value
+ applicability INVALID | UNKNOWN
-> frontier CURRENT
```

This carrier chooses Model B:

```text
value_state
  known { value_ref }
  unknown { reason_ref }

applicability
  status = applies | unknown | invalid
  receipt_ref
```

A shared generic classifier combines the supplied axes:

```text
INVALID applicability -> invalid, preserve known old value
UNKNOWN applicability -> unknown, preserve known old value
APPLIES + value UNKNOWN -> unknown
APPLIES + value KNOWN -> current
```

Generic code still executes no source-domain applicability logic. Source adapters supply typed applicability plus exact receipt.

Because admitted wire meaning changes, discriminator-observation and observation-frontier research schemas advance from v1 to v2. The retained three-family observation corpus carries explicit `applicability.status=applies` receipts.

## Closure controls

- every selected #179 discriminator remains current only through KNOWN+APPLIES;
- KNOWN + UNKNOWN applicability -> UNKNOWN frontier, known value retained;
- KNOWN + INVALID applicability -> INVALID frontier, known value retained;
- value UNKNOWN + APPLIES -> UNKNOWN;
- missing applicability receipt rejects;
- duplicate/conflict, source identity, wrong-subject, mixed-state, ordering, round-trip, and bounds controls remain;
- the exact #201 moved-head and missing-current-revision counterexamples are inverted into closure tests using the real shared applicability evaluator.

## Current-main promotion receipt

After #201 landed as `592111d1d747b4f89e900ea788adfd1a9607b445`, the seven repair blobs were flattened to one commit directly on that exact main tree:

```text
head: db78d92649a1df07ee0e7bf9b7410b7102ab157c
commits: 1
files: 7
```

Ordinary CI:

```text
run: 32270894042
job: 96126771850
result: success
```

Generated-provenance review:

```text
run: 32270894038
job: 96126771516
result: success
```

Formatter, strict Clippy, current repository policy guards, active-work preflight, all v2/closure tests, and repository/history/CI-filter/diff dogfood passed. Main remained at the exact base through the gate.

The earlier semantic receipt remains in `research/typed-observation-applicability.md`; this is the current-main closure receipt.

## Known source-data boundary

The retained Oxc row still carries the pre-#221 historical coordinate `8783524...:rules.rs`. Later source-adapter work earned the focused `228e8e0f...:rules.rs` observation. That source correction stays a separate later layer; this PR repairs the generic v2 knowledge/applicability contract only.

Files: `src/discriminator_observation.rs`, `src/observation_frontier.rs`, `tests/discriminator_observation.rs`, `tests/known_stale_observation_frontier.rs`, `tests/observation_frontier.rs`, `research/discriminator-observations/cultist-v1.json`, `research/typed-observation-applicability.md`.

Refs #123 #185 #187 #190 #194 #195 #201 #216 #221.