### PR TITLE
research: reconstruct a repeated-repair lesson promotion

### DIFF
--- a/examples/lesson_promotion.rs
+++ b/examples/lesson_promotion.rs
@@ -45,6 +45,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let memory_bytes = read_bounded(&memory_path, MAX_PROJECT_MEMORY_BYTES)?;
     let claim_bytes = read_bounded(&claim_path, MAX_LESSON_PROMOTION_BYTES)?;
     let memory = parse_project_memory_packet(&memory_bytes).map_err(invalid_data)?;
+    memory.summary().map_err(invalid_data)?;
     let claim = parse_lesson_promotion_claim(&claim_bytes).map_err(invalid_data)?;
     let evaluation = evaluate_lesson_promotion(&memory, &claim).map_err(invalid_data)?;
     println!("{}", serde_json::to_string_pretty(&evaluation)?);

--- a/examples/lesson_promotion.rs
+++ b/examples/lesson_promotion.rs
@@ -1,0 +1,69 @@
+#[path = "../src/project_memory.rs"]
+mod project_memory;
+#[path = "../src/lesson_promotion.rs"]
+mod lesson_promotion;
+
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use lesson_promotion::{
+    MAX_LESSON_PROMOTION_BYTES, evaluate_lesson_promotion, parse_lesson_promotion_claim,
+};
+use project_memory::{MAX_PROJECT_MEMORY_BYTES, parse_project_memory_packet};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("lesson-promotion: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut args = std::env::args().skip(1);
+    let memory_path = args.next().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "usage: lesson_promotion PROJECT_MEMORY.json PROMOTION_CLAIM.json",
+        )
+    })?;
+    let claim_path = args.next().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "usage: lesson_promotion PROJECT_MEMORY.json PROMOTION_CLAIM.json",
+        )
+    })?;
+    if args.next().is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "usage: lesson_promotion PROJECT_MEMORY.json PROMOTION_CLAIM.json",
+        )
+        .into());
+    }
+
+    let memory_bytes = read_bounded(&memory_path, MAX_PROJECT_MEMORY_BYTES)?;
+    let claim_bytes = read_bounded(&claim_path, MAX_LESSON_PROMOTION_BYTES)?;
+    let memory = parse_project_memory_packet(&memory_bytes).map_err(invalid_data)?;
+    let claim = parse_lesson_promotion_claim(&claim_bytes).map_err(invalid_data)?;
+    let evaluation = evaluate_lesson_promotion(&memory, &claim).map_err(invalid_data)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}
+
+fn read_bounded(path: impl AsRef<Path>, maximum: usize) -> Result<Vec<u8>, Box<dyn Error>> {
+    let path = path.as_ref();
+    let metadata = fs::metadata(path)?;
+    if metadata.len() > maximum as u64 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{} exceeds {maximum} bytes", path.display()),
+        )
+        .into());
+    }
+    Ok(fs::read(path)?)
+}
+
+fn invalid_data(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}

--- a/examples/lesson_promotion.rs
+++ b/examples/lesson_promotion.rs
@@ -1,7 +1,7 @@
-#[path = "../src/project_memory.rs"]
-mod project_memory;
 #[path = "../src/lesson_promotion.rs"]
 mod lesson_promotion;
+#[path = "../src/project_memory.rs"]
+mod project_memory;
 
 use std::error::Error;
 use std::fs;

--- a/research/lesson-promotion.md
+++ b/research/lesson-promotion.md
@@ -91,7 +91,7 @@ proposed_guard
 observed_promotion
 ```
 
-The retained real episode should evaluate to:
+The retained real episode evaluates to:
 
 ```text
 status                    observed_promotion
