### PR TITLE
research: close the Rust edit-class observation loop

### DIFF
--- a/examples/rust_edit_class_observation.rs
+++ b/examples/rust_edit_class_observation.rs
@@ -1,0 +1,68 @@
+use std::env;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+#[allow(dead_code)]
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[allow(dead_code)]
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[allow(dead_code)]
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[allow(dead_code)]
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[allow(dead_code)]
+#[path = "../src/justification.rs"]
+mod justification;
+#[allow(dead_code)]
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[allow(dead_code)]
+#[path = "../src/observation_probe_bridge.rs"]
+mod observation_probe_bridge;
+#[allow(dead_code)]
+#[path = "../src/rust_edit_class_source.rs"]
+mod rust_edit_class_source;
+
+use rust_edit_class_source::{RustEditClassSubject, collect_rust_edit_class_source};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("rust-edit-class-observation: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut args = env::args().skip(1);
+    let root = PathBuf::from(
+        args.next()
+            .ok_or("usage: rust_edit_class_observation REPO_ROOT REPOSITORY REVISION FILE")?,
+    );
+    let repository = args
+        .next()
+        .ok_or("usage: rust_edit_class_observation REPO_ROOT REPOSITORY REVISION FILE")?;
+    let revision = args
+        .next()
+        .ok_or("usage: rust_edit_class_observation REPO_ROOT REPOSITORY REVISION FILE")?;
+    let path = args
+        .next()
+        .ok_or("usage: rust_edit_class_observation REPO_ROOT REPOSITORY REVISION FILE")?;
+    if args.next().is_some() {
+        return Err("usage: rust_edit_class_observation REPO_ROOT REPOSITORY REVISION FILE".into());
+    }
+
+    let result = collect_rust_edit_class_source(
+        Path::new(&root),
+        &RustEditClassSubject {
+            repository,
+            revision,
+            path,
+        },
+    )?;
+    println!("{}", serde_json::to_string_pretty(&result)?);
+    Ok(())
+}

