### PR TITLE
research: surface actionable prior episodes before repeated work

### DIFF
--- a/examples/prior_episode_front.rs
+++ b/examples/prior_episode_front.rs
@@ -8,11 +8,11 @@ mod applicability;
 #[path = "../src/closure_episode.rs"]
 mod closure_episode;
 #[allow(dead_code)]
-#[path = "../src/review_memory.rs"]
-mod review_memory;
-#[allow(dead_code)]
 #[path = "../src/prior_episode_front.rs"]
 mod prior_episode_front;
+#[allow(dead_code)]
+#[path = "../src/review_memory.rs"]
+mod review_memory;
 
 use prior_episode_front::{
     MAX_PRIOR_EPISODE_FRONT_QUERY_BYTES, evaluate_prior_episode_front,

--- a/examples/prior_episode_front.rs
+++ b/examples/prior_episode_front.rs
@@ -1,0 +1,45 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+#[allow(dead_code)]
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[allow(dead_code)]
+#[path = "../src/closure_episode.rs"]
+mod closure_episode;
+#[allow(dead_code)]
+#[path = "../src/review_memory.rs"]
+mod review_memory;
+#[allow(dead_code)]
+#[path = "../src/prior_episode_front.rs"]
+mod prior_episode_front;
+
+use prior_episode_front::{
+    MAX_PRIOR_EPISODE_FRONT_QUERY_BYTES, evaluate_prior_episode_front,
+    parse_prior_episode_front_query,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("prior-episode-front: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_PRIOR_EPISODE_FRONT_QUERY_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_PRIOR_EPISODE_FRONT_QUERY_BYTES {
+        return Err(format!(
+            "prior-episode-front query exceeds the {MAX_PRIOR_EPISODE_FRONT_QUERY_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let query = parse_prior_episode_front_query(&bytes)?;
+    let front = evaluate_prior_episode_front(&query)?;
+    println!("{}", serde_json::to_string_pretty(&front)?);
+    Ok(())
+}

--- a/research/prior-episode-front.md
+++ b/research/prior-episode-front.md
@@ -1,0 +1,286 @@
+# Actionable prior-episode front
+
+Issue #217 tests a narrow delivery question over evidence Cultist has already earned:
+
+> Can the smallest historical fact that changes the first justified inspection appear at the front of task context without replacing the underlying review/closure evidence contracts?
+
+The v0 answer is a research-only composition layer.
+
+## Source semantics remain separate
+
+The front does not decide whether review evidence is current and does not decide whether an issue was cleared.
+
+It calls the existing source evaluators directly:
+
+```text
+ReviewMemoryQuery
+  -> evaluate_review_memory()
+
+IssueClosureEpisode
+  -> evaluate_closure_episode()
+```
+
+The complete source evaluation is retained inside every surfaced front item.
+
+This is important because the useful facts are already typed:
+
+```text
+review memory
+  concern lineage
+  exact-head applicability
+  prior outcome
+  reuse / refresh / need-context / new-thread disposition
+
+issue closure
+  lifecycle state
+  closure kind
+  explicit re-report relation
+  clearance UNKNOWN
+  inspect-prior-failure disposition
+```
+
+The front adds only a task-facing next-action projection.
+
+## Contract
+
+`src/prior_episode_front.rs` accepts a bounded list of tagged source inputs:
+
+```text
+review_memory
+  packet-local id
+  exact ReviewMemoryQuery
+
+issue_closure
+  packet-local id
+  exact IssueClosureEpisode
+```
+
+V0 admits at most 64 inputs inside a 512 KiB transport boundary.
+
+The output has two lists:
+
+```text
+items
+  historical evidence that earned front-of-context delivery
+
+quiet
+  admitted review-memory inputs that correctly produced no prior-episode item
+```
+
+There is no scalar score and no generic ranking. Surfaced items preserve admitted input order.
+
+## Review projection
+
+Source disposition maps narrowly:
+
+```text
+reuse_current_thread
+  -> reuse_existing_review_thread
+
+refresh_existing_thread
+  -> recompute_and_refresh_review_thread
+
+need_context + actual prior lineage
+  -> acquire_missing_review_coordinate
+
+new_thread
+  -> quiet receipt
+
+need_context + zero prior lineage
+  -> quiet receipt
+```
+
+The last distinction prevents a missing current head from manufacturing a fake historical episode when there is no prior matching concern.
+
+Quiet receipts retain the complete `ReviewMemoryEvaluation`, including unrelated same-key records when present.
+
+## Closure projection
+
+An admitted issue-closure episode currently has one earned source disposition:
+
+```text
+inspect_prior_failure
+```
+
+The front maps it to:
+
+```text
+inspect_prior_failure_and_rereport
+```
+
+and retains:
+
+- the complete `IssueClosureEvaluation`;
+- exact closure source reference;
+- exact re-report source reference;
+- duplicate-suggestion/rejection source references when that optional source evidence exists.
+
+Closing the later re-report does not remove this item because the source evaluator still reports clearance as `UNKNOWN`.
+
+## Real carrier A: PR-Agent review memory
+
+Retained input:
+
+```text
+research/prior-episode-front/pr-agent-2424.json
+```
+
+Human source: [PR-Agent PR #2424](https://redirect.github.com/The-PR-Agent/pr-agent/pull/2424).
+
+The exact coordinates were already executed and retained by merged #206:
+
+```text
+root review comment
+  3355870564
+
+reviewed head
+  8fb9e4e86b4794d39afba2d62413571cbc04a744
+
+resolution reply
+  3355925719
+
+current PR head
+  f6070fb1a45516565bbb8deeb02a1f66cec13d91
+
+path
+  pr_agent/git_providers/github_provider.py
+```
+
+The source review outcome is `patch_changed` because the selected direct reply is the retained resolution evidence used by #206.
+
+Expected front:
+
+```text
+source disposition
+  refresh_existing_thread
+
+prior outcome applicability
+  INVALID
+
+front next
+  recompute_and_refresh_review_thread
+```
+
+The front therefore preserves both halves of the desired behavior:
+
+```text
+remember the concern/thread
+expire the old resolution on the new head
+```
+
+## Real carrier B: Claude Code closure/re-report
+
+Retained input:
+
+```text
+research/prior-episode-front/claude-code-57507.json
+```
+
+Human sources: [Claude Code #31294](https://redirect.github.com/anthropics/claude-code/issues/31294) and [#57507](https://redirect.github.com/anthropics/claude-code/issues/57507).
+
+Merged #212 already executed the provider carrier and retained:
+
+```text
+#31294
+  closed by github-actions[bot]
+  state_reason not_planned
+  exact administrative-inactivity closure comment 4230270046
+
+#57507
+  explicitly re-reports #31294
+  later also closed
+```
+
+The canonical closure evidence intentionally retains the original `github.com/.../issues/new/choose` URL because exact source text is part of the admitted closure classifier. Human-facing links in this note use `redirect.github.com` under the repository link policy.
+
+Expected front:
+
+```text
+closure kind
+  administrative_inactive
+
+re-report
+  observed
+
+later state
+  closed
+
+clearance
+  UNKNOWN
+
+front next
+  inspect_prior_failure_and_rereport
+```
+
+This keeps `closed` useful without treating it as a repair receipt.
+
+## Quiet receipts are part of the experiment
+
+The front intentionally records why a review input stayed out of `items`:
+
+```text
+no_prior_review_lineage
+  no matching historical concern exists
+
+no_current_review_lineage
+  historical same-key records exist but belong to another work/scope lineage
+```
+
+That gives #137 a negative-control receipt. An A/B packet can prove that the front stayed quiet on an unrelated review instead of merely omitting it invisibly.
+
+## Standard controls
+
+`tests/prior_episode_front.rs` requires:
+
+- moved-head review -> recompute + refresh and preserved INVALID applicability;
+- exact-head review -> reuse current thread;
+- missing coordinate with prior lineage -> acquire coordinate;
+- missing coordinate without prior lineage -> quiet;
+- unrelated work lineage -> quiet with source evaluation retained;
+- explicit closure/re-report -> inspect with clearance UNKNOWN;
+- later re-report closure does not remove the front item;
+- empty input -> empty front + quiet set;
+- surfaced item order follows admitted input order;
+- duplicate packet-local IDs reject before projection;
+- source evaluator errors name the packet-local input ID;
+- unknown machine fields fail closed.
+
+`tests/prior_episode_front_real.rs` parses the two retained external carrier fixtures and asserts the same source semantics under the composition layer.
+
+## Behavioral gate
+
+This slice does not claim the front changed worker behavior.
+
+The retained carriers become held-out treatment packets for #137.
+
+Candidate A/B outcomes to observe:
+
+```text
+PR-Agent review carrier
+  prevented duplicate review interruption
+  prevented stale resolution reuse
+  reused an existing thread while recomputing current evidence
+
+Claude closure carrier
+  prevented closed-issue = fixed assumption
+  opened the prior reproduction or later discriminator earlier
+  reduced repeated issue archaeology
+```
+
+A useful behavioral receipt must name the concrete next action. Until then the front remains research output.
+
+## Boundary
+
+- research only;
+- no network/provider calls in the composition evaluator;
+- no similarity search;
+- no issue-title or review-text inference;
+- no concern-key generation;
+- no confidence/risk score;
+- no universal ordering beyond admitted input order;
+- no change to ordinary `cargo-cultist` commands or `AnalysisReport`;
+- no review, merge, issue-reopen, or external-effect authority.
+
+The front is allowed to be small precisely because the full typed source evidence remains attached and independently inspectable.
+
+Refs #18 #62 #67 #109 #123 #137 #192 #198 #202 #206 #207 #212 #217.

--- a/research/prior-episode-front/claude-code-57507.json
+++ b/research/prior-episode-front/claude-code-57507.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "inputs": [
+    {
+      "kind": "issue_closure",
+      "id": "claude-code:31294-to-57507:inactive-rereport",
+      "episode": {
+        "schema_version": 1,
+        "repository": "anthropics/claude-code",
+        "prior": {
+          "number": 31294,
+          "title": "[BUG] Subagents with `memory` field never create or update MEMORY.md — memory system not functional for Task() subagents",
+          "state": "closed",
+          "state_reason": "not_planned",
+          "created_at": "2026-03-06T00:41:05Z",
+          "closed_at": "2026-04-11T22:11:48Z",
+          "closed_by": "github-actions[bot]"
+        },
+        "later": {
+          "number": 57507,
+          "title": "[BUG] `memory:` field in subagent frontmatter not functional — reproduces on v2.1.137; tools allowlist appears to override auto-enable",
+          "state": "closed",
+          "state_reason": "not_planned",
+          "created_at": "2026-05-09T00:48:52Z",
+          "closed_at": "2026-06-09T11:10:27Z",
+          "closed_by": "github-actions[bot]"
+        },
+        "closure": {
+          "issue": 31294,
+          "comment_id": 4230270046,
+          "source_ref": "github:issue/31294/comment/4230270046",
+          "actor": "github-actions[bot]",
+          "kind": "administrative_inactive",
+          "evidence": "Closing for now — inactive for too long. Please [open a new issue](https://github.com/anthropics/claude-code/issues/new/choose) if this is still relevant."
+        },
+        "re_report": {
+          "from_issue": 57507,
+          "to_issue": 31294,
+          "relation": "re_report_of",
+          "source_ref": "github:issue/57507",
+          "evidence": "**Re-reporting** the bug from #31294 (closed-as-inactive 2026-04-11 by github-actions bot, not because it was fixed)."
+        },
+        "duplicate_challenge": {
+          "suggestion_comment_id": 4008755017,
+          "suggestion_source_ref": "github:issue/31294/comment/4008755017",
+          "suggestion_actor": "github-actions[bot]",
+          "suggestion_evidence": "Found 3 possible duplicate issues: #25140, #27942, and #29423. The bot announced possible automatic closure unless the reporter responded.",
+          "rejection_comment_id": 4008815491,
+          "rejection_source_ref": "github:issue/31294/comment/4008815491",
+          "rejection_actor": "Mationetap",
+          "rejection_evidence": "Not a duplicate of the suggested issues. The reporter distinguished all three suggested issues from the `memory: user|project|local` Task() subagent failure."
+        }
+      }
+    }
+  ]
+}

--- a/research/prior-episode-front/claude-code-57507.json
+++ b/research/prior-episode-front/claude-code-57507.json
@@ -39,16 +39,6 @@
           "relation": "re_report_of",
           "source_ref": "github:issue/57507",
           "evidence": "**Re-reporting** the bug from #31294 (closed-as-inactive 2026-04-11 by github-actions bot, not because it was fixed)."
-        },
-        "duplicate_challenge": {
-          "suggestion_comment_id": 4008755017,
-          "suggestion_source_ref": "github:issue/31294/comment/4008755017",
-          "suggestion_actor": "github-actions[bot]",
-          "suggestion_evidence": "Found 3 possible duplicate issues: #25140, #27942, and #29423. The bot announced possible automatic closure unless the reporter responded.",
-          "rejection_comment_id": 4008815491,
-          "rejection_source_ref": "github:issue/31294/comment/4008815491",
-          "rejection_actor": "Mationetap",
-          "rejection_evidence": "Not a duplicate of the suggested issues. The reporter distinguished all three suggested issues from the `memory: user|project|local` Task() subagent failure."
         }
       }
     }

--- a/research/prior-episode-front/pr-agent-2424.json
+++ b/research/prior-episode-front/pr-agent-2424.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "inputs": [
+    {
+      "kind": "review_memory",
+      "id": "pr-agent:2424:github-fallback-publish-state",
+      "query": {
+        "schema_version": 1,
+        "current": {
+          "concern_key": "pr-agent:persistent-inline-comments:github-fallback-publish-state",
+          "context": {
+            "repository": "The-PR-Agent/pr-agent",
+            "revision": "f6070fb1a45516565bbb8deeb02a1f66cec13d91",
+            "work": "github:pull/2424",
+            "path": "pr_agent/git_providers/github_provider.py"
+          }
+        },
+        "records": [
+          {
+            "event_id": "github:pull/2424/review-comment/3355870564",
+            "concern_key": "pr-agent:persistent-inline-comments:github-fallback-publish-state",
+            "source_ref": "github:pull/2424/review-comment/3355870564",
+            "subject": {
+              "repository": "The-PR-Agent/pr-agent",
+              "work": "github:pull/2424",
+              "revision": "8fb9e4e86b4794d39afba2d62413571cbc04a744",
+              "scope": {
+                "mode": "exact",
+                "path": "pr_agent/git_providers/github_provider.py"
+              }
+            },
+            "outcome": "patch_changed",
+            "resolution_ref": "github:pull/2424/review-comment/3355925719"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/prior_episode_front.rs
+++ b/src/prior_episode_front.rs
@@ -1,0 +1,285 @@
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::closure_episode::{
+    ClosureEpisodeDisposition, IssueClosureEpisode, IssueClosureEvaluation,
+    evaluate_closure_episode,
+};
+use crate::review_memory::{
+    ReviewMemoryEvaluation, ReviewMemoryQuery, ReviewThreadDisposition, evaluate_review_memory,
+};
+
+pub const PRIOR_EPISODE_FRONT_SCHEMA_VERSION: u32 = 1;
+pub const MAX_PRIOR_EPISODE_FRONT_QUERY_BYTES: usize = 512 * 1024;
+const MAX_INPUTS: usize = 64;
+const MAX_ID_BYTES: usize = 1024;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PriorEpisodeFrontQuery {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub inputs: Vec<PriorEpisodeInput>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PriorEpisodeInput {
+    ReviewMemory {
+        id: String,
+        query: ReviewMemoryQuery,
+    },
+    IssueClosure {
+        id: String,
+        episode: IssueClosureEpisode,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PriorEpisodeNextAction {
+    ReuseExistingReviewThread,
+    RecomputeAndRefreshReviewThread,
+    AcquireMissingReviewCoordinate,
+    InspectPriorFailureAndRereport,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PriorEpisodeFrontItem {
+    Review {
+        id: String,
+        next: PriorEpisodeNextAction,
+        evaluation: ReviewMemoryEvaluation,
+    },
+    IssueClosure {
+        id: String,
+        next: PriorEpisodeNextAction,
+        evaluation: IssueClosureEvaluation,
+        source_refs: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PriorEpisodeQuietReason {
+    NoPriorReviewLineage,
+    NoCurrentReviewLineage,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PriorEpisodeQuietReceipt {
+    pub id: String,
+    pub reason: PriorEpisodeQuietReason,
+    pub evaluation: ReviewMemoryEvaluation,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PriorEpisodeFront {
+    pub schema_version: u32,
+    pub items: Vec<PriorEpisodeFrontItem>,
+    pub quiet: Vec<PriorEpisodeQuietReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct PriorEpisodeFrontError {
+    message: String,
+}
+
+impl PriorEpisodeFrontError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for PriorEpisodeFrontError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for PriorEpisodeFrontError {}
+
+pub fn parse_prior_episode_front_query(
+    bytes: &[u8],
+) -> Result<PriorEpisodeFrontQuery, PriorEpisodeFrontError> {
+    if bytes.len() > MAX_PRIOR_EPISODE_FRONT_QUERY_BYTES {
+        return Err(PriorEpisodeFrontError::new(format!(
+            "prior-episode-front query exceeds the {MAX_PRIOR_EPISODE_FRONT_QUERY_BYTES}-byte limit"
+        )));
+    }
+    let query: PriorEpisodeFrontQuery = serde_json::from_slice(bytes).map_err(|error| {
+        PriorEpisodeFrontError::new(format!("invalid prior-episode-front JSON: {error}"))
+    })?;
+    validate_query(&query)?;
+    Ok(query)
+}
+
+pub fn evaluate_prior_episode_front(
+    query: &PriorEpisodeFrontQuery,
+) -> Result<PriorEpisodeFront, PriorEpisodeFrontError> {
+    validate_query(query)?;
+
+    let mut items = Vec::new();
+    let mut quiet = Vec::new();
+
+    for input in &query.inputs {
+        match input {
+            PriorEpisodeInput::ReviewMemory { id, query } => {
+                let evaluation = evaluate_review_memory(query).map_err(|error| {
+                    PriorEpisodeFrontError::new(format!(
+                        "prior-episode input `{id}` has invalid review-memory evidence: {error}"
+                    ))
+                })?;
+                project_review(id, evaluation, &mut items, &mut quiet);
+            }
+            PriorEpisodeInput::IssueClosure { id, episode } => {
+                let evaluation = evaluate_closure_episode(episode).map_err(|error| {
+                    PriorEpisodeFrontError::new(format!(
+                        "prior-episode input `{id}` has invalid issue-closure evidence: {error}"
+                    ))
+                })?;
+                if evaluation.disposition != ClosureEpisodeDisposition::InspectPriorFailure {
+                    return Err(PriorEpisodeFrontError::new(format!(
+                        "prior-episode input `{id}` returned unsupported issue-closure disposition"
+                    )));
+                }
+                items.push(PriorEpisodeFrontItem::IssueClosure {
+                    id: id.clone(),
+                    next: PriorEpisodeNextAction::InspectPriorFailureAndRereport,
+                    evaluation,
+                    source_refs: closure_source_refs(episode),
+                });
+            }
+        }
+    }
+
+    Ok(PriorEpisodeFront {
+        schema_version: PRIOR_EPISODE_FRONT_SCHEMA_VERSION,
+        items,
+        quiet,
+    })
+}
+
+fn project_review(
+    id: &str,
+    evaluation: ReviewMemoryEvaluation,
+    items: &mut Vec<PriorEpisodeFrontItem>,
+    quiet: &mut Vec<PriorEpisodeQuietReceipt>,
+) {
+    let has_prior_lineage = !evaluation.matches.is_empty();
+
+    match evaluation.disposition {
+        ReviewThreadDisposition::ReuseCurrentThread => {
+            items.push(PriorEpisodeFrontItem::Review {
+                id: id.to_string(),
+                next: PriorEpisodeNextAction::ReuseExistingReviewThread,
+                evaluation,
+            });
+        }
+        ReviewThreadDisposition::RefreshExistingThread => {
+            items.push(PriorEpisodeFrontItem::Review {
+                id: id.to_string(),
+                next: PriorEpisodeNextAction::RecomputeAndRefreshReviewThread,
+                evaluation,
+            });
+        }
+        ReviewThreadDisposition::NeedContext if has_prior_lineage => {
+            items.push(PriorEpisodeFrontItem::Review {
+                id: id.to_string(),
+                next: PriorEpisodeNextAction::AcquireMissingReviewCoordinate,
+                evaluation,
+            });
+        }
+        ReviewThreadDisposition::NeedContext => {
+            quiet.push(PriorEpisodeQuietReceipt {
+                id: id.to_string(),
+                reason: PriorEpisodeQuietReason::NoPriorReviewLineage,
+                evaluation,
+            });
+        }
+        ReviewThreadDisposition::NewThread => {
+            quiet.push(PriorEpisodeQuietReceipt {
+                id: id.to_string(),
+                reason: if has_prior_lineage {
+                    PriorEpisodeQuietReason::NoCurrentReviewLineage
+                } else {
+                    PriorEpisodeQuietReason::NoPriorReviewLineage
+                },
+                evaluation,
+            });
+        }
+    }
+}
+
+fn closure_source_refs(episode: &IssueClosureEpisode) -> Vec<String> {
+    let mut refs = vec![
+        episode.closure.source_ref.clone(),
+        episode.re_report.source_ref.clone(),
+    ];
+    if let Some(challenge) = &episode.duplicate_challenge {
+        refs.push(challenge.suggestion_source_ref.clone());
+        refs.push(challenge.rejection_source_ref.clone());
+    }
+    refs
+}
+
+fn validate_query(query: &PriorEpisodeFrontQuery) -> Result<(), PriorEpisodeFrontError> {
+    if query.schema_version != PRIOR_EPISODE_FRONT_SCHEMA_VERSION {
+        return Err(PriorEpisodeFrontError::new(format!(
+            "unsupported prior-episode-front schema {}; expected {PRIOR_EPISODE_FRONT_SCHEMA_VERSION}",
+            query.schema_version
+        )));
+    }
+    if query.inputs.len() > MAX_INPUTS {
+        return Err(PriorEpisodeFrontError::new(format!(
+            "prior-episode-front query may contain at most {MAX_INPUTS} inputs"
+        )));
+    }
+
+    let mut by_id = BTreeMap::<&str, &PriorEpisodeInput>::new();
+    for input in &query.inputs {
+        let id = input.id();
+        validate_id(id)?;
+        if let Some(existing) = by_id.insert(id, input) {
+            let kind = if existing == input {
+                "duplicate"
+            } else {
+                "conflicting duplicate"
+            };
+            return Err(PriorEpisodeFrontError::new(format!(
+                "{kind} prior-episode input id `{id}`"
+            )));
+        }
+    }
+    Ok(())
+}
+
+impl PriorEpisodeInput {
+    fn id(&self) -> &str {
+        match self {
+            Self::ReviewMemory { id, .. } | Self::IssueClosure { id, .. } => id,
+        }
+    }
+}
+
+fn validate_id(value: &str) -> Result<(), PriorEpisodeFrontError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_ID_BYTES
+        || value.contains('\0')
+        || value.chars().any(char::is_control)
+    {
+        return Err(PriorEpisodeFrontError::new(
+            "prior-episode input id must be a bounded non-empty canonical coordinate",
+        ));
+    }
+    Ok(())
+}

--- a/src/prior_episode_front.rs
+++ b/src/prior_episode_front.rs
@@ -34,7 +34,7 @@ pub enum PriorEpisodeInput {
     },
     IssueClosure {
         id: String,
-        episode: IssueClosureEpisode,
+        episode: Box<IssueClosureEpisode>,
     },
 }
 

--- a/tests/prior_episode_front.rs
+++ b/tests/prior_episode_front.rs
@@ -4,10 +4,10 @@
 mod applicability;
 #[path = "../src/closure_episode.rs"]
 mod closure_episode;
-#[path = "../src/review_memory.rs"]
-mod review_memory;
 #[path = "../src/prior_episode_front.rs"]
 mod prior_episode_front;
+#[path = "../src/review_memory.rs"]
+mod review_memory;
 
 use applicability::{ApplicabilityStatus, EvaluationContext, PathScope, PathScopeMode};
 use closure_episode::{
@@ -327,7 +327,12 @@ fn surfaced_items_preserve_admitted_input_order_across_species() {
         },
         PriorEpisodeInput::ReviewMemory {
             id: "review:quiet".to_string(),
-            query: review_query(Vec::new(), Some(HEAD_A), Some("github:pull/7"), Some("src/lib.rs")),
+            query: review_query(
+                Vec::new(),
+                Some(HEAD_A),
+                Some("github:pull/7"),
+                Some("src/lib.rs"),
+            ),
         },
         PriorEpisodeInput::IssueClosure {
             id: "issue:third".to_string(),
@@ -353,10 +358,19 @@ fn surfaced_items_preserve_admitted_input_order_across_species() {
 fn duplicate_packet_local_ids_reject_before_source_projection() {
     let input = PriorEpisodeInput::ReviewMemory {
         id: "duplicate".to_string(),
-        query: review_query(Vec::new(), Some(HEAD_A), Some("github:pull/7"), Some("src/lib.rs")),
+        query: review_query(
+            Vec::new(),
+            Some(HEAD_A),
+            Some("github:pull/7"),
+            Some("src/lib.rs"),
+        ),
     };
     let error = evaluate_prior_episode_front(&front(vec![input.clone(), input])).unwrap_err();
-    assert!(error.to_string().contains("duplicate prior-episode input id"));
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate prior-episode input id")
+    );
 }
 
 #[test]

--- a/tests/prior_episode_front.rs
+++ b/tests/prior_episode_front.rs
@@ -261,7 +261,7 @@ fn unrelated_review_lineage_stays_quiet_with_receipt() {
 fn explicit_closure_rereport_surfaces_inspection_with_unknown_clearance() {
     let output = evaluate_prior_episode_front(&front(vec![PriorEpisodeInput::IssueClosure {
         id: "issue:rereport".to_string(),
-        episode: closure_episode(IssueState::Open),
+        episode: Box::new(closure_episode(IssueState::Open)),
     }]))
     .unwrap();
 
@@ -295,7 +295,7 @@ fn explicit_closure_rereport_surfaces_inspection_with_unknown_clearance() {
 fn closing_later_rereport_does_not_remove_front_item() {
     let output = evaluate_prior_episode_front(&front(vec![PriorEpisodeInput::IssueClosure {
         id: "issue:closed-rereport".to_string(),
-        episode: closure_episode(IssueState::Closed),
+        episode: Box::new(closure_episode(IssueState::Closed)),
     }]))
     .unwrap();
 
@@ -336,7 +336,7 @@ fn surfaced_items_preserve_admitted_input_order_across_species() {
         },
         PriorEpisodeInput::IssueClosure {
             id: "issue:third".to_string(),
-            episode: closure_episode(IssueState::Open),
+            episode: Box::new(closure_episode(IssueState::Open)),
         },
     ]))
     .unwrap();

--- a/tests/prior_episode_front.rs
+++ b/tests/prior_episode_front.rs
@@ -1,0 +1,391 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/closure_episode.rs"]
+mod closure_episode;
+#[path = "../src/review_memory.rs"]
+mod review_memory;
+#[path = "../src/prior_episode_front.rs"]
+mod prior_episode_front;
+
+use applicability::{ApplicabilityStatus, EvaluationContext, PathScope, PathScopeMode};
+use closure_episode::{
+    CLOSURE_EPISODE_SCHEMA_VERSION, ClearanceStatus, ClosureKind, ClosureReceipt,
+    DuplicateChallengeReceipt, IssueClosureEpisode, IssueSnapshot, IssueState, ReReportReceipt,
+    ReReportRelation,
+};
+use prior_episode_front::{
+    PRIOR_EPISODE_FRONT_SCHEMA_VERSION, PriorEpisodeFrontItem, PriorEpisodeFrontQuery,
+    PriorEpisodeInput, PriorEpisodeNextAction, PriorEpisodeQuietReason,
+    evaluate_prior_episode_front, parse_prior_episode_front_query,
+};
+use review_memory::{
+    CurrentConcern, REVIEW_MEMORY_SCHEMA_VERSION, ReviewMemoryQuery, ReviewMemoryRecord,
+    ReviewOutcome, ReviewSubject, ReviewThreadDisposition,
+};
+
+const HEAD_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const HEAD_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+fn review_record(revision: &str, work: &str) -> ReviewMemoryRecord {
+    ReviewMemoryRecord {
+        event_id: "github:pull/7/review-comment/100".to_string(),
+        concern_key: "review:fixture:unused-result".to_string(),
+        source_ref: "github:pull/7/review-comment/100".to_string(),
+        subject: ReviewSubject {
+            repository: "owner/repo".to_string(),
+            work: work.to_string(),
+            revision: revision.to_string(),
+            scope: Some(PathScope {
+                mode: PathScopeMode::Exact,
+                path: "src/lib.rs".to_string(),
+            }),
+        },
+        outcome: ReviewOutcome::Dismissed,
+        resolution_ref: Some("github:pull/7/review-comment/101".to_string()),
+    }
+}
+
+fn review_query(
+    records: Vec<ReviewMemoryRecord>,
+    revision: Option<&str>,
+    work: Option<&str>,
+    path: Option<&str>,
+) -> ReviewMemoryQuery {
+    ReviewMemoryQuery {
+        schema_version: REVIEW_MEMORY_SCHEMA_VERSION,
+        current: CurrentConcern {
+            concern_key: "review:fixture:unused-result".to_string(),
+            context: EvaluationContext {
+                repository: Some("owner/repo".to_string()),
+                revision: revision.map(str::to_string),
+                work: work.map(str::to_string),
+                path: path.map(str::to_string),
+            },
+        },
+        records,
+    }
+}
+
+fn issue(number: u64, state: IssueState) -> IssueSnapshot {
+    IssueSnapshot {
+        number,
+        title: format!("issue {number}"),
+        state,
+        state_reason: Some("not_planned".to_string()),
+        created_at: "2026-01-01T00:00:00Z".to_string(),
+        closed_at: (state == IssueState::Closed).then(|| "2026-01-02T00:00:00Z".to_string()),
+        closed_by: (state == IssueState::Closed).then(|| "github-actions[bot]".to_string()),
+    }
+}
+
+fn closure_episode(later_state: IssueState) -> IssueClosureEpisode {
+    IssueClosureEpisode {
+        schema_version: CLOSURE_EPISODE_SCHEMA_VERSION,
+        repository: "owner/repo".to_string(),
+        prior: issue(10, IssueState::Closed),
+        later: issue(20, later_state),
+        closure: ClosureReceipt {
+            issue: 10,
+            comment_id: 100,
+            source_ref: "github:issue/10/comment/100".to_string(),
+            actor: "github-actions[bot]".to_string(),
+            kind: ClosureKind::AdministrativeInactive,
+            evidence: "Closing for now — inactive for too long. Please [open a new issue](https://github.com/owner/repo/issues/new/choose) if this is still relevant.".to_string(),
+        },
+        re_report: ReReportReceipt {
+            from_issue: 20,
+            to_issue: 10,
+            relation: ReReportRelation::ReReportOf,
+            source_ref: "github:issue/20".to_string(),
+            evidence: "**Re-reporting** the bug from #10 (closed earlier).".to_string(),
+        },
+        duplicate_challenge: Some(DuplicateChallengeReceipt {
+            suggestion_comment_id: 90,
+            suggestion_source_ref: "github:issue/10/comment/90".to_string(),
+            suggestion_actor: "github-actions[bot]".to_string(),
+            suggestion_evidence: "Found possible duplicate issues.".to_string(),
+            rejection_comment_id: 91,
+            rejection_source_ref: "github:issue/10/comment/91".to_string(),
+            rejection_actor: "reporter".to_string(),
+            rejection_evidence: "Not a duplicate of the suggested issues.".to_string(),
+        }),
+    }
+}
+
+fn front(inputs: Vec<PriorEpisodeInput>) -> PriorEpisodeFrontQuery {
+    PriorEpisodeFrontQuery {
+        schema_version: PRIOR_EPISODE_FRONT_SCHEMA_VERSION,
+        inputs,
+    }
+}
+
+#[test]
+fn moved_head_review_surfaces_recompute_and_refresh() {
+    let output = evaluate_prior_episode_front(&front(vec![PriorEpisodeInput::ReviewMemory {
+        id: "review:stale".to_string(),
+        query: review_query(
+            vec![review_record(HEAD_A, "github:pull/7")],
+            Some(HEAD_B),
+            Some("github:pull/7"),
+            Some("src/lib.rs"),
+        ),
+    }]))
+    .unwrap();
+
+    assert_eq!(output.items.len(), 1);
+    assert!(output.quiet.is_empty());
+    let PriorEpisodeFrontItem::Review {
+        id,
+        next,
+        evaluation,
+    } = &output.items[0]
+    else {
+        panic!("expected review front item")
+    };
+    assert_eq!(id, "review:stale");
+    assert_eq!(
+        *next,
+        PriorEpisodeNextAction::RecomputeAndRefreshReviewThread
+    );
+    assert_eq!(
+        evaluation.disposition,
+        ReviewThreadDisposition::RefreshExistingThread
+    );
+    assert_eq!(
+        evaluation.matches[0].applicability.status,
+        ApplicabilityStatus::Invalid
+    );
+}
+
+#[test]
+fn exact_head_review_surfaces_thread_reuse() {
+    let output = evaluate_prior_episode_front(&front(vec![PriorEpisodeInput::ReviewMemory {
+        id: "review:current".to_string(),
+        query: review_query(
+            vec![review_record(HEAD_A, "github:pull/7")],
+            Some(HEAD_A),
+            Some("github:pull/7"),
+            Some("src/lib.rs"),
+        ),
+    }]))
+    .unwrap();
+
+    let PriorEpisodeFrontItem::Review {
+        next, evaluation, ..
+    } = &output.items[0]
+    else {
+        panic!("expected review front item")
+    };
+    assert_eq!(*next, PriorEpisodeNextAction::ReuseExistingReviewThread);
+    assert_eq!(
+        evaluation.disposition,
+        ReviewThreadDisposition::ReuseCurrentThread
+    );
+}
+
+#[test]
+fn missing_coordinate_with_prior_lineage_surfaces_need_context() {
+    let output = evaluate_prior_episode_front(&front(vec![PriorEpisodeInput::ReviewMemory {
+        id: "review:missing-head".to_string(),
+        query: review_query(
+            vec![review_record(HEAD_A, "github:pull/7")],
+            None,
+            Some("github:pull/7"),
+            Some("src/lib.rs"),
+        ),
+    }]))
+    .unwrap();
+
+    let PriorEpisodeFrontItem::Review {
+        next, evaluation, ..
+    } = &output.items[0]
+    else {
+        panic!("expected review front item")
+    };
+    assert_eq!(
+        *next,
+        PriorEpisodeNextAction::AcquireMissingReviewCoordinate
+    );
+    assert_eq!(evaluation.disposition, ReviewThreadDisposition::NeedContext);
+}
+
+#[test]
+fn missing_coordinate_without_prior_lineage_stays_quiet() {
+    let output = evaluate_prior_episode_front(&front(vec![PriorEpisodeInput::ReviewMemory {
+        id: "review:no-memory".to_string(),
+        query: review_query(Vec::new(), None, Some("github:pull/7"), Some("src/lib.rs")),
+    }]))
+    .unwrap();
+
+    assert!(output.items.is_empty());
+    assert_eq!(output.quiet.len(), 1);
+    assert_eq!(
+        output.quiet[0].reason,
+        PriorEpisodeQuietReason::NoPriorReviewLineage
+    );
+    assert_eq!(
+        output.quiet[0].evaluation.disposition,
+        ReviewThreadDisposition::NeedContext
+    );
+}
+
+#[test]
+fn unrelated_review_lineage_stays_quiet_with_receipt() {
+    let output = evaluate_prior_episode_front(&front(vec![PriorEpisodeInput::ReviewMemory {
+        id: "review:other-work".to_string(),
+        query: review_query(
+            vec![review_record(HEAD_A, "github:pull/7")],
+            Some(HEAD_A),
+            Some("github:pull/8"),
+            Some("src/lib.rs"),
+        ),
+    }]))
+    .unwrap();
+
+    assert!(output.items.is_empty());
+    assert_eq!(output.quiet.len(), 1);
+    assert_eq!(
+        output.quiet[0].reason,
+        PriorEpisodeQuietReason::NoCurrentReviewLineage
+    );
+    assert_eq!(
+        output.quiet[0].evaluation.disposition,
+        ReviewThreadDisposition::NewThread
+    );
+    assert_eq!(output.quiet[0].evaluation.matches.len(), 1);
+}
+
+#[test]
+fn explicit_closure_rereport_surfaces_inspection_with_unknown_clearance() {
+    let output = evaluate_prior_episode_front(&front(vec![PriorEpisodeInput::IssueClosure {
+        id: "issue:rereport".to_string(),
+        episode: closure_episode(IssueState::Open),
+    }]))
+    .unwrap();
+
+    assert_eq!(output.items.len(), 1);
+    let PriorEpisodeFrontItem::IssueClosure {
+        next,
+        evaluation,
+        source_refs,
+        ..
+    } = &output.items[0]
+    else {
+        panic!("expected issue-closure front item")
+    };
+    assert_eq!(
+        *next,
+        PriorEpisodeNextAction::InspectPriorFailureAndRereport
+    );
+    assert_eq!(evaluation.clearance, ClearanceStatus::Unknown);
+    assert_eq!(
+        source_refs,
+        &vec![
+            "github:issue/10/comment/100".to_string(),
+            "github:issue/20".to_string(),
+            "github:issue/10/comment/90".to_string(),
+            "github:issue/10/comment/91".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn closing_later_rereport_does_not_remove_front_item() {
+    let output = evaluate_prior_episode_front(&front(vec![PriorEpisodeInput::IssueClosure {
+        id: "issue:closed-rereport".to_string(),
+        episode: closure_episode(IssueState::Closed),
+    }]))
+    .unwrap();
+
+    let PriorEpisodeFrontItem::IssueClosure { evaluation, .. } = &output.items[0] else {
+        panic!("expected issue-closure front item")
+    };
+    assert_eq!(evaluation.later_state, IssueState::Closed);
+    assert_eq!(evaluation.clearance, ClearanceStatus::Unknown);
+}
+
+#[test]
+fn empty_input_produces_empty_front_and_quiet_set() {
+    let output = evaluate_prior_episode_front(&front(Vec::new())).unwrap();
+    assert!(output.items.is_empty());
+    assert!(output.quiet.is_empty());
+}
+
+#[test]
+fn surfaced_items_preserve_admitted_input_order_across_species() {
+    let output = evaluate_prior_episode_front(&front(vec![
+        PriorEpisodeInput::ReviewMemory {
+            id: "review:first".to_string(),
+            query: review_query(
+                vec![review_record(HEAD_A, "github:pull/7")],
+                Some(HEAD_B),
+                Some("github:pull/7"),
+                Some("src/lib.rs"),
+            ),
+        },
+        PriorEpisodeInput::ReviewMemory {
+            id: "review:quiet".to_string(),
+            query: review_query(Vec::new(), Some(HEAD_A), Some("github:pull/7"), Some("src/lib.rs")),
+        },
+        PriorEpisodeInput::IssueClosure {
+            id: "issue:third".to_string(),
+            episode: closure_episode(IssueState::Open),
+        },
+    ]))
+    .unwrap();
+
+    assert_eq!(output.items.len(), 2);
+    assert_eq!(output.quiet.len(), 1);
+    assert!(matches!(
+        &output.items[0],
+        PriorEpisodeFrontItem::Review { id, .. } if id == "review:first"
+    ));
+    assert!(matches!(
+        &output.items[1],
+        PriorEpisodeFrontItem::IssueClosure { id, .. } if id == "issue:third"
+    ));
+    assert_eq!(output.quiet[0].id, "review:quiet");
+}
+
+#[test]
+fn duplicate_packet_local_ids_reject_before_source_projection() {
+    let input = PriorEpisodeInput::ReviewMemory {
+        id: "duplicate".to_string(),
+        query: review_query(Vec::new(), Some(HEAD_A), Some("github:pull/7"), Some("src/lib.rs")),
+    };
+    let error = evaluate_prior_episode_front(&front(vec![input.clone(), input])).unwrap_err();
+    assert!(error.to_string().contains("duplicate prior-episode input id"));
+}
+
+#[test]
+fn source_evaluator_error_names_packet_local_id() {
+    let output = evaluate_prior_episode_front(&front(vec![PriorEpisodeInput::ReviewMemory {
+        id: "bad-review".to_string(),
+        query: review_query(
+            vec![review_record(
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "github:pull/7",
+            )],
+            Some(HEAD_B),
+            Some("github:pull/7"),
+            Some("src/lib.rs"),
+        ),
+    }]));
+    let error = output.unwrap_err();
+    assert!(error.to_string().contains("`bad-review`"));
+    assert!(error.to_string().contains("review-memory evidence"));
+}
+
+#[test]
+fn parser_rejects_unknown_machine_fields() {
+    let mut value = serde_json::to_value(front(Vec::new())).unwrap();
+    value
+        .as_object_mut()
+        .unwrap()
+        .insert("score".to_string(), serde_json::json!(1.0));
+    let bytes = serde_json::to_vec(&value).unwrap();
+    let error = parse_prior_episode_front_query(&bytes).unwrap_err();
+    assert!(error.to_string().contains("unknown field"));
+}

--- a/tests/prior_episode_front_real.rs
+++ b/tests/prior_episode_front_real.rs
@@ -4,10 +4,10 @@
 mod applicability;
 #[path = "../src/closure_episode.rs"]
 mod closure_episode;
-#[path = "../src/review_memory.rs"]
-mod review_memory;
 #[path = "../src/prior_episode_front.rs"]
 mod prior_episode_front;
+#[path = "../src/review_memory.rs"]
+mod review_memory;
 
 use applicability::ApplicabilityStatus;
 use closure_episode::{ClearanceStatus, ClosureKind, IssueState};
@@ -88,8 +88,6 @@ fn claude_code_rereport_front_keeps_clearance_unknown_after_second_close() {
         &vec![
             "github:issue/31294/comment/4230270046".to_string(),
             "github:issue/57507".to_string(),
-            "github:issue/31294/comment/4008755017".to_string(),
-            "github:issue/31294/comment/4008815491".to_string(),
         ]
     );
 }

--- a/tests/prior_episode_front_real.rs
+++ b/tests/prior_episode_front_real.rs
@@ -1,0 +1,95 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/closure_episode.rs"]
+mod closure_episode;
+#[path = "../src/review_memory.rs"]
+mod review_memory;
+#[path = "../src/prior_episode_front.rs"]
+mod prior_episode_front;
+
+use applicability::ApplicabilityStatus;
+use closure_episode::{ClearanceStatus, ClosureKind, IssueState};
+use prior_episode_front::{
+    PriorEpisodeFrontItem, PriorEpisodeNextAction, evaluate_prior_episode_front,
+    parse_prior_episode_front_query,
+};
+use review_memory::ReviewThreadDisposition;
+
+#[test]
+fn pr_agent_2424_front_preserves_stale_review_invalidation() {
+    let query = parse_prior_episode_front_query(include_bytes!(
+        "../research/prior-episode-front/pr-agent-2424.json"
+    ))
+    .unwrap();
+    let front = evaluate_prior_episode_front(&query).unwrap();
+
+    assert_eq!(front.items.len(), 1);
+    assert!(front.quiet.is_empty());
+    let PriorEpisodeFrontItem::Review {
+        id,
+        next,
+        evaluation,
+    } = &front.items[0]
+    else {
+        panic!("expected review item")
+    };
+    assert_eq!(id, "pr-agent:2424:github-fallback-publish-state");
+    assert_eq!(
+        *next,
+        PriorEpisodeNextAction::RecomputeAndRefreshReviewThread
+    );
+    assert_eq!(
+        evaluation.disposition,
+        ReviewThreadDisposition::RefreshExistingThread
+    );
+    assert_eq!(evaluation.matches.len(), 1);
+    assert_eq!(
+        evaluation.matches[0].applicability.status,
+        ApplicabilityStatus::Invalid
+    );
+    assert_eq!(
+        evaluation.matches[0].source_ref,
+        "github:pull/2424/review-comment/3355870564"
+    );
+}
+
+#[test]
+fn claude_code_rereport_front_keeps_clearance_unknown_after_second_close() {
+    let query = parse_prior_episode_front_query(include_bytes!(
+        "../research/prior-episode-front/claude-code-57507.json"
+    ))
+    .unwrap();
+    let front = evaluate_prior_episode_front(&query).unwrap();
+
+    assert_eq!(front.items.len(), 1);
+    assert!(front.quiet.is_empty());
+    let PriorEpisodeFrontItem::IssueClosure {
+        id,
+        next,
+        evaluation,
+        source_refs,
+    } = &front.items[0]
+    else {
+        panic!("expected issue-closure item")
+    };
+    assert_eq!(id, "claude-code:31294-to-57507:inactive-rereport");
+    assert_eq!(
+        *next,
+        PriorEpisodeNextAction::InspectPriorFailureAndRereport
+    );
+    assert_eq!(evaluation.prior_state, IssueState::Closed);
+    assert_eq!(evaluation.later_state, IssueState::Closed);
+    assert_eq!(evaluation.closure_kind, ClosureKind::AdministrativeInactive);
+    assert_eq!(evaluation.clearance, ClearanceStatus::Unknown);
+    assert_eq!(
+        source_refs,
+        &vec![
+            "github:issue/31294/comment/4230270046".to_string(),
+            "github:issue/57507".to_string(),
+            "github:issue/31294/comment/4008755017".to_string(),
+            "github:issue/31294/comment/4008815491".to_string(),
+        ]
+    );
+}


### PR DESCRIPTION
## What

Progress #217 by composing two already-earned historical evidence contracts into a bounded front-of-context projection:

```text
ReviewMemoryQuery
IssueClosureEpisode
  -> existing source evaluators
  -> actionable prior-episode front
```

The composition layer does not reimplement applicability, closure, or clearance semantics. Every surfaced item retains the complete source evaluation.

## Front actions

```text
review current
  reuse_existing_review_thread

review stale
  recompute_and_refresh_review_thread

review need-context + actual prior lineage
  acquire_missing_review_coordinate

issue closure + explicit re-report
  inspect_prior_failure_and_rereport
```

`review_memory -> new_thread` stays quiet. A missing current review coordinate with zero prior matching lineage also stays quiet, so missing context alone cannot manufacture a fake historical episode.

Quiet cases retain the complete `ReviewMemoryEvaluation` as an omission/negative-control receipt.

## Real carriers

### PR-Agent

Retains the exact #206 provider carrier from [PR-Agent PR #2424](https://redirect.github.com/The-PR-Agent/pr-agent/pull/2424):

```text
root review comment 3355870564
reviewed head         8fb9e4e86b4794d39afba2d62413571cbc04a744
resolution reply      3355925719
current head          f6070fb1a45516565bbb8deeb02a1f66cec13d91
```

Expected front:

```text
source disposition   refresh_existing_thread
old applicability    INVALID
next                  recompute_and_refresh_review_thread
```

### Claude Code

Retains the #212 carrier from [Claude Code #31294](https://redirect.github.com/anthropics/claude-code/issues/31294) -> [#57507](https://redirect.github.com/anthropics/claude-code/issues/57507).

Expected front:

```text
closure kind          administrative_inactive
later issue           closed
clearance             UNKNOWN
next                  inspect_prior_failure_and_rereport
```

The canonical closure evidence keeps its original `github.com/.../issues/new/choose` URL because that exact source string is part of the admitted classifier; human-facing links use `redirect.github.com` under the new repository policy.

## Verification

Standard controls cover current/stale/missing/unrelated review cases, quiet receipts, closure/re-report semantics, later re-closure, ordering, duplicate IDs, source-error provenance, fail-closed JSON, and empty inputs.

Two retained real fixtures are also parsed by the ordinary Rust suite:

- `research/prior-episode-front/pr-agent-2424.json`
- `research/prior-episode-front/claude-code-57507.json`

## Behavioral boundary

This PR does **not** claim that front delivery changes worker behavior. These become held-out treatment packets for #137. Promotion requires an observed consequence such as avoiding duplicate review interruption, rejecting stale review resolution, avoiding `closed = fixed`, or reducing repeated archaeology.

No ordinary CLI/report-schema change; no provider/network calls; no score/ranking/similarity model; no review/merge/reopen authority.

Closes #217.

Refs #18 #62 #67 #109 #123 #137 #192 #198 #202 #206 #207 #212.