### PR TITLE
research: decompose worker failures before model attribution

### DIFF
--- a/tests/worker_capability_decomposition.rs
+++ b/tests/worker_capability_decomposition.rs
@@ -3,6 +3,7 @@ enum FailureBoundary {
     None,
     SpecificationGap,
     EvidenceAbsent,
+    EvidenceMisrepresented,
     SelectionMiss,
     AttentionMiss,
     InterpretationMiss,
@@ -32,6 +33,7 @@ struct EpisodeFacts {
     specification_complete: bool,
     decisive_evidence_required: bool,
     decisive_evidence_available: bool,
+    decisive_evidence_semantics_valid: bool,
     decisive_evidence_selected: bool,
     decisive_evidence_recovered_manually: bool,
     decisive_evidence_inspected: bool,
@@ -50,6 +52,7 @@ impl EpisodeFacts {
             specification_complete: true,
             decisive_evidence_required: true,
             decisive_evidence_available: true,
+            decisive_evidence_semantics_valid: true,
             decisive_evidence_selected: true,
             decisive_evidence_recovered_manually: false,
             decisive_evidence_inspected: true,
@@ -75,6 +78,8 @@ fn assess_episode(facts: EpisodeFacts) -> EpisodeAssessment {
         FailureBoundary::SpecificationGap
     } else if facts.decisive_evidence_required && !facts.decisive_evidence_available {
         FailureBoundary::EvidenceAbsent
+    } else if facts.decisive_evidence_required && !facts.decisive_evidence_semantics_valid {
+        FailureBoundary::EvidenceMisrepresented
     } else if facts.decisive_evidence_required && !facts.decisive_evidence_selected {
         FailureBoundary::SelectionMiss
     } else if facts.decisive_evidence_required && !facts.decisive_evidence_inspected {
@@ -155,6 +160,19 @@ fn identical_failed_outcome_does_not_imply_identical_worker_skill_failure() {
     assert_ne!(
         assess_episode(selection_miss),
         assess_episode(interpretation_miss)
+    );
+}
+
+#[test]
+fn wrong_machine_semantics_are_upstream_of_worker_interpretation() {
+    let mut facts = EpisodeFacts::baseline_failure();
+    facts.decisive_evidence_semantics_valid = false;
+    facts.interpretation_matches_oracle = Some(false);
+    facts.plan_matches_contract = None;
+
+    assert_eq!(
+        assess_episode(facts).boundary,
+        FailureBoundary::EvidenceMisrepresented
     );
 }
 

--- a/tests/worker_capability_decomposition.rs
+++ b/tests/worker_capability_decomposition.rs
@@ -33,6 +33,7 @@ struct EpisodeFacts {
     decisive_evidence_required: bool,
     decisive_evidence_available: bool,
     decisive_evidence_selected: bool,
+    decisive_evidence_recovered_manually: bool,
     decisive_evidence_inspected: bool,
     interpretation_matches_oracle: Option<bool>,
     plan_matches_contract: Option<bool>,
@@ -50,6 +51,7 @@ impl EpisodeFacts {
             decisive_evidence_required: true,
             decisive_evidence_available: true,
             decisive_evidence_selected: true,
+            decisive_evidence_recovered_manually: false,
             decisive_evidence_inspected: true,
             interpretation_matches_oracle: Some(true),
             plan_matches_contract: Some(true),
@@ -108,6 +110,29 @@ fn assess_episode(facts: EpisodeFacts) -> EpisodeAssessment {
     EpisodeAssessment { boundary, response }
 }
 
+fn boundary_chain(facts: EpisodeFacts) -> Vec<FailureBoundary> {
+    let primary = assess_episode(facts).boundary;
+    let mut chain = match primary {
+        FailureBoundary::None | FailureBoundary::Unexplained => Vec::new(),
+        boundary => vec![boundary],
+    };
+
+    if primary == FailureBoundary::SelectionMiss && facts.decisive_evidence_recovered_manually {
+        let mut recovered = facts;
+        recovered.decisive_evidence_selected = true;
+        recovered.decisive_evidence_recovered_manually = false;
+        let downstream = assess_episode(recovered).boundary;
+        if !matches!(
+            downstream,
+            FailureBoundary::None | FailureBoundary::Unexplained
+        ) {
+            chain.push(downstream);
+        }
+    }
+
+    chain
+}
+
 #[test]
 fn identical_failed_outcome_does_not_imply_identical_worker_skill_failure() {
     let mut selection_miss = EpisodeFacts::baseline_failure();
@@ -128,7 +153,10 @@ fn identical_failed_outcome_does_not_imply_identical_worker_skill_failure() {
         assess_episode(interpretation_miss).boundary,
         FailureBoundary::InterpretationMiss
     );
-    assert_ne!(assess_episode(selection_miss), assess_episode(interpretation_miss));
+    assert_ne!(
+        assess_episode(selection_miss),
+        assess_episode(interpretation_miss)
+    );
 }
 
 #[test]
@@ -207,15 +235,26 @@ fn escalation_does_not_excuse_ignoring_evidence_that_was_already_selected() {
 }
 
 #[test]
+fn selection_miss_can_precede_a_downstream_worker_failure_after_manual_recovery() {
+    let mut facts = EpisodeFacts::baseline_failure();
+    facts.decisive_evidence_selected = false;
+    facts.decisive_evidence_recovered_manually = true;
+    facts.required_validation_completed = false;
+
+    assert_eq!(
+        boundary_chain(facts),
+        vec![FailureBoundary::SelectionMiss, FailureBoundary::ValidationMiss]
+    );
+}
+
+#[test]
 fn insufficient_receipts_stay_unexplained_instead_of_becoming_model_blame() {
     let mut facts = EpisodeFacts::baseline_failure();
     facts.interpretation_matches_oracle = None;
     facts.plan_matches_contract = None;
 
-    assert_eq!(
-        assess_episode(facts).boundary,
-        FailureBoundary::Unexplained
-    );
+    assert_eq!(assess_episode(facts).boundary, FailureBoundary::Unexplained);
+    assert!(boundary_chain(facts).is_empty());
 }
 
 #[test]
@@ -230,4 +269,5 @@ fn completed_task_is_success_without_failure_attribution() {
             response: ResponseQuality::Success,
         }
     );
+    assert!(boundary_chain(facts).is_empty());
 }

--- a/tests/worker_capability_decomposition.rs
+++ b/tests/worker_capability_decomposition.rs
@@ -11,6 +11,7 @@ enum FailureBoundary {
     AffordanceMiss,
     ExecutionMiss,
     ValidationMiss,
+    CompletionContractMiss,
     Unexplained,
 }
 
@@ -29,7 +30,8 @@ struct EpisodeAssessment {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 struct EpisodeFacts {
-    task_completed: bool,
+    task_reported_complete: bool,
+    completion_contract_satisfied: bool,
     specification_complete: bool,
     decisive_evidence_required: bool,
     decisive_evidence_available: bool,
@@ -48,7 +50,8 @@ struct EpisodeFacts {
 impl EpisodeFacts {
     fn baseline_failure() -> Self {
         Self {
-            task_completed: false,
+            task_reported_complete: false,
+            completion_contract_satisfied: false,
             specification_complete: true,
             decisive_evidence_required: true,
             decisive_evidence_available: true,
@@ -67,7 +70,7 @@ impl EpisodeFacts {
 }
 
 fn assess_episode(facts: EpisodeFacts) -> EpisodeAssessment {
-    if facts.task_completed {
+    if facts.completion_contract_satisfied {
         return EpisodeAssessment {
             boundary: FailureBoundary::None,
             response: ResponseQuality::Success,
@@ -94,6 +97,8 @@ fn assess_episode(facts: EpisodeFacts) -> EpisodeAssessment {
         FailureBoundary::ExecutionMiss
     } else if !facts.required_validation_completed {
         FailureBoundary::ValidationMiss
+    } else if facts.task_reported_complete {
+        FailureBoundary::CompletionContractMiss
     } else {
         FailureBoundary::Unexplained
     };
@@ -268,6 +273,20 @@ fn selection_miss_can_precede_a_downstream_worker_failure_after_manual_recovery(
 }
 
 #[test]
+fn reported_completion_without_verified_contract_is_not_success() {
+    let mut facts = EpisodeFacts::baseline_failure();
+    facts.task_reported_complete = true;
+
+    assert_eq!(
+        assess_episode(facts),
+        EpisodeAssessment {
+            boundary: FailureBoundary::CompletionContractMiss,
+            response: ResponseQuality::Failed,
+        }
+    );
+}
+
+#[test]
 fn insufficient_receipts_stay_unexplained_instead_of_becoming_model_blame() {
     let mut facts = EpisodeFacts::baseline_failure();
     facts.interpretation_matches_oracle = None;
@@ -278,9 +297,9 @@ fn insufficient_receipts_stay_unexplained_instead_of_becoming_model_blame() {
 }
 
 #[test]
-fn completed_task_is_success_without_failure_attribution() {
+fn verified_completion_contract_is_success_without_failure_attribution() {
     let mut facts = EpisodeFacts::baseline_failure();
-    facts.task_completed = true;
+    facts.completion_contract_satisfied = true;
 
     assert_eq!(
         assess_episode(facts),

--- a/tests/worker_capability_decomposition.rs
+++ b/tests/worker_capability_decomposition.rs
@@ -100,8 +100,7 @@ fn assess_episode(facts: EpisodeFacts) -> EpisodeAssessment {
                 | FailureBoundary::EvidenceAbsent
                 | FailureBoundary::SelectionMiss
                 | FailureBoundary::AffordanceMiss
-        )
-    {
+        ) {
         ResponseQuality::CorrectEscalation
     } else {
         ResponseQuality::Failed
@@ -243,7 +242,10 @@ fn selection_miss_can_precede_a_downstream_worker_failure_after_manual_recovery(
 
     assert_eq!(
         boundary_chain(facts),
-        vec![FailureBoundary::SelectionMiss, FailureBoundary::ValidationMiss]
+        vec![
+            FailureBoundary::SelectionMiss,
+            FailureBoundary::ValidationMiss
+        ]
     );
 }
 

--- a/tests/worker_capability_decomposition.rs
+++ b/tests/worker_capability_decomposition.rs
@@ -1,0 +1,233 @@
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum FailureBoundary {
+    None,
+    SpecificationGap,
+    EvidenceAbsent,
+    SelectionMiss,
+    AttentionMiss,
+    InterpretationMiss,
+    PlanningMiss,
+    AffordanceMiss,
+    ExecutionMiss,
+    ValidationMiss,
+    Unexplained,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum ResponseQuality {
+    Success,
+    CorrectEscalation,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct EpisodeAssessment {
+    boundary: FailureBoundary,
+    response: ResponseQuality,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct EpisodeFacts {
+    task_completed: bool,
+    specification_complete: bool,
+    decisive_evidence_required: bool,
+    decisive_evidence_available: bool,
+    decisive_evidence_selected: bool,
+    decisive_evidence_inspected: bool,
+    interpretation_matches_oracle: Option<bool>,
+    plan_matches_contract: Option<bool>,
+    required_affordance_available: bool,
+    implementation_completed: bool,
+    required_validation_completed: bool,
+    requested_exact_missing_discriminator: bool,
+}
+
+impl EpisodeFacts {
+    fn baseline_failure() -> Self {
+        Self {
+            task_completed: false,
+            specification_complete: true,
+            decisive_evidence_required: true,
+            decisive_evidence_available: true,
+            decisive_evidence_selected: true,
+            decisive_evidence_inspected: true,
+            interpretation_matches_oracle: Some(true),
+            plan_matches_contract: Some(true),
+            required_affordance_available: true,
+            implementation_completed: true,
+            required_validation_completed: true,
+            requested_exact_missing_discriminator: false,
+        }
+    }
+}
+
+fn assess_episode(facts: EpisodeFacts) -> EpisodeAssessment {
+    if facts.task_completed {
+        return EpisodeAssessment {
+            boundary: FailureBoundary::None,
+            response: ResponseQuality::Success,
+        };
+    }
+
+    let boundary = if !facts.specification_complete {
+        FailureBoundary::SpecificationGap
+    } else if facts.decisive_evidence_required && !facts.decisive_evidence_available {
+        FailureBoundary::EvidenceAbsent
+    } else if facts.decisive_evidence_required && !facts.decisive_evidence_selected {
+        FailureBoundary::SelectionMiss
+    } else if facts.decisive_evidence_required && !facts.decisive_evidence_inspected {
+        FailureBoundary::AttentionMiss
+    } else if facts.interpretation_matches_oracle == Some(false) {
+        FailureBoundary::InterpretationMiss
+    } else if facts.plan_matches_contract == Some(false) {
+        FailureBoundary::PlanningMiss
+    } else if !facts.required_affordance_available {
+        FailureBoundary::AffordanceMiss
+    } else if !facts.implementation_completed {
+        FailureBoundary::ExecutionMiss
+    } else if !facts.required_validation_completed {
+        FailureBoundary::ValidationMiss
+    } else {
+        FailureBoundary::Unexplained
+    };
+
+    let response = if facts.requested_exact_missing_discriminator
+        && matches!(
+            boundary,
+            FailureBoundary::SpecificationGap
+                | FailureBoundary::EvidenceAbsent
+                | FailureBoundary::SelectionMiss
+                | FailureBoundary::AffordanceMiss
+        )
+    {
+        ResponseQuality::CorrectEscalation
+    } else {
+        ResponseQuality::Failed
+    };
+
+    EpisodeAssessment { boundary, response }
+}
+
+#[test]
+fn identical_failed_outcome_does_not_imply_identical_worker_skill_failure() {
+    let mut selection_miss = EpisodeFacts::baseline_failure();
+    selection_miss.decisive_evidence_selected = false;
+    selection_miss.decisive_evidence_inspected = false;
+    selection_miss.interpretation_matches_oracle = None;
+    selection_miss.plan_matches_contract = None;
+
+    let mut interpretation_miss = EpisodeFacts::baseline_failure();
+    interpretation_miss.interpretation_matches_oracle = Some(false);
+    interpretation_miss.plan_matches_contract = None;
+
+    assert_eq!(
+        assess_episode(selection_miss).boundary,
+        FailureBoundary::SelectionMiss
+    );
+    assert_eq!(
+        assess_episode(interpretation_miss).boundary,
+        FailureBoundary::InterpretationMiss
+    );
+    assert_ne!(assess_episode(selection_miss), assess_episode(interpretation_miss));
+}
+
+#[test]
+fn selected_but_uninspected_evidence_is_attention_not_interpretation() {
+    let mut facts = EpisodeFacts::baseline_failure();
+    facts.decisive_evidence_inspected = false;
+    facts.interpretation_matches_oracle = None;
+    facts.plan_matches_contract = None;
+
+    assert_eq!(
+        assess_episode(facts).boundary,
+        FailureBoundary::AttentionMiss
+    );
+}
+
+#[test]
+fn missing_tool_affordance_is_not_model_reasoning_failure() {
+    let mut facts = EpisodeFacts::baseline_failure();
+    facts.required_affordance_available = false;
+    facts.implementation_completed = false;
+    facts.required_validation_completed = false;
+
+    assert_eq!(
+        assess_episode(facts).boundary,
+        FailureBoundary::AffordanceMiss
+    );
+}
+
+#[test]
+fn validation_failure_is_distinct_after_correct_evidence_plan_and_execution() {
+    let mut facts = EpisodeFacts::baseline_failure();
+    facts.required_validation_completed = false;
+
+    assert_eq!(
+        assess_episode(facts).boundary,
+        FailureBoundary::ValidationMiss
+    );
+}
+
+#[test]
+fn exact_escalation_is_positive_when_the_upstream_requirement_is_genuinely_missing() {
+    let mut facts = EpisodeFacts::baseline_failure();
+    facts.decisive_evidence_available = false;
+    facts.decisive_evidence_selected = false;
+    facts.decisive_evidence_inspected = false;
+    facts.interpretation_matches_oracle = None;
+    facts.plan_matches_contract = None;
+    facts.implementation_completed = false;
+    facts.required_validation_completed = false;
+    facts.requested_exact_missing_discriminator = true;
+
+    assert_eq!(
+        assess_episode(facts),
+        EpisodeAssessment {
+            boundary: FailureBoundary::EvidenceAbsent,
+            response: ResponseQuality::CorrectEscalation,
+        }
+    );
+}
+
+#[test]
+fn escalation_does_not_excuse_ignoring_evidence_that_was_already_selected() {
+    let mut facts = EpisodeFacts::baseline_failure();
+    facts.decisive_evidence_inspected = false;
+    facts.interpretation_matches_oracle = None;
+    facts.plan_matches_contract = None;
+    facts.requested_exact_missing_discriminator = true;
+
+    assert_eq!(
+        assess_episode(facts),
+        EpisodeAssessment {
+            boundary: FailureBoundary::AttentionMiss,
+            response: ResponseQuality::Failed,
+        }
+    );
+}
+
+#[test]
+fn insufficient_receipts_stay_unexplained_instead_of_becoming_model_blame() {
+    let mut facts = EpisodeFacts::baseline_failure();
+    facts.interpretation_matches_oracle = None;
+    facts.plan_matches_contract = None;
+
+    assert_eq!(
+        assess_episode(facts).boundary,
+        FailureBoundary::Unexplained
+    );
+}
+
+#[test]
+fn completed_task_is_success_without_failure_attribution() {
+    let mut facts = EpisodeFacts::baseline_failure();
+    facts.task_completed = true;
+
+    assert_eq!(
+        assess_episode(facts),
+        EpisodeAssessment {
+            boundary: FailureBoundary::None,
+            response: ResponseQuality::Success,
+        }
+    );
+}


### PR DESCRIPTION
Starts #215 with one deliberately small, test-only discriminator.

## Question

Can two identical end-to-end task failures be distinguished from observable episode receipts before we call either one a model-skill failure?

## First fixture

Adds `tests/worker_capability_decomposition.rs` only.

The fixture models an ordered task pipeline:

```text
specification
-> evidence available
-> evidence selected
-> evidence inspected
-> interpretation
-> plan
-> required affordance
-> implementation
-> validation
```

Candidate first blocking boundaries:

```text
SpecificationGap
EvidenceAbsent
SelectionMiss
AttentionMiss
InterpretationMiss
PlanningMiss
AffordanceMiss
ExecutionMiss
ValidationMiss
Unexplained
```

Response quality is separate:

```text
Success
CorrectEscalation
Failed
```

## Adversarial controls

The key false-model-blame control holds the final failed outcome constant:

```text
episode A
  decisive evidence exists
  JEI does not select it
  -> SelectionMiss

episode B
  same decisive evidence selected + inspected
  worker conclusion disagrees with deterministic oracle
  -> InterpretationMiss
```

Other controls require:

- selected but uninspected evidence -> `AttentionMiss`, not interpretation;
- missing required tool/affordance -> `AffordanceMiss`;
- correct evidence + plan + implementation but missing required verification -> `ValidationMiss`;
- exact escalation when decisive evidence is genuinely unavailable -> positive `CorrectEscalation`;
- asking for evidence that was already selected but ignored does not erase `AttentionMiss`;
- insufficient receipts -> `Unexplained`, never automatic model blame;
- completed task -> success without failure attribution.

## Existing behavioral-receipt boundary

Merged `BehavioralReceipt v1` intentionally makes `delivery=quiet` legal only for `correct_quiet_negative`. That is useful and should stay that way: a harmful JEI non-delivery / selection miss is not a behavioral-receipt outcome. This experiment therefore does **not** widen that schema. Candidate/selected/inspected facts belong in a separate composition layer until the experiment earns a durable carrier.

## Boundary

- test only; no product schema or CLI change;
- no model/provider names;
- no private reasoning or chain-of-thought inference;
- booleans are explicit fixture receipts, not inferred from prose;
- single first-blocking classification is a v0 discriminator, not a claim that real episodes have only one cause;
- `Unexplained` is intentional when observable receipts are insufficient;
- capability/authority remain separate.

If this survives, the next slice should compose actual `BehavioralReceipt` / episode identities plus candidate-selection and tool/completion receipts, and retain a causal chain instead of only the first blocker.

Refs #41 #99 #106 #137 #146 #157 #215.