### PR TITLE
research: separate issue closure from failure clearance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,13 @@ jobs:
             scripts/review_memory_github.py \
             scripts/review_memory_github_test.py
           python scripts/review_memory_github_test.py
+      - name: GitHub issue-closure adapter controls
+        run: |
+          python -m py_compile \
+            scripts/project_memory_github.py \
+            scripts/closure_episode_github.py \
+            scripts/closure_episode_github_test.py
+          python scripts/closure_episode_github_test.py
       - name: Active work heads-up
         if: github.event_name == 'pull_request'
         continue-on-error: true

--- a/.github/workflows/closure-episode-github.yml
+++ b/.github/workflows/closure-episode-github.yml
@@ -1,0 +1,164 @@
+name: GitHub issue-closure carrier
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: Public GitHub owner/repository
+        required: true
+        default: anthropics/claude-code
+        type: string
+      later_issue:
+        description: Explicit re-report issue number
+        required: true
+        default: "57507"
+        type: string
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  closure-episode:
+    if: github.event_name == 'workflow_dispatch' || github.head_ref == 'research/issue-closure-evidence'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Cultist
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Run collector regression controls
+        run: |
+          python -m py_compile \
+            scripts/project_memory_github.py \
+            scripts/closure_episode_github.py \
+            scripts/closure_episode_github_test.py
+          python scripts/closure_episode_github_test.py
+
+      - name: Resolve carrier inputs
+        id: carrier
+        env:
+          INPUT_REPOSITORY: ${{ inputs.repository }}
+          INPUT_LATER_ISSUE: ${{ inputs.later_issue }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            repository="anthropics/claude-code"
+            later_issue="57507"
+            carrier="true"
+          else
+            repository="$INPUT_REPOSITORY"
+            later_issue="$INPUT_LATER_ISSUE"
+            carrier="false"
+          fi
+          {
+            echo "repository=$repository"
+            echo "later_issue=$later_issue"
+            echo "carrier=$carrier"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Collect closure episode
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TARGET_REPOSITORY: ${{ steps.carrier.outputs.repository }}
+          TARGET_LATER_ISSUE: ${{ steps.carrier.outputs.later_issue }}
+        run: |
+          set -euo pipefail
+          python scripts/closure_episode_github.py \
+            --repository "$TARGET_REPOSITORY" \
+            --later-issue "$TARGET_LATER_ISSUE" \
+            --output closure-episode.json \
+            --receipt-output closure-episode-github-receipt.json \
+            > /tmp/closure-episode-github.stdout
+
+      - name: Validate through independent Rust evaluator
+        run: |
+          cargo run --quiet --example closure_episode \
+            < closure-episode.json \
+            > closure-episode-evaluation.json
+
+      - name: Assert Claude Code inactive-closure carrier
+        if: steps.carrier.outputs.carrier == 'true'
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          episode = json.loads(Path("closure-episode.json").read_text())
+          receipt = json.loads(Path("closure-episode-github-receipt.json").read_text())
+          evaluation = json.loads(Path("closure-episode-evaluation.json").read_text())
+
+          assert episode["repository"] == "anthropics/claude-code", episode
+          assert episode["prior"]["number"] == 31294, episode
+          assert episode["later"]["number"] == 57507, episode
+          assert episode["prior"]["state"] == "closed", episode
+          assert episode["later"]["state"] == "closed", episode
+          assert episode["prior"]["state_reason"] == "not_planned", episode
+          assert episode["later"]["state_reason"] == "not_planned", episode
+          assert episode["closure"]["comment_id"] == 4230270046, episode
+          assert episode["closure"]["actor"] == "github-actions[bot]", episode
+          assert episode["closure"]["kind"] == "administrative_inactive", episode
+          assert "inactive for too long" in episode["closure"]["evidence"], episode
+          assert episode["re_report"]["relation"] == "re_report_of", episode
+          assert episode["re_report"]["from_issue"] == 57507, episode
+          assert episode["re_report"]["to_issue"] == 31294, episode
+          assert "not because it was fixed" in episode["re_report"]["evidence"], episode
+
+          challenge = episode["duplicate_challenge"]
+          assert challenge["suggestion_comment_id"] == 4008755017, challenge
+          assert challenge["rejection_comment_id"] == 4008815491, challenge
+          assert challenge["suggestion_actor"] == "github-actions[bot]", challenge
+          assert challenge["rejection_actor"] == "Mationetap", challenge
+
+          assert receipt["prior_comment_count"] == 5, receipt
+          assert receipt["pagination_complete"] is True, receipt
+          assert receipt["duplicate_challenge_retained"] is True, receipt
+
+          assert evaluation["prior_state"] == "closed", evaluation
+          assert evaluation["later_state"] == "closed", evaluation
+          assert evaluation["closure_kind"] == "administrative_inactive", evaluation
+          assert evaluation["re_report_observed"] is True, evaluation
+          assert evaluation["clearance"] == "unknown", evaluation
+          assert evaluation["disposition"] == "inspect_prior_failure", evaluation
+          PY
+
+      - name: Write job summary
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          episode = json.loads(Path("closure-episode.json").read_text())
+          receipt = json.loads(Path("closure-episode-github-receipt.json").read_text())
+          evaluation = json.loads(Path("closure-episode-evaluation.json").read_text())
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as out:
+              out.write("## GitHub issue closure episode\n\n")
+              out.write(
+                  f"Episode: `{episode['repository']}#{episode['later']['number']}` "
+                  f"re-reports `#{episode['prior']['number']}`\n\n"
+              )
+              out.write(
+                  f"Closure comment: `{episode['closure']['comment_id']}` · "
+                  f"kind: **{episode['closure']['kind']}**\n\n"
+              )
+              out.write(
+                  f"Prior comments scanned: **{receipt['prior_comment_count']}** · "
+                  f"clearance: **{evaluation['clearance']}** · "
+                  f"disposition: **{evaluation['disposition']}**\n"
+              )
+          PY
+
+      - name: Upload closure receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: closure-episode-${{ github.run_id }}
+          path: |
+            closure-episode.json
+            closure-episode-github-receipt.json
+            closure-episode-evaluation.json
+          if-no-files-found: error

--- a/examples/closure_episode.rs
+++ b/examples/closure_episode.rs
@@ -1,0 +1,35 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+#[allow(dead_code)]
+#[path = "../src/closure_episode.rs"]
+mod closure_episode;
+
+use closure_episode::{
+    MAX_CLOSURE_EPISODE_BYTES, evaluate_closure_episode, parse_closure_episode,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("closure-episode: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_CLOSURE_EPISODE_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_CLOSURE_EPISODE_BYTES {
+        return Err(format!(
+            "closure episode exceeds the {MAX_CLOSURE_EPISODE_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let episode = parse_closure_episode(&bytes)?;
+    let evaluation = evaluate_closure_episode(&episode)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}

--- a/examples/closure_episode.rs
+++ b/examples/closure_episode.rs
@@ -5,9 +5,7 @@ use std::io::{self, Read};
 #[path = "../src/closure_episode.rs"]
 mod closure_episode;
 
-use closure_episode::{
-    MAX_CLOSURE_EPISODE_BYTES, evaluate_closure_episode, parse_closure_episode,
-};
+use closure_episode::{MAX_CLOSURE_EPISODE_BYTES, evaluate_closure_episode, parse_closure_episode};
 
 fn main() {
     if let Err(error) = run() {
@@ -22,10 +20,9 @@ fn run() -> Result<(), Box<dyn Error>> {
         .take((MAX_CLOSURE_EPISODE_BYTES + 1) as u64)
         .read_to_end(&mut bytes)?;
     if bytes.len() > MAX_CLOSURE_EPISODE_BYTES {
-        return Err(format!(
-            "closure episode exceeds the {MAX_CLOSURE_EPISODE_BYTES}-byte limit"
-        )
-        .into());
+        return Err(
+            format!("closure episode exceeds the {MAX_CLOSURE_EPISODE_BYTES}-byte limit").into(),
+        );
     }
 
     let episode = parse_closure_episode(&bytes)?;

--- a/research/closure-episode.md
+++ b/research/closure-episode.md
@@ -1,0 +1,218 @@
+# Issue closure evidence versus failure clearance
+
+Issue #207 tests one narrow archaeology/project-memory distinction:
+
+```text
+issue lifecycle state
+  open / closed / state reason / closure event
+
+failure clearance
+  evidence that establishes the reported condition stopped applying
+```
+
+The first experiment intentionally refuses to derive the second from the first.
+
+## Typed episode
+
+`src/closure_episode.rs` defines a research-only `IssueClosureEpisode` containing:
+
+```text
+repository
+prior issue snapshot
+later issue snapshot
+exact closure receipt
+exact re-report receipt
+optional duplicate-challenge receipts
+```
+
+The corresponding evaluator exposes:
+
+```text
+prior_state
+later_state
+closure_kind
+re_report_observed
+clearance
+thread/work disposition
+```
+
+V0 has one clearance status:
+
+```text
+UNKNOWN
+```
+
+That is deliberate. This slice earns a way to say why an issue was closed and that it was later explicitly re-reported. It does not yet define a general evidence species that proves a failure has been repaired.
+
+## Administrative inactivity is exact evidence
+
+V0 recognizes only one administrative closure form:
+
+```text
+actor
+  github-actions[bot]
+
+evidence
+  Closing for now — inactive for too long. Please [open a new issue](https://github.com/OWNER/REPO/issues/new/choose) if this is still relevant.
+```
+
+Both actor and exact repository-bound sentence are required.
+
+`state_reason=not_planned` alone does not classify the closure as administrative inactivity. A human posting similar prose also does not gain the typed classification.
+
+This keeps GitHub lifecycle metadata and project meaning separate.
+
+## Re-report relation is explicit
+
+The admitted provider relation is also intentionally narrow:
+
+```text
+**Re-reporting** the bug from #N ...
+```
+
+The exact source line is retained. The relation means only:
+
+```text
+the later issue explicitly says it re-reports #N
+```
+
+It does not prove that both reports have an identical root cause or that every detail of the earlier issue applies unchanged.
+
+## External discriminator: Claude Code #31294 -> #57507
+
+`anthropics/claude-code#31294` reports Task()-spawned subagents configured with the `memory:` frontmatter field failing to create or update `MEMORY.md`.
+
+Its comment history preserves three useful events:
+
+```text
+comment 4008755017
+  github-actions[bot] suggests three possible duplicates and announces possible auto-closure
+
+comment 4008815491
+  reporter Mationetap explains why each suggested issue is a different failure species
+
+comment 4230270046
+  github-actions[bot] closes for inactivity and tells users to open a new issue if still relevant
+```
+
+The issue is closed with `state_reason=not_planned`.
+
+`#57507` later starts with:
+
+```text
+**Re-reporting** the bug from #31294 (closed-as-inactive 2026-04-11 by github-actions bot, not because it was fixed).
+```
+
+It adds a fresh reproduction and a candidate discriminator around explicit `tools:` allowlists. Its thread also contains an independent reproduction. It is later closed by the same inactivity sentence and also has `state_reason=not_planned`.
+
+That makes the pair a useful control against treating `closed` as equivalent to “historical failure exhausted.”
+
+## GitHub collector
+
+The optional adapter is:
+
+```text
+scripts/closure_episode_github.py
+```
+
+Example:
+
+```bash
+python scripts/closure_episode_github.py \
+  --repository anthropics/claude-code \
+  --later-issue 57507 \
+  --output closure-episode.json \
+  --receipt-output closure-episode-github-receipt.json
+
+cargo run --quiet --example closure_episode \
+  < closure-episode.json
+```
+
+The adapter:
+
+1. fetches the explicitly selected later issue;
+2. requires exactly one admitted re-report line;
+3. fetches only the named prior same-repository issue;
+4. requires the prior issue to be closed;
+5. reads prior issue comments completely up to the bound;
+6. selects exactly one admitted administrative-inactivity bot comment;
+7. optionally retains one explicit duplicate-suggestion + reporter-rejection pair;
+8. emits the typed episode;
+9. leaves clearance semantics to the Rust evaluator.
+
+No title similarity or chronology search is used to discover the prior issue.
+
+## Bounds
+
+V0 admits:
+
+```text
+prior issue comments: <= 256
+later issue body:     <= 64 KiB
+selected comment evidence: <= 32 KiB each
+episode:              <= 256 KiB
+provider receipt:     <= 128 KiB
+```
+
+Pagination is complete-or-fail through the comment bound.
+
+## Standard controls
+
+Rust controls require:
+
+- administrative inactivity + explicit re-report -> clearance UNKNOWN;
+- closing the later re-report still leaves clearance UNKNOWN;
+- `not_planned` alone does not create administrative-inactivity semantics;
+- exact inactivity evidence requires the bot actor and exact repository-bound sentence;
+- re-report evidence must name the declared prior issue;
+- arbitrary `Related to #N` prose is not admitted as a re-report;
+- prior issue must actually be closed;
+- duplicate-challenge receipts do not change clearance;
+- unknown machine fields fail closed.
+
+Provider controls require:
+
+- one exact re-report line before prior-provider work begins;
+- exact inactivity comment from the bot;
+- the same sentence from a human stays unclassified;
+- open prior issue rejects;
+- partial/ambiguous duplicate-challenge evidence rejects;
+- comment inventory overflow fails instead of truncating;
+- malformed repository/issue selection rejects before provider access.
+
+## Live carrier expectation
+
+`.github/workflows/closure-episode-github.yml` runs the public Claude Code episode on the research PR and validates it through the independent Rust example.
+
+The expected projection is:
+
+```text
+prior_state       closed
+later_state       closed
+closure_kind      administrative_inactive
+re_report_observed true
+clearance         unknown
+disposition       inspect_prior_failure
+```
+
+The important property is that closing #57507 again does not retroactively manufacture a clearing receipt for #31294.
+
+## Product pressure test
+
+The next behavioral question for #137 is small:
+
+> When a fresh worker lands on closed #31294, does this episode send them to the later reproduction and earlier rejected-duplicate context before they repeat the same investigation or assume closure meant repair?
+
+If it does, closure episodes become a candidate input to pre-edit/review evidence selection. If it does not change useful work, the evidence can remain queryable archaeology.
+
+## Boundary
+
+- no issue similarity model;
+- no sentiment classifier;
+- no automatic reopening or provider mutation;
+- no claim that administrative closure is bad policy;
+- no claim that the re-report proves identical root cause;
+- no `fixed=false` field in the canonical episode;
+- ordinary Cultist commands remain local and read-only.
+
+Refs #16 #18 #62 #109 #137 #183 #188 #202 #206 #207.

--- a/research/closure-episode.md
+++ b/research/closure-episode.md
@@ -197,6 +197,61 @@ disposition       inspect_prior_failure
 
 The important property is that closing #57507 again does not retroactively manufacture a clearing receipt for #31294.
 
+### Executed receipt
+
+PR #212 executed the live carrier successfully.
+
+```text
+workflow run
+  32251752639
+
+artifact
+  9364678861
+
+artifact digest
+  sha256:922bc95b6fc63236226f15ffc65ef1ee6efc6524e7a14ff62e557d447beb0438
+
+prior issue #31294
+  created  2026-03-06T00:41:05Z
+  closed   2026-04-11T22:11:48Z
+  closed_by github-actions[bot]
+  state_reason not_planned
+
+closure comment
+  4230270046
+  github-actions[bot]
+  administrative_inactive
+
+later issue #57507
+  created  2026-05-09T00:48:52Z
+  closed   2026-06-09T11:10:27Z
+  closed_by github-actions[bot]
+  state_reason not_planned
+
+re-report evidence
+  **Re-reporting** the bug from #31294 (closed-as-inactive 2026-04-11 by github-actions bot, not because it was fixed). ...
+
+duplicate challenge
+  suggestion comment 4008755017 by github-actions[bot]
+  rejection comment  4008815491 by Mationetap
+
+prior issue comments scanned
+  5
+```
+
+The independent Rust evaluation returned:
+
+```text
+prior_state        closed
+later_state        closed
+closure_kind       administrative_inactive
+re_report_observed true
+clearance          unknown
+disposition        inspect_prior_failure
+```
+
+The sequence therefore demonstrates the exact distinction under test: lifecycle closure is established twice, while no clearing state is manufactured from either closure event.
+
 ## Product pressure test
 
 The next behavioral question for #137 is small:

--- a/scripts/closure_episode_github.py
+++ b/scripts/closure_episode_github.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Collect one explicit GitHub re-report + administrative closure episode."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+import project_memory_github as github_memory
+
+MAX_COMMENTS = 256
+MAX_BODY_BYTES = 64 * 1024
+MAX_COMMENT_EVIDENCE_BYTES = 32 * 1024
+MAX_EPISODE_BYTES = 256 * 1024
+MAX_RECEIPT_BYTES = 128 * 1024
+RE_REPORT_RE = re.compile(r"^\*\*Re-reporting\*\* the bug from #([1-9][0-9]*)\b.*$")
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description=(
+            "Collect a selected GitHub issue that explicitly re-reports an earlier "
+            "same-repository issue, preserving exact administrative closure evidence."
+        )
+    )
+    result.add_argument("--repository", required=True)
+    result.add_argument("--later-issue", required=True, type=int)
+    result.add_argument("--output", required=True, type=Path)
+    result.add_argument("--receipt-output", required=True, type=Path)
+    return result
+
+
+def bounded_body(value: object, field: str, maximum: int = MAX_BODY_BYTES) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise github_memory.CollectorError(f"{field} is empty or malformed")
+    if len(value.encode("utf-8")) > maximum:
+        raise github_memory.CollectorError(f"{field} exceeds the {maximum}-byte bound")
+    return value
+
+
+def bounded_comment_evidence(value: object, field: str) -> str:
+    return bounded_body(value, field, MAX_COMMENT_EVIDENCE_BYTES)
+
+
+def login_from_user(value: object, field: str) -> str:
+    if not isinstance(value, dict):
+        raise github_memory.CollectorError(f"{field} user is malformed")
+    return github_memory.bounded_text(
+        value.get("login"), f"{field} login", 512, single_line=True
+    )
+
+
+def optional_login_from_user(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    return login_from_user(value, field)
+
+
+def issue_snapshot(raw: dict[str, Any], expected_number: int) -> tuple[dict[str, Any], str]:
+    if raw.get("number") != expected_number or "pull_request" in raw:
+        raise github_memory.CollectorError(
+            f"GitHub issue #{expected_number} payload is malformed or is a pull request"
+        )
+    title = github_memory.bounded_text(
+        raw.get("title"), "issue title", 1024, single_line=True
+    )
+    state = raw.get("state")
+    if state not in {"open", "closed"}:
+        raise github_memory.CollectorError(f"unsupported issue state: {state!r}")
+    created_at = github_memory.timestamp(raw.get("created_at"), "issue created_at")
+    closed_at = github_memory.optional_timestamp(raw.get("closed_at"), "issue closed_at")
+    if state == "open" and closed_at is not None:
+        raise github_memory.CollectorError("open issue unexpectedly has closed_at")
+    if state == "closed" and closed_at is None:
+        raise github_memory.CollectorError("closed issue is missing closed_at")
+
+    state_reason = raw.get("state_reason")
+    if state_reason is not None:
+        state_reason = github_memory.bounded_text(
+            state_reason, "issue state_reason", 512, single_line=True
+        )
+    closed_by = optional_login_from_user(raw.get("closed_by"), "closed_by")
+    if state == "open" and closed_by is not None:
+        raise github_memory.CollectorError("open issue unexpectedly has closed_by")
+    reporter = login_from_user(raw.get("user"), "issue reporter")
+
+    snapshot: dict[str, Any] = {
+        "number": expected_number,
+        "title": title,
+        "state": state,
+        "created_at": created_at,
+    }
+    if state_reason is not None:
+        snapshot["state_reason"] = state_reason
+    if closed_at is not None:
+        snapshot["closed_at"] = closed_at
+    if closed_by is not None:
+        snapshot["closed_by"] = closed_by
+    return snapshot, reporter
+
+
+def re_report_relation(body: str) -> tuple[int, str]:
+    matches: list[tuple[int, str]] = []
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        match = RE_REPORT_RE.fullmatch(line)
+        if match is None:
+            continue
+        if len(line.encode("utf-8")) > MAX_COMMENT_EVIDENCE_BYTES:
+            raise github_memory.CollectorError("re-report evidence exceeds admitted bound")
+        matches.append((int(match.group(1)), line))
+    if not matches:
+        raise github_memory.CollectorError(
+            "later issue has no admitted explicit `**Re-reporting** the bug from #N` line"
+        )
+    if len(matches) != 1:
+        raise github_memory.CollectorError(
+            "later issue has multiple admitted re-report lines; selection is ambiguous"
+        )
+    return matches[0]
+
+
+def list_issue_comments(
+    client: github_memory.GitHubClient, repository: str, number: int
+) -> list[dict[str, Any]]:
+    comments: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        raw = client.get_json(
+            f"/repos/{repository}/issues/{number}/comments?per_page=100&page={page}"
+        )
+        if not isinstance(raw, list):
+            raise github_memory.CollectorError("GitHub issue-comment list is malformed")
+        if len(raw) > 100:
+            raise github_memory.CollectorError("GitHub issue-comment page exceeds bound")
+        for item in raw:
+            if not isinstance(item, dict):
+                raise github_memory.CollectorError("GitHub issue-comment entry is malformed")
+            comments.append(item)
+            if len(comments) > MAX_COMMENTS:
+                raise github_memory.CollectorError(
+                    f"issue-comment inventory exceeds the {MAX_COMMENTS}-comment bound"
+                )
+        if len(raw) < 100:
+            break
+        page += 1
+    return comments
+
+
+def comment_record(comment: dict[str, Any], field: str) -> dict[str, Any]:
+    comment_id = comment.get("id")
+    if not isinstance(comment_id, int) or isinstance(comment_id, bool) or comment_id <= 0:
+        raise github_memory.CollectorError(f"{field} id must be positive")
+    actor = login_from_user(comment.get("user"), field)
+    body = bounded_comment_evidence(comment.get("body"), f"{field} body")
+    return {
+        "comment_id": comment_id,
+        "source_ref": f"github:issue-comment/{comment_id}",
+        "actor": actor,
+        "evidence": body,
+    }
+
+
+def administrative_inactive_evidence(repository: str) -> str:
+    return (
+        "Closing for now — inactive for too long. Please "
+        f"[open a new issue](https://github.com/{repository}/issues/new/choose) "
+        "if this is still relevant."
+    )
+
+
+def select_closure(
+    comments: list[dict[str, Any]], repository: str
+) -> dict[str, Any]:
+    expected = administrative_inactive_evidence(repository)
+    matches: list[dict[str, Any]] = []
+    for comment in comments:
+        record = comment_record(comment, "closure candidate")
+        if record["actor"] == "github-actions[bot]" and record["evidence"] == expected:
+            matches.append(record)
+    if not matches:
+        raise github_memory.CollectorError(
+            "prior issue has no admitted exact administrative-inactivity closure comment"
+        )
+    if len(matches) != 1:
+        raise github_memory.CollectorError(
+            "prior issue has multiple exact administrative-inactivity closure comments"
+        )
+    selected = matches[0]
+    return {
+        "issue": None,
+        "comment_id": selected["comment_id"],
+        "source_ref": selected["source_ref"],
+        "actor": selected["actor"],
+        "kind": "administrative_inactive",
+        "evidence": selected["evidence"],
+    }
+
+
+def select_duplicate_challenge(
+    comments: list[dict[str, Any]], reporter: str
+) -> dict[str, Any] | None:
+    suggestions: list[dict[str, Any]] = []
+    rejections: list[dict[str, Any]] = []
+    for comment in comments:
+        record = comment_record(comment, "duplicate-challenge candidate")
+        evidence = record["evidence"]
+        if (
+            record["actor"] == "github-actions[bot]"
+            and "possible duplicate issues:" in evidence
+            and "This issue will be automatically closed as a duplicate in 3 days." in evidence
+        ):
+            suggestions.append(record)
+        if record["actor"] == reporter and evidence.startswith(
+            "Not a duplicate of the suggested issues."
+        ):
+            rejections.append(record)
+
+    if not suggestions and not rejections:
+        return None
+    if len(suggestions) != 1 or len(rejections) != 1:
+        raise github_memory.CollectorError(
+            "duplicate challenge evidence is incomplete or ambiguous"
+        )
+    suggestion = suggestions[0]
+    rejection = rejections[0]
+    if suggestion["comment_id"] == rejection["comment_id"]:
+        raise github_memory.CollectorError("duplicate challenge comments must differ")
+    return {
+        "suggestion_comment_id": suggestion["comment_id"],
+        "suggestion_source_ref": suggestion["source_ref"],
+        "suggestion_actor": suggestion["actor"],
+        "suggestion_evidence": suggestion["evidence"],
+        "rejection_comment_id": rejection["comment_id"],
+        "rejection_source_ref": rejection["source_ref"],
+        "rejection_actor": rejection["actor"],
+        "rejection_evidence": rejection["evidence"],
+    }
+
+
+def collect(
+    repository: str,
+    later_number: int,
+    *,
+    client: github_memory.GitHubClient | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if github_memory.REPOSITORY_RE.fullmatch(repository) is None:
+        raise github_memory.CollectorError("repository must be canonical owner/name")
+    if later_number <= 0:
+        raise github_memory.CollectorError("later issue number must be positive")
+
+    if client is None:
+        token = os.environ.get("GITHUB_TOKEN")
+        client = github_memory.GitHubClient(token if token else None)
+
+    later_raw = client.get_json(f"/repos/{repository}/issues/{later_number}")
+    if not isinstance(later_raw, dict):
+        raise github_memory.CollectorError("later GitHub issue payload is malformed")
+    later_snapshot, _later_reporter = issue_snapshot(later_raw, later_number)
+    later_body = bounded_body(later_raw.get("body"), "later issue body")
+    prior_number, relation_evidence = re_report_relation(later_body)
+    if prior_number == later_number:
+        raise github_memory.CollectorError("later issue may not re-report itself")
+
+    prior_raw = client.get_json(f"/repos/{repository}/issues/{prior_number}")
+    if not isinstance(prior_raw, dict):
+        raise github_memory.CollectorError("prior GitHub issue payload is malformed")
+    prior_snapshot, prior_reporter = issue_snapshot(prior_raw, prior_number)
+    if prior_snapshot["state"] != "closed":
+        raise github_memory.CollectorError("selected prior issue is not closed")
+
+    comments = list_issue_comments(client, repository, prior_number)
+    closure = select_closure(comments, repository)
+    closure["issue"] = prior_number
+    duplicate_challenge = select_duplicate_challenge(comments, prior_reporter)
+
+    episode: dict[str, Any] = {
+        "schema_version": 1,
+        "repository": repository,
+        "prior": prior_snapshot,
+        "later": later_snapshot,
+        "closure": closure,
+        "re_report": {
+            "from_issue": later_number,
+            "to_issue": prior_number,
+            "relation": "re_report_of",
+            "source_ref": f"github:issue/{later_number}",
+            "evidence": relation_evidence,
+        },
+    }
+    if duplicate_challenge is not None:
+        episode["duplicate_challenge"] = duplicate_challenge
+
+    receipt = {
+        "schema_version": 1,
+        "provider": "github_issue_closure_episode",
+        "repository": repository,
+        "later_issue": later_number,
+        "prior_issue": prior_number,
+        "prior_comment_count": len(comments),
+        "pagination_complete": True,
+        "closure_comment_id": closure["comment_id"],
+        "closure_actor": closure["actor"],
+        "duplicate_challenge_retained": duplicate_challenge is not None,
+        "prior_state_reason": prior_snapshot.get("state_reason"),
+        "later_state_reason": later_snapshot.get("state_reason"),
+    }
+
+    episode_bytes = (json.dumps(episode, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    if len(episode_bytes) > MAX_EPISODE_BYTES:
+        raise github_memory.CollectorError(
+            f"closure episode exceeds the {MAX_EPISODE_BYTES}-byte bound"
+        )
+    receipt_bytes = (json.dumps(receipt, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    if len(receipt_bytes) > MAX_RECEIPT_BYTES:
+        raise github_memory.CollectorError(
+            f"closure provider receipt exceeds the {MAX_RECEIPT_BYTES}-byte bound"
+        )
+    return episode, receipt
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        episode, receipt = collect(args.repository, args.later_issue)
+        encoded_episode = json.dumps(episode, indent=2, sort_keys=True) + "\n"
+        encoded_receipt = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.receipt_output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded_episode, encoding="utf-8")
+        args.receipt_output.write_text(encoded_receipt, encoding="utf-8")
+    except (github_memory.CollectorError, OSError) as error:
+        print(f"closure-episode-github: {error}", file=sys.stderr)
+        return 1
+
+    print(encoded_episode, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/closure_episode_github_test.py
+++ b/scripts/closure_episode_github_test.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Regression controls for the GitHub issue closure episode collector."""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+import closure_episode_github as adapter
+import project_memory_github as github_memory
+
+REPOSITORY = "owner/repo"
+PRIOR = 10
+LATER = 20
+
+
+class FakeGitHubClient:
+    def __init__(self, responses: dict[str, Any]) -> None:
+        self.responses = responses
+        self.calls: list[str] = []
+
+    def get_json(self, path: str) -> Any:
+        self.calls.append(path)
+        if path not in self.responses:
+            raise AssertionError(f"unexpected GitHub request: {path}")
+        return self.responses[path]
+
+
+def issue_payload(
+    number: int,
+    *,
+    body: str,
+    state: str,
+    reporter: str = "reporter",
+    closed_by: str | None = "github-actions[bot]",
+    state_reason: str | None = "not_planned",
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": f"issue {number}",
+        "body": body,
+        "state": state,
+        "state_reason": state_reason,
+        "created_at": "2026-01-01T00:00:00Z",
+        "closed_at": "2026-01-02T00:00:00Z" if state == "closed" else None,
+        "closed_by": {"login": closed_by} if state == "closed" and closed_by else None,
+        "user": {"login": reporter},
+    }
+
+
+def comment(comment_id: int, actor: str, body: str) -> dict[str, Any]:
+    return {"id": comment_id, "user": {"login": actor}, "body": body}
+
+
+def admin_closure(repository: str = REPOSITORY) -> str:
+    return (
+        "Closing for now — inactive for too long. Please "
+        f"[open a new issue](https://github.com/{repository}/issues/new/choose) "
+        "if this is still relevant."
+    )
+
+
+def base_responses(
+    *,
+    later_body: str | None = None,
+    prior_state: str = "closed",
+    comments: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    if later_body is None:
+        later_body = "**Re-reporting** the bug from #10 (closed earlier, not fixed)."
+    if comments is None:
+        comments = [
+            comment(
+                90,
+                "github-actions[bot]",
+                "Found 3 possible duplicate issues:\n\nThis issue will be automatically closed as a duplicate in 3 days.",
+            ),
+            comment(
+                91,
+                "reporter",
+                "Not a duplicate of the suggested issues.\n\nThey describe different failure modes.",
+            ),
+            comment(100, "github-actions[bot]", admin_closure()),
+        ]
+    return {
+        f"/repos/{REPOSITORY}/issues/{LATER}": issue_payload(
+            LATER,
+            body=later_body,
+            state="closed",
+            reporter="later-reporter",
+        ),
+        f"/repos/{REPOSITORY}/issues/{PRIOR}": issue_payload(
+            PRIOR,
+            body="original report",
+            state=prior_state,
+            reporter="reporter",
+        ),
+        f"/repos/{REPOSITORY}/issues/{PRIOR}/comments?per_page=100&page=1": comments,
+    }
+
+
+class ClosureEpisodeGithubTests(unittest.TestCase):
+    def test_collects_exact_closure_rereport_and_duplicate_challenge(self) -> None:
+        client = FakeGitHubClient(base_responses())
+
+        episode, receipt = adapter.collect(REPOSITORY, LATER, client=client)
+
+        self.assertEqual(episode["prior"]["number"], PRIOR)
+        self.assertEqual(episode["prior"]["state"], "closed")
+        self.assertEqual(episode["prior"]["state_reason"], "not_planned")
+        self.assertEqual(episode["later"]["number"], LATER)
+        self.assertEqual(episode["later"]["state"], "closed")
+        self.assertEqual(episode["closure"]["kind"], "administrative_inactive")
+        self.assertEqual(episode["closure"]["comment_id"], 100)
+        self.assertEqual(episode["re_report"]["to_issue"], PRIOR)
+        self.assertEqual(episode["re_report"]["from_issue"], LATER)
+        self.assertEqual(episode["re_report"]["relation"], "re_report_of")
+        self.assertEqual(
+            episode["duplicate_challenge"]["suggestion_comment_id"], 90
+        )
+        self.assertEqual(
+            episode["duplicate_challenge"]["rejection_comment_id"], 91
+        )
+        self.assertEqual(receipt["prior_comment_count"], 3)
+        self.assertTrue(receipt["pagination_complete"])
+
+    def test_closed_state_reason_without_exact_closure_receipt_fails(self) -> None:
+        client = FakeGitHubClient(
+            base_responses(comments=[comment(100, "maintainer", "Closed")])
+        )
+
+        with self.assertRaisesRegex(
+            github_memory.CollectorError, "no admitted exact administrative-inactivity"
+        ):
+            adapter.collect(REPOSITORY, LATER, client=client)
+
+    def test_exact_closure_sentence_from_non_bot_does_not_classify(self) -> None:
+        client = FakeGitHubClient(
+            base_responses(comments=[comment(100, "human", admin_closure())])
+        )
+
+        with self.assertRaisesRegex(
+            github_memory.CollectorError, "no admitted exact administrative-inactivity"
+        ):
+            adapter.collect(REPOSITORY, LATER, client=client)
+
+    def test_arbitrary_or_ambiguous_relation_does_not_create_rereport(self) -> None:
+        arbitrary = FakeGitHubClient(base_responses(later_body="Related to #10"))
+        with self.assertRaisesRegex(github_memory.CollectorError, "no admitted explicit"):
+            adapter.collect(REPOSITORY, LATER, client=arbitrary)
+        self.assertNotIn(f"/repos/{REPOSITORY}/issues/{PRIOR}", arbitrary.calls)
+
+        ambiguous = FakeGitHubClient(
+            base_responses(
+                later_body=(
+                    "**Re-reporting** the bug from #10.\n"
+                    "**Re-reporting** the bug from #11."
+                )
+            )
+        )
+        with self.assertRaisesRegex(github_memory.CollectorError, "multiple admitted"):
+            adapter.collect(REPOSITORY, LATER, client=ambiguous)
+
+    def test_prior_issue_must_be_closed(self) -> None:
+        client = FakeGitHubClient(base_responses(prior_state="open"))
+
+        with self.assertRaisesRegex(github_memory.CollectorError, "prior issue is not closed"):
+            adapter.collect(REPOSITORY, LATER, client=client)
+
+    def test_duplicate_challenge_must_be_complete_when_detected(self) -> None:
+        comments = [
+            comment(
+                90,
+                "github-actions[bot]",
+                "Found 3 possible duplicate issues:\n\nThis issue will be automatically closed as a duplicate in 3 days.",
+            ),
+            comment(100, "github-actions[bot]", admin_closure()),
+        ]
+        client = FakeGitHubClient(base_responses(comments=comments))
+
+        with self.assertRaisesRegex(
+            github_memory.CollectorError, "duplicate challenge evidence is incomplete"
+        ):
+            adapter.collect(REPOSITORY, LATER, client=client)
+
+    def test_comment_inventory_overflow_fails_instead_of_truncating(self) -> None:
+        all_comments = [comment(index + 1, "someone", "evidence") for index in range(257)]
+        all_comments[-1] = comment(257, "github-actions[bot]", admin_closure())
+        responses = base_responses(comments=[])
+        for page in range(1, 4):
+            start = (page - 1) * 100
+            responses[
+                f"/repos/{REPOSITORY}/issues/{PRIOR}/comments?per_page=100&page={page}"
+            ] = all_comments[start : start + 100]
+        client = FakeGitHubClient(responses)
+
+        with self.assertRaisesRegex(
+            github_memory.CollectorError, "exceeds the 256-comment bound"
+        ):
+            adapter.collect(REPOSITORY, LATER, client=client)
+
+    def test_invalid_selection_rejects_before_provider_work(self) -> None:
+        client = FakeGitHubClient({})
+        with self.assertRaisesRegex(github_memory.CollectorError, "canonical owner/name"):
+            adapter.collect("bad/repo/name", LATER, client=client)
+        with self.assertRaisesRegex(github_memory.CollectorError, "must be positive"):
+            adapter.collect(REPOSITORY, 0, client=client)
+        self.assertEqual(client.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/closure_episode.rs
+++ b/src/closure_episode.rs
@@ -145,8 +145,9 @@ pub fn parse_closure_episode(bytes: &[u8]) -> Result<IssueClosureEpisode, Closur
             "closure episode exceeds the {MAX_CLOSURE_EPISODE_BYTES}-byte limit"
         )));
     }
-    let episode: IssueClosureEpisode = serde_json::from_slice(bytes)
-        .map_err(|error| ClosureEpisodeError::new(format!("invalid closure-episode JSON: {error}")))?;
+    let episode: IssueClosureEpisode = serde_json::from_slice(bytes).map_err(|error| {
+        ClosureEpisodeError::new(format!("invalid closure-episode JSON: {error}"))
+    })?;
     validate_episode(&episode)?;
     Ok(episode)
 }
@@ -205,7 +206,11 @@ fn validate_issue(issue: &IssueSnapshot, label: &str) -> Result<(), ClosureEpiso
     }
     validate_single_line(&issue.title, &format!("{label} title"), MAX_TITLE_BYTES)?;
     if let Some(reason) = &issue.state_reason {
-        validate_single_line(reason, &format!("{label} state_reason"), MAX_COORDINATE_BYTES)?;
+        validate_single_line(
+            reason,
+            &format!("{label} state_reason"),
+            MAX_COORDINATE_BYTES,
+        )?;
     }
     validate_timestamp(&issue.created_at, &format!("{label} created_at"))?;
     if let Some(closed_by) = &issue.closed_by {
@@ -255,7 +260,11 @@ fn validate_closure(
             "closure comment id must be positive",
         ));
     }
-    validate_single_line(&closure.source_ref, "closure source_ref", MAX_COORDINATE_BYTES)?;
+    validate_single_line(
+        &closure.source_ref,
+        "closure source_ref",
+        MAX_COORDINATE_BYTES,
+    )?;
     validate_single_line(&closure.actor, "closure actor", MAX_COORDINATE_BYTES)?;
     validate_evidence(&closure.evidence, "closure evidence")?;
     if closure.kind == ClosureKind::AdministrativeInactive {
@@ -327,7 +336,10 @@ fn validate_duplicate_challenge(
         "duplicate suggestion actor",
         MAX_COORDINATE_BYTES,
     )?;
-    validate_evidence(&challenge.suggestion_evidence, "duplicate suggestion evidence")?;
+    validate_evidence(
+        &challenge.suggestion_evidence,
+        "duplicate suggestion evidence",
+    )?;
     validate_single_line(
         &challenge.rejection_source_ref,
         "duplicate rejection source_ref",
@@ -338,7 +350,10 @@ fn validate_duplicate_challenge(
         "duplicate rejection actor",
         MAX_COORDINATE_BYTES,
     )?;
-    validate_evidence(&challenge.rejection_evidence, "duplicate rejection evidence")?;
+    validate_evidence(
+        &challenge.rejection_evidence,
+        "duplicate rejection evidence",
+    )?;
     Ok(())
 }
 
@@ -364,7 +379,10 @@ fn re_report_target(evidence: &str) -> Option<u64> {
         cursor += 1;
     }
     if cursor < bytes.len()
-        && !matches!(bytes[cursor], b' ' | b'(' | b'.' | b',' | b':' | b';' | b'-')
+        && !matches!(
+            bytes[cursor],
+            b' ' | b'(' | b'.' | b',' | b':' | b';' | b'-'
+        )
     {
         return None;
     }

--- a/src/closure_episode.rs
+++ b/src/closure_episode.rs
@@ -1,0 +1,436 @@
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+pub const CLOSURE_EPISODE_SCHEMA_VERSION: u32 = 1;
+pub const MAX_CLOSURE_EPISODE_BYTES: usize = 256 * 1024;
+const MAX_COORDINATE_BYTES: usize = 2048;
+const MAX_TITLE_BYTES: usize = 1024;
+const MAX_EVIDENCE_BYTES: usize = 32 * 1024;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssueClosureEpisode {
+    pub schema_version: u32,
+    pub repository: String,
+    pub prior: IssueSnapshot,
+    pub later: IssueSnapshot,
+    pub closure: ClosureReceipt,
+    pub re_report: ReReportReceipt,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duplicate_challenge: Option<DuplicateChallengeReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssueSnapshot {
+    pub number: u64,
+    pub title: String,
+    pub state: IssueState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_reason: Option<String>,
+    pub created_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub closed_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub closed_by: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IssueState {
+    Open,
+    Closed,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClosureReceipt {
+    pub issue: u64,
+    pub comment_id: u64,
+    pub source_ref: String,
+    pub actor: String,
+    pub kind: ClosureKind,
+    pub evidence: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClosureKind {
+    AdministrativeInactive,
+    Other,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReReportReceipt {
+    pub from_issue: u64,
+    pub to_issue: u64,
+    pub relation: ReReportRelation,
+    pub source_ref: String,
+    pub evidence: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReReportRelation {
+    ReReportOf,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DuplicateChallengeReceipt {
+    pub suggestion_comment_id: u64,
+    pub suggestion_source_ref: String,
+    pub suggestion_actor: String,
+    pub suggestion_evidence: String,
+    pub rejection_comment_id: u64,
+    pub rejection_source_ref: String,
+    pub rejection_actor: String,
+    pub rejection_evidence: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClearanceStatus {
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClosureEpisodeDisposition {
+    InspectPriorFailure,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssueClosureEvaluation {
+    pub schema_version: u32,
+    pub repository: String,
+    pub prior_issue: u64,
+    pub later_issue: u64,
+    pub prior_state: IssueState,
+    pub later_state: IssueState,
+    pub closure_kind: ClosureKind,
+    pub re_report_observed: bool,
+    pub clearance: ClearanceStatus,
+    pub disposition: ClosureEpisodeDisposition,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ClosureEpisodeError {
+    message: String,
+}
+
+impl ClosureEpisodeError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ClosureEpisodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for ClosureEpisodeError {}
+
+pub fn parse_closure_episode(bytes: &[u8]) -> Result<IssueClosureEpisode, ClosureEpisodeError> {
+    if bytes.len() > MAX_CLOSURE_EPISODE_BYTES {
+        return Err(ClosureEpisodeError::new(format!(
+            "closure episode exceeds the {MAX_CLOSURE_EPISODE_BYTES}-byte limit"
+        )));
+    }
+    let episode: IssueClosureEpisode = serde_json::from_slice(bytes)
+        .map_err(|error| ClosureEpisodeError::new(format!("invalid closure-episode JSON: {error}")))?;
+    validate_episode(&episode)?;
+    Ok(episode)
+}
+
+pub fn evaluate_closure_episode(
+    episode: &IssueClosureEpisode,
+) -> Result<IssueClosureEvaluation, ClosureEpisodeError> {
+    validate_episode(episode)?;
+    Ok(IssueClosureEvaluation {
+        schema_version: CLOSURE_EPISODE_SCHEMA_VERSION,
+        repository: episode.repository.clone(),
+        prior_issue: episode.prior.number,
+        later_issue: episode.later.number,
+        prior_state: episode.prior.state,
+        later_state: episode.later.state,
+        closure_kind: episode.closure.kind,
+        re_report_observed: true,
+        clearance: ClearanceStatus::Unknown,
+        disposition: ClosureEpisodeDisposition::InspectPriorFailure,
+    })
+}
+
+fn validate_episode(episode: &IssueClosureEpisode) -> Result<(), ClosureEpisodeError> {
+    if episode.schema_version != CLOSURE_EPISODE_SCHEMA_VERSION {
+        return Err(ClosureEpisodeError::new(format!(
+            "unsupported closure-episode schema {}; expected {CLOSURE_EPISODE_SCHEMA_VERSION}",
+            episode.schema_version
+        )));
+    }
+    validate_repository(&episode.repository)?;
+    validate_issue(&episode.prior, "prior")?;
+    validate_issue(&episode.later, "later")?;
+    if episode.prior.number == episode.later.number {
+        return Err(ClosureEpisodeError::new(
+            "prior and later issue identities must differ",
+        ));
+    }
+    if episode.prior.state != IssueState::Closed {
+        return Err(ClosureEpisodeError::new(
+            "closure episode requires the prior issue to be closed",
+        ));
+    }
+    validate_closure(&episode.repository, &episode.prior, &episode.closure)?;
+    validate_re_report(&episode.prior, &episode.later, &episode.re_report)?;
+    if let Some(challenge) = &episode.duplicate_challenge {
+        validate_duplicate_challenge(challenge)?;
+    }
+    Ok(())
+}
+
+fn validate_issue(issue: &IssueSnapshot, label: &str) -> Result<(), ClosureEpisodeError> {
+    if issue.number == 0 {
+        return Err(ClosureEpisodeError::new(format!(
+            "{label} issue number must be positive"
+        )));
+    }
+    validate_single_line(&issue.title, &format!("{label} title"), MAX_TITLE_BYTES)?;
+    if let Some(reason) = &issue.state_reason {
+        validate_single_line(reason, &format!("{label} state_reason"), MAX_COORDINATE_BYTES)?;
+    }
+    validate_timestamp(&issue.created_at, &format!("{label} created_at"))?;
+    if let Some(closed_by) = &issue.closed_by {
+        validate_single_line(
+            closed_by,
+            &format!("{label} closed_by"),
+            MAX_COORDINATE_BYTES,
+        )?;
+    }
+    match (issue.state, issue.closed_at.as_deref()) {
+        (IssueState::Open, None) => {
+            if issue.closed_by.is_some() {
+                return Err(ClosureEpisodeError::new(format!(
+                    "open {label} issue may not carry closed_by"
+                )));
+            }
+        }
+        (IssueState::Open, Some(_)) => {
+            return Err(ClosureEpisodeError::new(format!(
+                "open {label} issue may not carry closed_at"
+            )));
+        }
+        (IssueState::Closed, Some(closed_at)) => {
+            validate_timestamp(closed_at, &format!("{label} closed_at"))?;
+        }
+        (IssueState::Closed, None) => {
+            return Err(ClosureEpisodeError::new(format!(
+                "closed {label} issue requires closed_at"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_closure(
+    repository: &str,
+    prior: &IssueSnapshot,
+    closure: &ClosureReceipt,
+) -> Result<(), ClosureEpisodeError> {
+    if closure.issue != prior.number {
+        return Err(ClosureEpisodeError::new(
+            "closure receipt issue does not match prior issue",
+        ));
+    }
+    if closure.comment_id == 0 {
+        return Err(ClosureEpisodeError::new(
+            "closure comment id must be positive",
+        ));
+    }
+    validate_single_line(&closure.source_ref, "closure source_ref", MAX_COORDINATE_BYTES)?;
+    validate_single_line(&closure.actor, "closure actor", MAX_COORDINATE_BYTES)?;
+    validate_evidence(&closure.evidence, "closure evidence")?;
+    if closure.kind == ClosureKind::AdministrativeInactive {
+        if closure.actor != "github-actions[bot]" {
+            return Err(ClosureEpisodeError::new(
+                "administrative_inactive closure requires github-actions[bot] actor",
+            ));
+        }
+        let expected = administrative_inactive_evidence(repository);
+        if closure.evidence != expected {
+            return Err(ClosureEpisodeError::new(
+                "administrative_inactive closure evidence is not the admitted exact GitHub bot form",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_re_report(
+    prior: &IssueSnapshot,
+    later: &IssueSnapshot,
+    receipt: &ReReportReceipt,
+) -> Result<(), ClosureEpisodeError> {
+    if receipt.from_issue != later.number || receipt.to_issue != prior.number {
+        return Err(ClosureEpisodeError::new(
+            "re-report receipt endpoints do not match later/prior issues",
+        ));
+    }
+    validate_single_line(
+        &receipt.source_ref,
+        "re-report source_ref",
+        MAX_COORDINATE_BYTES,
+    )?;
+    validate_evidence(&receipt.evidence, "re-report evidence")?;
+    let Some(target) = re_report_target(&receipt.evidence) else {
+        return Err(ClosureEpisodeError::new(
+            "re-report evidence is not an admitted exact re-report form",
+        ));
+    };
+    if target != prior.number {
+        return Err(ClosureEpisodeError::new(format!(
+            "re-report evidence names issue #{target}, not prior issue #{}",
+            prior.number
+        )));
+    }
+    Ok(())
+}
+
+fn validate_duplicate_challenge(
+    challenge: &DuplicateChallengeReceipt,
+) -> Result<(), ClosureEpisodeError> {
+    if challenge.suggestion_comment_id == 0 || challenge.rejection_comment_id == 0 {
+        return Err(ClosureEpisodeError::new(
+            "duplicate-challenge comment ids must be positive",
+        ));
+    }
+    if challenge.suggestion_comment_id == challenge.rejection_comment_id {
+        return Err(ClosureEpisodeError::new(
+            "duplicate suggestion and rejection must be different comments",
+        ));
+    }
+    validate_single_line(
+        &challenge.suggestion_source_ref,
+        "duplicate suggestion source_ref",
+        MAX_COORDINATE_BYTES,
+    )?;
+    validate_single_line(
+        &challenge.suggestion_actor,
+        "duplicate suggestion actor",
+        MAX_COORDINATE_BYTES,
+    )?;
+    validate_evidence(&challenge.suggestion_evidence, "duplicate suggestion evidence")?;
+    validate_single_line(
+        &challenge.rejection_source_ref,
+        "duplicate rejection source_ref",
+        MAX_COORDINATE_BYTES,
+    )?;
+    validate_single_line(
+        &challenge.rejection_actor,
+        "duplicate rejection actor",
+        MAX_COORDINATE_BYTES,
+    )?;
+    validate_evidence(&challenge.rejection_evidence, "duplicate rejection evidence")?;
+    Ok(())
+}
+
+fn administrative_inactive_evidence(repository: &str) -> String {
+    format!(
+        "Closing for now — inactive for too long. Please [open a new issue](https://github.com/{repository}/issues/new/choose) if this is still relevant."
+    )
+}
+
+fn re_report_target(evidence: &str) -> Option<u64> {
+    let prefix = "**Re-reporting** the bug from #";
+    let rest = evidence.strip_prefix(prefix)?;
+    let bytes = rest.as_bytes();
+    if bytes.is_empty() || bytes[0] == b'0' || !bytes[0].is_ascii_digit() {
+        return None;
+    }
+    let mut value = 0u64;
+    let mut cursor = 0usize;
+    while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+        value = value
+            .checked_mul(10)?
+            .checked_add((bytes[cursor] - b'0') as u64)?;
+        cursor += 1;
+    }
+    if cursor < bytes.len()
+        && !matches!(bytes[cursor], b' ' | b'(' | b'.' | b',' | b':' | b';' | b'-')
+    {
+        return None;
+    }
+    Some(value)
+}
+
+fn validate_repository(value: &str) -> Result<(), ClosureEpisodeError> {
+    if value.is_empty()
+        || value.len() > MAX_COORDINATE_BYTES
+        || value.contains('\n')
+        || value.contains('\r')
+    {
+        return Err(ClosureEpisodeError::new(
+            "repository must be a bounded canonical owner/name coordinate",
+        ));
+    }
+    let Some((owner, repository)) = value.split_once('/') else {
+        return Err(ClosureEpisodeError::new(
+            "repository must be a bounded canonical owner/name coordinate",
+        ));
+    };
+    if owner.is_empty()
+        || repository.is_empty()
+        || repository.contains('/')
+        || !owner.bytes().all(valid_repository_char)
+        || !repository.bytes().all(valid_repository_char)
+    {
+        return Err(ClosureEpisodeError::new(
+            "repository must be a bounded canonical owner/name coordinate",
+        ));
+    }
+    Ok(())
+}
+
+fn valid_repository_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')
+}
+
+fn validate_timestamp(value: &str, field: &str) -> Result<(), ClosureEpisodeError> {
+    validate_single_line(value, field, 64)
+}
+
+fn validate_single_line(
+    value: &str,
+    field: &str,
+    maximum: usize,
+) -> Result<(), ClosureEpisodeError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > maximum
+        || value.contains('\0')
+        || value.contains('\n')
+        || value.contains('\r')
+    {
+        return Err(ClosureEpisodeError::new(format!(
+            "{field} must be a bounded non-empty single-line value"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_evidence(value: &str, field: &str) -> Result<(), ClosureEpisodeError> {
+    if value.is_empty() || value.len() > MAX_EVIDENCE_BYTES || value.contains('\0') {
+        return Err(ClosureEpisodeError::new(format!(
+            "{field} must be bounded non-empty evidence"
+        )));
+    }
+    Ok(())
+}

--- a/tests/closure_episode.rs
+++ b/tests/closure_episode.rs
@@ -1,0 +1,157 @@
+#![allow(dead_code)]
+
+#[path = "../src/closure_episode.rs"]
+mod closure_episode;
+
+use closure_episode::{
+    CLOSURE_EPISODE_SCHEMA_VERSION, ClearanceStatus, ClosureEpisodeDisposition, ClosureKind,
+    ClosureReceipt, DuplicateChallengeReceipt, IssueClosureEpisode, IssueSnapshot, IssueState,
+    ReReportReceipt, ReReportRelation, evaluate_closure_episode, parse_closure_episode,
+};
+
+const REPOSITORY: &str = "owner/repo";
+const ADMIN_CLOSURE: &str = "Closing for now — inactive for too long. Please [open a new issue](https://github.com/owner/repo/issues/new/choose) if this is still relevant.";
+
+fn issue(number: u64, state: IssueState) -> IssueSnapshot {
+    IssueSnapshot {
+        number,
+        title: format!("issue {number}"),
+        state,
+        state_reason: Some("not_planned".to_string()),
+        created_at: "2026-01-01T00:00:00Z".to_string(),
+        closed_at: (state == IssueState::Closed).then(|| "2026-01-02T00:00:00Z".to_string()),
+        closed_by: (state == IssueState::Closed).then(|| "github-actions[bot]".to_string()),
+    }
+}
+
+fn episode() -> IssueClosureEpisode {
+    IssueClosureEpisode {
+        schema_version: CLOSURE_EPISODE_SCHEMA_VERSION,
+        repository: REPOSITORY.to_string(),
+        prior: issue(10, IssueState::Closed),
+        later: issue(20, IssueState::Open),
+        closure: ClosureReceipt {
+            issue: 10,
+            comment_id: 100,
+            source_ref: "github:issue/10/comment/100".to_string(),
+            actor: "github-actions[bot]".to_string(),
+            kind: ClosureKind::AdministrativeInactive,
+            evidence: ADMIN_CLOSURE.to_string(),
+        },
+        re_report: ReReportReceipt {
+            from_issue: 20,
+            to_issue: 10,
+            relation: ReReportRelation::ReReportOf,
+            source_ref: "github:issue/20".to_string(),
+            evidence: "**Re-reporting** the bug from #10 (closed earlier).".to_string(),
+        },
+        duplicate_challenge: None,
+    }
+}
+
+#[test]
+fn administrative_closure_plus_rereport_keeps_clearance_unknown() {
+    let evaluation = evaluate_closure_episode(&episode()).unwrap();
+
+    assert_eq!(evaluation.prior_state, IssueState::Closed);
+    assert_eq!(evaluation.later_state, IssueState::Open);
+    assert_eq!(evaluation.closure_kind, ClosureKind::AdministrativeInactive);
+    assert!(evaluation.re_report_observed);
+    assert_eq!(evaluation.clearance, ClearanceStatus::Unknown);
+    assert_eq!(
+        evaluation.disposition,
+        ClosureEpisodeDisposition::InspectPriorFailure
+    );
+}
+
+#[test]
+fn closing_the_later_rereport_does_not_clear_the_prior_failure() {
+    let mut input = episode();
+    input.later = issue(20, IssueState::Closed);
+
+    let evaluation = evaluate_closure_episode(&input).unwrap();
+
+    assert_eq!(evaluation.later_state, IssueState::Closed);
+    assert_eq!(evaluation.clearance, ClearanceStatus::Unknown);
+    assert_eq!(
+        evaluation.disposition,
+        ClosureEpisodeDisposition::InspectPriorFailure
+    );
+}
+
+#[test]
+fn not_planned_state_reason_alone_does_not_create_inactivity_semantics() {
+    let mut input = episode();
+    input.closure.kind = ClosureKind::Other;
+    input.closure.actor = "maintainer".to_string();
+    input.closure.evidence = "Closed without a retained repair receipt.".to_string();
+
+    let evaluation = evaluate_closure_episode(&input).unwrap();
+
+    assert_eq!(evaluation.closure_kind, ClosureKind::Other);
+    assert_eq!(evaluation.clearance, ClearanceStatus::Unknown);
+}
+
+#[test]
+fn administrative_inactive_requires_exact_bot_actor_and_evidence() {
+    let mut wrong_actor = episode();
+    wrong_actor.closure.actor = "human".to_string();
+    let error = evaluate_closure_episode(&wrong_actor).unwrap_err();
+    assert!(error.to_string().contains("github-actions[bot]"));
+
+    let mut wrong_evidence = episode();
+    wrong_evidence.closure.evidence = "Closing because inactive.".to_string();
+    let error = evaluate_closure_episode(&wrong_evidence).unwrap_err();
+    assert!(error.to_string().contains("admitted exact GitHub bot form"));
+}
+
+#[test]
+fn rereport_evidence_must_name_the_declared_prior_issue() {
+    let mut input = episode();
+    input.re_report.evidence = "**Re-reporting** the bug from #11 (closed earlier).".to_string();
+    let error = evaluate_closure_episode(&input).unwrap_err();
+    assert!(error.to_string().contains("not prior issue #10"));
+
+    let mut arbitrary = episode();
+    arbitrary.re_report.evidence = "Related to #10".to_string();
+    let error = evaluate_closure_episode(&arbitrary).unwrap_err();
+    assert!(error.to_string().contains("not an admitted exact re-report form"));
+}
+
+#[test]
+fn prior_issue_must_actually_be_closed() {
+    let mut input = episode();
+    input.prior = issue(10, IssueState::Open);
+    let error = evaluate_closure_episode(&input).unwrap_err();
+    assert!(error.to_string().contains("prior issue to be closed"));
+}
+
+#[test]
+fn duplicate_challenge_is_source_evidence_without_changing_clearance() {
+    let mut input = episode();
+    input.duplicate_challenge = Some(DuplicateChallengeReceipt {
+        suggestion_comment_id: 90,
+        suggestion_source_ref: "github:issue/10/comment/90".to_string(),
+        suggestion_actor: "github-actions[bot]".to_string(),
+        suggestion_evidence: "Found 3 possible duplicate issues.".to_string(),
+        rejection_comment_id: 91,
+        rejection_source_ref: "github:issue/10/comment/91".to_string(),
+        rejection_actor: "reporter".to_string(),
+        rejection_evidence: "Not a duplicate of the suggested issues.".to_string(),
+    });
+
+    let evaluation = evaluate_closure_episode(&input).unwrap();
+    assert_eq!(evaluation.clearance, ClearanceStatus::Unknown);
+}
+
+#[test]
+fn parser_rejects_unknown_machine_fields() {
+    let mut value = serde_json::to_value(episode()).unwrap();
+    value
+        .as_object_mut()
+        .unwrap()
+        .insert("confidence".to_string(), serde_json::json!(0.99));
+    let bytes = serde_json::to_vec(&value).unwrap();
+    let error = parse_closure_episode(&bytes).unwrap_err();
+    assert!(error.to_string().contains("unknown field"));
+}

--- a/tests/closure_episode.rs
+++ b/tests/closure_episode.rs
@@ -115,7 +115,11 @@ fn rereport_evidence_must_name_the_declared_prior_issue() {
     let mut arbitrary = episode();
     arbitrary.re_report.evidence = "Related to #10".to_string();
     let error = evaluate_closure_episode(&arbitrary).unwrap_err();
-    assert!(error.to_string().contains("not an admitted exact re-report form"));
+    assert!(
+        error
+            .to_string()
+            .contains("not an admitted exact re-report form")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

Progress #18/#137 through #207 with a typed issue-closure episode that keeps repository lifecycle evidence separate from evidence that a reported failure was actually cleared.

The core evaluator receives:

```text
prior issue snapshot
later issue snapshot
exact closure receipt
exact explicit re-report receipt
optional duplicate-challenge receipts
```

and deliberately exposes only:

```text
closure kind
re-report observed
clearance = UNKNOWN
disposition = inspect_prior_failure
```

There is no `fixed=false` input bit and no inference that `state=closed` means repair.

## Live discriminator

[Claude Code #31294](https://redirect.github.com/anthropics/claude-code/issues/31294) reported Task()-spawned subagent memory failing to create/update `MEMORY.md`.

Its history preserves:

- bot duplicate suggestions in comment `4008755017`;
- reporter rejection of those suggestions in `4008815491`;
- exact bot inactivity closure in `4230270046`: `Closing for now — inactive for too long... open a new issue if this is still relevant.`

[Claude Code #57507](https://redirect.github.com/anthropics/claude-code/issues/57507) later begins with the exact admitted relation:

```text
**Re-reporting** the bug from #31294 (closed-as-inactive ... not because it was fixed).
```

It adds a fresh reproduction and is itself later closed by the same inactivity mechanism.

The PR carrier requires the independent Rust evaluator to return:

```text
prior_state        closed
later_state        closed
closure_kind       administrative_inactive
re_report_observed true
clearance          unknown
disposition        inspect_prior_failure
```

Closing the re-report again therefore does not manufacture clearing evidence for the earlier failure.

## Admission boundary

`administrative_inactive` requires both:

```text
actor = github-actions[bot]
exact repository-bound inactivity sentence
```

`state_reason=not_planned` alone is insufficient. The same sentence from a human remains unclassified by the provider.

The re-report relation requires exactly one line beginning with the admitted `**Re-reporting** the bug from #N` form. No title similarity, chronology search, or issue-neighbor inference is used.

## Verification

Rust controls cover closure vs clearance, later re-closure, state-reason insufficiency, exact actor/evidence admission, endpoint mismatch, arbitrary relation prose, open-prior rejection, duplicate-challenge independence, and fail-closed JSON fields.

Provider controls cover exact re-report selection before prior fetch, exact bot closure classification, non-bot negative control, open prior, incomplete duplicate challenge, bounded complete comment pagination, and malformed selection before provider work.

Ordinary CI keeps the Python collector controls green; a dedicated public workflow runs the #31294/#57507 carrier through the independent Rust example.

Remote collection stays opt-in; ordinary Cultist commands remain local/read-only.

Closes #207.

Refs #16 #18 #62 #109 #137 #183 #188 #202 #206.