@@ -127,6 +127,42 @@ cargo run --example lesson_promotion -- \
 ```
 
 The reader consumes the existing project-memory packet plus the small typed promotion claim and prints the evaluation as JSON.
+
+## Executed current-main receipt
+
+The semantic code + retained claim head was:
+
+```text
+branch head: 133e4a9e0cb99bd5076880e2ea62aec44dff13e7
+main:        9ba02d8664ca6cb47573e7cde270cfec15fed50c
+merge view:  c1ae70c4e58fa42c32da0f7ae9d8761ddd8336d7
+```
+
+Current-base GitHub Actions receipt:
+
+```text
+CI run:                    32257963686  success
+Generated provenance run:  32257963257  success
+```
+
+The CI merge view passed:
+
+```text
+rustfmt
+all-target Clippy with -D warnings
+project-memory lineage controls
+GitHub review-memory adapter controls
+GitHub issue-closure adapter controls
+external GitHub reference controls
+full Rust tests
+repository scan text + JSON dogfood
+bounded history text + JSON dogfood
+CI test-filter text + JSON dogfood
+positive/control CI-filter fixtures
+pull-request diff text + JSON dogfood
+```
+
+The retained promotion tests passed all adversarial states above. The only changes after this semantic receipt are the durable receipt prose in this research note.
 
 ## Boundary
 

--- a/research/lesson-promotion.md
+++ b/research/lesson-promotion.md
@@ -1,0 +1,145 @@
+# Reconstructing a lesson-promotion episode
+
+Issue #41 asks whether Stensibly's agent-heavy history can expose cases where repeated failures become durable executable guards. Issue #11 keeps the authority boundary clear: repeated evidence can justify a promotion candidate, while repository acceptance remains an explicit project event.
+
+This experiment reconstructs one already-completed historical episode from the retained project-memory packet instead of synthesizing a new rule.
+
+## External reference policy
+
+Human-facing external GitHub links in this note use `redirect.github.com`:
+
+- [Stensibly PR #1569](https://redirect.github.com/teamleaderleo/stensibly/pull/1569)
+- [Stensibly PR #1571](https://redirect.github.com/teamleaderleo/stensibly/pull/1571)
+- [Stensibly PR #1573](https://redirect.github.com/teamleaderleo/stensibly/pull/1573)
+- [Stensibly PR #1575](https://redirect.github.com/teamleaderleo/stensibly/pull/1575)
+
+The retained project-memory packet keeps provider/source text as evidence. Presentation hygiene stays separate from machine identity.
+
+## Existing evidence packet
+
+`research/project-memory/stensibly-1575.json` already preserves exact PR identities, revisions, changed paths, selected source text, and explicit lineage.
+
+The important lineage is broader than the candidate failure class:
+
+```text
+#1569  Node-runtime bundling failure
+#1571  Convex index identifier over 64 characters
+#1573  another Convex index identifier over 64 characters
+#1575  follow-up guard after all three deployability repairs
+```
+
+The promotion question therefore cannot be answered by counting predecessors.
+
+## Candidate discriminator
+
+The retained promotion claim supplies one source-owned discriminator:
+
+```text
+discriminator_id = convex_production_failure_class
+candidate value  = index_identifier_limit
+repair marker    = "64-character identifier limit"
+```
+
+Two repairs satisfy that exact retained marker:
+
+```text
+#1571
+#1573
+```
+
+The adjacent predecessor carries the same broad discriminator ID with a different value:
+
+```text
+#1569
+value = node_runtime_bundle
+marker = `node:crypto`
+```
+
+This keeps deployment sequence and failure class as separate facts.
+
+## Generalized guard
+
+PR #1575 supplies the later enforcement artifact:
+
+```text
+path   test/convex-index-identifier-limit.test.ts
+scope  convex/**/*.ts
+kind   regression_test
+```
+
+Its retained text says ordinary CI previously accepted two `by_*` identifiers over the 64-character limit, then adds one regression scanning retained `convex/**/*.ts` literals and reconstructing the two historical mail index names.
+
+The claim therefore names exactly these covered repair receipts:
+
+```text
+#1571
+#1573
+```
+
+#1569 remains visible as adjacent lineage and stays outside same-class guard coverage.
+
+## Evaluation states
+
+The research evaluator returns one of:
+
+```text
+insufficient_repeated_repairs
+guard_class_mismatch
+guard_coverage_includes_different_class
+guard_coverage_incomplete
+proposed_guard
+observed_promotion
+```
+
+The retained real episode should evaluate to:
+
+```text
+status                    observed_promotion
+same-class repairs         #1571 #1573
+adjacent different class   #1569
+guard                      #1575
+automatic policy authority false
+```
+
+`observed_promotion` describes a historical repository event: the common guard already merged. It grants zero authority to create future policy from similar evidence.
+
+## Adversarial controls
+
+The ordinary Rust suite requires:
+
+1. adding #1569 to guard coverage yields `guard_coverage_includes_different_class`;
+2. omitting #1573 yields `guard_coverage_incomplete`;
+3. retaining only one same-class repair yields `insufficient_repeated_repairs`;
+4. changing the guard discriminator yields `guard_class_mismatch`;
+5. making the guard unmerged yields `proposed_guard`;
+6. relabeling #1569 as same-class fails because its retained source evidence lacks the exact repair marker;
+7. invented source excerpts fail against the retained project-memory text;
+8. the claimed enforcement path must occur in the guard PR's changed paths.
+
+The key negative control is #1569. Sequence adjacency and explicit follow-up lineage remain useful history while contributing zero same-class repair count.
+
+## Replay
+
+```text
+cargo run --example lesson_promotion -- \
+  research/project-memory/stensibly-1575.json \
+  research/lesson-promotion/stensibly-1575.json
+```
+
+The reader consumes the existing project-memory packet plus the small typed promotion claim and prints the evaluation as JSON.
+
+## Boundary
+
+This slice reconstructs an observed historical promotion. It provides no automatic rule synthesis, no scalar confidence, no title-similarity classifier, and no chronology-to-causality upgrade.
+
+Future prospective promotion can reuse the same distinction:
+
+```text
+repeated same-class reviewed receipts
++ explicit common guard proposal
+-> candidate for human/project acceptance
+```
+
+A merged/accepted enforcement artifact can then become historical project memory for later workers.
+
+Refs #11 #18 #41 #74 #148 #160 #162.

--- a/research/lesson-promotion/stensibly-1575.json
+++ b/research/lesson-promotion/stensibly-1575.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "repository": "teamleaderleo/stensibly",
+  "candidate_id": "stensibly-convex-index-limit-guard-promotion",
+  "candidate_discriminator_id": "convex_production_failure_class",
+  "candidate_value_ref": "index_identifier_limit",
+  "repair_marker": "64-character identifier limit",
+  "repair_evidence": [
+    {
+      "artifact": {
+        "kind": "pull_request",
+        "number": 1571
+      },
+      "source_evidence": "After #1569 cleared the `node:crypto` Convex bundle failure, production schema evaluation exposed the next blocker: one Gmail semantic-admission index name exceeds Convex's 64-character identifier limit, so the real Convex deployment still never runs."
+    },
+    {
+      "artifact": {
+        "kind": "pull_request",
+        "number": 1573
+      },
+      "source_evidence": "Production Convex analysis now gets past the outbound runtime and semantic-admission blockers, then rejects the merged #1522 exact-message disposition lane because its six-field index name exceeds Convex's 64-character identifier limit. This packet changes only that identifier so the already-merged semantics can deploy."
+    }
+  ],
+  "adjacent_predecessors": [
+    {
+      "artifact": {
+        "kind": "pull_request",
+        "number": 1569
+      },
+      "discriminator_id": "convex_production_failure_class",
+      "value_ref": "node_runtime_bundle",
+      "marker": "`node:crypto`",
+      "source_evidence": "Repair the production Convex deployment failure exposed after #1524. Ordinary Convex mail functions import the shared mail-thread contract; that contract imported `node:crypto`, so production `convex codegen --dry-run --typecheck enable` could not bundle the hosted outbound functions and the actual Convex deploy step never ran."
+    }
+  ],
+  "guard": {
+    "artifact": {
+      "kind": "pull_request",
+      "number": 1575
+    },
+    "discriminator_id": "convex_production_failure_class",
+    "value_ref": "index_identifier_limit",
+    "marker": "two historical mail index names",
+    "source_evidence": "Prevent the same class of production-only Convex failure from merging again. Ordinary CI previously accepted two `by_*` index identifiers over Convex's 64-character limit; protected production schema analysis caught them only after merge.\n\nAdd one Bun regression that scans retained `convex/**/*.ts` string literals matching `by_*` and fails when any exceed 64 characters. Generated Convex files are excluded. The test also reconstructs the two historical mail index names from fragments and proves both exceed the production limit.",
+    "enforcement_kind": "regression_test",
+    "enforcement_path": "test/convex-index-identifier-limit.test.ts",
+    "scope_ref": "convex/**/*.ts",
+    "covered_repairs": [
+      {
+        "kind": "pull_request",
+        "number": 1571
+      },
+      {
+        "kind": "pull_request",
+        "number": 1573
+      }
+    ]
+  }
+}

--- a/src/lesson_promotion.rs
+++ b/src/lesson_promotion.rs
@@ -1,0 +1,489 @@
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::project_memory::{ArtifactKind, ArtifactRef, ProjectArtifact, ProjectMemoryPacket};
+
+pub const LESSON_PROMOTION_SCHEMA_VERSION: u32 = 1;
+pub const MAX_LESSON_PROMOTION_BYTES: usize = 128 * 1024;
+const MAX_CANDIDATE_ID_BYTES: usize = 256;
+const MAX_DISCRIMINATOR_BYTES: usize = 256;
+const MAX_MARKER_BYTES: usize = 512;
+const MAX_SOURCE_EVIDENCE_BYTES: usize = 8 * 1024;
+const MAX_SCOPE_BYTES: usize = 1024;
+const MAX_PATH_BYTES: usize = 4096;
+const MAX_REPAIRS: usize = 16;
+const MAX_ADJACENT: usize = 16;
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepairEvidence {
+    pub artifact: ArtifactRef,
+    pub source_evidence: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AdjacentEvidence {
+    pub artifact: ArtifactRef,
+    pub discriminator_id: String,
+    pub value_ref: String,
+    pub marker: String,
+    pub source_evidence: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnforcementKind {
+    RegressionTest,
+    Lint,
+    CiPolicy,
+    ProjectRule,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GuardEvidence {
+    pub artifact: ArtifactRef,
+    pub discriminator_id: String,
+    pub value_ref: String,
+    pub marker: String,
+    pub source_evidence: String,
+    pub enforcement_kind: EnforcementKind,
+    pub enforcement_path: String,
+    pub scope_ref: String,
+    pub covered_repairs: Vec<ArtifactRef>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LessonPromotionClaim {
+    pub schema_version: u32,
+    pub repository: String,
+    pub candidate_id: String,
+    pub candidate_discriminator_id: String,
+    pub candidate_value_ref: String,
+    pub repair_marker: String,
+    pub repair_evidence: Vec<RepairEvidence>,
+    #[serde(default)]
+    pub adjacent_predecessors: Vec<AdjacentEvidence>,
+    pub guard: GuardEvidence,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromotionStatus {
+    InsufficientRepeatedRepairs,
+    GuardClassMismatch,
+    GuardCoverageIncludesDifferentClass,
+    GuardCoverageIncomplete,
+    ProposedGuard,
+    ObservedPromotion,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct LessonPromotionEvaluation {
+    pub schema_version: u32,
+    pub repository: String,
+    pub candidate_id: String,
+    pub status: PromotionStatus,
+    pub candidate_discriminator_id: String,
+    pub candidate_value_ref: String,
+    pub same_class_repairs: Vec<ArtifactRef>,
+    pub adjacent_different_class: Vec<ArtifactRef>,
+    pub guard: ArtifactRef,
+    pub enforcement_kind: EnforcementKind,
+    pub enforcement_path: String,
+    pub scope_ref: String,
+    pub missing_repair_coverage: Vec<ArtifactRef>,
+    pub different_class_coverage: Vec<ArtifactRef>,
+    pub automatic_policy_authority: bool,
+}
+
+pub fn parse_lesson_promotion_claim(bytes: &[u8]) -> Result<LessonPromotionClaim, String> {
+    if bytes.len() > MAX_LESSON_PROMOTION_BYTES {
+        return Err(format!(
+            "lesson-promotion claim exceeds {} bytes",
+            MAX_LESSON_PROMOTION_BYTES
+        ));
+    }
+    let claim: LessonPromotionClaim = serde_json::from_slice(bytes)
+        .map_err(|error| format!("invalid lesson-promotion JSON: {error}"))?;
+    claim.validate_shape()?;
+    Ok(claim)
+}
+
+pub fn evaluate_lesson_promotion(
+    memory: &ProjectMemoryPacket,
+    claim: &LessonPromotionClaim,
+) -> Result<LessonPromotionEvaluation, String> {
+    memory.validate()?;
+    claim.validate_against(memory)?;
+
+    let same_class_repairs = sorted_refs(claim.repair_evidence.iter().map(|item| item.artifact));
+    let adjacent_different_class =
+        sorted_refs(claim.adjacent_predecessors.iter().map(|item| item.artifact));
+    let covered = claim
+        .guard
+        .covered_repairs
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let repair_set = same_class_repairs.iter().copied().collect::<BTreeSet<_>>();
+    let adjacent_set = adjacent_different_class
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+
+    let missing_repair_coverage = repair_set
+        .difference(&covered)
+        .copied()
+        .collect::<Vec<_>>();
+    let different_class_coverage = covered
+        .intersection(&adjacent_set)
+        .copied()
+        .collect::<Vec<_>>();
+
+    let guard = artifact(memory, claim.guard.artifact)?;
+    let guard_merged = guard
+        .revision
+        .as_ref()
+        .is_some_and(|revision| revision.merged);
+
+    let status = if same_class_repairs.len() < 2 {
+        PromotionStatus::InsufficientRepeatedRepairs
+    } else if claim.guard.discriminator_id != claim.candidate_discriminator_id
+        || claim.guard.value_ref != claim.candidate_value_ref
+    {
+        PromotionStatus::GuardClassMismatch
+    } else if !different_class_coverage.is_empty() {
+        PromotionStatus::GuardCoverageIncludesDifferentClass
+    } else if !missing_repair_coverage.is_empty() {
+        PromotionStatus::GuardCoverageIncomplete
+    } else if !guard_merged {
+        PromotionStatus::ProposedGuard
+    } else {
+        PromotionStatus::ObservedPromotion
+    };
+
+    Ok(LessonPromotionEvaluation {
+        schema_version: LESSON_PROMOTION_SCHEMA_VERSION,
+        repository: claim.repository.clone(),
+        candidate_id: claim.candidate_id.clone(),
+        status,
+        candidate_discriminator_id: claim.candidate_discriminator_id.clone(),
+        candidate_value_ref: claim.candidate_value_ref.clone(),
+        same_class_repairs,
+        adjacent_different_class,
+        guard: claim.guard.artifact,
+        enforcement_kind: claim.guard.enforcement_kind,
+        enforcement_path: claim.guard.enforcement_path.clone(),
+        scope_ref: claim.guard.scope_ref.clone(),
+        missing_repair_coverage,
+        different_class_coverage,
+        automatic_policy_authority: false,
+    })
+}
+
+impl LessonPromotionClaim {
+    fn validate_shape(&self) -> Result<(), String> {
+        if self.schema_version != LESSON_PROMOTION_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported lesson-promotion schema version {}",
+                self.schema_version
+            ));
+        }
+        validate_repository(&self.repository)?;
+        validate_bounded_single_line(
+            &self.candidate_id,
+            "candidate_id",
+            MAX_CANDIDATE_ID_BYTES,
+        )?;
+        validate_bounded_single_line(
+            &self.candidate_discriminator_id,
+            "candidate_discriminator_id",
+            MAX_DISCRIMINATOR_BYTES,
+        )?;
+        validate_bounded_single_line(
+            &self.candidate_value_ref,
+            "candidate_value_ref",
+            MAX_DISCRIMINATOR_BYTES,
+        )?;
+        validate_bounded_single_line(&self.repair_marker, "repair_marker", MAX_MARKER_BYTES)?;
+        if self.repair_evidence.is_empty() || self.repair_evidence.len() > MAX_REPAIRS {
+            return Err(format!(
+                "lesson-promotion claim must contain 1..={MAX_REPAIRS} repair receipts"
+            ));
+        }
+        if self.adjacent_predecessors.len() > MAX_ADJACENT {
+            return Err(format!(
+                "lesson-promotion claim may contain at most {MAX_ADJACENT} adjacent predecessors"
+            ));
+        }
+
+        let mut role_refs = BTreeSet::new();
+        for repair in &self.repair_evidence {
+            validate_pr_ref(repair.artifact, "repair artifact")?;
+            validate_source_evidence(&repair.source_evidence)?;
+            if !role_refs.insert(repair.artifact) {
+                return Err(format!(
+                    "duplicate lesson-promotion artifact {}",
+                    display_ref(repair.artifact)
+                ));
+            }
+        }
+        for adjacent in &self.adjacent_predecessors {
+            validate_pr_ref(adjacent.artifact, "adjacent predecessor")?;
+            validate_bounded_single_line(
+                &adjacent.discriminator_id,
+                "adjacent discriminator_id",
+                MAX_DISCRIMINATOR_BYTES,
+            )?;
+            validate_bounded_single_line(
+                &adjacent.value_ref,
+                "adjacent value_ref",
+                MAX_DISCRIMINATOR_BYTES,
+            )?;
+            validate_bounded_single_line(&adjacent.marker, "adjacent marker", MAX_MARKER_BYTES)?;
+            validate_source_evidence(&adjacent.source_evidence)?;
+            if adjacent.discriminator_id == self.candidate_discriminator_id
+                && adjacent.value_ref == self.candidate_value_ref
+            {
+                return Err(format!(
+                    "adjacent predecessor {} cannot carry the candidate discriminator value",
+                    display_ref(adjacent.artifact)
+                ));
+            }
+            if !role_refs.insert(adjacent.artifact) {
+                return Err(format!(
+                    "duplicate lesson-promotion artifact {}",
+                    display_ref(adjacent.artifact)
+                ));
+            }
+        }
+
+        validate_pr_ref(self.guard.artifact, "guard artifact")?;
+        validate_bounded_single_line(
+            &self.guard.discriminator_id,
+            "guard discriminator_id",
+            MAX_DISCRIMINATOR_BYTES,
+        )?;
+        validate_bounded_single_line(
+            &self.guard.value_ref,
+            "guard value_ref",
+            MAX_DISCRIMINATOR_BYTES,
+        )?;
+        validate_bounded_single_line(&self.guard.marker, "guard marker", MAX_MARKER_BYTES)?;
+        validate_source_evidence(&self.guard.source_evidence)?;
+        validate_repository_path(&self.guard.enforcement_path)?;
+        validate_bounded_single_line(&self.guard.scope_ref, "guard scope_ref", MAX_SCOPE_BYTES)?;
+        if !role_refs.insert(self.guard.artifact) {
+            return Err(format!(
+                "guard artifact {} is also used as a predecessor",
+                display_ref(self.guard.artifact)
+            ));
+        }
+
+        let mut coverage = BTreeSet::new();
+        for covered in &self.guard.covered_repairs {
+            validate_pr_ref(*covered, "covered repair")?;
+            if !coverage.insert(*covered) {
+                return Err(format!(
+                    "duplicate covered repair {}",
+                    display_ref(*covered)
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_against(&self, memory: &ProjectMemoryPacket) -> Result<(), String> {
+        self.validate_shape()?;
+        if memory.repository != self.repository {
+            return Err(format!(
+                "lesson-promotion repository `{}` disagrees with project-memory repository `{}`",
+                self.repository, memory.repository
+            ));
+        }
+
+        for repair in &self.repair_evidence {
+            let artifact = artifact(memory, repair.artifact)?;
+            validate_merged_predecessor(artifact, repair.artifact)?;
+            validate_exact_source_excerpt(artifact, &repair.source_evidence, repair.artifact)?;
+            if !repair.source_evidence.contains(&self.repair_marker) {
+                return Err(format!(
+                    "repair evidence for {} does not contain candidate marker `{}`",
+                    display_ref(repair.artifact), self.repair_marker
+                ));
+            }
+        }
+
+        for adjacent in &self.adjacent_predecessors {
+            let artifact = artifact(memory, adjacent.artifact)?;
+            validate_merged_predecessor(artifact, adjacent.artifact)?;
+            validate_exact_source_excerpt(artifact, &adjacent.source_evidence, adjacent.artifact)?;
+            if !adjacent.source_evidence.contains(&adjacent.marker) {
+                return Err(format!(
+                    "adjacent evidence for {} does not contain marker `{}`",
+                    display_ref(adjacent.artifact), adjacent.marker
+                ));
+            }
+        }
+
+        let guard = artifact(memory, self.guard.artifact)?;
+        validate_exact_source_excerpt(guard, &self.guard.source_evidence, self.guard.artifact)?;
+        if !self.guard.source_evidence.contains(&self.guard.marker) {
+            return Err(format!(
+                "guard evidence for {} does not contain marker `{}`",
+                display_ref(self.guard.artifact), self.guard.marker
+            ));
+        }
+        if !guard.changed_paths.contains(&self.guard.enforcement_path) {
+            return Err(format!(
+                "guard enforcement path `{}` is absent from {} changed paths",
+                self.guard.enforcement_path,
+                display_ref(self.guard.artifact)
+            ));
+        }
+
+        let predecessor_refs = self
+            .repair_evidence
+            .iter()
+            .map(|item| item.artifact)
+            .chain(self.adjacent_predecessors.iter().map(|item| item.artifact))
+            .collect::<BTreeSet<_>>();
+        for covered in &self.guard.covered_repairs {
+            if !predecessor_refs.contains(covered) {
+                return Err(format!(
+                    "guard coverage references {} outside the admitted predecessor set",
+                    display_ref(*covered)
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn artifact(
+    memory: &ProjectMemoryPacket,
+    reference: ArtifactRef,
+) -> Result<&ProjectArtifact, String> {
+    memory
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.reference == reference)
+        .ok_or_else(|| {
+            format!(
+                "lesson-promotion artifact {} is absent from project memory",
+                display_ref(reference)
+            )
+        })
+}
+
+fn validate_merged_predecessor(
+    artifact: &ProjectArtifact,
+    reference: ArtifactRef,
+) -> Result<(), String> {
+    if artifact.reference.kind != ArtifactKind::PullRequest {
+        return Err(format!(
+            "lesson-promotion predecessor {} must be a pull request",
+            display_ref(reference)
+        ));
+    }
+    if !artifact
+        .revision
+        .as_ref()
+        .is_some_and(|revision| revision.merged)
+    {
+        return Err(format!(
+            "lesson-promotion predecessor {} must be merged",
+            display_ref(reference)
+        ));
+    }
+    Ok(())
+}
+
+fn validate_exact_source_excerpt(
+    artifact: &ProjectArtifact,
+    evidence: &str,
+    reference: ArtifactRef,
+) -> Result<(), String> {
+    if !artifact.evidence_text.contains(evidence) {
+        return Err(format!(
+            "lesson-promotion evidence for {} is absent from retained project-memory text",
+            display_ref(reference)
+        ));
+    }
+    Ok(())
+}
+
+fn validate_pr_ref(reference: ArtifactRef, label: &str) -> Result<(), String> {
+    if reference.kind != ArtifactKind::PullRequest || reference.number == 0 {
+        return Err(format!("{label} must be a positive pull-request reference"));
+    }
+    Ok(())
+}
+
+fn validate_source_evidence(value: &str) -> Result<(), String> {
+    if value.is_empty() || value.len() > MAX_SOURCE_EVIDENCE_BYTES || value.contains('\0') {
+        return Err("source_evidence is empty, malformed, or too long".to_string());
+    }
+    Ok(())
+}
+
+fn validate_bounded_single_line(value: &str, label: &str, maximum: usize) -> Result<(), String> {
+    if value.is_empty()
+        || value.len() > maximum
+        || value.contains('\0')
+        || value.bytes().any(|byte| matches!(byte, b'\n' | b'\r'))
+    {
+        return Err(format!("{label} is empty, malformed, or too long"));
+    }
+    Ok(())
+}
+
+fn validate_repository(value: &str) -> Result<(), String> {
+    let Some((owner, repository)) = value.split_once('/') else {
+        return Err("repository must be canonical owner/name".to_string());
+    };
+    if owner.is_empty()
+        || repository.is_empty()
+        || repository.contains('/')
+        || !owner.bytes().all(valid_repository_char)
+        || !repository.bytes().all(valid_repository_char)
+    {
+        return Err("repository must be canonical owner/name".to_string());
+    }
+    Ok(())
+}
+
+fn valid_repository_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')
+}
+
+fn validate_repository_path(path: &str) -> Result<(), String> {
+    if path.is_empty()
+        || path.len() > MAX_PATH_BYTES
+        || path.starts_with('/')
+        || path.contains('\\')
+        || path.contains('\0')
+        || path
+            .split('/')
+            .any(|component| component.is_empty() || matches!(component, "." | ".."))
+    {
+        return Err(format!("non-canonical repository-relative path `{path}`"));
+    }
+    Ok(())
+}
+
+fn sorted_refs(values: impl Iterator<Item = ArtifactRef>) -> Vec<ArtifactRef> {
+    values.collect::<BTreeSet<_>>().into_iter().collect()
+}
+
+fn display_ref(reference: ArtifactRef) -> String {
+    let kind = match reference.kind {
+        ArtifactKind::PullRequest => "pr",
+        ArtifactKind::Issue => "issue",
+    };
+    format!("{kind}#{}", reference.number)
+}

--- a/src/lesson_promotion.rs
+++ b/src/lesson_promotion.rs
@@ -135,10 +135,7 @@ pub fn evaluate_lesson_promotion(
         .copied()
         .collect::<BTreeSet<_>>();
 
-    let missing_repair_coverage = repair_set
-        .difference(&covered)
-        .copied()
-        .collect::<Vec<_>>();
+    let missing_repair_coverage = repair_set.difference(&covered).copied().collect::<Vec<_>>();
     let different_class_coverage = covered
         .intersection(&adjacent_set)
         .copied()
@@ -194,11 +191,7 @@ impl LessonPromotionClaim {
             ));
         }
         validate_repository(&self.repository)?;
-        validate_bounded_single_line(
-            &self.candidate_id,
-            "candidate_id",
-            MAX_CANDIDATE_ID_BYTES,
-        )?;
+        validate_bounded_single_line(&self.candidate_id, "candidate_id", MAX_CANDIDATE_ID_BYTES)?;
         validate_bounded_single_line(
             &self.candidate_discriminator_id,
             "candidate_discriminator_id",
@@ -313,7 +306,8 @@ impl LessonPromotionClaim {
             if !repair.source_evidence.contains(&self.repair_marker) {
                 return Err(format!(
                     "repair evidence for {} does not contain candidate marker `{}`",
-                    display_ref(repair.artifact), self.repair_marker
+                    display_ref(repair.artifact),
+                    self.repair_marker
                 ));
             }
         }
@@ -325,7 +319,8 @@ impl LessonPromotionClaim {
             if !adjacent.source_evidence.contains(&adjacent.marker) {
                 return Err(format!(
                     "adjacent evidence for {} does not contain marker `{}`",
-                    display_ref(adjacent.artifact), adjacent.marker
+                    display_ref(adjacent.artifact),
+                    adjacent.marker
                 ));
             }
         }
@@ -335,7 +330,8 @@ impl LessonPromotionClaim {
         if !self.guard.source_evidence.contains(&self.guard.marker) {
             return Err(format!(
                 "guard evidence for {} does not contain marker `{}`",
-                display_ref(self.guard.artifact), self.guard.marker
+                display_ref(self.guard.artifact),
+                self.guard.marker
             ));
         }
         if !guard.changed_paths.contains(&self.guard.enforcement_path) {

--- a/tests/lesson_promotion.rs
+++ b/tests/lesson_promotion.rs
@@ -1,7 +1,7 @@
-#[path = "../src/project_memory.rs"]
-mod project_memory;
 #[path = "../src/lesson_promotion.rs"]
 mod lesson_promotion;
+#[path = "../src/project_memory.rs"]
+mod project_memory;
 
 use lesson_promotion::{
     MAX_LESSON_PROMOTION_BYTES, PromotionStatus, evaluate_lesson_promotion,

--- a/tests/lesson_promotion.rs
+++ b/tests/lesson_promotion.rs
@@ -1,0 +1,145 @@
+#[path = "../src/project_memory.rs"]
+mod project_memory;
+#[path = "../src/lesson_promotion.rs"]
+mod lesson_promotion;
+
+use lesson_promotion::{
+    MAX_LESSON_PROMOTION_BYTES, PromotionStatus, evaluate_lesson_promotion,
+    parse_lesson_promotion_claim,
+};
+use project_memory::{ArtifactKind, ArtifactRef, parse_project_memory_packet};
+
+const MEMORY: &[u8] = include_bytes!("../research/project-memory/stensibly-1575.json");
+const CLAIM: &[u8] = include_bytes!("../research/lesson-promotion/stensibly-1575.json");
+
+fn inputs() -> (
+    project_memory::ProjectMemoryPacket,
+    lesson_promotion::LessonPromotionClaim,
+) {
+    (
+        parse_project_memory_packet(MEMORY).unwrap(),
+        parse_lesson_promotion_claim(CLAIM).unwrap(),
+    )
+}
+
+fn pr(number: u64) -> ArtifactRef {
+    ArtifactRef {
+        kind: ArtifactKind::PullRequest,
+        number,
+    }
+}
+
+#[test]
+fn retained_stensibly_episode_is_an_observed_promotion() {
+    let (memory, claim) = inputs();
+    let evaluation = evaluate_lesson_promotion(&memory, &claim).unwrap();
+
+    assert_eq!(evaluation.status, PromotionStatus::ObservedPromotion);
+    assert_eq!(evaluation.same_class_repairs, vec![pr(1571), pr(1573)]);
+    assert_eq!(evaluation.adjacent_different_class, vec![pr(1569)]);
+    assert_eq!(evaluation.guard, pr(1575));
+    assert_eq!(
+        evaluation.enforcement_path,
+        "test/convex-index-identifier-limit.test.ts"
+    );
+    assert_eq!(evaluation.scope_ref, "convex/**/*.ts");
+    assert!(evaluation.missing_repair_coverage.is_empty());
+    assert!(evaluation.different_class_coverage.is_empty());
+    assert!(!evaluation.automatic_policy_authority);
+}
+
+#[test]
+fn adjacent_different_class_predecessor_cannot_count_as_guard_coverage() {
+    let (memory, mut claim) = inputs();
+    claim.guard.covered_repairs.push(pr(1569));
+
+    let evaluation = evaluate_lesson_promotion(&memory, &claim).unwrap();
+    assert_eq!(
+        evaluation.status,
+        PromotionStatus::GuardCoverageIncludesDifferentClass
+    );
+    assert_eq!(evaluation.different_class_coverage, vec![pr(1569)]);
+}
+
+#[test]
+fn missing_same_class_repair_keeps_guard_coverage_incomplete() {
+    let (memory, mut claim) = inputs();
+    claim.guard.covered_repairs.retain(|item| *item != pr(1573));
+
+    let evaluation = evaluate_lesson_promotion(&memory, &claim).unwrap();
+    assert_eq!(evaluation.status, PromotionStatus::GuardCoverageIncomplete);
+    assert_eq!(evaluation.missing_repair_coverage, vec![pr(1573)]);
+}
+
+#[test]
+fn one_repair_is_insufficient_for_repeated_repair_promotion() {
+    let (memory, mut claim) = inputs();
+    claim.repair_evidence.truncate(1);
+    claim.guard.covered_repairs = vec![pr(1571)];
+
+    let evaluation = evaluate_lesson_promotion(&memory, &claim).unwrap();
+    assert_eq!(
+        evaluation.status,
+        PromotionStatus::InsufficientRepeatedRepairs
+    );
+}
+
+#[test]
+fn mismatched_guard_discriminator_stays_separate() {
+    let (memory, mut claim) = inputs();
+    claim.guard.value_ref = "node_runtime_bundle".to_string();
+
+    let evaluation = evaluate_lesson_promotion(&memory, &claim).unwrap();
+    assert_eq!(evaluation.status, PromotionStatus::GuardClassMismatch);
+}
+
+#[test]
+fn unmerged_common_guard_is_only_proposed() {
+    let (mut memory, claim) = inputs();
+    let guard = memory
+        .artifacts
+        .iter_mut()
+        .find(|artifact| artifact.reference == pr(1575))
+        .unwrap();
+    guard.revision.as_mut().unwrap().merged = false;
+
+    let evaluation = evaluate_lesson_promotion(&memory, &claim).unwrap();
+    assert_eq!(evaluation.status, PromotionStatus::ProposedGuard);
+}
+
+#[test]
+fn different_class_predecessor_cannot_be_relabelled_as_same_class_without_marker() {
+    let (memory, mut claim) = inputs();
+    let adjacent = claim.adjacent_predecessors.remove(0);
+    claim.repair_evidence[0].artifact = adjacent.artifact;
+    claim.repair_evidence[0].source_evidence = adjacent.source_evidence;
+
+    let error = evaluate_lesson_promotion(&memory, &claim).unwrap_err();
+    assert!(error.contains("does not contain candidate marker"));
+}
+
+#[test]
+fn invented_source_excerpt_is_rejected() {
+    let (memory, mut claim) = inputs();
+    claim.repair_evidence[0].source_evidence =
+        "This repair definitely proves the universal rule.".to_string();
+
+    let error = evaluate_lesson_promotion(&memory, &claim).unwrap_err();
+    assert!(error.contains("absent from retained project-memory text"));
+}
+
+#[test]
+fn guard_enforcement_path_must_be_in_guard_diff() {
+    let (memory, mut claim) = inputs();
+    claim.guard.enforcement_path = "convex/schema.ts".to_string();
+
+    let error = evaluate_lesson_promotion(&memory, &claim).unwrap_err();
+    assert!(error.contains("absent from pr#1575 changed paths"));
+}
+
+#[test]
+fn claim_input_is_bounded_before_json_parse() {
+    let bytes = vec![b' '; MAX_LESSON_PROMOTION_BYTES + 1];
+    let error = parse_lesson_promotion_claim(&bytes).unwrap_err();
+    assert!(error.contains("exceeds"));
+}

--- a/tests/lesson_promotion.rs
+++ b/tests/lesson_promotion.rs
@@ -16,10 +16,10 @@ fn inputs() -> (
     project_memory::ProjectMemoryPacket,
     lesson_promotion::LessonPromotionClaim,
 ) {
-    (
-        parse_project_memory_packet(MEMORY).unwrap(),
-        parse_lesson_promotion_claim(CLAIM).unwrap(),
-    )
+    let memory = parse_project_memory_packet(MEMORY).unwrap();
+    memory.summary().unwrap();
+    let claim = parse_lesson_promotion_claim(CLAIM).unwrap();
+    (memory, claim)
 }
 
 fn pr(number: u64) -> ArtifactRef {


### PR DESCRIPTION
## Goal

Progress #41 / #11 with one historical lesson-promotion replay that composes the already-merged project-memory packet instead of inventing a second history collector.

The discriminator is intentionally adversarial: [Stensibly #1575](https://redirect.github.com/teamleaderleo/stensibly/pull/1575) explicitly follows three deployability repairs, while only [#1571](https://redirect.github.com/teamleaderleo/stensibly/pull/1571) and [#1573](https://redirect.github.com/teamleaderleo/stensibly/pull/1573) share the Convex 64-character index-identifier failure class. [#1569](https://redirect.github.com/teamleaderleo/stensibly/pull/1569) is real predecessor lineage for a different `node:crypto` bundling failure.

## Composition

The replay consumes existing:

```text
research/project-memory/stensibly-1575.json
```

and adds only a small typed promotion claim:

```text
candidate discriminator/value
exact retained repair marker
same-class repair refs
adjacent different-class predecessor refs
guard discriminator/value
guard changed path + scope
guard-covered repair refs
exact source excerpts
```

`src/lesson_promotion.rs` validates every excerpt against the retained project-memory artifact text and every referenced PR/path against the existing exact packet.

## Retained real episode

Candidate:

```text
discriminator  convex_production_failure_class
value          index_identifier_limit
repair marker  "64-character identifier limit"
```

Same-class merged repairs:

```text
#1571
#1573
```

Adjacent different-class merged predecessor:

```text
#1569
value  node_runtime_bundle
marker `node:crypto`
```

Merged common guard:

```text
#1575
test/convex-index-identifier-limit.test.ts
scope convex/**/*.ts
kind regression_test
covered repairs #1571/#1573
```

Executed evaluation:

```text
observed_promotion
automatic_policy_authority = false
```

`observed_promotion` describes a historical accepted repository event. It grants no authority to synthesize or enforce future policy.

## Adversarial controls

The ordinary Rust suite requires:

- adding #1569 to same-class guard coverage -> `guard_coverage_includes_different_class`;
- omitting #1573 -> `guard_coverage_incomplete`;
- one same-class repair -> `insufficient_repeated_repairs`;
- guard discriminator drift -> `guard_class_mismatch`;
- unmerged guard -> `proposed_guard`;
- relabeling #1569 as same-class rejects because its retained source text lacks the exact candidate repair marker;
- invented source excerpts reject;
- a guard path absent from the guard PR diff rejects;
- claim input is bounded before JSON parse.

This protects the key distinction: explicit lineage and same-class evidence are separate axes.

## Executed current-main receipts

Semantic code/fixture head:

```text
head:       133e4a9e0cb99bd5076880e2ea62aec44dff13e7
main:       9ba02d8664ca6cb47573e7cde270cfec15fed50c
merge view: c1ae70c4e58fa42c32da0f7ae9d8761ddd8336d7
CI:         32257963686 success
provenance: 32257963257 success
```

Final head adds only the durable receipt prose in `research/lesson-promotion.md`:

```text
head:       dbee6362000706ee9b9c132a82f48d10011f5dcb
CI:         32258197167 success
provenance: 32258196916 success
```

Both merge-view CI runs passed formatter, all-target Clippy with warnings denied, full tests, project-memory adapter controls, external GitHub reference controls, and normal Cultist repository/history/CI/diff dogfood.

## Replay

```text
cargo run --example lesson_promotion -- \
  research/project-memory/stensibly-1575.json \
  research/lesson-promotion/stensibly-1575.json
```

## External GitHub references

Human-facing external links in this PR and the research note use `redirect.github.com` per current repository policy. Provider/source text inside retained evidence remains exact.

## Boundary

Research-only files:

- `src/lesson_promotion.rs`
- `tests/lesson_promotion.rs`
- `examples/lesson_promotion.rs`
- `research/lesson-promotion/stensibly-1575.json`
- `research/lesson-promotion.md`

No product CLI/report-schema change; no provider/network call; no automatic promotion; no title-similarity or chronology classifier; no scalar confidence score.

The final merge view is current `main@9ba02d8664ca6cb47573e7cde270cfec15fed50c` plus this five-file research lane; the intervening #219 files are disjoint and passed in the combined CI view.

Progresses #11
Progresses #41
Refs #18 #74 #148 #160 #162.