### PR TITLE
research: map observation frontiers to admitted probes

### DIFF
--- a/examples/observation_probe_plan.rs
+++ b/examples/observation_probe_plan.rs
@@ -1,0 +1,54 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+#[allow(dead_code)]
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[allow(dead_code)]
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[allow(dead_code)]
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[allow(dead_code)]
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[allow(dead_code)]
+#[path = "../src/justification.rs"]
+mod justification;
+#[allow(dead_code)]
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[allow(dead_code)]
+#[path = "../src/observation_probe_bridge.rs"]
+mod observation_probe_bridge;
+
+use observation_probe_bridge::{
+    MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES, parse_observation_probe_plan_request,
+    plan_observation_probe,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("observation-probe-plan: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES {
+        return Err(format!(
+            "observation probe plan request exceeds the {MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let request = parse_observation_probe_plan_request(&bytes)?;
+    let plan = plan_observation_probe(&request)?;
+    println!("{}", serde_json::to_string_pretty(&plan)?);
+    Ok(())
+}

--- a/research/observation-probe-bridge.md
+++ b/research/observation-probe-bridge.md
@@ -1,0 +1,147 @@
+# Observation frontier to probe bridge
+
+Tracking: #190 Phase B. Composes the green #210 v2 observation/frontier semantics with the green #164 evidence planner.
+
+## Question
+
+When a selected analyzer refinement needs one current observation `D@S`, and the v2 frontier says that observation is missing, unknown, or invalid, how can Cultist ask the existing #145 planner for bounded evidence work without assuming the observation discriminator vocabulary and probe vocabulary are identical?
+
+## Source-owned mapping
+
+V0 adds one explicit record:
+
+```text
+ObservationProbeBridge
+  bridge_id
+  observation_discriminator_id
+  observation_subject_ref
+  probe_discriminator
+    kind
+    target
+  clearing_requirements
+  source_receipt
+```
+
+The bridge is supplied evidence that one #145 probe discriminator and one exact clearing coordinate are admitted producers for the required observation.
+
+No mapping is inferred from:
+
+- equal or similar strings;
+- the known/old observation value;
+- path ancestry;
+- probe cost;
+- chronology;
+- source-receipt prose.
+
+One exact `D@S` may have at most one admitted v0 bridge. Multiple competing mappings remain a future source-selection question instead of becoming hidden generic ranking.
+
+## Composition
+
+For a noncurrent frontier with one exact bridge, the adapter creates one ordinary `DurableObligation`:
+
+```text
+missing_discriminator = bridge.probe_discriminator
+subject               = bridge.clearing_requirements
+clearing condition     = same discriminator + same requirements
+```
+
+It then calls the existing #164 planner unchanged.
+
+The planner still owns:
+
+- capability matching;
+- exact clearing-condition matching;
+- applicability/current-context checks;
+- conservative cost ordering;
+- read-only / external-read / effectful boundaries;
+- selected / blocked / unresolved / stale outcomes.
+
+The bridge grants zero execution authority.
+
+## V2 currentness boundary
+
+#201 proved the old observation model could represent:
+
+```text
+KNOWN old value
++ INVALID or UNKNOWN applicability
+-> CURRENT frontier
+```
+
+#210 repaired that. This bridge consumes the repaired frontier directly:
+
+```text
+CURRENT
+  -> already_current; no acquisition plan
+
+MISSING / UNKNOWN / INVALID
+  -> exact bridge lookup
+  -> existing evidence planner
+```
+
+A retained old value under an INVALID frontier may justify planning a current-head refresh, but the bridge does not reclassify that old observation. The returned bridge plan preserves the original frontier status until a source actually emits a new current observation.
+
+## Controls
+
+The standard test carrier covers:
+
+1. exact mapped source probe is selected while a cheaper similarly named probe is `incapable`;
+2. similarly named probe with no explicit bridge leaves the frontier `no_admitted_mapping`;
+3. bridge for another subject cannot map the required frontier;
+4. CURRENT frontier produces no acquisition plan;
+5. UNKNOWN value at an applicable coordinate can select deeper evidence work;
+6. INVALID old value can select a current-head refresh while the frontier remains INVALID;
+7. missing current revision stays blocked through the existing planner;
+8. effectful mapped probe remains `effect_authority_required` when authority is absent;
+9. duplicate exact `D@S` mappings reject;
+10. incoherent frontier receipts reject before planning;
+11. request JSON round-trip and a 1 MiB input bound are explicit.
+
+## Reader
+
+```text
+cargo run --example observation_probe_plan < request.json
+```
+
+The reader revalidates the bounded request before planning.
+
+## Boundary
+
+- research only;
+- no source analyzer execution;
+- no implicit `discriminator_id == probe.kind` convention;
+- no conversion from `value_ref` to evidence strength;
+- no generic source relevance score;
+- no effect authorization;
+- no automatic claim that a planned probe cleared the observation;
+- source adapters own the mapping receipt;
+- #145 planner semantics remain unchanged.
+
+## Execution receipt
+
+The explicit composition base was created by merging green #164 evidence-planner head `3284895e50831811af53d60a9436e0d4ffb3c267` into a branch pinned to #210 v2 frontier head `7b5c4e5add71356e2d58ac234680e26ed0fc8ba9`. The merge commit is `32cef81ac5e57c4d8285cce00fd644265a67e5fd`.
+
+The first Phase B CI attempt stopped only at `cargo fmt --check`; the formatter delta changed line wrapping and module ordering only.
+
+Formatted semantic head:
+
+```text
+959d1712235a4f7c7e1f48e524baeecbcf1df0a3
+```
+
+GitHub Actions CI run `32256195538` / run number `1453` completed successfully. It passed:
+
+- `cargo fmt --check`;
+- strict Clippy;
+- active-work preflight;
+- full `cargo test`, including mapped/unmapped/wrong-subject/current/UNKNOWN/INVALID/missing-context/effect-authority bridge controls;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON and positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+Main advanced independently while this ran, but the intervening five main commits changed only CI/reference-policy tooling and `AGENTS.md`; they did not touch the observation/frontier/planner/bridge files.
+
+North star:
+
+> Turn a noncurrent observation into bounded investigation only when the source explicitly proves which admitted probe can produce the current observation.

--- a/src/observation_probe_bridge.rs
+++ b/src/observation_probe_bridge.rs
@@ -1,0 +1,329 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::applicability::{EvaluationContext, EvidenceRequirements};
+use crate::durable_obligation::{
+    ClearingCondition, DURABLE_OBLIGATION_SCHEMA_VERSION, DiscriminatorKey, DurableObligation,
+};
+use crate::evidence_planner::{
+    EVIDENCE_PLANNER_SCHEMA_VERSION, EvidencePlan, EvidenceProbe, ProbePlanRequest,
+    ProbeSelectionPolicy, plan_evidence,
+};
+use crate::observation_frontier::{ObservationFrontierReceipt, ObservationFrontierStatus};
+
+pub const OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION: u32 = 1;
+pub const MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES: usize = 1024 * 1024;
+const MAX_BRIDGES: usize = 128;
+const MAX_ID_BYTES: usize = 256;
+const MAX_REFERENCE_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationProbeBridge {
+    pub bridge_id: String,
+    pub observation_discriminator_id: String,
+    pub observation_subject_ref: String,
+    pub probe_discriminator: DiscriminatorKey,
+    pub clearing_requirements: EvidenceRequirements,
+    pub source_receipt: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationProbePlanRequest {
+    pub schema_version: u32,
+    pub frontier: ObservationFrontierReceipt,
+    pub bridges: Vec<ObservationProbeBridge>,
+    pub context: EvaluationContext,
+    pub probes: Vec<EvidenceProbe>,
+    pub allow_effectful: bool,
+    pub policy: ProbeSelectionPolicy,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationProbePlanStatus {
+    AlreadyCurrent,
+    NoAdmittedMapping,
+    Planned,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationProbePlan {
+    pub schema_version: u32,
+    pub observation_discriminator_id: String,
+    pub observation_subject_ref: String,
+    pub frontier_status: ObservationFrontierStatus,
+    pub status: ObservationProbePlanStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bridge_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bridge_source_receipt: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence_plan: Option<EvidencePlan>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ObservationProbeBridgeError {
+    message: String,
+}
+
+impl ObservationProbeBridgeError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ObservationProbeBridgeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for ObservationProbeBridgeError {}
+
+pub fn parse_observation_probe_plan_request(
+    bytes: &[u8],
+) -> Result<ObservationProbePlanRequest, ObservationProbeBridgeError> {
+    if bytes.len() > MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES {
+        return Err(ObservationProbeBridgeError::new(format!(
+            "observation probe plan request exceeds the {MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES}-byte limit"
+        )));
+    }
+    let request: ObservationProbePlanRequest = serde_json::from_slice(bytes).map_err(|error| {
+        ObservationProbeBridgeError::new(format!("invalid observation probe plan JSON: {error}"))
+    })?;
+    validate_request(&request)?;
+    Ok(request)
+}
+
+pub fn plan_observation_probe(
+    request: &ObservationProbePlanRequest,
+) -> Result<ObservationProbePlan, ObservationProbeBridgeError> {
+    validate_request(request)?;
+
+    let frontier = &request.frontier;
+    if frontier.status == ObservationFrontierStatus::Current {
+        return Ok(base_plan(
+            frontier,
+            ObservationProbePlanStatus::AlreadyCurrent,
+        ));
+    }
+
+    let matching = request
+        .bridges
+        .iter()
+        .filter(|bridge| bridge_matches_frontier(bridge, frontier))
+        .collect::<Vec<_>>();
+
+    let Some(bridge) = matching.first().copied() else {
+        return Ok(base_plan(
+            frontier,
+            ObservationProbePlanStatus::NoAdmittedMapping,
+        ));
+    };
+
+    let obligation = DurableObligation {
+        schema_version: DURABLE_OBLIGATION_SCHEMA_VERSION,
+        id: format!("observation-bridge:{}", bridge.bridge_id),
+        question: format!(
+            "Acquire current observation through bridge {}",
+            bridge.bridge_id
+        ),
+        subject: bridge.clearing_requirements.clone(),
+        established_evidence: Vec::new(),
+        missing_discriminator: bridge.probe_discriminator.clone(),
+        clearing_conditions: vec![ClearingCondition {
+            discriminator: bridge.probe_discriminator.clone(),
+            requirements: bridge.clearing_requirements.clone(),
+        }],
+    };
+
+    let evidence_plan = plan_evidence(&ProbePlanRequest {
+        schema_version: EVIDENCE_PLANNER_SCHEMA_VERSION,
+        obligation,
+        context: request.context.clone(),
+        probes: request.probes.clone(),
+        allow_effectful: request.allow_effectful,
+        policy: request.policy,
+    })
+    .map_err(|error| {
+        ObservationProbeBridgeError::new(format!("evidence planning failed: {error}"))
+    })?;
+
+    Ok(ObservationProbePlan {
+        schema_version: OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION,
+        observation_discriminator_id: frontier.discriminator_id.clone(),
+        observation_subject_ref: frontier.subject_ref.clone(),
+        frontier_status: frontier.status,
+        status: ObservationProbePlanStatus::Planned,
+        bridge_id: Some(bridge.bridge_id.clone()),
+        bridge_source_receipt: Some(bridge.source_receipt.clone()),
+        evidence_plan: Some(evidence_plan),
+    })
+}
+
+fn base_plan(
+    frontier: &ObservationFrontierReceipt,
+    status: ObservationProbePlanStatus,
+) -> ObservationProbePlan {
+    ObservationProbePlan {
+        schema_version: OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION,
+        observation_discriminator_id: frontier.discriminator_id.clone(),
+        observation_subject_ref: frontier.subject_ref.clone(),
+        frontier_status: frontier.status,
+        status,
+        bridge_id: None,
+        bridge_source_receipt: None,
+        evidence_plan: None,
+    }
+}
+
+fn bridge_matches_frontier(
+    bridge: &ObservationProbeBridge,
+    frontier: &ObservationFrontierReceipt,
+) -> bool {
+    bridge.observation_discriminator_id == frontier.discriminator_id
+        && bridge.observation_subject_ref == frontier.subject_ref
+}
+
+fn validate_request(
+    request: &ObservationProbePlanRequest,
+) -> Result<(), ObservationProbeBridgeError> {
+    if request.schema_version != OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION {
+        return Err(ObservationProbeBridgeError::new(format!(
+            "unsupported observation probe bridge schema {}; expected {OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION}",
+            request.schema_version
+        )));
+    }
+    validate_frontier(&request.frontier)?;
+    if request.bridges.len() > MAX_BRIDGES {
+        return Err(ObservationProbeBridgeError::new(
+            "observation probe bridges exceed the admitted boundary",
+        ));
+    }
+
+    let mut bridge_ids = BTreeSet::new();
+    let mut mappings = BTreeSet::new();
+    for bridge in &request.bridges {
+        validate_bridge(bridge)?;
+        if !bridge_ids.insert(bridge.bridge_id.clone()) {
+            return Err(ObservationProbeBridgeError::new(format!(
+                "duplicate observation probe bridge id {}",
+                bridge.bridge_id
+            )));
+        }
+        let mapping = (
+            bridge.observation_discriminator_id.clone(),
+            bridge.observation_subject_ref.clone(),
+        );
+        if !mappings.insert(mapping) {
+            return Err(ObservationProbeBridgeError::new(format!(
+                "multiple admitted bridges for observation {} @ {}",
+                bridge.observation_discriminator_id, bridge.observation_subject_ref
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_frontier(
+    frontier: &ObservationFrontierReceipt,
+) -> Result<(), ObservationProbeBridgeError> {
+    validate_atom(
+        &frontier.discriminator_id,
+        "frontier discriminator_id",
+        MAX_ID_BYTES,
+    )?;
+    validate_atom(
+        &frontier.subject_ref,
+        "frontier subject_ref",
+        MAX_REFERENCE_BYTES,
+    )?;
+
+    let coherent = match frontier.status {
+        ObservationFrontierStatus::Current => !frontier.current.is_empty(),
+        ObservationFrontierStatus::Unknown => {
+            frontier.current.is_empty() && !frontier.unknown.is_empty()
+        }
+        ObservationFrontierStatus::Invalid => {
+            frontier.current.is_empty()
+                && frontier.unknown.is_empty()
+                && !frontier.invalid.is_empty()
+        }
+        ObservationFrontierStatus::Missing => {
+            frontier.current.is_empty()
+                && frontier.unknown.is_empty()
+                && frontier.invalid.is_empty()
+        }
+    };
+    if !coherent {
+        return Err(ObservationProbeBridgeError::new(
+            "observation frontier status disagrees with its current/unknown/invalid receipts",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_bridge(bridge: &ObservationProbeBridge) -> Result<(), ObservationProbeBridgeError> {
+    validate_atom(&bridge.bridge_id, "bridge id", MAX_ID_BYTES)?;
+    validate_atom(
+        &bridge.observation_discriminator_id,
+        "bridge observation_discriminator_id",
+        MAX_ID_BYTES,
+    )?;
+    validate_atom(
+        &bridge.observation_subject_ref,
+        "bridge observation_subject_ref",
+        MAX_REFERENCE_BYTES,
+    )?;
+    validate_atom(
+        &bridge.probe_discriminator.kind,
+        "bridge probe discriminator kind",
+        MAX_ID_BYTES,
+    )?;
+    validate_atom(
+        &bridge.probe_discriminator.target,
+        "bridge probe discriminator target",
+        MAX_REFERENCE_BYTES,
+    )?;
+    validate_atom(
+        &bridge.source_receipt,
+        "bridge source_receipt",
+        MAX_REFERENCE_BYTES,
+    )?;
+    if bridge.clearing_requirements.repository.is_none()
+        && bridge.clearing_requirements.revision.is_none()
+        && bridge.clearing_requirements.work.is_none()
+        && bridge.clearing_requirements.scope.is_none()
+    {
+        return Err(ObservationProbeBridgeError::new(
+            "bridge clearing_requirements must carry at least one applicability coordinate",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_atom(
+    value: &str,
+    field: &str,
+    max_bytes: usize,
+) -> Result<(), ObservationProbeBridgeError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > max_bytes
+        || value.contains('\0')
+        || value.contains(['\n', '\r'])
+    {
+        return Err(ObservationProbeBridgeError::new(format!(
+            "{field} must be bounded canonical single-line text"
+        )));
+    }
+    Ok(())
+}

--- a/tests/observation_probe_bridge.rs
+++ b/tests/observation_probe_bridge.rs
@@ -1,0 +1,444 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[path = "../src/justification.rs"]
+mod justification;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/observation_probe_bridge.rs"]
+mod observation_probe_bridge;
+
+use applicability::{EvaluationContext, EvidenceRequirements};
+use durable_obligation::DiscriminatorKey;
+use evidence_planner::{
+    EvidencePlanStatus, EvidenceProbe, ProbeCandidateStatus, ProbeCost, ProbeEffect,
+    ProbeSelectionPolicy,
+};
+use observation_frontier::{
+    CurrentObservationReceipt, NonCurrentObservationReceipt, ObservationFrontierReceipt,
+    ObservationFrontierStatus,
+};
+use observation_probe_bridge::{
+    MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES, OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION,
+    ObservationProbeBridge, ObservationProbePlanRequest, ObservationProbePlanStatus,
+    parse_observation_probe_plan_request, plan_observation_probe,
+};
+
+fn requirements(revision: Option<&str>) -> EvidenceRequirements {
+    EvidenceRequirements {
+        repository: Some("owner/repo".to_string()),
+        revision: revision.map(str::to_string),
+        work: None,
+        scope: None,
+    }
+}
+
+fn context(revision: Option<&str>) -> EvaluationContext {
+    EvaluationContext {
+        repository: Some("owner/repo".to_string()),
+        revision: revision.map(str::to_string),
+        work: None,
+        path: None,
+    }
+}
+
+fn probe_key() -> DiscriminatorKey {
+    DiscriminatorKey {
+        kind: "source_edit_class".to_string(),
+        target: "commit:subject-a".to_string(),
+    }
+}
+
+fn probe(
+    id: &str,
+    key: DiscriminatorKey,
+    revision: Option<&str>,
+    effect: ProbeEffect,
+    cost: ProbeCost,
+) -> EvidenceProbe {
+    EvidenceProbe {
+        id: id.to_string(),
+        produces: key,
+        requirements: requirements(revision),
+        effect,
+        cost,
+    }
+}
+
+fn bridge(subject_ref: &str, revision: &str) -> ObservationProbeBridge {
+    ObservationProbeBridge {
+        bridge_id: format!("edit-class-{revision}"),
+        observation_discriminator_id: "edit_class".to_string(),
+        observation_subject_ref: subject_ref.to_string(),
+        probe_discriminator: probe_key(),
+        clearing_requirements: requirements(Some(revision)),
+        source_receipt: format!("source-adapter:edit-class:{revision}"),
+    }
+}
+
+fn missing_frontier(subject_ref: &str) -> ObservationFrontierReceipt {
+    ObservationFrontierReceipt {
+        discriminator_id: "edit_class".to_string(),
+        subject_ref: subject_ref.to_string(),
+        status: ObservationFrontierStatus::Missing,
+        current: Vec::new(),
+        unknown: Vec::new(),
+        invalid: Vec::new(),
+        other_subject: Vec::new(),
+    }
+}
+
+fn unknown_frontier(subject_ref: &str) -> ObservationFrontierReceipt {
+    ObservationFrontierReceipt {
+        discriminator_id: "edit_class".to_string(),
+        subject_ref: subject_ref.to_string(),
+        status: ObservationFrontierStatus::Unknown,
+        current: Vec::new(),
+        unknown: vec![NonCurrentObservationReceipt {
+            observation_id: "obs:unknown".to_string(),
+            source_receipt: "source:unknown".to_string(),
+            known_value_ref: None,
+            value_unknown_reason_ref: Some("classifier:missing-value".to_string()),
+            applicability_ref: "applicability:head-a:applies".to_string(),
+        }],
+        invalid: Vec::new(),
+        other_subject: Vec::new(),
+    }
+}
+
+fn invalid_frontier(subject_ref: &str) -> ObservationFrontierReceipt {
+    ObservationFrontierReceipt {
+        discriminator_id: "edit_class".to_string(),
+        subject_ref: subject_ref.to_string(),
+        status: ObservationFrontierStatus::Invalid,
+        current: Vec::new(),
+        unknown: Vec::new(),
+        invalid: vec![NonCurrentObservationReceipt {
+            observation_id: "obs:old-head".to_string(),
+            source_receipt: "source:old-head".to_string(),
+            known_value_ref: Some("syntax_changed".to_string()),
+            value_unknown_reason_ref: None,
+            applicability_ref: "applicability:old-head->head-b:invalid".to_string(),
+        }],
+        other_subject: Vec::new(),
+    }
+}
+
+fn current_frontier(subject_ref: &str) -> ObservationFrontierReceipt {
+    ObservationFrontierReceipt {
+        discriminator_id: "edit_class".to_string(),
+        subject_ref: subject_ref.to_string(),
+        status: ObservationFrontierStatus::Current,
+        current: vec![CurrentObservationReceipt {
+            observation_id: "obs:current".to_string(),
+            source_receipt: "source:current".to_string(),
+            value_ref: "syntax_changed".to_string(),
+            applicability_ref: "applicability:head-a:applies".to_string(),
+        }],
+        unknown: Vec::new(),
+        invalid: Vec::new(),
+        other_subject: Vec::new(),
+    }
+}
+
+fn request(
+    frontier: ObservationFrontierReceipt,
+    bridges: Vec<ObservationProbeBridge>,
+    context: EvaluationContext,
+    probes: Vec<EvidenceProbe>,
+    allow_effectful: bool,
+) -> ObservationProbePlanRequest {
+    ObservationProbePlanRequest {
+        schema_version: OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION,
+        frontier,
+        bridges,
+        context,
+        probes,
+        allow_effectful,
+        policy: ProbeSelectionPolicy::Conservative,
+    }
+}
+
+#[test]
+fn exact_source_bridge_selects_capable_probe_and_rejects_similar_name_as_incapable() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        missing_frontier(subject),
+        vec![bridge(subject, "head-a")],
+        context(Some("head-a")),
+        vec![
+            probe(
+                "cheap-similar-name",
+                DiscriminatorKey {
+                    kind: "edit_class".to_string(),
+                    target: subject.to_string(),
+                },
+                Some("head-a"),
+                ProbeEffect::ReadOnly,
+                ProbeCost::default(),
+            ),
+            probe(
+                "mapped-source-probe",
+                probe_key(),
+                Some("head-a"),
+                ProbeEffect::ReadOnly,
+                ProbeCost {
+                    git_subprocesses: 1,
+                    ..ProbeCost::default()
+                },
+            ),
+        ],
+        false,
+    ))
+    .unwrap();
+
+    assert_eq!(plan.status, ObservationProbePlanStatus::Planned);
+    let evidence = plan.evidence_plan.unwrap();
+    assert_eq!(evidence.status, EvidencePlanStatus::Selected);
+    assert_eq!(evidence.selected.unwrap().id, "mapped-source-probe");
+    assert_eq!(
+        evidence
+            .candidates
+            .iter()
+            .find(|candidate| candidate.id == "cheap-similar-name")
+            .unwrap()
+            .status,
+        ProbeCandidateStatus::Incapable
+    );
+}
+
+#[test]
+fn similarly_named_probe_without_explicit_bridge_leaves_frontier_unmapped() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        missing_frontier(subject),
+        Vec::new(),
+        context(Some("head-a")),
+        vec![probe(
+            "looks-related",
+            DiscriminatorKey {
+                kind: "edit_class".to_string(),
+                target: subject.to_string(),
+            },
+            Some("head-a"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    ))
+    .unwrap();
+
+    assert_eq!(plan.status, ObservationProbePlanStatus::NoAdmittedMapping);
+    assert!(plan.evidence_plan.is_none());
+}
+
+#[test]
+fn bridge_for_wrong_subject_does_not_map_required_frontier() {
+    let plan = plan_observation_probe(&request(
+        missing_frontier("commit:subject-a"),
+        vec![bridge("commit:subject-b", "head-a")],
+        context(Some("head-a")),
+        vec![probe(
+            "mapped-source-probe",
+            probe_key(),
+            Some("head-a"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    ))
+    .unwrap();
+
+    assert_eq!(plan.status, ObservationProbePlanStatus::NoAdmittedMapping);
+}
+
+#[test]
+fn current_frontier_needs_no_acquisition_plan() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        current_frontier(subject),
+        vec![bridge(subject, "head-a")],
+        context(Some("head-a")),
+        vec![probe(
+            "mapped-source-probe",
+            probe_key(),
+            Some("head-a"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    ))
+    .unwrap();
+
+    assert_eq!(plan.status, ObservationProbePlanStatus::AlreadyCurrent);
+    assert!(plan.evidence_plan.is_none());
+}
+
+#[test]
+fn unknown_value_with_current_coordinate_can_plan_deeper_acquisition() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        unknown_frontier(subject),
+        vec![bridge(subject, "head-a")],
+        context(Some("head-a")),
+        vec![probe(
+            "mapped-source-probe",
+            probe_key(),
+            Some("head-a"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    ))
+    .unwrap();
+
+    assert_eq!(plan.frontier_status, ObservationFrontierStatus::Unknown);
+    assert_eq!(
+        plan.evidence_plan.unwrap().status,
+        EvidencePlanStatus::Selected
+    );
+}
+
+#[test]
+fn invalid_old_value_can_plan_current_head_refresh_without_becoming_current() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        invalid_frontier(subject),
+        vec![bridge(subject, "head-b")],
+        context(Some("head-b")),
+        vec![probe(
+            "refresh-current-head",
+            probe_key(),
+            Some("head-b"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    ))
+    .unwrap();
+
+    assert_eq!(plan.frontier_status, ObservationFrontierStatus::Invalid);
+    let evidence = plan.evidence_plan.unwrap();
+    assert_eq!(evidence.status, EvidencePlanStatus::Selected);
+    assert_eq!(evidence.selected.unwrap().id, "refresh-current-head");
+}
+
+#[test]
+fn missing_current_coordinate_stays_blocked_in_existing_planner() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        unknown_frontier(subject),
+        vec![bridge(subject, "head-a")],
+        context(None),
+        vec![probe(
+            "mapped-source-probe",
+            probe_key(),
+            Some("head-a"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    ))
+    .unwrap();
+
+    let evidence = plan.evidence_plan.unwrap();
+    assert_eq!(evidence.status, EvidencePlanStatus::Blocked);
+    assert_eq!(
+        evidence.candidates[0].status,
+        ProbeCandidateStatus::MissingContext
+    );
+}
+
+#[test]
+fn bridge_grants_zero_effect_authority() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        missing_frontier(subject),
+        vec![bridge(subject, "head-a")],
+        context(Some("head-a")),
+        vec![probe(
+            "effectful-source-probe",
+            probe_key(),
+            Some("head-a"),
+            ProbeEffect::Effectful,
+            ProbeCost {
+                effectful_executions: 1,
+                ..ProbeCost::default()
+            },
+        )],
+        false,
+    ))
+    .unwrap();
+
+    let evidence = plan.evidence_plan.unwrap();
+    assert_eq!(evidence.status, EvidencePlanStatus::Blocked);
+    assert_eq!(
+        evidence.candidates[0].status,
+        ProbeCandidateStatus::EffectAuthorityRequired
+    );
+}
+
+#[test]
+fn duplicate_mapping_for_exact_observation_requirement_rejects() {
+    let subject = "commit:subject-a";
+    let mut duplicate = bridge(subject, "head-a");
+    duplicate.bridge_id = "second-bridge".to_string();
+    let error = plan_observation_probe(&request(
+        missing_frontier(subject),
+        vec![bridge(subject, "head-a"), duplicate],
+        context(Some("head-a")),
+        Vec::new(),
+        false,
+    ))
+    .unwrap_err();
+
+    assert!(error.to_string().contains("multiple admitted bridges"));
+}
+
+#[test]
+fn incoherent_frontier_receipt_rejects_before_planning() {
+    let mut frontier = missing_frontier("commit:subject-a");
+    frontier.status = ObservationFrontierStatus::Current;
+    let error = plan_observation_probe(&request(
+        frontier,
+        Vec::new(),
+        context(Some("head-a")),
+        Vec::new(),
+        false,
+    ))
+    .unwrap_err();
+
+    assert!(error.to_string().contains("status disagrees"));
+}
+
+#[test]
+fn request_round_trip_and_byte_bound_are_explicit() {
+    let subject = "commit:subject-a";
+    let request = request(
+        missing_frontier(subject),
+        vec![bridge(subject, "head-a")],
+        context(Some("head-a")),
+        vec![probe(
+            "mapped-source-probe",
+            probe_key(),
+            Some("head-a"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    );
+    let encoded = serde_json::to_vec(&request).unwrap();
+    let decoded = parse_observation_probe_plan_request(&encoded).unwrap();
+    assert_eq!(decoded, request);
+
+    let oversized = vec![b' '; MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES + 1];
+    let error = parse_observation_probe_plan_request(&oversized).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}


### PR DESCRIPTION
Progresses #190 Phase B as the now-canonical four-file observation-frontier→probe bridge.

## Contract

One explicit source-owned record maps an exact observation requirement to an admitted probe discriminator and clearing coordinate:

```text
ObservationProbeBridge
  observation_discriminator_id
  observation_subject_ref
  probe_discriminator { kind, target }
  clearing_requirements
  source_receipt
```

No mapping is inferred from equal/similar strings, known values, path ancestry, cost, chronology, or receipt prose.

For MISSING / UNKNOWN / INVALID v2 frontiers, the bridge creates one ordinary durable obligation and calls the landed #164 planner unchanged. CURRENT produces `already_current`; absent exact mapping produces `no_admitted_mapping`.

## Controls

- exact mapped probe selected while a cheaper similarly named probe remains incapable;
- similarly named probe with no bridge stays unmapped;
- wrong-subject bridge cannot satisfy the frontier;
- CURRENT creates no plan;
- UNKNOWN can plan deeper acquisition;
- INVALID known-old evidence can plan a refresh while the frontier stays INVALID;
- missing current revision remains blocked through the planner;
- effectful mapped probe still requires effect authority;
- duplicate exact D@S mappings reject;
- incoherent frontier receipts reject;
- bounded JSON reader/round-trip remain explicit.

## Current-main promotion receipt

The historical 37-commit composition ancestry was discarded after #210, #159, and #164 reached main. The four exact bridge blobs were rebuilt directly on the planner line, then replayed once more after unrelated #269 organizer-receipt work advanced main.

Final exact-current carrier:

```text
main: edecb3b91134bb4a644bb3f5dfc49d423dc9c767
head: bd50d19f6e3b18f29a10241668ed60d222c5e591
commits: 1
files: 4
```

Ordinary CI:

```text
run: 32273977639
job: 96136855595
result: success
```

Generated-provenance review:

```text
run: 32273977670
job: 96136856261
result: success
```

Formatter, strict Clippy, project/review/closure/external-reference guards, active-work preflight, all bridge/planner controls, and repository/history/CI-filter/diff dogfood passed. Main remained at the exact base through the final gate.

Earlier bridge receipts remain in `research/observation-probe-bridge.md`; this run is the canonical main-based promotion receipt.

## Boundary / next

Research only; no source analyzer execution, implicit discriminator-name mapping, evidence-strength inference, effect authorization, or automatic currentness transition.

The next earned child is #221: the first real Rust source adapter that emits the bridge, runs the read-only edit-class classifier, writes a v2 observation, and closes an exact frontier.

Files: `src/observation_probe_bridge.rs`, `tests/observation_probe_bridge.rs`, `examples/observation_probe_plan.rs`, `research/observation-probe-bridge.md`.

Refs #123 #145 #159 #164 #185 #190 #194 #210 #220 #221.