--- a/examples/rust_syntax_cohort.rs
+++ b/examples/rust_syntax_cohort.rs
@@ -20,7 +20,7 @@ struct Commit {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum RustEditClass {
+pub(crate) enum RustEditClass {
     SyntaxChanged,
     CommentsOrWhitespaceOnly,
     Unclassified,
@@ -230,7 +230,7 @@ fn commit_metadata(root: &Path, sha: &str) -> Result<(String, BTreeSet<PathBuf>)
     Ok((subject.trim().to_string(), paths))
 }
 
-fn classify_rust_edit(root: &Path, sha: &str, anchor: &Path) -> RustEditClass {
+pub(crate) fn classify_rust_edit(root: &Path, sha: &str, anchor: &Path) -> RustEditClass {
     let after = source_at_revision(root, sha, anchor);
     let before = source_at_revision(root, &format!("{sha}^"), anchor);
     let (Some(before), Some(after)) = (before, after) else {

--- a/research/discriminator-observations/cultist-v1.json
+++ b/research/discriminator-observations/cultist-v1.json
@@ -18,15 +18,15 @@
     {
       "observation_id": "history/oxc-edit-class-v1:current-edit-class",
       "discriminator_id": "edit_class",
-      "subject_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588:crates/oxc_linter/src/rules.rs",
-      "source_receipt": "research:rust-syntax-cohort-replay.md",
+      "subject_ref": "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs",
+      "source_receipt": "github-actions:run/32257998359#focused-oxc-edit-class",
       "value_state": {
         "state": "known",
         "value_ref": "syntax_changed"
       },
       "applicability": {
         "status": "applies",
-        "receipt_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588"
+        "receipt_ref": "github-actions:run/32257998359#focused-oxc-applicability"
       }
     },
     {

--- a/research/rust-edit-class-observation-loop.md
+++ b/research/rust-edit-class-observation-loop.md
@@ -1,0 +1,269 @@
+# Rust edit-class observation acquisition loop
+
+Tracking: #220, building on #54, #185, #210, and #216.
+
+## Question
+
+Can one retained analyzer family complete the full deterministic loop:
+
+```text
+noncurrent source discriminator
+-> explicit source bridge
+-> existing evidence planner
+-> source probe execution
+-> v2 current observation
+-> current frontier
+```
+
+without copying source semantics into the generic bridge or planner?
+
+The first carrier uses the Oxc `edit_class` discriminator because #54 already earned a deterministic producer: select a focused non-merge commit that changes one Rust anchor, compare that anchor with its first parent, tokenize both versions with `proc_macro2`, recursively remove doc attributes, and classify whether lexical Rust syntax changed.
+
+## Reuse boundary
+
+`examples/rust_syntax_cohort.rs` remains the owning classifier. This carrier changes only visibility of:
+
+```text
+RustEditClass
+classify_rust_edit(...)
+```
+
+so the source adapter can call that exact implementation. The token/fingerprint/classification logic is unchanged.
+
+## Focused-commit admission
+
+The first public carrier exposed an important precondition that had been implicit in #54.
+
+#54 never called the classifier on arbitrary repository heads. It first selected commits from:
+
+```text
+git log --no-merges -- anchor.rs
+```
+
+then classified each selected commit against its first parent.
+
+Calling the raw token comparator at pinned Oxc repository head:
+
+```text
+8783524015b1e6ff1c39ccf426df0bb07cbbc588
+```
+
+produced equal `rules.rs` token streams because that repository commit does not change `crates/oxc_linter/src/rules.rs`. Without an explicit focus check, unchanged-anchor equality was indistinguishable from a comment/docs/whitespace-only edit.
+
+The source adapter now admits a value only when:
+
+```text
+revision has exactly one parent
++ exact anchor path changed in that revision
+```
+
+Otherwise it emits value UNKNOWN with one of:
+
+```text
+rust-edit-class:not-single-parent:...
+rust-edit-class:anchor-unchanged:...
+```
+
+This keeps repository/head applicability separate from whether an `edit_class` observation exists for the anchor at that commit.
+
+## Source contract
+
+`src/rust_edit_class_source.rs` owns one source-specific record:
+
+```text
+RustEditClassSubject
+  repository
+  exact 40-hex revision
+  normalized repository-relative .rs path
+```
+
+Collection emits:
+
+```text
+RustEditClassSourceResult
+  subject
+  current_head
+  bridge
+  probe
+  observation
+```
+
+### Bridge
+
+The adapter explicitly maps:
+
+```text
+edit_class @ repository@revision:path
+-> probe kind rust_edit_class
+-> target same exact subject ref
+-> repository + revision + exact-path clearing requirements
+```
+
+The bridge carries a source receipt. No generic string equality convention is introduced.
+
+### Probe
+
+The admitted probe is read-only and forecasts the source work performed by the focused first-parent classifier:
+
+```text
+git subprocesses: 5
+Rust files parsed: 2
+remote requests: 0
+effectful executions: 0
+```
+
+The existing #145 planner remains responsible for capability, clearing-coordinate applicability, cost, and effect authority.
+
+### Observation
+
+For an admitted focused commit, the adapter maps only the existing classifier result:
+
+```text
+SyntaxChanged
+  -> KNOWN syntax_changed
+
+CommentsOrWhitespaceOnly
+  -> KNOWN comments_or_docs_only
+
+Unclassified
+  -> UNKNOWN with exact source reason receipt
+```
+
+A root/merge/unrelated-anchor revision stays UNKNOWN before this mapping.
+
+Current applicability is evaluated through the shared #123 evaluator against:
+
+```text
+required
+  repository
+  exact revision
+  exact file path
+
+current
+  repository label
+  git rev-parse HEAD
+  exact file path
+```
+
+A moved checkout can therefore preserve an old known edit class while applicability becomes INVALID. It cannot claim the old classification is current.
+
+Every emitted observation is revalidated through the v2 #210/#185 observation batch contract before return.
+
+## Local deterministic controls
+
+`tests/rust_edit_class_source.rs` creates temporary local Git repositories and exercises the actual retained classifier:
+
+1. lexical Rust code change -> KNOWN `syntax_changed` + APPLIES;
+2. comment-only change -> KNOWN `comments_or_docs_only` + APPLIES;
+3. root commit with no single parent -> value UNKNOWN + APPLIES;
+4. unrelated repository commit that leaves the anchor unchanged -> value UNKNOWN `anchor-unchanged` + APPLIES;
+5. previously known syntax edit after HEAD advances -> KNOWN old value + INVALID;
+6. exact source bridge/probe is planned by #216/#145;
+7. inserting the produced observation changes the exact v2 frontier from MISSING to CURRENT;
+8. emitted observation round-trips through v2 validation;
+9. traversing/non-Rust paths and non-exact revisions fail closed.
+
+## Retained public Oxc carrier
+
+The workflow pins the historical repository window at:
+
+```text
+oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588
+anchor: crates/oxc_linter/src/rules.rs
+```
+
+It keeps that repository head as the negative control:
+
+```text
+8783524...
+anchor unchanged
+-> value UNKNOWN / anchor-unchanged
+-> applicability APPLIES to the exact repo/head/path coordinate
+```
+
+Within that pinned history, the workflow resolves the latest actual focused anchor commit through the same admission species as #54:
+
+```text
+228e8e0f85c0e7aeded02c5e27fd810004d3b41a
+fix(linter): resolve inactive React compiler rules (#25830)
+```
+
+The workflow then executes three independent readers in sequence on that exact focused commit:
+
+```text
+rust_edit_class_observation
+  -> source bridge + probe + KNOWN syntax_changed observation
+
+observation_probe_plan
+  -> MISSING frontier + exact source bridge
+  -> selected read-only probe
+
+observation_frontiers
+  -> produced observation
+  -> CURRENT edit_class frontier
+```
+
+The resulting source subject is:
+
+```text
+oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs
+```
+
+This corrects the inherited #185 retained observation coordinate. The pinned repository head remains the historical cohort window and explicit unchanged-anchor negative control; the actual `edit_class=syntax_changed` observation belongs to the focused file-touching commit.
+
+## Boundary
+
+- research only;
+- Rust lexical syntax class is not behavioral equivalence;
+- edit class does not prove generator ownership or regeneration intent;
+- source observation values grant no evidence strength or action authority;
+- the generic #216 bridge/planner/frontier remain unchanged;
+- source execution produces evidence, not a claim that any higher-level refinement should be promoted;
+- the public carrier preserves both exact repository-window and exact focused-commit coordinates.
+
+## Execution receipt
+
+The first public carrier run `32257281636` / run number `1` compiled all readers, collected a source result, selected the bridge probe, and fed the result to a CURRENT frontier. Its final assertion failed because arbitrary pinned repository head `8783524...` emitted `comments_or_docs_only`; inspection showed the anchor did not change in that commit. This failure produced the focused-commit admission repair above.
+
+After adding explicit single-parent + anchor-changed admission, public carrier run:
+
+```text
+GitHub Actions run: 32257998359
+workflow run number: 7
+result: success
+```
+
+proved both controls:
+
+```text
+pinned repository head 8783524...
+  -> UNKNOWN anchor-unchanged
+
+focused rules.rs commit 228e8e0f85c0...
+  -> KNOWN syntax_changed
+  -> applicability APPLIES
+  -> exact read-only probe selected
+  -> final frontier CURRENT
+```
+
+The emitted focused observation, bridge, selected probe, and final frontier all use the exact `228e8e0f...:rules.rs` subject coordinate.
+
+After correcting the inherited #185 observation corpus and recording the receipt, the branch's current semantic state passed:
+
+```text
+ordinary CI
+  run: 32258258665
+  run number: 1533
+  result: success
+
+public Oxc carrier
+  run: 32258258680
+  run number: 9
+  result: success
+```
+
+Ordinary CI passed format, strict Clippy, active-work preflight, the full local Git/source/bridge/frontier suite, and repository/history/CI-filter/diff dogfood. The public carrier again reproduced the pinned-head UNKNOWN control and focused-commit `syntax_changed -> selected probe -> CURRENT frontier` loop.
+
+North star:
+
+> Let one real source discriminator complete the investigation loop while every handoff remains typed, exact-coordinate, and replayable.

--- a/src/rust_edit_class_source.rs
+++ b/src/rust_edit_class_source.rs
@@ -1,0 +1,339 @@
+use std::error::Error;
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use crate::applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, PathScope, PathScopeMode, evaluate_query,
+};
+use crate::discriminator_observation::{
+    DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation,
+    DiscriminatorObservationBatch, DiscriminatorValueState, ObservationApplicability,
+    ObservationApplicabilityStatus, validate_discriminator_observation_batch,
+};
+use crate::durable_obligation::DiscriminatorKey;
+use crate::evidence_planner::{EvidenceProbe, ProbeCost, ProbeEffect};
+use crate::observation_probe_bridge::ObservationProbeBridge;
+
+#[allow(dead_code)]
+#[path = "../examples/rust_syntax_cohort.rs"]
+mod rust_syntax_cohort;
+
+use rust_syntax_cohort::{RustEditClass, classify_rust_edit};
+
+pub const RUST_EDIT_CLASS_DISCRIMINATOR_ID: &str = "edit_class";
+pub const RUST_EDIT_CLASS_PROBE_KIND: &str = "rust_edit_class";
+const MAX_REPOSITORY_BYTES: usize = 256;
+const MAX_PATH_BYTES: usize = 2048;
+const SHA_BYTES: usize = 40;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustEditClassSubject {
+    pub repository: String,
+    pub revision: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustEditClassSourceResult {
+    pub subject: RustEditClassSubject,
+    pub current_head: String,
+    pub bridge: ObservationProbeBridge,
+    pub probe: EvidenceProbe,
+    pub observation: DiscriminatorObservation,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RustEditClassSourceError {
+    message: String,
+}
+
+impl RustEditClassSourceError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for RustEditClassSourceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for RustEditClassSourceError {}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum FocusAdmission {
+    Focused,
+    NotSingleParent,
+    AnchorUnchanged,
+}
+
+pub fn collect_rust_edit_class_source(
+    root: &Path,
+    subject: &RustEditClassSubject,
+) -> Result<RustEditClassSourceResult, RustEditClassSourceError> {
+    validate_subject(subject)?;
+    let root = root.canonicalize().map_err(|error| {
+        RustEditClassSourceError::new(format!("cannot canonicalize repository root: {error}"))
+    })?;
+    let current_head = git_head(&root)?;
+    let path = PathBuf::from(&subject.path);
+    let subject_ref = subject_ref(subject);
+    let requirements = exact_requirements(subject);
+    let context = EvaluationContext {
+        repository: Some(subject.repository.clone()),
+        revision: Some(current_head.clone()),
+        work: None,
+        path: Some(subject.path.clone()),
+    };
+    let applicability = evaluate_query(&ApplicabilityQuery {
+        schema_version: APPLICABILITY_SCHEMA_VERSION,
+        requirements: requirements.clone(),
+        context,
+    })
+    .map_err(|error| {
+        RustEditClassSourceError::new(format!("edit-class applicability failed: {error}"))
+    })?;
+
+    let value_state = match focus_admission(&root, &subject.revision, &path)? {
+        FocusAdmission::Focused => match classify_rust_edit(&root, &subject.revision, &path) {
+            RustEditClass::SyntaxChanged => DiscriminatorValueState::Known {
+                value_ref: "syntax_changed".to_string(),
+            },
+            RustEditClass::CommentsOrWhitespaceOnly => DiscriminatorValueState::Known {
+                value_ref: "comments_or_docs_only".to_string(),
+            },
+            RustEditClass::Unclassified => DiscriminatorValueState::Unknown {
+                reason_ref: format!("rust-edit-class:unclassified:{subject_ref}"),
+            },
+        },
+        FocusAdmission::NotSingleParent => DiscriminatorValueState::Unknown {
+            reason_ref: format!("rust-edit-class:not-single-parent:{subject_ref}"),
+        },
+        FocusAdmission::AnchorUnchanged => DiscriminatorValueState::Unknown {
+            reason_ref: format!("rust-edit-class:anchor-unchanged:{subject_ref}"),
+        },
+    };
+    let applicability_status = match applicability.status {
+        ApplicabilityStatus::Applies => ObservationApplicabilityStatus::Applies,
+        ApplicabilityStatus::Unknown => ObservationApplicabilityStatus::Unknown,
+        ApplicabilityStatus::Invalid => ObservationApplicabilityStatus::Invalid,
+    };
+    let applicability_ref =
+        format!("rust-edit-class:applicability:{subject_ref}:current={current_head}");
+    let source_receipt = format!("rust-syntax-cohort:{subject_ref}");
+    let observation = DiscriminatorObservation {
+        observation_id: format!("rust-edit-class:{subject_ref}"),
+        discriminator_id: RUST_EDIT_CLASS_DISCRIMINATOR_ID.to_string(),
+        subject_ref: subject_ref.clone(),
+        source_receipt,
+        value_state,
+        applicability: ObservationApplicability {
+            status: applicability_status,
+            receipt_ref: applicability_ref,
+        },
+    };
+    validate_discriminator_observation_batch(&DiscriminatorObservationBatch {
+        schema_version: DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+        observations: vec![observation.clone()],
+    })
+    .map_err(|error| {
+        RustEditClassSourceError::new(format!("produced observation failed validation: {error}"))
+    })?;
+
+    let probe_discriminator = DiscriminatorKey {
+        kind: RUST_EDIT_CLASS_PROBE_KIND.to_string(),
+        target: subject_ref.clone(),
+    };
+    let suffix = &subject.revision[..12];
+    let bridge = ObservationProbeBridge {
+        bridge_id: format!("rust-edit-class-{suffix}"),
+        observation_discriminator_id: RUST_EDIT_CLASS_DISCRIMINATOR_ID.to_string(),
+        observation_subject_ref: subject_ref.clone(),
+        probe_discriminator: probe_discriminator.clone(),
+        clearing_requirements: requirements.clone(),
+        source_receipt: format!("rust-edit-class-adapter:{subject_ref}"),
+    };
+    let probe = EvidenceProbe {
+        id: format!("rust-edit-class-{suffix}"),
+        produces: probe_discriminator,
+        requirements,
+        effect: ProbeEffect::ReadOnly,
+        cost: ProbeCost {
+            git_subprocesses: 5,
+            rust_files_parsed: 2,
+            ..ProbeCost::default()
+        },
+    };
+
+    Ok(RustEditClassSourceResult {
+        subject: subject.clone(),
+        current_head,
+        bridge,
+        probe,
+        observation,
+    })
+}
+
+pub fn subject_ref(subject: &RustEditClassSubject) -> String {
+    format!(
+        "{}@{}:{}",
+        subject.repository, subject.revision, subject.path
+    )
+}
+
+fn exact_requirements(subject: &RustEditClassSubject) -> EvidenceRequirements {
+    EvidenceRequirements {
+        repository: Some(subject.repository.clone()),
+        revision: Some(subject.revision.clone()),
+        work: None,
+        scope: Some(PathScope {
+            mode: PathScopeMode::Exact,
+            path: subject.path.clone(),
+        }),
+    }
+}
+
+fn git_head(root: &Path) -> Result<String, RustEditClassSourceError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .map_err(|error| {
+            RustEditClassSourceError::new(format!("cannot execute git rev-parse: {error}"))
+        })?;
+    if !output.status.success() {
+        return Err(RustEditClassSourceError::new(format!(
+            "git rev-parse HEAD failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    let head = String::from_utf8(output.stdout)
+        .map_err(|error| RustEditClassSourceError::new(format!("invalid git head UTF-8: {error}")))?
+        .trim()
+        .to_string();
+    validate_revision(&head, "current git head")?;
+    Ok(head)
+}
+
+fn focus_admission(
+    root: &Path,
+    revision: &str,
+    path: &Path,
+) -> Result<FocusAdmission, RustEditClassSourceError> {
+    let parents = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-list", "--parents", "-n", "1", revision])
+        .output()
+        .map_err(|error| {
+            RustEditClassSourceError::new(format!("cannot inspect edit-class parents: {error}"))
+        })?;
+    if !parents.status.success() {
+        return Err(RustEditClassSourceError::new(format!(
+            "git rev-list failed for {revision}: {}",
+            String::from_utf8_lossy(&parents.stderr)
+        )));
+    }
+    let parents = String::from_utf8(parents.stdout).map_err(|error| {
+        RustEditClassSourceError::new(format!("invalid parent-list UTF-8: {error}"))
+    })?;
+    if parents.split_whitespace().count() != 2 {
+        return Ok(FocusAdmission::NotSingleParent);
+    }
+
+    let changed = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args([
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "-r",
+            revision,
+            "--",
+        ])
+        .arg(path)
+        .output()
+        .map_err(|error| {
+            RustEditClassSourceError::new(format!("cannot inspect edit-class path change: {error}"))
+        })?;
+    if !changed.status.success() {
+        return Err(RustEditClassSourceError::new(format!(
+            "git diff-tree failed for {revision}: {}",
+            String::from_utf8_lossy(&changed.stderr)
+        )));
+    }
+    if String::from_utf8(changed.stdout)
+        .map_err(|error| {
+            RustEditClassSourceError::new(format!("invalid changed-path UTF-8: {error}"))
+        })?
+        .lines()
+        .all(|line| line.trim().is_empty())
+    {
+        return Ok(FocusAdmission::AnchorUnchanged);
+    }
+    Ok(FocusAdmission::Focused)
+}
+
+fn validate_subject(subject: &RustEditClassSubject) -> Result<(), RustEditClassSourceError> {
+    if subject.repository.is_empty()
+        || subject.repository.trim() != subject.repository
+        || subject.repository.len() > MAX_REPOSITORY_BYTES
+        || subject.repository.contains(['\n', '\r', '\0'])
+    {
+        return Err(RustEditClassSourceError::new(
+            "repository must be bounded canonical single-line text",
+        ));
+    }
+    validate_revision(&subject.revision, "subject revision")?;
+    if subject.path.is_empty()
+        || subject.path.trim() != subject.path
+        || subject.path.len() > MAX_PATH_BYTES
+        || subject.path.contains(['\n', '\r', '\0', '\\'])
+    {
+        return Err(RustEditClassSourceError::new(
+            "path must be bounded canonical repository-relative text",
+        ));
+    }
+    let path = Path::new(&subject.path);
+    if path.is_absolute()
+        || path.extension().and_then(|extension| extension.to_str()) != Some("rs")
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(RustEditClassSourceError::new(
+            "path must be a normalized repository-relative Rust source path",
+        ));
+    }
+    let reference = subject_ref(subject);
+    if reference.len() > 480 {
+        return Err(RustEditClassSourceError::new(
+            "edit-class subject reference exceeds the admitted boundary",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_revision(value: &str, label: &str) -> Result<(), RustEditClassSourceError> {
+    if value.len() != SHA_BYTES
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(RustEditClassSourceError::new(format!(
+            "{label} must be an exact lowercase 40-hex Git commit"
+        )));
+    }
+    Ok(())
+}

--- a/tests/rust_edit_class_source.rs
+++ b/tests/rust_edit_class_source.rs
@@ -1,0 +1,304 @@
+#![allow(dead_code)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[path = "../src/justification.rs"]
+mod justification;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/observation_probe_bridge.rs"]
+mod observation_probe_bridge;
+#[path = "../src/rust_edit_class_source.rs"]
+mod rust_edit_class_source;
+
+use applicability::EvaluationContext;
+use discriminator_observation::{
+    DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservationBatch,
+    DiscriminatorValueState, ObservationApplicabilityStatus, parse_discriminator_observation_batch,
+};
+use evidence_planner::{EvidencePlanStatus, ProbeEffect, ProbeSelectionPolicy};
+use observation_frontier::{
+    OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierRequest, ObservationFrontierStatus,
+    ObservationRequirement, evaluate_observation_frontiers,
+};
+use observation_probe_bridge::{
+    OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION, ObservationProbePlanRequest,
+    ObservationProbePlanStatus, plan_observation_probe,
+};
+use rust_edit_class_source::{RustEditClassSubject, collect_rust_edit_class_source, subject_ref};
+
+struct TempRepo {
+    root: PathBuf,
+}
+
+impl TempRepo {
+    fn new(label: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cultist-rust-edit-class-{label}-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(root.join("src")).unwrap();
+        run_git(&root, &["init", "-q"]);
+        run_git(&root, &["config", "user.email", "cultist@example.invalid"]);
+        run_git(&root, &["config", "user.name", "Cultist Test"]);
+        Self { root }
+    }
+
+    fn write(&self, source: &str) {
+        fs::write(self.root.join("src/lib.rs"), source).unwrap();
+    }
+
+    fn commit(&self, message: &str) -> String {
+        run_git(&self.root, &["add", "src/lib.rs"]);
+        run_git(&self.root, &["commit", "-q", "-m", message]);
+        git_output(&self.root, &["rev-parse", "HEAD"])
+    }
+
+    fn commit_other_path(&self, message: &str) -> String {
+        fs::write(self.root.join("README.md"), "unrelated\n").unwrap();
+        run_git(&self.root, &["add", "README.md"]);
+        run_git(&self.root, &["commit", "-q", "-m", message]);
+        git_output(&self.root, &["rev-parse", "HEAD"])
+    }
+}
+
+impl Drop for TempRepo {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn run_git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_output(root: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
+fn subject(revision: &str) -> RustEditClassSubject {
+    RustEditClassSubject {
+        repository: "owner/repo".to_string(),
+        revision: revision.to_string(),
+        path: "src/lib.rs".to_string(),
+    }
+}
+
+fn seeded_repo() -> (TempRepo, String, String, String) {
+    let repo = TempRepo::new("cohorts");
+    repo.write("fn answer() -> usize { 41 }\n");
+    let root = repo.commit("root");
+    repo.write("fn answer() -> usize { 42 }\n");
+    let syntax = repo.commit("syntax");
+    repo.write("// retained comment\nfn answer() -> usize { 42 }\n");
+    let comments = repo.commit("comments");
+    (repo, root, syntax, comments)
+}
+
+#[test]
+fn comment_only_edit_emits_current_known_observation_and_exact_bridge() {
+    let (repo, _root, _syntax, comments) = seeded_repo();
+    let result = collect_rust_edit_class_source(&repo.root, &subject(&comments)).unwrap();
+
+    assert_eq!(result.current_head, comments);
+    assert_eq!(result.observation.discriminator_id, "edit_class");
+    assert_eq!(
+        result.observation.value_state,
+        DiscriminatorValueState::Known {
+            value_ref: "comments_or_docs_only".to_string()
+        }
+    );
+    assert_eq!(
+        result.observation.applicability.status,
+        ObservationApplicabilityStatus::Applies
+    );
+    assert_eq!(
+        result.bridge.observation_subject_ref,
+        subject_ref(&subject(&comments))
+    );
+    assert_eq!(result.probe.effect, ProbeEffect::ReadOnly);
+}
+
+#[test]
+fn syntax_commit_is_classified_separately_from_comment_only_commit() {
+    let (repo, _root, syntax, _comments) = seeded_repo();
+    run_git(&repo.root, &["checkout", "-q", &syntax]);
+    let result = collect_rust_edit_class_source(&repo.root, &subject(&syntax)).unwrap();
+    assert_eq!(
+        result.observation.value_state,
+        DiscriminatorValueState::Known {
+            value_ref: "syntax_changed".to_string()
+        }
+    );
+    assert_eq!(
+        result.observation.applicability.status,
+        ObservationApplicabilityStatus::Applies
+    );
+}
+
+#[test]
+fn root_commit_is_unknown_instead_of_guessed() {
+    let (repo, root, _syntax, _comments) = seeded_repo();
+    run_git(&repo.root, &["checkout", "-q", &root]);
+    let result = collect_rust_edit_class_source(&repo.root, &subject(&root)).unwrap();
+    assert!(matches!(
+        result.observation.value_state,
+        DiscriminatorValueState::Unknown { .. }
+    ));
+    assert_eq!(
+        result.observation.applicability.status,
+        ObservationApplicabilityStatus::Applies
+    );
+}
+
+#[test]
+fn unrelated_repository_commit_is_unknown_instead_of_comment_only() {
+    let (repo, _root, _syntax, _comments) = seeded_repo();
+    let unrelated = repo.commit_other_path("unrelated");
+    let result = collect_rust_edit_class_source(&repo.root, &subject(&unrelated)).unwrap();
+    assert!(matches!(
+        &result.observation.value_state,
+        DiscriminatorValueState::Unknown { reason_ref }
+            if reason_ref.contains("anchor-unchanged")
+    ));
+    assert_eq!(
+        result.observation.applicability.status,
+        ObservationApplicabilityStatus::Applies
+    );
+}
+
+#[test]
+fn known_old_classification_stays_invalid_after_head_moves() {
+    let (repo, _root, syntax, comments) = seeded_repo();
+    assert_eq!(git_output(&repo.root, &["rev-parse", "HEAD"]), comments);
+    let result = collect_rust_edit_class_source(&repo.root, &subject(&syntax)).unwrap();
+    assert_eq!(
+        result.observation.value_state,
+        DiscriminatorValueState::Known {
+            value_ref: "syntax_changed".to_string()
+        }
+    );
+    assert_eq!(
+        result.observation.applicability.status,
+        ObservationApplicabilityStatus::Invalid
+    );
+}
+
+#[test]
+fn selected_probe_then_produced_observation_closes_missing_frontier() {
+    let (repo, _root, _syntax, comments) = seeded_repo();
+    let source = collect_rust_edit_class_source(&repo.root, &subject(&comments)).unwrap();
+    let required_subject = source.observation.subject_ref.clone();
+    let missing = observation_frontier::ObservationFrontierReceipt {
+        discriminator_id: "edit_class".to_string(),
+        subject_ref: required_subject.clone(),
+        status: ObservationFrontierStatus::Missing,
+        current: Vec::new(),
+        unknown: Vec::new(),
+        invalid: Vec::new(),
+        other_subject: Vec::new(),
+    };
+
+    let plan = plan_observation_probe(&ObservationProbePlanRequest {
+        schema_version: OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION,
+        frontier: missing,
+        bridges: vec![source.bridge.clone()],
+        context: EvaluationContext {
+            repository: Some("owner/repo".to_string()),
+            revision: Some(comments.clone()),
+            work: None,
+            path: Some("src/lib.rs".to_string()),
+        },
+        probes: vec![source.probe.clone()],
+        allow_effectful: false,
+        policy: ProbeSelectionPolicy::Conservative,
+    })
+    .unwrap();
+    assert_eq!(plan.status, ObservationProbePlanStatus::Planned);
+    assert_eq!(
+        plan.evidence_plan.unwrap().status,
+        EvidencePlanStatus::Selected
+    );
+
+    let evaluation = evaluate_observation_frontiers(&ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements: vec![ObservationRequirement {
+            discriminator_id: "edit_class".to_string(),
+            subject_ref: required_subject,
+        }],
+        observations: DiscriminatorObservationBatch {
+            schema_version: DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+            observations: vec![source.observation.clone()],
+        },
+    })
+    .unwrap();
+    assert_eq!(
+        evaluation.frontiers[0].status,
+        ObservationFrontierStatus::Current
+    );
+    assert_eq!(
+        evaluation.frontiers[0].current[0].value_ref,
+        "comments_or_docs_only"
+    );
+}
+
+#[test]
+fn produced_observation_round_trips_through_v2_validation() {
+    let (repo, _root, _syntax, comments) = seeded_repo();
+    let result = collect_rust_edit_class_source(&repo.root, &subject(&comments)).unwrap();
+    let batch = DiscriminatorObservationBatch {
+        schema_version: DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+        observations: vec![result.observation],
+    };
+    let encoded = serde_json::to_vec(&batch).unwrap();
+    let decoded = parse_discriminator_observation_batch(&encoded).unwrap();
+    assert_eq!(decoded, batch);
+}
+
+#[test]
+fn path_and_revision_admission_fail_closed() {
+    let (repo, _root, _syntax, comments) = seeded_repo();
+    let mut bad_path = subject(&comments);
+    bad_path.path = "../src/lib.rs".to_string();
+    assert!(collect_rust_edit_class_source(&repo.root, &bad_path).is_err());
+
+    let mut short_revision = subject(&comments);
+    short_revision.revision = "deadbeef".to_string();
+    assert!(collect_rust_edit_class_source(&repo.root, &short_revision).is_err());
+}


### PR DESCRIPTION
Progresses #220 as the first real source-adapter child of green #216.

## Closed loop

This carrier reuses #54's existing Rust first-parent token classifier and exercises:

```text
MISSING edit_class @ exact focused repo/revision/path
-> source-owned bridge
-> existing #216 / #145 planner selects read-only rust_edit_class probe
-> existing classifier executes
-> v2 source observation
-> exact frontier becomes CURRENT
```

The generic bridge, planner, applicability evaluator, and frontier modules remain unchanged.

## Focused-commit correction

The first public run exposed a hidden #54 precondition. Pinned repository head `8783524015b1e6ff1c39ccf426df0bb07cbbc588` does not change `crates/oxc_linter/src/rules.rs`. Raw token equality there initially looked like `comments_or_docs_only`, while #54 only classified non-merge commits selected by `git log -- rules.rs`.

The adapter now requires exactly one parent plus an actual change to the exact anchor path before emitting a known edit class. Repository head `8783524…` is retained as a negative control and emits UNKNOWN `anchor-unchanged` + APPLIES.

The latest actual focused `rules.rs` commit under that pinned history is:

```text
228e8e0f85c0e7aeded02c5e27fd810004d3b41a
fix(linter): resolve inactive React compiler rules (#25830)
```

That exact commit reproduces KNOWN `syntax_changed` + APPLIES.

## Source contract

`RustEditClassSubject` binds repository, exact 40-hex revision, and normalized repository-relative Rust path. Collection emits one source-owned bridge, one read-only probe definition, and one v2 `DiscriminatorObservation`.

Focused classifier states map only as syntax_changed / comments_or_docs_only / UNKNOWN. Root/merge/anchor-unchanged revisions are UNKNOWN before classification. Shared applicability binds repository + exact revision + exact path to the checkout's actual HEAD; a moved checkout preserves an old known value only as INVALID current evidence.

## Public and local controls

Local Git fixtures cover syntax change, comment-only change, root UNKNOWN, unrelated-anchor UNKNOWN, moved-head INVALID, v2 round-trip, admission failures, and full MISSING -> selected probe -> produced observation -> CURRENT composition.

The public Oxc workflow preserves both earned coordinates:

```text
pinned head 8783524…
  -> UNKNOWN anchor-unchanged

focused commit 228e8e0f85c0…
  -> KNOWN syntax_changed
  -> applicability APPLIES
  -> read-only probe SELECTED
  -> final frontier CURRENT
```

The inherited #185 observation corpus is corrected on this branch to the exact focused subject and workflow receipt.

## Validation

The exploratory public run `32257281636` / #1 exposed the arbitrary-head precondition bug. After the focused-commit repair, public run `32257998359` / #7 succeeded; the corrected corpus then passed ordinary CI #1533 and public carrier #9.

The branch was compacted to one semantic child commit:

```text
08d4521a22baa250c38d87852af7bfc611ac39bb
```

on #216 head `2f20ef16fb05313b1df4cf73cee913dce19b8318`.

That exact compacted head passed full CI run `32258598148` / #1541 and public Oxc carrier run `32258599172` / #11.

## Reuse boundary

The only #54 producer edit is visibility for `RustEditClass` and `classify_rust_edit`; token/fingerprint/classification semantics are unchanged. Generic #216 modules are unchanged.

Refs #54 #142 #145 #168 #179 #185 #190 #210 #216 #220.