### PR TITLE
research: probe applicability skill with metamorphic evidence controls

### DIFF
--- a/examples/discriminator_observations.rs
+++ b/examples/discriminator_observations.rs
@@ -1,0 +1,37 @@
+#![allow(dead_code)]
+
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+
+use discriminator_observation::{
+    MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES, enumerate_discriminator_partitions,
+    parse_discriminator_observation_batch,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("discriminator-observations: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES {
+        return Err(format!(
+            "discriminator observation batch exceeds the {MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let batch = parse_discriminator_observation_batch(&bytes)?;
+    let enumeration = enumerate_discriminator_partitions(&batch)?;
+    println!("{}", serde_json::to_string_pretty(&enumeration)?);
+    Ok(())
+}

--- a/examples/observation_frontiers.rs
+++ b/examples/observation_frontiers.rs
@@ -1,0 +1,39 @@
+#![allow(dead_code)]
+
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+
+use observation_frontier::{
+    MAX_OBSERVATION_FRONTIER_REQUEST_BYTES, evaluate_observation_frontiers,
+    parse_observation_frontier_request,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("observation-frontiers: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_OBSERVATION_FRONTIER_REQUEST_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_OBSERVATION_FRONTIER_REQUEST_BYTES {
+        return Err(format!(
+            "observation frontier request exceeds the {MAX_OBSERVATION_FRONTIER_REQUEST_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let request = parse_observation_frontier_request(&bytes)?;
+    let evaluation = evaluate_observation_frontiers(&request)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}

--- a/examples/refinement_episodes.rs
+++ b/examples/refinement_episodes.rs
@@ -1,0 +1,33 @@
+#![allow(dead_code)]
+
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+
+use refinement_episode::{MAX_REFINEMENT_EPISODE_BATCH_BYTES, parse_refinement_episode_batch};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("refinement-episodes: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_REFINEMENT_EPISODE_BATCH_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_REFINEMENT_EPISODE_BATCH_BYTES {
+        return Err(format!(
+            "refinement episode batch exceeds the {MAX_REFINEMENT_EPISODE_BATCH_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let batch = parse_refinement_episode_batch(&bytes)?;
+    println!("{}", serde_json::to_string_pretty(&batch)?);
+    Ok(())
+}

--- a/research/discriminator-observations.md
+++ b/research/discriminator-observations.md
@@ -141,6 +141,31 @@ cargo run --example discriminator_observations \
 
 The reader validates the supplied observation batch and prints generic current/unknown/invalid partition receipts.
 
+## Executed GitHub receipt
+
+Draft PR #187 was compacted to one semantic commit on #179's exact green receipt head.
+
+Exact semantic head:
+
+```text
+bea8b42be1d372096c64e41c7dce37cb363b8f1a
+```
+
+GitHub Actions CI run `32248518562` / run number `1266` completed successfully. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work preflight;
+- full `cargo test`, including selected #179 discriminator coverage, KNOWN/UNKNOWN/INVALID partition behavior, duplicate/conflict identity controls, distinct-source identity preservation, deterministic round trip, and opaque value semantics;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The first CI attempt failed only at rustfmt before Clippy or tests. The exact formatter delta was applied, then the branch was compacted back to the single semantic commit above before the successful run.
+
+Because #187 is stacked on #179 rather than `main`, the PR executes the ordinary CI workflow; the generated-provenance PR workflow is not part of this stacked carrier's gate.
+
 ## Boundary
 
 - research-only reference seam;
@@ -153,7 +178,7 @@ The reader validates the supplied observation batch and prints generic current/u
 
 ## Next discriminator
 
-If this three-family reference seam survives CI, the next useful experiment is deliberately tiny:
+The three-family reference seam survived CI. The next useful experiment is deliberately tiny:
 
 ```text
 #179 candidate needs discriminator D
@@ -161,9 +186,9 @@ If this three-family reference seam survives CI, the next useful experiment is d
 -> return explicit missing-observation frontier
 ```
 
-Then compare that frontier with #145's probe-capability planning. A useful composition would let #145 select a source-owned probe capable of producing observation D without making #185 execute it.
+Compare that frontier with #145's probe-capability planning while keeping their vocabularies separate. #185 identifies the missing generic observation reference; a source adapter must map that need to #145's `{kind,target}` clearing/probe contract. The generic layer must not assume that a matching string means a probe can produce the observation.
 
-If the bridge requires family-specific probe semantics inside #185, keep the bridge in adapters and preserve the reference module as the narrow boundary earned here.
+A useful composition would let #145 select a source-owned probe capable of producing observation D while #185 remains a read-only reference/partition layer. If the bridge requires family-specific probe semantics inside #185, keep the bridge in adapters and preserve the reference module as the narrow boundary earned here.
 
 North star:
 

--- a/research/discriminator-observations.md
+++ b/research/discriminator-observations.md
@@ -1,0 +1,170 @@
+# Source-owned discriminator observation references
+
+Tracking: #185. Stacked on the green #179 / #148 refinement-episode carrier.
+
+## Question
+
+Can three very different analyzer families expose one tiny typed reference seam for already-earned discriminator observations without moving their domain evaluators into the analyzer-refinement layer?
+
+V0 deliberately models **references to observations**, not the logic that produces them.
+
+## Observation contract
+
+```text
+DiscriminatorObservation
+  observation_id
+  discriminator_id
+  subject_ref
+  source_receipt
+  value_state
+    known { value_ref }
+    unknown { reason_ref }
+    invalid { reason_ref }
+  applicability_ref?
+```
+
+The fields mean:
+
+- `observation_id` — identity of this supplied observation event/object;
+- `discriminator_id` — which distinction the source analyzer says this observation answers;
+- `subject_ref` — exact source-owned subject identity;
+- `source_receipt` — where the value/status came from;
+- `value_ref` — opaque supplied partition value when current;
+- `reason_ref` — source-owned explanation reference for UNKNOWN/INVALID;
+- `applicability_ref` — optional exact reference to the source applicability/coordinate receipt.
+
+The generic layer parses none of those reference strings for semantic meaning.
+
+## Enumeration contract
+
+`enumerate_discriminator_partitions` groups only KNOWN observations by:
+
+```text
+discriminator_id
+  -> value_ref
+     -> current observation receipts[]
+```
+
+UNKNOWN and INVALID observations remain separate inspectable lists under the same discriminator and never enter current partitions.
+
+Each current partition keeps every observation identity, subject, source receipt, and applicability reference. Equal values from two source receipts therefore remain two observations rather than being silently deduplicated into one evidence event.
+
+## Retained three-family corpus
+
+`research/discriminator-observations/cultist-v1.json` supplies one current observation for every discriminator used by the selected transitions in #179.
+
+### A. Justification / durable UNKNOWN
+
+```text
+discriminator_id = clearing_evidence_presence
+value_ref        = absent
+source           = #159 exact durable-obligation head
+```
+
+The reference layer does not decide whether `absent` means OPEN or whether the subject remains applicable. #159/#123 own those semantics.
+
+### B. Historical companion refinement
+
+```text
+discriminator_id = edit_class
+value_ref        = syntax_changed
+source           = retained Oxc syntax-cohort replay
+```
+
+The reference layer does not tokenize Rust or decide that exact commit identity is overfit. Those results remain in the source research and #168.
+
+### C. Project-memory contract refinement
+
+```text
+discriminator_id = primary_case_evidence_form
+value_ref        = primary_case_issue_block
+
+discriminator_id = same_repository_issue_target
+value_ref        = same_repository_issue
+
+source           = #174 exact repair head
+```
+
+The reference layer does not parse `Primary case:`, GitHub URLs, repositories, issue numbers, or relation types. #174/project-memory validation owns those checks.
+
+## Composition with #179
+
+The strongest first control is cross-object rather than family-specific:
+
+```text
+for every selected transition in the retained #179 corpus:
+  for every discriminator_ref used by that selected candidate:
+    a current KNOWN discriminator observation must exist
+```
+
+The test uses only exact discriminator IDs and supplied observation state. It does not execute the source analyzers.
+
+This proves the narrow seam #185 is asking for: #179 can consume current source-owned discriminator references without learning how those discriminators were produced.
+
+## Adversarial controls
+
+The standard test harness requires:
+
+- KNOWN observations enumerate deterministically by discriminator/value;
+- UNKNOWN stays visible and out of current partitions;
+- INVALID stays visible and out of current partitions;
+- exact duplicate observation identity rejects;
+- same observation identity with changed semantics rejects as a conflict;
+- missing source receipt rejects;
+- same value from distinct source receipts preserves both observation identities;
+- batch/enum JSON round trips and ordering remain deterministic;
+- oversized input rejects before JSON parsing;
+- an alarming value spelling such as `approve_and_merge_everything` remains an opaque value reference and grants no authority/disposition.
+
+## What V0 intentionally cannot do
+
+This module does not decide:
+
+```text
+which discriminator to acquire
+whether a partition is causal
+whether a partition is overfit
+whether a candidate improves replay
+whether evidence is strong enough
+whether a source observation is authorized
+what action/disposition follows
+```
+
+Those questions remain in #145, #168, #179, applicability, or the originating analyzer.
+
+## Research reader
+
+```text
+cargo run --example discriminator_observations \
+  < research/discriminator-observations/cultist-v1.json
+```
+
+The reader validates the supplied observation batch and prints generic current/unknown/invalid partition receipts.
+
+## Boundary
+
+- research-only reference seam;
+- no universal fact ontology;
+- no source analyzer duplication;
+- no string parsing for semantic authority;
+- no behavioral identity conflation;
+- no automatic analyzer refinement/promotion;
+- no product CLI/report-schema change.
+
+## Next discriminator
+
+If this three-family reference seam survives CI, the next useful experiment is deliberately tiny:
+
+```text
+#179 candidate needs discriminator D
+#185 has zero current KNOWN observations for D
+-> return explicit missing-observation frontier
+```
+
+Then compare that frontier with #145's probe-capability planning. A useful composition would let #145 select a source-owned probe capable of producing observation D without making #185 execute it.
+
+If the bridge requires family-specific probe semantics inside #185, keep the bridge in adapters and preserve the reference module as the narrow boundary earned here.
+
+North star:
+
+> Exchange references to analyzer-earned distinctions; keep the knowledge of how those distinctions are proved with the analyzer that owns them.

--- a/research/discriminator-observations/cultist-v1.json
+++ b/research/discriminator-observations/cultist-v1.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "observations": [
+    {
+      "observation_id": "justification/open-obligation-v1:clearing-evidence-presence",
+      "discriminator_id": "clearing_evidence_presence",
+      "subject_ref": "refinement:justification/open-obligation-v1",
+      "source_receipt": "github:pull/159@1c1a0086a199168fd0e21445d103936183063dc7",
+      "value_state": {
+        "state": "known",
+        "value_ref": "absent"
+      },
+      "applicability_ref": "research:durable-unknown-obligation.md#evaluation"
+    },
+    {
+      "observation_id": "history/oxc-edit-class-v1:current-edit-class",
+      "discriminator_id": "edit_class",
+      "subject_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588:crates/oxc_linter/src/rules.rs",
+      "source_receipt": "research:rust-syntax-cohort-replay.md",
+      "value_state": {
+        "state": "known",
+        "value_ref": "syntax_changed"
+      },
+      "applicability_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588"
+    },
+    {
+      "observation_id": "project-memory/primary-case-contract-collision-v1:evidence-form",
+      "discriminator_id": "primary_case_evidence_form",
+      "subject_ref": "refinement:project-memory/primary-case-contract-collision-v1",
+      "source_receipt": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca",
+      "value_state": {
+        "state": "known",
+        "value_ref": "primary_case_issue_block"
+      },
+      "applicability_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+    },
+    {
+      "observation_id": "project-memory/primary-case-contract-collision-v1:target-relation",
+      "discriminator_id": "same_repository_issue_target",
+      "subject_ref": "refinement:project-memory/primary-case-contract-collision-v1",
+      "source_receipt": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca",
+      "value_state": {
+        "state": "known",
+        "value_ref": "same_repository_issue"
+      },
+      "applicability_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+    }
+  ]
+}

--- a/research/discriminator-observations/cultist-v1.json
+++ b/research/discriminator-observations/cultist-v1.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "observations": [
     {
       "observation_id": "justification/open-obligation-v1:clearing-evidence-presence",
@@ -10,7 +10,10 @@
         "state": "known",
         "value_ref": "absent"
       },
-      "applicability_ref": "research:durable-unknown-obligation.md#evaluation"
+      "applicability": {
+        "status": "applies",
+        "receipt_ref": "research:durable-unknown-obligation.md#evaluation"
+      }
     },
     {
       "observation_id": "history/oxc-edit-class-v1:current-edit-class",
@@ -21,7 +24,10 @@
         "state": "known",
         "value_ref": "syntax_changed"
       },
-      "applicability_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588"
+      "applicability": {
+        "status": "applies",
+        "receipt_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588"
+      }
     },
     {
       "observation_id": "project-memory/primary-case-contract-collision-v1:evidence-form",
@@ -32,7 +38,10 @@
         "state": "known",
         "value_ref": "primary_case_issue_block"
       },
-      "applicability_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+      "applicability": {
+        "status": "applies",
+        "receipt_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+      }
     },
     {
       "observation_id": "project-memory/primary-case-contract-collision-v1:target-relation",
@@ -43,7 +52,10 @@
         "state": "known",
         "value_ref": "same_repository_issue"
       },
-      "applicability_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+      "applicability": {
+        "status": "applies",
+        "receipt_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+      }
     }
   ]
 }

--- a/research/observation-frontiers.md
+++ b/research/observation-frontiers.md
@@ -1,0 +1,134 @@
+# Missing discriminator observation frontiers
+
+Tracking: #190 Phase A. Stacked on #187/#185 and #179/#148.
+
+## Question
+
+When a selected refinement requires discriminator `D` for exact subject `S`, can Cultist state whether a usable source-owned observation currently exists without running the source analyzer or guessing from another subject?
+
+Phase A adds only the read-only frontier.
+
+## Exact requirement identity
+
+```text
+ObservationRequirement
+  discriminator_id
+  subject_ref
+```
+
+A requirement is satisfied only by observations with the exact same pair.
+
+This deliberately prevents a source observation such as:
+
+```text
+edit_class = syntax_changed
+subject = file A
+```
+
+from satisfying the same discriminator for file B.
+
+Observations with the same discriminator and another subject stay visible under `other_subject`; they never satisfy the requested frontier.
+
+## Frontier states
+
+```text
+current
+  >= 1 matching KNOWN observation
+
+unknown
+  zero matching KNOWN
+  >= 1 matching UNKNOWN
+
+invalid
+  zero matching KNOWN/UNKNOWN
+  >= 1 matching INVALID
+
+missing
+  zero matching observations
+```
+
+All matching receipts remain visible even when a higher-precedence state wins. For example:
+
+```text
+KNOWN + UNKNOWN
+  -> current
+  -> preserve both current and unknown receipts
+
+UNKNOWN + INVALID
+  -> unknown
+  -> preserve both unknown and invalid receipts
+```
+
+The precedence represents current usability, not evidence strength:
+
+```text
+current > unknown > invalid > missing
+```
+
+## Composition controls
+
+The first standard-suite control derives exact requirements from the retained #179 selected transitions plus #187 observation corpus. All four selected discriminator requirements resolve `current`.
+
+Then adversarial controls mutate the same supplied observations:
+
+- remove one selected observation -> explicit `missing`;
+- keep the discriminator but move it to another subject -> `missing` + `other_subject` receipt;
+- change matching observation to UNKNOWN -> `unknown`;
+- change matching observation to INVALID -> `invalid`;
+- add UNKNOWN beside KNOWN -> `current`, preserving both;
+- add INVALID beside UNKNOWN -> `unknown`, preserving both;
+- duplicate exact requirements reject;
+- frontier order is deterministic;
+- request JSON round trip revalidates the embedded observation batch;
+- input above 512 KiB rejects before JSON parsing.
+
+## Bounded research reader
+
+```text
+cargo run --example observation_frontiers < request.json
+```
+
+The request embeds the bounded #185 observation batch and a bounded requirement list. The reader validates and prints only frontier receipts.
+
+## Boundary
+
+Phase A performs zero acquisition work:
+
+- no source analyzer execution;
+- no probe capability lookup;
+- no mapping from `discriminator_id` to #145 `{kind,target}`;
+- no evidence-strength or authority inference;
+- no action/disposition decision;
+- no duplicate applicability evaluator.
+
+UNKNOWN/INVALID reason and applicability references remain source-owned strings. The frontier carries them; it does not interpret them.
+
+## Phase B discriminator
+
+After Phase A survives CI, test one explicit source-owned adapter mapping:
+
+```text
+missing observation D@S
+-> adapter receipt
+   observation discriminator D
+   observation subject S
+   #145 probe discriminator {kind,target}
+   clearing requirements
+-> existing #145 planner
+```
+
+Negative control:
+
+```text
+similarly named probe
++ no explicit adapter mapping
+-> frontier remains unresolved for acquisition
+```
+
+Effect authorization remains #145's existing responsibility.
+
+The bridge should be a separate carrier because #190 currently spans two independent research stacks: #179/#187 frontier semantics and #159/#164 probe planning. Proving Phase A first avoids copying #145 types into this read-only layer just to make the stacks meet.
+
+North star:
+
+> Name the exact missing analyzer observation before deciding which evidence work, if any, can produce it.

--- a/research/observation-frontiers.md
+++ b/research/observation-frontiers.md
@@ -90,6 +90,43 @@ cargo run --example observation_frontiers < request.json
 
 The request embeds the bounded #185 observation batch and a bounded requirement list. The reader validates and prints only frontier receipts.
 
+## Executed GitHub receipt
+
+Draft PR #194 was compacted to one semantic commit on #187's exact green receipt head.
+
+Exact semantic head:
+
+```text
+b54ed3213994c96ec818ef36bb9728b0dc1f7eb6
+```
+
+GitHub Actions CI run `32249440070` / run number `1293` completed successfully. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work preflight;
+- full `cargo test`, including current coverage for all four selected #179/#187 requirements, explicit missing after observation removal, wrong-subject isolation, UNKNOWN/INVALID states, mixed-state receipt preservation and precedence, duplicate requirement rejection, deterministic ordering, bounded request parsing, and JSON round trip;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The first CI attempt stopped at rustfmt before Clippy or tests. The exact formatter delta was applied, then the branch was compacted back to the single semantic commit above before the successful run.
+
+The central Phase A result is now executable:
+
+```text
+same discriminator + wrong subject
+  -> other_subject receipt remains visible
+  -> exact required frontier stays missing
+```
+
+and mixed source states preserve their receipts while current usability follows:
+
+```text
+current > unknown > invalid > missing
+```
+
 ## Boundary
 
 Phase A performs zero acquisition work:
@@ -105,7 +142,7 @@ UNKNOWN/INVALID reason and applicability references remain source-owned strings.
 
 ## Phase B discriminator
 
-After Phase A survives CI, test one explicit source-owned adapter mapping:
+Phase A survived CI. The next experiment can test one explicit source-owned adapter mapping:
 
 ```text
 missing observation D@S
@@ -127,7 +164,7 @@ similarly named probe
 
 Effect authorization remains #145's existing responsibility.
 
-The bridge should be a separate carrier because #190 currently spans two independent research stacks: #179/#187 frontier semantics and #159/#164 probe planning. Proving Phase A first avoids copying #145 types into this read-only layer just to make the stacks meet.
+The bridge should be a separate carrier because #190 currently spans two independent research stacks: #179/#187 frontier semantics and #159/#164 probe planning. Phase A now gives that bridge a precise input without copying #145 types into the read-only frontier layer.
 
 North star:
 

--- a/research/refinement-episodes.md
+++ b/research/refinement-episodes.md
@@ -1,0 +1,243 @@
+# Counterexample-guided analyzer refinement episodes
+
+Tracking: #148. Built after #141/#144, #142/#168, project-memory contract refinement #174, and the behavioral episode work in #137/#175/#178.
+
+## Question
+
+Can Cultist preserve analyzer-research transitions as bounded, replayable records while leaving domain facts and predicates with the analyzers that produced them?
+
+V0 answers only the bookkeeping layer.
+
+## Episode contract
+
+```text
+RefinementEpisode
+  id
+  family
+  hypothesis_before
+  counterexample_refs[]
+  admitted_discriminators[]
+  candidate_refinements[]
+  selected_transition?
+  source_receipts[]
+  behavioral_episode_ids[]
+```
+
+Each candidate carries:
+
+```text
+hypothesis_after
+admitted discriminator refs
+source replay receipts
+replay_result
+  expected_cases_retained
+  counterexamples_resolved
+  expected_cases_lost
+  counterexamples_remaining
+  held_out_status
+status
+  retained
+  weakened
+  split
+  rejected_no_improvement
+  rejected_overfit
+  rejected_lost_expected_case
+```
+
+The replay counts are supplied by exact source receipts. This layer does zero Rust edit classification, obligation applicability, historical co-change analysis, project-memory relation parsing, or domain predicate evaluation.
+
+## Meta-level invariants
+
+The validator checks only properties the refinement ledger itself owns:
+
+- episode, candidate, discriminator, and reference identities are bounded and unique where required;
+- every candidate discriminator reference names one discriminator admitted by the episode;
+- a selected transition names an existing `retained`, `weakened`, or `split` candidate;
+- kept candidates retain every expected replay case, resolve at least one counterexample, and cannot carry a failed held-out result;
+- `rejected_no_improvement` resolves zero counterexamples and loses zero expected cases;
+- `rejected_lost_expected_case` records at least one lost expected case;
+- rejected-overfit status stays a supplied source conclusion because overfit criteria belong to the source experiment;
+- behavioral episode IDs remain optional explicit links to already-observed #165 episodes.
+
+The last point composes with #175: a research transition can link to observed receiver episodes and descriptive summaries while deterministic replay remains independently inspectable.
+
+## Retained episode A: justification / open obligation
+
+The first episode records the refinement discovered by stacking #144 on #141.
+
+```text
+H0
+  every obligation requires >= 1 observed clearing edge
+
+counterexample
+  a durable material UNKNOWN can exist before clearing evidence arrives
+
+selected transition
+  allow zero-edge OPEN obligations
+  keep typed clearing receipts when evidence later arrives
+```
+
+Source receipts point at the #156/#159 research heads and CI. The meta replay records expected cases retained, the counterexample resolved, and zero expected cases lost.
+
+No behavioral episode is attached because this was a deterministic semantic refinement rather than an observed receiver episode.
+
+## Retained episode B: Oxc edit-class cohort
+
+The second episode records the already-executed Oxc result:
+
+```text
+raw forward cohort
+  99 support / 1 counterexample
+
+edit_class = syntax_changed
+  99 support / 0 counterexamples
+```
+
+The selected `edit_class` refinement is `weakened` because it narrows the original file-change hypothesis.
+
+Two rejected candidates remain beside it:
+
+```text
+reverse edit-class control
+  94 support / 6 counterexamples
+  -> rejected_no_improvement
+
+exact commit identity partition
+  one-current-observation cohort
+  -> rejected_overfit
+```
+
+The source receipts preserve the full Rust syntax cohort replay, #168's generic refinement evaluator, its green CI run, and the earlier held-out generated-companion product proof.
+
+## Retained episode C: project-memory Primary case contract
+
+The third episode came from a real producer/consumer collision between merged #166 and #167.
+
+```text
+H0
+  current project-memory relation admission composes with collector evidence
+
+#166 consumer
+  strict single-line relation admission + exact target mention
+
+#167 producer
+  Primary case:\nURL issue evidence block
+
+counterexample
+  both landed with zero path overlap
+  current-main packet no longer passed the consumer contract
+```
+
+#174 split the admission rule instead of weakening every relation edge:
+
+```text
+ordinary relationship prose
+  -> existing strict single-line classifier
+
+exact Primary case block
+  -> separate validated path
+     exact label
+     admitted GitHub origin
+     packet repository match
+     canonical positive issue number
+     relation = related
+     declared target match
+```
+
+The source replay admits the two intended Primary case forms, resolves the integration counterexample, loses zero expected cases, and passed #174 CI/provenance on head `e1196c553ab496df13a230535de997f30c2d63ca`.
+
+This episode also carries the real #178 behavioral episode:
+
+```text
+project-memory:primary-case-contract-collision:9792bfe->df5ae59
+```
+
+The standard refinement test resolves that ID against the retained #165 behavioral batch and requires its observed outcome to be `changed_next_action`.
+
+## Why rejected candidates stay in the object
+
+Keeping only the winner would erase the research path. The durable episode instead records:
+
+```text
+what broad claim existed
+which counterexample challenged it
+which discriminators were admitted
+which candidate survived
+which tempting candidates failed
+which exact receipts justify those statuses
+```
+
+That gives a future worker enough information to resume the research question without reconstructing the discarded alternatives from prose or chronology.
+
+## Behavioral boundary
+
+`behavioral_episode_ids[]` is an explicit optional join to merged #165 observation identity.
+
+Episodes A and B stay empty because no observed worker episode has been collected for those exact research transitions. Episode C links one already-retained #178 observation and verifies that the ID exists in the behavioral corpus.
+
+A deterministic replay result never manufactures a behavioral receipt. Behavioral identity and deterministic refinement identity remain separate records joined by explicit ID only when an observation exists.
+
+## Research reader
+
+```text
+cargo run --example refinement_episodes \
+  < research/refinement-episodes/cultist-v1.json
+```
+
+The reader validates the bounded batch and reprints the typed records.
+
+## Initial executed GitHub receipt
+
+The first two-family version of draft PR #179 passed on exact head:
+
+```text
+f4d92b05e061a99e262a1ef1eb2f2be424686359
+```
+
+GitHub Actions CI run `32247329835` / run number `1222` completed successfully, including format, strict Clippy, active-work preflight, full tests, repository/history/CI-filter/diff dogfood. Generated provenance review run `32247329697` / run number `219` also passed.
+
+The first CI attempt failed only at rustfmt before Clippy or tests. The formatter delta was applied verbatim, and the standalone reader received fixture-local dead-code containment.
+
+The three-family extension is rebuilt directly on main after merged #178 so the behavioral join is tested against the current retained observation corpus. Record its exact execution separately after the new head runs.
+
+## Boundary
+
+- research-only ledger;
+- no analyzer predicate language;
+- no automatic discriminator enumeration;
+- no scalar research score;
+- no automatic promotion/demotion;
+- no chronology-derived causality;
+- no fabricated behavioral evidence;
+- exact source receipts remain the authority for domain replay claims.
+
+## Next discriminator
+
+Three independent families now fit the ledger, but they expose different fact-production mechanisms:
+
+```text
+justification
+  typed clearing-evidence presence
+
+historical companion
+  supplied Rust edit class
+
+project memory
+  exact evidence-form + target/repository contract
+```
+
+That diversity argues for one more restraint: episode count alone does not earn automatic candidate enumeration. The next useful question is whether these source analyzers can expose a common **discriminator reference interface** without moving their domain logic into #148.
+
+A small future experiment can ask each source family for only:
+
+```text
+discriminator id
+source receipt
+current supplied value / applicability
+```
+
+and then test whether the refinement ledger can enumerate candidates over those references while still delegating semantics to the source evaluator. If the adapters need family-specific execution logic, keep enumeration outside the meta-layer.
+
+North star:
+
+> Preserve every analyzer refinement as an inspectable transition from broad hypothesis through counterexample and replay, including the rejected alternatives that explain why the surviving rule earned its narrower claim.

--- a/research/refinement-episodes.md
+++ b/research/refinement-episodes.md
@@ -186,7 +186,7 @@ cargo run --example refinement_episodes \
 
 The reader validates the bounded batch and reprints the typed records.
 
-## Initial executed GitHub receipt
+## Executed GitHub receipts
 
 The first two-family version of draft PR #179 passed on exact head:
 
@@ -194,11 +194,28 @@ The first two-family version of draft PR #179 passed on exact head:
 f4d92b05e061a99e262a1ef1eb2f2be424686359
 ```
 
-GitHub Actions CI run `32247329835` / run number `1222` completed successfully, including format, strict Clippy, active-work preflight, full tests, repository/history/CI-filter/diff dogfood. Generated provenance review run `32247329697` / run number `219` also passed.
+CI run `32247329835` / run number `1222` and generated provenance review run `32247329697` / run number `219` completed successfully. The first CI attempt had failed only at rustfmt before Clippy or tests; the formatter delta was applied verbatim and the standalone reader received fixture-local dead-code containment.
 
-The first CI attempt failed only at rustfmt before Clippy or tests. The formatter delta was applied verbatim, and the standalone reader received fixture-local dead-code containment.
+The three-family carrier was then rebuilt as one commit on merged #178 main so its behavioral join resolves against the current retained observation corpus.
 
-The three-family extension is rebuilt directly on main after merged #178 so the behavioral join is tested against the current retained observation corpus. Record its exact execution separately after the new head runs.
+Exact three-family semantic head:
+
+```text
+dbb39fb729df762ffefcf97d024e52fd647832cf
+```
+
+GitHub Actions CI run `32247721374` / run number `1235` completed successfully. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work preflight;
+- full `cargo test`, including the three retained refinement episodes, rejected-candidate controls, and the cross-corpus #178 behavioral ID/outcome assertion;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+Generated provenance review dogfood run `32247721348` / run number `223` also completed successfully on the same three-family head.
 
 ## Boundary
 

--- a/research/refinement-episodes/cultist-v1.json
+++ b/research/refinement-episodes/cultist-v1.json
@@ -1,0 +1,209 @@
+{
+  "schema_version": 1,
+  "episodes": [
+    {
+      "id": "justification/open-obligation-v1",
+      "family": "justification",
+      "hypothesis_before": {
+        "id": "requires-clearing-edge",
+        "statement": "Every obligation node requires at least one observed clearing edge."
+      },
+      "counterexample_refs": [
+        "github:issue/144#open-before-clearing-evidence"
+      ],
+      "admitted_discriminators": [
+        {
+          "id": "clearing_evidence_presence",
+          "source_ref": "github:pull/159@1c1a0086a199168fd0e21445d103936183063dc7"
+        }
+      ],
+      "candidate_refinements": [
+        {
+          "id": "allow-open-zero-edge",
+          "hypothesis_after": {
+            "id": "observed-clearing-edge-is-optional",
+            "statement": "An obligation may remain open before clearing evidence arrives; observed clearing edges remain typed receipts when present."
+          },
+          "discriminator_refs": [
+            "clearing_evidence_presence"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 7,
+            "counterexamples_resolved": 1,
+            "expected_cases_lost": 0,
+            "counterexamples_remaining": 0,
+            "held_out_status": "not_run"
+          },
+          "status": "weakened",
+          "source_receipts": [
+            "github:pull/156@9beaeaab2bece20a4e0bb9c880f510f740bf8cfb",
+            "github:pull/159@1c1a0086a199168fd0e21445d103936183063dc7",
+            "github-actions:run/32243719268"
+          ]
+        }
+      ],
+      "selected_transition": "allow-open-zero-edge",
+      "source_receipts": [
+        "research:justification-graph.md",
+        "research:durable-unknown-obligation.md"
+      ],
+      "behavioral_episode_ids": []
+    },
+    {
+      "id": "history/oxc-edit-class-v1",
+      "family": "historical_companion",
+      "hypothesis_before": {
+        "id": "raw-source-change-cohort",
+        "statement": "Every source-file change belongs to one historical companion cohort for evaluating the generated-file expectation."
+      },
+      "counterexample_refs": [
+        "oxc:5e113baf716b9f3781331b268b4142d23cac0541#docs-license-notices"
+      ],
+      "admitted_discriminators": [
+        {
+          "id": "edit_class",
+          "source_ref": "research:rust-syntax-cohort-replay.md"
+        },
+        {
+          "id": "commit_identity",
+          "source_ref": "github:pull/168@b8c6457de8d05a38a662289962fc11a124d32861"
+        }
+      ],
+      "candidate_refinements": [
+        {
+          "id": "syntax-changing-current-cohort",
+          "hypothesis_after": {
+            "id": "syntax-changing-source-cohort",
+            "statement": "Evaluate the forward generated-companion expectation inside the supplied Rust syntax-changing edit cohort."
+          },
+          "discriminator_refs": [
+            "edit_class"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 99,
+            "counterexamples_resolved": 1,
+            "expected_cases_lost": 0,
+            "counterexamples_remaining": 0,
+            "held_out_status": "passed"
+          },
+          "status": "weakened",
+          "source_receipts": [
+            "research:rust-syntax-cohort-replay.md",
+            "github:pull/168@b8c6457de8d05a38a662289962fc11a124d32861",
+            "github-actions:run/32245110401",
+            "github:pull/72"
+          ]
+        },
+        {
+          "id": "reverse-edit-class-control",
+          "hypothesis_after": {
+            "id": "reverse-syntax-cohort-improves",
+            "statement": "Applying the same edit-class discriminator to generated-to-source history should remove reverse-direction counterexamples."
+          },
+          "discriminator_refs": [
+            "edit_class"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 94,
+            "counterexamples_resolved": 0,
+            "expected_cases_lost": 0,
+            "counterexamples_remaining": 6,
+            "held_out_status": "passed"
+          },
+          "status": "rejected_no_improvement",
+          "source_receipts": [
+            "research:rust-syntax-cohort-replay.md",
+            "github:pull/168@b8c6457de8d05a38a662289962fc11a124d32861"
+          ]
+        },
+        {
+          "id": "singleton-commit-partition",
+          "hypothesis_after": {
+            "id": "exact-commit-is-cohort",
+            "statement": "Use exact commit identity as the discriminator so the current observation defines its own cohort."
+          },
+          "discriminator_refs": [
+            "commit_identity"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 1,
+            "counterexamples_resolved": 1,
+            "expected_cases_lost": 98,
+            "counterexamples_remaining": 0,
+            "held_out_status": "not_run"
+          },
+          "status": "rejected_overfit",
+          "source_receipts": [
+            "github:pull/168@b8c6457de8d05a38a662289962fc11a124d32861"
+          ]
+        }
+      ],
+      "selected_transition": "syntax-changing-current-cohort",
+      "source_receipts": [
+        "research:history-companion-replay.md",
+        "research:rust-syntax-cohort-replay.md",
+        "research:cohort-refinement.md"
+      ],
+      "behavioral_episode_ids": []
+    },
+    {
+      "id": "project-memory/primary-case-contract-collision-v1",
+      "family": "project_memory",
+      "hypothesis_before": {
+        "id": "single-line-admission-covers-collector-evidence",
+        "statement": "The existing project-memory relation admission contract composes with every explicit relationship evidence form emitted by current collectors."
+      },
+      "counterexample_refs": [
+        "github:issue/172#primary-case-multiline-contract-collision"
+      ],
+      "admitted_discriminators": [
+        {
+          "id": "primary_case_evidence_form",
+          "source_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca"
+        },
+        {
+          "id": "same_repository_issue_target",
+          "source_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca"
+        }
+      ],
+      "candidate_refinements": [
+        {
+          "id": "split-primary-case-admission",
+          "hypothesis_after": {
+            "id": "typed-primary-case-admission",
+            "statement": "Keep ordinary relation evidence on the strict single-line grammar and admit only the exact same-repository Primary case issue block through a separate validated path."
+          },
+          "discriminator_refs": [
+            "primary_case_evidence_form",
+            "same_repository_issue_target"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 2,
+            "counterexamples_resolved": 1,
+            "expected_cases_lost": 0,
+            "counterexamples_remaining": 0,
+            "held_out_status": "passed"
+          },
+          "status": "split",
+          "source_receipts": [
+            "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca",
+            "github-actions:run/32246042100",
+            "github-actions:run/32246042091"
+          ]
+        }
+      ],
+      "selected_transition": "split-primary-case-admission",
+      "source_receipts": [
+        "github:pull/166",
+        "github:pull/167",
+        "github:issue/172",
+        "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca",
+        "github:pull/178@22fa1d9405737ae6868d9b1f6643b4107c6f058a",
+        "research:behavioral-receipts/project-memory-primary-case-collision-174.json"
+      ],
+      "behavioral_episode_ids": [
+        "project-memory:primary-case-contract-collision:9792bfe->df5ae59"
+      ]
+    }
+  ]
+}

--- a/research/typed-observation-applicability.md
+++ b/research/typed-observation-applicability.md
@@ -1,0 +1,122 @@
+# Typed discriminator applicability repair
+
+Tracking: #195. Stacked on the green #201 negative control over #194/#187.
+
+## Counterexample that earned the repair
+
+#201 composes the real shared applicability evaluator with the v1 discriminator observation and observation frontier types.
+
+It proves both of these states were admitted:
+
+```text
+value_state = KNOWN(syntax_changed)
+shared applicability = INVALID after exact-head movement
+frontier = CURRENT
+```
+
+and:
+
+```text
+value_state = KNOWN(syntax_changed)
+shared applicability = UNKNOWN because current revision is missing
+frontier = CURRENT
+```
+
+#201 head `1614cc2ae82df50ec3c8b5c4a9e428ad01c1d50f` passed CI run `32250242114` / #1341, so the ambiguity was executable.
+
+The cause is precise: v1 carries only an opaque `applicability_ref`, while generic currentness is decided entirely from `value_state=KNOWN`.
+
+## Disposition: separate axes
+
+The repair chooses #195 Model B.
+
+V2 discriminator observations carry two independent supplied facts:
+
+```text
+value_state
+  known { value_ref }
+  unknown { reason_ref }
+
+applicability
+  status = applies | unknown | invalid
+  receipt_ref
+```
+
+`INVALID` leaves the value-knowledge axis. Stale/coordinate invalidity belongs to applicability.
+
+The generic module still performs no Git/repository/source-domain applicability evaluation. A source adapter supplies the typed applicability state plus the exact receipt that earned it.
+
+## Shared combination rule
+
+One source-owned helper combines the two axes for both generic consumers:
+
+```text
+applicability INVALID
+  -> INVALID
+  preserve known old value when present
+
+applicability UNKNOWN
+  -> UNKNOWN
+  preserve known old value when present
+
+applicability APPLIES + value UNKNOWN
+  -> UNKNOWN
+
+applicability APPLIES + value KNOWN
+  -> CURRENT
+```
+
+Both discriminator partition enumeration and observation frontier evaluation call this same classifier. The rule therefore cannot drift between #187 and #194.
+
+## Wire/version change
+
+Because the v1 observation meaning allowed KNOWN to outrun applicability, this is an incompatible research wire change:
+
+```text
+DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION: 1 -> 2
+OBSERVATION_FRONTIER_SCHEMA_VERSION:        1 -> 2
+```
+
+The retained three-family observation corpus is rewritten to v2 and gives every current observation an explicit `applicability.status = applies` plus its source receipt.
+
+## Adversarial controls
+
+The repaired standard harness requires:
+
+- retained selected #179 discriminators are current only through `KNOWN + APPLIES`;
+- value UNKNOWN with APPLIES remains unknown;
+- known value + applicability UNKNOWN remains unknown and preserves the known value;
+- known value + applicability INVALID remains invalid and preserves the known value;
+- missing applicability receipt rejects;
+- duplicate/conflicting observation identity controls remain intact;
+- equal values from different source receipts remain distinct observations;
+- opaque value spelling still grants zero authority/disposition;
+- #194 wrong-subject isolation and mixed-state precedence remain intact;
+- the exact #201 moved-head and missing-current-revision cases now produce INVALID/UNKNOWN frontiers instead of CURRENT.
+
+## Phase B consequence
+
+#190 probe planning must consume the repaired frontier semantics.
+
+A historical known value can remain useful as a receipt while current acquisition still proceeds:
+
+```text
+KNOWN old value
++ applicability INVALID
+-> frontier INVALID
+-> source adapter may propose current evidence acquisition
+```
+
+The known value is preserved in the noncurrent receipt; it simply cannot suppress current work.
+
+## Boundary
+
+- source adapters supply applicability state; generic modules do not execute the shared evaluator;
+- applicability receipt strings remain opaque references after the typed state is supplied;
+- no implicit mapping to #145 probe capability;
+- no evidence strength, authority, or disposition is inferred from either axis;
+- v1 receipts remain retained as the historical counterexample/earlier experiment.
+
+North star:
+
+> Preserve what was learned from stale evidence while making current usability an explicit typed fact that stale knowledge cannot silently override.

--- a/research/typed-observation-applicability.md
+++ b/research/typed-observation-applicability.md
@@ -94,6 +94,45 @@ The repaired standard harness requires:
 - #194 wrong-subject isolation and mixed-state precedence remain intact;
 - the exact #201 moved-head and missing-current-revision cases now produce INVALID/UNKNOWN frontiers instead of CURRENT.
 
+## Executed GitHub receipt
+
+The v2 repair was compacted to one semantic commit directly on #201's exact green counterexample head.
+
+Exact semantic head:
+
+```text
+5c84155eb1616b6774f0c5ac764f17ac5d61fa9b
+```
+
+GitHub Actions CI run `32251969947` / run number `1417` completed successfully. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work preflight;
+- full `cargo test`, including the v2 discriminator enumeration controls, exact-subject frontier controls, and the two #201 closure tests using the real shared applicability evaluator;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The first repair attempt stopped only at rustfmt before Clippy or tests. The exact formatter deltas touched the three v2 test files only. After those mechanical edits, the intermediate head passed the full gate; the branch was then compacted back to the one semantic commit above and revalidated through CI #1417.
+
+Because #210 is a stacked research PR, the ordinary CI workflow is its authoritative gate; generated-provenance PR dogfood is not part of this stack's trigger set.
+
+The central closure is now executable:
+
+```text
+KNOWN old value + applicability INVALID
+  -> frontier INVALID
+  -> known old value preserved
+
+KNOWN old value + applicability UNKNOWN
+  -> frontier UNKNOWN
+  -> known old value preserved
+```
+
+Stale knowledge can no longer suppress a current observation frontier.
+
 ## Phase B consequence
 
 #190 probe planning must consume the repaired frontier semantics.

--- a/src/discriminator_observation.rs
+++ b/src/discriminator_observation.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-pub const DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION: u32 = 1;
+pub const DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION: u32 = 2;
 pub const MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES: usize = 256 * 1024;
 const MAX_OBSERVATIONS: usize = 1024;
 const MAX_ID_BYTES: usize = 512;
@@ -25,8 +25,7 @@ pub struct DiscriminatorObservation {
     pub subject_ref: String,
     pub source_receipt: String,
     pub value_state: DiscriminatorValueState,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub applicability: ObservationApplicability,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -34,7 +33,21 @@ pub struct DiscriminatorObservation {
 pub enum DiscriminatorValueState {
     Known { value_ref: String },
     Unknown { reason_ref: String },
-    Invalid { reason_ref: String },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationApplicability {
+    pub status: ObservationApplicabilityStatus,
+    pub receipt_ref: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationApplicabilityStatus {
+    Applies,
+    Unknown,
+    Invalid,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -66,8 +79,7 @@ pub struct CurrentObservationReceipt {
     pub observation_id: String,
     pub subject_ref: String,
     pub source_receipt: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub applicability_ref: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -76,9 +88,29 @@ pub struct NonCurrentObservationReceipt {
     pub observation_id: String,
     pub subject_ref: String,
     pub source_receipt: String,
-    pub reason_ref: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub known_value_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_unknown_reason_ref: Option<String>,
+    pub applicability_ref: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ObservationCurrentness<'a> {
+    Current {
+        value_ref: &'a str,
+        applicability_ref: &'a str,
+    },
+    Unknown {
+        known_value_ref: Option<&'a str>,
+        value_unknown_reason_ref: Option<&'a str>,
+        applicability_ref: &'a str,
+    },
+    Invalid {
+        known_value_ref: Option<&'a str>,
+        value_unknown_reason_ref: Option<&'a str>,
+        applicability_ref: &'a str,
+    },
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -156,6 +188,39 @@ pub fn validate_discriminator_observation_batch(
     Ok(())
 }
 
+pub fn classify_observation_currentness(
+    observation: &DiscriminatorObservation,
+) -> ObservationCurrentness<'_> {
+    let (known_value_ref, value_unknown_reason_ref) = match &observation.value_state {
+        DiscriminatorValueState::Known { value_ref } => (Some(value_ref.as_str()), None),
+        DiscriminatorValueState::Unknown { reason_ref } => (None, Some(reason_ref.as_str())),
+    };
+
+    match observation.applicability.status {
+        ObservationApplicabilityStatus::Invalid => ObservationCurrentness::Invalid {
+            known_value_ref,
+            value_unknown_reason_ref,
+            applicability_ref: &observation.applicability.receipt_ref,
+        },
+        ObservationApplicabilityStatus::Unknown => ObservationCurrentness::Unknown {
+            known_value_ref,
+            value_unknown_reason_ref,
+            applicability_ref: &observation.applicability.receipt_ref,
+        },
+        ObservationApplicabilityStatus::Applies => match known_value_ref {
+            Some(value_ref) => ObservationCurrentness::Current {
+                value_ref,
+                applicability_ref: &observation.applicability.receipt_ref,
+            },
+            None => ObservationCurrentness::Unknown {
+                known_value_ref: None,
+                value_unknown_reason_ref,
+                applicability_ref: &observation.applicability.receipt_ref,
+            },
+        },
+    }
+}
+
 pub fn enumerate_discriminator_partitions(
     batch: &DiscriminatorObservationBatch,
 ) -> Result<DiscriminatorEnumeration, DiscriminatorObservationError> {
@@ -173,24 +238,42 @@ pub fn enumerate_discriminator_partitions(
         let builder = builders
             .entry(observation.discriminator_id.clone())
             .or_default();
-        match &observation.value_state {
-            DiscriminatorValueState::Known { value_ref } => {
+        match classify_observation_currentness(observation) {
+            ObservationCurrentness::Current {
+                value_ref,
+                applicability_ref,
+            } => {
                 builder
                     .known
-                    .entry(value_ref.clone())
+                    .entry(value_ref.to_string())
                     .or_default()
-                    .push(current_receipt(observation));
+                    .push(CurrentObservationReceipt {
+                        observation_id: observation.observation_id.clone(),
+                        subject_ref: observation.subject_ref.clone(),
+                        source_receipt: observation.source_receipt.clone(),
+                        applicability_ref: applicability_ref.to_string(),
+                    });
             }
-            DiscriminatorValueState::Unknown { reason_ref } => {
-                builder
-                    .unknown
-                    .push(non_current_receipt(observation, reason_ref));
-            }
-            DiscriminatorValueState::Invalid { reason_ref } => {
-                builder
-                    .invalid
-                    .push(non_current_receipt(observation, reason_ref));
-            }
+            ObservationCurrentness::Unknown {
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            } => builder.unknown.push(non_current_receipt(
+                observation,
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            )),
+            ObservationCurrentness::Invalid {
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            } => builder.invalid.push(non_current_receipt(
+                observation,
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            )),
         }
     }
 
@@ -230,25 +313,19 @@ pub fn enumerate_discriminator_partitions(
     })
 }
 
-fn current_receipt(observation: &DiscriminatorObservation) -> CurrentObservationReceipt {
-    CurrentObservationReceipt {
-        observation_id: observation.observation_id.clone(),
-        subject_ref: observation.subject_ref.clone(),
-        source_receipt: observation.source_receipt.clone(),
-        applicability_ref: observation.applicability_ref.clone(),
-    }
-}
-
 fn non_current_receipt(
     observation: &DiscriminatorObservation,
-    reason_ref: &str,
+    known_value_ref: Option<&str>,
+    value_unknown_reason_ref: Option<&str>,
+    applicability_ref: &str,
 ) -> NonCurrentObservationReceipt {
     NonCurrentObservationReceipt {
         observation_id: observation.observation_id.clone(),
         subject_ref: observation.subject_ref.clone(),
         source_receipt: observation.source_receipt.clone(),
-        reason_ref: reason_ref.to_string(),
-        applicability_ref: observation.applicability_ref.clone(),
+        known_value_ref: known_value_ref.map(str::to_string),
+        value_unknown_reason_ref: value_unknown_reason_ref.map(str::to_string),
+        applicability_ref: applicability_ref.to_string(),
     }
 }
 
@@ -267,18 +344,19 @@ fn validate_observation(
         "source_receipt",
         MAX_REFERENCE_BYTES,
     )?;
-    if let Some(applicability_ref) = &observation.applicability_ref {
-        validate_atom(applicability_ref, "applicability_ref", MAX_REFERENCE_BYTES)?;
-    }
     match &observation.value_state {
         DiscriminatorValueState::Known { value_ref } => {
-            validate_atom(value_ref, "value_ref", MAX_REFERENCE_BYTES)
+            validate_atom(value_ref, "value_ref", MAX_REFERENCE_BYTES)?;
         }
-        DiscriminatorValueState::Unknown { reason_ref }
-        | DiscriminatorValueState::Invalid { reason_ref } => {
-            validate_atom(reason_ref, "reason_ref", MAX_REFERENCE_BYTES)
+        DiscriminatorValueState::Unknown { reason_ref } => {
+            validate_atom(reason_ref, "value reason_ref", MAX_REFERENCE_BYTES)?;
         }
     }
+    validate_atom(
+        &observation.applicability.receipt_ref,
+        "applicability receipt_ref",
+        MAX_REFERENCE_BYTES,
+    )
 }
 
 fn validate_atom(

--- a/src/discriminator_observation.rs
+++ b/src/discriminator_observation.rs
@@ -1,0 +1,300 @@
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+pub const DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION: u32 = 1;
+pub const MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES: usize = 256 * 1024;
+const MAX_OBSERVATIONS: usize = 1024;
+const MAX_ID_BYTES: usize = 512;
+const MAX_REFERENCE_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorObservationBatch {
+    pub schema_version: u32,
+    pub observations: Vec<DiscriminatorObservation>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorObservation {
+    pub observation_id: String,
+    pub discriminator_id: String,
+    pub subject_ref: String,
+    pub source_receipt: String,
+    pub value_state: DiscriminatorValueState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DiscriminatorValueState {
+    Known { value_ref: String },
+    Unknown { reason_ref: String },
+    Invalid { reason_ref: String },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorEnumeration {
+    pub schema_version: u32,
+    pub discriminators: Vec<EnumeratedDiscriminator>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EnumeratedDiscriminator {
+    pub discriminator_id: String,
+    pub known_partitions: Vec<KnownPartition>,
+    pub unknown: Vec<NonCurrentObservationReceipt>,
+    pub invalid: Vec<NonCurrentObservationReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct KnownPartition {
+    pub value_ref: String,
+    pub observations: Vec<CurrentObservationReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CurrentObservationReceipt {
+    pub observation_id: String,
+    pub subject_ref: String,
+    pub source_receipt: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct NonCurrentObservationReceipt {
+    pub observation_id: String,
+    pub subject_ref: String,
+    pub source_receipt: String,
+    pub reason_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DiscriminatorObservationError {
+    message: String,
+}
+
+impl DiscriminatorObservationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for DiscriminatorObservationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for DiscriminatorObservationError {}
+
+pub fn parse_discriminator_observation_batch(
+    bytes: &[u8],
+) -> Result<DiscriminatorObservationBatch, DiscriminatorObservationError> {
+    if bytes.len() > MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES {
+        return Err(DiscriminatorObservationError::new(format!(
+            "discriminator observation batch exceeds the {MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES}-byte limit"
+        )));
+    }
+    let batch: DiscriminatorObservationBatch = serde_json::from_slice(bytes).map_err(|error| {
+        DiscriminatorObservationError::new(format!(
+            "invalid discriminator observation JSON: {error}"
+        ))
+    })?;
+    validate_discriminator_observation_batch(&batch)?;
+    Ok(batch)
+}
+
+pub fn validate_discriminator_observation_batch(
+    batch: &DiscriminatorObservationBatch,
+) -> Result<(), DiscriminatorObservationError> {
+    if batch.schema_version != DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION {
+        return Err(DiscriminatorObservationError::new(format!(
+            "unsupported discriminator observation schema {}; expected {DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION}",
+            batch.schema_version
+        )));
+    }
+    if batch.observations.is_empty() || batch.observations.len() > MAX_OBSERVATIONS {
+        return Err(DiscriminatorObservationError::new(
+            "discriminator observation batch must contain a bounded non-empty observation set",
+        ));
+    }
+
+    let mut seen = BTreeMap::<String, DiscriminatorObservation>::new();
+    for observation in &batch.observations {
+        validate_observation(observation)?;
+        if let Some(existing) = seen.get(&observation.observation_id) {
+            let message = if existing == observation {
+                format!(
+                    "duplicate discriminator observation id {}",
+                    observation.observation_id
+                )
+            } else {
+                format!(
+                    "conflicting discriminator observation id {}",
+                    observation.observation_id
+                )
+            };
+            return Err(DiscriminatorObservationError::new(message));
+        }
+        seen.insert(observation.observation_id.clone(), observation.clone());
+    }
+    Ok(())
+}
+
+pub fn enumerate_discriminator_partitions(
+    batch: &DiscriminatorObservationBatch,
+) -> Result<DiscriminatorEnumeration, DiscriminatorObservationError> {
+    validate_discriminator_observation_batch(batch)?;
+
+    #[derive(Default)]
+    struct Builder {
+        known: BTreeMap<String, Vec<CurrentObservationReceipt>>,
+        unknown: Vec<NonCurrentObservationReceipt>,
+        invalid: Vec<NonCurrentObservationReceipt>,
+    }
+
+    let mut builders = BTreeMap::<String, Builder>::new();
+    for observation in &batch.observations {
+        let builder = builders
+            .entry(observation.discriminator_id.clone())
+            .or_default();
+        match &observation.value_state {
+            DiscriminatorValueState::Known { value_ref } => {
+                builder
+                    .known
+                    .entry(value_ref.clone())
+                    .or_default()
+                    .push(current_receipt(observation));
+            }
+            DiscriminatorValueState::Unknown { reason_ref } => {
+                builder
+                    .unknown
+                    .push(non_current_receipt(observation, reason_ref));
+            }
+            DiscriminatorValueState::Invalid { reason_ref } => {
+                builder
+                    .invalid
+                    .push(non_current_receipt(observation, reason_ref));
+            }
+        }
+    }
+
+    let discriminators = builders
+        .into_iter()
+        .map(|(discriminator_id, mut builder)| {
+            let known_partitions = builder
+                .known
+                .into_iter()
+                .map(|(value_ref, mut observations)| {
+                    observations
+                        .sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+                    KnownPartition {
+                        value_ref,
+                        observations,
+                    }
+                })
+                .collect();
+            builder
+                .unknown
+                .sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+            builder
+                .invalid
+                .sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+            EnumeratedDiscriminator {
+                discriminator_id,
+                known_partitions,
+                unknown: builder.unknown,
+                invalid: builder.invalid,
+            }
+        })
+        .collect();
+
+    Ok(DiscriminatorEnumeration {
+        schema_version: DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+        discriminators,
+    })
+}
+
+fn current_receipt(observation: &DiscriminatorObservation) -> CurrentObservationReceipt {
+    CurrentObservationReceipt {
+        observation_id: observation.observation_id.clone(),
+        subject_ref: observation.subject_ref.clone(),
+        source_receipt: observation.source_receipt.clone(),
+        applicability_ref: observation.applicability_ref.clone(),
+    }
+}
+
+fn non_current_receipt(
+    observation: &DiscriminatorObservation,
+    reason_ref: &str,
+) -> NonCurrentObservationReceipt {
+    NonCurrentObservationReceipt {
+        observation_id: observation.observation_id.clone(),
+        subject_ref: observation.subject_ref.clone(),
+        source_receipt: observation.source_receipt.clone(),
+        reason_ref: reason_ref.to_string(),
+        applicability_ref: observation.applicability_ref.clone(),
+    }
+}
+
+fn validate_observation(
+    observation: &DiscriminatorObservation,
+) -> Result<(), DiscriminatorObservationError> {
+    validate_atom(&observation.observation_id, "observation_id", MAX_ID_BYTES)?;
+    validate_atom(
+        &observation.discriminator_id,
+        "discriminator_id",
+        MAX_ID_BYTES,
+    )?;
+    validate_atom(&observation.subject_ref, "subject_ref", MAX_REFERENCE_BYTES)?;
+    validate_atom(
+        &observation.source_receipt,
+        "source_receipt",
+        MAX_REFERENCE_BYTES,
+    )?;
+    if let Some(applicability_ref) = &observation.applicability_ref {
+        validate_atom(applicability_ref, "applicability_ref", MAX_REFERENCE_BYTES)?;
+    }
+    match &observation.value_state {
+        DiscriminatorValueState::Known { value_ref } => {
+            validate_atom(value_ref, "value_ref", MAX_REFERENCE_BYTES)
+        }
+        DiscriminatorValueState::Unknown { reason_ref }
+        | DiscriminatorValueState::Invalid { reason_ref } => {
+            validate_atom(reason_ref, "reason_ref", MAX_REFERENCE_BYTES)
+        }
+    }
+}
+
+fn validate_atom(
+    value: &str,
+    field: &str,
+    max_bytes: usize,
+) -> Result<(), DiscriminatorObservationError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > max_bytes
+        || value.contains('\0')
+        || value.contains(['\n', '\r'])
+    {
+        return Err(DiscriminatorObservationError::new(format!(
+            "{field} must be bounded canonical single-line text"
+        )));
+    }
+    Ok(())
+}

--- a/src/observation_frontier.rs
+++ b/src/observation_frontier.rs
@@ -5,11 +5,11 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 use crate::discriminator_observation::{
-    DiscriminatorObservation, DiscriminatorObservationBatch, DiscriminatorValueState,
-    validate_discriminator_observation_batch,
+    DiscriminatorObservation, DiscriminatorObservationBatch, ObservationCurrentness,
+    classify_observation_currentness, validate_discriminator_observation_batch,
 };
 
-pub const OBSERVATION_FRONTIER_SCHEMA_VERSION: u32 = 1;
+pub const OBSERVATION_FRONTIER_SCHEMA_VERSION: u32 = 2;
 pub const MAX_OBSERVATION_FRONTIER_REQUEST_BYTES: usize = 512 * 1024;
 const MAX_REQUIREMENTS: usize = 256;
 const MAX_ID_BYTES: usize = 512;
@@ -64,8 +64,7 @@ pub struct CurrentObservationReceipt {
     pub observation_id: String,
     pub source_receipt: String,
     pub value_ref: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub applicability_ref: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -73,15 +72,17 @@ pub struct CurrentObservationReceipt {
 pub struct NonCurrentObservationReceipt {
     pub observation_id: String,
     pub source_receipt: String,
-    pub reason_ref: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub known_value_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_unknown_reason_ref: Option<String>,
+    pub applicability_ref: String,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ObservationValueStateKind {
-    Known,
+pub enum ObservationCurrentnessKind {
+    Current,
     Unknown,
     Invalid,
 }
@@ -92,7 +93,7 @@ pub struct OtherSubjectObservationReceipt {
     pub observation_id: String,
     pub subject_ref: String,
     pub source_receipt: String,
-    pub state: ObservationValueStateKind,
+    pub state: ObservationCurrentnessKind,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -166,41 +167,47 @@ fn evaluate_requirement(
         .iter()
         .filter(|observation| observation.discriminator_id == requirement.discriminator_id)
     {
+        let currentness = classify_observation_currentness(observation);
         if observation.subject_ref != requirement.subject_ref {
             other_subject.push(OtherSubjectObservationReceipt {
                 observation_id: observation.observation_id.clone(),
                 subject_ref: observation.subject_ref.clone(),
                 source_receipt: observation.source_receipt.clone(),
-                state: value_state_kind(&observation.value_state),
+                state: currentness_kind(currentness),
             });
             continue;
         }
 
-        match &observation.value_state {
-            DiscriminatorValueState::Known { value_ref } => {
-                current.push(CurrentObservationReceipt {
-                    observation_id: observation.observation_id.clone(),
-                    source_receipt: observation.source_receipt.clone(),
-                    value_ref: value_ref.clone(),
-                    applicability_ref: observation.applicability_ref.clone(),
-                });
-            }
-            DiscriminatorValueState::Unknown { reason_ref } => {
-                unknown.push(NonCurrentObservationReceipt {
-                    observation_id: observation.observation_id.clone(),
-                    source_receipt: observation.source_receipt.clone(),
-                    reason_ref: reason_ref.clone(),
-                    applicability_ref: observation.applicability_ref.clone(),
-                });
-            }
-            DiscriminatorValueState::Invalid { reason_ref } => {
-                invalid.push(NonCurrentObservationReceipt {
-                    observation_id: observation.observation_id.clone(),
-                    source_receipt: observation.source_receipt.clone(),
-                    reason_ref: reason_ref.clone(),
-                    applicability_ref: observation.applicability_ref.clone(),
-                });
-            }
+        match currentness {
+            ObservationCurrentness::Current {
+                value_ref,
+                applicability_ref,
+            } => current.push(CurrentObservationReceipt {
+                observation_id: observation.observation_id.clone(),
+                source_receipt: observation.source_receipt.clone(),
+                value_ref: value_ref.to_string(),
+                applicability_ref: applicability_ref.to_string(),
+            }),
+            ObservationCurrentness::Unknown {
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            } => unknown.push(non_current_receipt(
+                observation,
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            )),
+            ObservationCurrentness::Invalid {
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            } => invalid.push(non_current_receipt(
+                observation,
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            )),
         }
     }
 
@@ -230,11 +237,26 @@ fn evaluate_requirement(
     }
 }
 
-fn value_state_kind(value_state: &DiscriminatorValueState) -> ObservationValueStateKind {
-    match value_state {
-        DiscriminatorValueState::Known { .. } => ObservationValueStateKind::Known,
-        DiscriminatorValueState::Unknown { .. } => ObservationValueStateKind::Unknown,
-        DiscriminatorValueState::Invalid { .. } => ObservationValueStateKind::Invalid,
+fn currentness_kind(currentness: ObservationCurrentness<'_>) -> ObservationCurrentnessKind {
+    match currentness {
+        ObservationCurrentness::Current { .. } => ObservationCurrentnessKind::Current,
+        ObservationCurrentness::Unknown { .. } => ObservationCurrentnessKind::Unknown,
+        ObservationCurrentness::Invalid { .. } => ObservationCurrentnessKind::Invalid,
+    }
+}
+
+fn non_current_receipt(
+    observation: &DiscriminatorObservation,
+    known_value_ref: Option<&str>,
+    value_unknown_reason_ref: Option<&str>,
+    applicability_ref: &str,
+) -> NonCurrentObservationReceipt {
+    NonCurrentObservationReceipt {
+        observation_id: observation.observation_id.clone(),
+        source_receipt: observation.source_receipt.clone(),
+        known_value_ref: known_value_ref.map(str::to_string),
+        value_unknown_reason_ref: value_unknown_reason_ref.map(str::to_string),
+        applicability_ref: applicability_ref.to_string(),
     }
 }
 

--- a/src/observation_frontier.rs
+++ b/src/observation_frontier.rs
@@ -1,0 +1,295 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::discriminator_observation::{
+    DiscriminatorObservation, DiscriminatorObservationBatch, DiscriminatorValueState,
+    validate_discriminator_observation_batch,
+};
+
+pub const OBSERVATION_FRONTIER_SCHEMA_VERSION: u32 = 1;
+pub const MAX_OBSERVATION_FRONTIER_REQUEST_BYTES: usize = 512 * 1024;
+const MAX_REQUIREMENTS: usize = 256;
+const MAX_ID_BYTES: usize = 512;
+const MAX_REFERENCE_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationFrontierRequest {
+    pub schema_version: u32,
+    pub requirements: Vec<ObservationRequirement>,
+    pub observations: DiscriminatorObservationBatch,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationRequirement {
+    pub discriminator_id: String,
+    pub subject_ref: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationFrontierStatus {
+    Current,
+    Unknown,
+    Invalid,
+    Missing,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationFrontierEvaluation {
+    pub schema_version: u32,
+    pub frontiers: Vec<ObservationFrontierReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationFrontierReceipt {
+    pub discriminator_id: String,
+    pub subject_ref: String,
+    pub status: ObservationFrontierStatus,
+    pub current: Vec<CurrentObservationReceipt>,
+    pub unknown: Vec<NonCurrentObservationReceipt>,
+    pub invalid: Vec<NonCurrentObservationReceipt>,
+    pub other_subject: Vec<OtherSubjectObservationReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CurrentObservationReceipt {
+    pub observation_id: String,
+    pub source_receipt: String,
+    pub value_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct NonCurrentObservationReceipt {
+    pub observation_id: String,
+    pub source_receipt: String,
+    pub reason_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationValueStateKind {
+    Known,
+    Unknown,
+    Invalid,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OtherSubjectObservationReceipt {
+    pub observation_id: String,
+    pub subject_ref: String,
+    pub source_receipt: String,
+    pub state: ObservationValueStateKind,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ObservationFrontierError {
+    message: String,
+}
+
+impl ObservationFrontierError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ObservationFrontierError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for ObservationFrontierError {}
+
+pub fn parse_observation_frontier_request(
+    bytes: &[u8],
+) -> Result<ObservationFrontierRequest, ObservationFrontierError> {
+    if bytes.len() > MAX_OBSERVATION_FRONTIER_REQUEST_BYTES {
+        return Err(ObservationFrontierError::new(format!(
+            "observation frontier request exceeds the {MAX_OBSERVATION_FRONTIER_REQUEST_BYTES}-byte limit"
+        )));
+    }
+    let request: ObservationFrontierRequest = serde_json::from_slice(bytes).map_err(|error| {
+        ObservationFrontierError::new(format!("invalid observation frontier JSON: {error}"))
+    })?;
+    validate_request(&request)?;
+    Ok(request)
+}
+
+pub fn evaluate_observation_frontiers(
+    request: &ObservationFrontierRequest,
+) -> Result<ObservationFrontierEvaluation, ObservationFrontierError> {
+    validate_request(request)?;
+
+    let mut frontiers = request
+        .requirements
+        .iter()
+        .map(|requirement| evaluate_requirement(requirement, &request.observations.observations))
+        .collect::<Vec<_>>();
+    frontiers.sort_by(|left, right| {
+        left.discriminator_id
+            .cmp(&right.discriminator_id)
+            .then_with(|| left.subject_ref.cmp(&right.subject_ref))
+    });
+
+    Ok(ObservationFrontierEvaluation {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        frontiers,
+    })
+}
+
+fn evaluate_requirement(
+    requirement: &ObservationRequirement,
+    observations: &[DiscriminatorObservation],
+) -> ObservationFrontierReceipt {
+    let mut current = Vec::new();
+    let mut unknown = Vec::new();
+    let mut invalid = Vec::new();
+    let mut other_subject = Vec::new();
+
+    for observation in observations
+        .iter()
+        .filter(|observation| observation.discriminator_id == requirement.discriminator_id)
+    {
+        if observation.subject_ref != requirement.subject_ref {
+            other_subject.push(OtherSubjectObservationReceipt {
+                observation_id: observation.observation_id.clone(),
+                subject_ref: observation.subject_ref.clone(),
+                source_receipt: observation.source_receipt.clone(),
+                state: value_state_kind(&observation.value_state),
+            });
+            continue;
+        }
+
+        match &observation.value_state {
+            DiscriminatorValueState::Known { value_ref } => {
+                current.push(CurrentObservationReceipt {
+                    observation_id: observation.observation_id.clone(),
+                    source_receipt: observation.source_receipt.clone(),
+                    value_ref: value_ref.clone(),
+                    applicability_ref: observation.applicability_ref.clone(),
+                });
+            }
+            DiscriminatorValueState::Unknown { reason_ref } => {
+                unknown.push(NonCurrentObservationReceipt {
+                    observation_id: observation.observation_id.clone(),
+                    source_receipt: observation.source_receipt.clone(),
+                    reason_ref: reason_ref.clone(),
+                    applicability_ref: observation.applicability_ref.clone(),
+                });
+            }
+            DiscriminatorValueState::Invalid { reason_ref } => {
+                invalid.push(NonCurrentObservationReceipt {
+                    observation_id: observation.observation_id.clone(),
+                    source_receipt: observation.source_receipt.clone(),
+                    reason_ref: reason_ref.clone(),
+                    applicability_ref: observation.applicability_ref.clone(),
+                });
+            }
+        }
+    }
+
+    current.sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+    unknown.sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+    invalid.sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+    other_subject.sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+
+    let status = if !current.is_empty() {
+        ObservationFrontierStatus::Current
+    } else if !unknown.is_empty() {
+        ObservationFrontierStatus::Unknown
+    } else if !invalid.is_empty() {
+        ObservationFrontierStatus::Invalid
+    } else {
+        ObservationFrontierStatus::Missing
+    };
+
+    ObservationFrontierReceipt {
+        discriminator_id: requirement.discriminator_id.clone(),
+        subject_ref: requirement.subject_ref.clone(),
+        status,
+        current,
+        unknown,
+        invalid,
+        other_subject,
+    }
+}
+
+fn value_state_kind(value_state: &DiscriminatorValueState) -> ObservationValueStateKind {
+    match value_state {
+        DiscriminatorValueState::Known { .. } => ObservationValueStateKind::Known,
+        DiscriminatorValueState::Unknown { .. } => ObservationValueStateKind::Unknown,
+        DiscriminatorValueState::Invalid { .. } => ObservationValueStateKind::Invalid,
+    }
+}
+
+fn validate_request(request: &ObservationFrontierRequest) -> Result<(), ObservationFrontierError> {
+    if request.schema_version != OBSERVATION_FRONTIER_SCHEMA_VERSION {
+        return Err(ObservationFrontierError::new(format!(
+            "unsupported observation frontier schema {}; expected {OBSERVATION_FRONTIER_SCHEMA_VERSION}",
+            request.schema_version
+        )));
+    }
+    if request.requirements.is_empty() || request.requirements.len() > MAX_REQUIREMENTS {
+        return Err(ObservationFrontierError::new(
+            "observation frontier requirements must be bounded and non-empty",
+        ));
+    }
+    validate_discriminator_observation_batch(&request.observations).map_err(|error| {
+        ObservationFrontierError::new(format!("observation batch validation failed: {error}"))
+    })?;
+
+    let mut seen = BTreeSet::new();
+    for requirement in &request.requirements {
+        validate_atom(
+            &requirement.discriminator_id,
+            "requirement discriminator_id",
+            MAX_ID_BYTES,
+        )?;
+        validate_atom(
+            &requirement.subject_ref,
+            "requirement subject_ref",
+            MAX_REFERENCE_BYTES,
+        )?;
+        if !seen.insert(requirement.clone()) {
+            return Err(ObservationFrontierError::new(format!(
+                "duplicate observation requirement {} @ {}",
+                requirement.discriminator_id, requirement.subject_ref
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_atom(
+    value: &str,
+    field: &str,
+    max_bytes: usize,
+) -> Result<(), ObservationFrontierError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > max_bytes
+        || value.contains('\0')
+        || value.contains(['\n', '\r'])
+    {
+        return Err(ObservationFrontierError::new(format!(
+            "{field} must be bounded canonical single-line text"
+        )));
+    }
+    Ok(())
+}

--- a/src/refinement_episode.rs
+++ b/src/refinement_episode.rs
@@ -1,0 +1,362 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+pub const REFINEMENT_EPISODE_SCHEMA_VERSION: u32 = 1;
+pub const MAX_REFINEMENT_EPISODE_BATCH_BYTES: usize = 256 * 1024;
+const MAX_EPISODES: usize = 128;
+const MAX_CANDIDATES: usize = 64;
+const MAX_REFERENCES: usize = 256;
+const MAX_ID_BYTES: usize = 512;
+const MAX_TEXT_BYTES: usize = 8 * 1024;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementEpisodeBatch {
+    pub schema_version: u32,
+    pub episodes: Vec<RefinementEpisode>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementEpisode {
+    pub id: String,
+    pub family: String,
+    pub hypothesis_before: ResearchHypothesis,
+    pub counterexample_refs: Vec<String>,
+    pub admitted_discriminators: Vec<DiscriminatorRef>,
+    pub candidate_refinements: Vec<CandidateRefinement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_transition: Option<String>,
+    pub source_receipts: Vec<String>,
+    #[serde(default)]
+    pub behavioral_episode_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResearchHypothesis {
+    pub id: String,
+    pub statement: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorRef {
+    pub id: String,
+    pub source_ref: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CandidateRefinement {
+    pub id: String,
+    pub hypothesis_after: ResearchHypothesis,
+    pub discriminator_refs: Vec<String>,
+    pub replay_result: ReplayResult,
+    pub status: RefinementStatus,
+    pub source_receipts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReplayResult {
+    pub expected_cases_retained: usize,
+    pub counterexamples_resolved: usize,
+    pub expected_cases_lost: usize,
+    pub counterexamples_remaining: usize,
+    pub held_out_status: HeldOutStatus,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HeldOutStatus {
+    NotRun,
+    Passed,
+    Failed,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefinementStatus {
+    Retained,
+    Weakened,
+    Split,
+    RejectedNoImprovement,
+    RejectedOverfit,
+    RejectedLostExpectedCase,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RefinementEpisodeError {
+    message: String,
+}
+
+impl RefinementEpisodeError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for RefinementEpisodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for RefinementEpisodeError {}
+
+pub fn parse_refinement_episode_batch(
+    bytes: &[u8],
+) -> Result<RefinementEpisodeBatch, RefinementEpisodeError> {
+    if bytes.len() > MAX_REFINEMENT_EPISODE_BATCH_BYTES {
+        return Err(RefinementEpisodeError::new(format!(
+            "refinement episode batch exceeds the {MAX_REFINEMENT_EPISODE_BATCH_BYTES}-byte limit"
+        )));
+    }
+    let batch: RefinementEpisodeBatch = serde_json::from_slice(bytes).map_err(|error| {
+        RefinementEpisodeError::new(format!("invalid refinement episode JSON: {error}"))
+    })?;
+    validate_refinement_episode_batch(&batch)?;
+    Ok(batch)
+}
+
+pub fn validate_refinement_episode_batch(
+    batch: &RefinementEpisodeBatch,
+) -> Result<(), RefinementEpisodeError> {
+    if batch.schema_version != REFINEMENT_EPISODE_SCHEMA_VERSION {
+        return Err(RefinementEpisodeError::new(format!(
+            "unsupported refinement episode schema {}; expected {REFINEMENT_EPISODE_SCHEMA_VERSION}",
+            batch.schema_version
+        )));
+    }
+    if batch.episodes.is_empty() || batch.episodes.len() > MAX_EPISODES {
+        return Err(RefinementEpisodeError::new(
+            "refinement episode batch must contain a bounded non-empty episode set",
+        ));
+    }
+
+    let mut episode_ids = BTreeSet::new();
+    for episode in &batch.episodes {
+        validate_episode(episode)?;
+        if !episode_ids.insert(episode.id.clone()) {
+            return Err(RefinementEpisodeError::new(format!(
+                "duplicate refinement episode id {}",
+                episode.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_episode(episode: &RefinementEpisode) -> Result<(), RefinementEpisodeError> {
+    validate_atom(&episode.id, "episode id", MAX_ID_BYTES)?;
+    validate_atom(&episode.family, "episode family", MAX_ID_BYTES)?;
+    validate_hypothesis(&episode.hypothesis_before, "hypothesis_before")?;
+    validate_reference_set(&episode.counterexample_refs, "counterexample_refs", false)?;
+    validate_reference_set(&episode.source_receipts, "source_receipts", false)?;
+    validate_reference_set(
+        &episode.behavioral_episode_ids,
+        "behavioral_episode_ids",
+        true,
+    )?;
+
+    if episode.admitted_discriminators.is_empty()
+        || episode.admitted_discriminators.len() > MAX_REFERENCES
+    {
+        return Err(RefinementEpisodeError::new(
+            "admitted_discriminators must be bounded and non-empty",
+        ));
+    }
+    let mut discriminator_ids = BTreeSet::new();
+    for discriminator in &episode.admitted_discriminators {
+        validate_atom(&discriminator.id, "discriminator id", MAX_ID_BYTES)?;
+        validate_atom(
+            &discriminator.source_ref,
+            "discriminator source_ref",
+            MAX_TEXT_BYTES,
+        )?;
+        if !discriminator_ids.insert(discriminator.id.clone()) {
+            return Err(RefinementEpisodeError::new(format!(
+                "duplicate admitted discriminator {}",
+                discriminator.id
+            )));
+        }
+    }
+
+    if episode.candidate_refinements.is_empty()
+        || episode.candidate_refinements.len() > MAX_CANDIDATES
+    {
+        return Err(RefinementEpisodeError::new(
+            "candidate_refinements must be bounded and non-empty",
+        ));
+    }
+    let mut candidate_ids = BTreeSet::new();
+    for candidate in &episode.candidate_refinements {
+        validate_candidate(candidate, &discriminator_ids)?;
+        if !candidate_ids.insert(candidate.id.clone()) {
+            return Err(RefinementEpisodeError::new(format!(
+                "duplicate candidate refinement id {}",
+                candidate.id
+            )));
+        }
+    }
+
+    if let Some(selected) = &episode.selected_transition {
+        validate_atom(selected, "selected_transition", MAX_ID_BYTES)?;
+        let candidate = episode
+            .candidate_refinements
+            .iter()
+            .find(|candidate| candidate.id == *selected)
+            .ok_or_else(|| {
+                RefinementEpisodeError::new(format!(
+                    "selected transition {selected} is absent from candidate_refinements"
+                ))
+            })?;
+        if !matches!(
+            candidate.status,
+            RefinementStatus::Retained | RefinementStatus::Weakened | RefinementStatus::Split
+        ) {
+            return Err(RefinementEpisodeError::new(format!(
+                "selected transition {selected} has rejected status {:?}",
+                candidate.status
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_candidate(
+    candidate: &CandidateRefinement,
+    admitted_discriminators: &BTreeSet<String>,
+) -> Result<(), RefinementEpisodeError> {
+    validate_atom(&candidate.id, "candidate id", MAX_ID_BYTES)?;
+    validate_hypothesis(&candidate.hypothesis_after, "hypothesis_after")?;
+    validate_reference_set(
+        &candidate.discriminator_refs,
+        "candidate discriminator_refs",
+        false,
+    )?;
+    validate_reference_set(
+        &candidate.source_receipts,
+        "candidate source_receipts",
+        false,
+    )?;
+
+    for discriminator in &candidate.discriminator_refs {
+        if !admitted_discriminators.contains(discriminator) {
+            return Err(RefinementEpisodeError::new(format!(
+                "candidate {} references unadmitted discriminator {discriminator}",
+                candidate.id
+            )));
+        }
+    }
+
+    match candidate.status {
+        RefinementStatus::Retained | RefinementStatus::Weakened | RefinementStatus::Split => {
+            if candidate.replay_result.expected_cases_lost != 0 {
+                return Err(RefinementEpisodeError::new(format!(
+                    "kept candidate {} loses expected replay cases",
+                    candidate.id
+                )));
+            }
+            if candidate.replay_result.counterexamples_resolved == 0 {
+                return Err(RefinementEpisodeError::new(format!(
+                    "kept candidate {} resolves no counterexample",
+                    candidate.id
+                )));
+            }
+            if candidate.replay_result.held_out_status == HeldOutStatus::Failed {
+                return Err(RefinementEpisodeError::new(format!(
+                    "kept candidate {} has failed held-out replay",
+                    candidate.id
+                )));
+            }
+        }
+        RefinementStatus::RejectedNoImprovement => {
+            if candidate.replay_result.counterexamples_resolved != 0
+                || candidate.replay_result.expected_cases_lost != 0
+            {
+                return Err(RefinementEpisodeError::new(format!(
+                    "rejected_no_improvement candidate {} must preserve the baseline replay",
+                    candidate.id
+                )));
+            }
+        }
+        RefinementStatus::RejectedLostExpectedCase => {
+            if candidate.replay_result.expected_cases_lost == 0 {
+                return Err(RefinementEpisodeError::new(format!(
+                    "rejected_lost_expected_case candidate {} must lose at least one expected case",
+                    candidate.id
+                )));
+            }
+        }
+        RefinementStatus::RejectedOverfit => {}
+    }
+
+    Ok(())
+}
+
+fn validate_hypothesis(
+    hypothesis: &ResearchHypothesis,
+    field: &str,
+) -> Result<(), RefinementEpisodeError> {
+    validate_atom(&hypothesis.id, &format!("{field} id"), MAX_ID_BYTES)?;
+    validate_text(
+        &hypothesis.statement,
+        &format!("{field} statement"),
+        MAX_TEXT_BYTES,
+    )
+}
+
+fn validate_reference_set(
+    values: &[String],
+    field: &str,
+    allow_empty: bool,
+) -> Result<(), RefinementEpisodeError> {
+    if (!allow_empty && values.is_empty()) || values.len() > MAX_REFERENCES {
+        return Err(RefinementEpisodeError::new(format!(
+            "{field} must be within the admitted reference bound"
+        )));
+    }
+    let mut seen = BTreeSet::new();
+    for value in values {
+        validate_atom(value, field, MAX_TEXT_BYTES)?;
+        if !seen.insert(value.clone()) {
+            return Err(RefinementEpisodeError::new(format!(
+                "{field} contains duplicate reference {value}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_atom(value: &str, field: &str, max_bytes: usize) -> Result<(), RefinementEpisodeError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > max_bytes
+        || value.contains('\0')
+        || value.contains(['\n', '\r'])
+    {
+        return Err(RefinementEpisodeError::new(format!(
+            "{field} must be bounded canonical single-line text"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, field: &str, max_bytes: usize) -> Result<(), RefinementEpisodeError> {
+    if value.is_empty() || value.trim() != value || value.len() > max_bytes || value.contains('\0')
+    {
+        return Err(RefinementEpisodeError::new(format!(
+            "{field} must be bounded non-empty text"
+        )));
+    }
+    Ok(())
+}

--- a/tests/discriminator_observation.rs
+++ b/tests/discriminator_observation.rs
@@ -9,8 +9,9 @@ mod refinement_episode;
 
 use discriminator_observation::{
     DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation, DiscriminatorValueState,
-    MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES, enumerate_discriminator_partitions,
-    parse_discriminator_observation_batch, validate_discriminator_observation_batch,
+    MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES, ObservationApplicabilityStatus,
+    enumerate_discriminator_partitions, parse_discriminator_observation_batch,
+    validate_discriminator_observation_batch,
 };
 use refinement_episode::parse_refinement_episode_batch;
 
@@ -49,14 +50,14 @@ fn retained_observations_cover_every_selected_refinement_discriminator() {
             assert_eq!(
                 current.get(discriminator.as_str()),
                 Some(&true),
-                "selected discriminator {discriminator} lacks a current KNOWN observation"
+                "selected discriminator {discriminator} lacks a current KNOWN+APPLIES observation"
             );
         }
     }
 }
 
 #[test]
-fn known_observations_enumerate_by_discriminator_and_value() {
+fn known_applicable_observations_enumerate_by_discriminator_and_value() {
     let batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
     let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
     assert_eq!(
@@ -72,10 +73,10 @@ fn known_observations_enumerate_by_discriminator_and_value() {
 }
 
 #[test]
-fn unknown_observation_stays_visible_and_out_of_current_partitions() {
+fn unknown_value_with_applicable_source_stays_unknown() {
     let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
     batch.observations[0].value_state = DiscriminatorValueState::Unknown {
-        reason_ref: "applicability:missing-current-revision".to_string(),
+        reason_ref: "classifier:missing-value".to_string(),
     };
 
     let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
@@ -86,15 +87,38 @@ fn unknown_observation_stays_visible_and_out_of_current_partitions() {
         .unwrap();
     assert!(discriminator.known_partitions.is_empty());
     assert_eq!(discriminator.unknown.len(), 1);
-    assert!(discriminator.invalid.is_empty());
+    assert_eq!(
+        discriminator.unknown[0].value_unknown_reason_ref.as_deref(),
+        Some("classifier:missing-value")
+    );
 }
 
 #[test]
-fn invalid_observation_stays_visible_and_out_of_current_partitions() {
+fn known_value_with_unknown_applicability_stays_unknown_and_preserves_value() {
     let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
-    batch.observations[1].value_state = DiscriminatorValueState::Invalid {
-        reason_ref: "applicability:revision-moved".to_string(),
-    };
+    batch.observations[0].applicability.status = ObservationApplicabilityStatus::Unknown;
+    batch.observations[0].applicability.receipt_ref =
+        "applicability:missing-current-revision".to_string();
+
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let discriminator = enumeration
+        .discriminators
+        .iter()
+        .find(|item| item.discriminator_id == "clearing_evidence_presence")
+        .unwrap();
+    assert!(discriminator.known_partitions.is_empty());
+    assert_eq!(discriminator.unknown.len(), 1);
+    assert_eq!(
+        discriminator.unknown[0].known_value_ref.as_deref(),
+        Some("absent")
+    );
+}
+
+#[test]
+fn known_value_with_invalid_applicability_stays_invalid_and_preserves_value() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[1].applicability.status = ObservationApplicabilityStatus::Invalid;
+    batch.observations[1].applicability.receipt_ref = "applicability:revision-moved".to_string();
 
     let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
     let discriminator = enumeration
@@ -103,8 +127,11 @@ fn invalid_observation_stays_visible_and_out_of_current_partitions() {
         .find(|item| item.discriminator_id == "edit_class")
         .unwrap();
     assert!(discriminator.known_partitions.is_empty());
-    assert!(discriminator.unknown.is_empty());
     assert_eq!(discriminator.invalid.len(), 1);
+    assert_eq!(
+        discriminator.invalid[0].known_value_ref.as_deref(),
+        Some("syntax_changed")
+    );
 }
 
 #[test]
@@ -141,6 +168,14 @@ fn missing_source_receipt_rejects() {
     batch.observations[0].source_receipt.clear();
     let error = validate_discriminator_observation_batch(&batch).unwrap_err();
     assert!(error.to_string().contains("source_receipt"));
+}
+
+#[test]
+fn missing_applicability_receipt_rejects() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[0].applicability.receipt_ref.clear();
+    let error = validate_discriminator_observation_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("applicability receipt_ref"));
 }
 
 #[test]

--- a/tests/discriminator_observation.rs
+++ b/tests/discriminator_observation.rs
@@ -1,0 +1,210 @@
+#![allow(dead_code)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+
+use discriminator_observation::{
+    DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation, DiscriminatorValueState,
+    MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES, enumerate_discriminator_partitions,
+    parse_discriminator_observation_batch, validate_discriminator_observation_batch,
+};
+use refinement_episode::parse_refinement_episode_batch;
+
+const OBSERVATIONS: &[u8] =
+    include_bytes!("../research/discriminator-observations/cultist-v1.json");
+const REFINEMENTS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+
+#[test]
+fn retained_observations_cover_every_selected_refinement_discriminator() {
+    let observations = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let enumeration = enumerate_discriminator_partitions(&observations).unwrap();
+    let refinements = parse_refinement_episode_batch(REFINEMENTS).unwrap();
+
+    let current = enumeration
+        .discriminators
+        .iter()
+        .map(|discriminator| {
+            (
+                discriminator.discriminator_id.as_str(),
+                !discriminator.known_partitions.is_empty(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    for episode in &refinements.episodes {
+        let selected = episode
+            .selected_transition
+            .as_ref()
+            .expect("retained fixture has selected transition");
+        let candidate = episode
+            .candidate_refinements
+            .iter()
+            .find(|candidate| candidate.id == *selected)
+            .expect("selected candidate exists");
+        for discriminator in &candidate.discriminator_refs {
+            assert_eq!(
+                current.get(discriminator.as_str()),
+                Some(&true),
+                "selected discriminator {discriminator} lacks a current KNOWN observation"
+            );
+        }
+    }
+}
+
+#[test]
+fn known_observations_enumerate_by_discriminator_and_value() {
+    let batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    assert_eq!(
+        enumeration.schema_version,
+        DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION
+    );
+    assert_eq!(enumeration.discriminators.len(), 4);
+    assert!(enumeration.discriminators.iter().all(|discriminator| {
+        discriminator.known_partitions.len() == 1
+            && discriminator.unknown.is_empty()
+            && discriminator.invalid.is_empty()
+    }));
+}
+
+#[test]
+fn unknown_observation_stays_visible_and_out_of_current_partitions() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[0].value_state = DiscriminatorValueState::Unknown {
+        reason_ref: "applicability:missing-current-revision".to_string(),
+    };
+
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let discriminator = enumeration
+        .discriminators
+        .iter()
+        .find(|item| item.discriminator_id == "clearing_evidence_presence")
+        .unwrap();
+    assert!(discriminator.known_partitions.is_empty());
+    assert_eq!(discriminator.unknown.len(), 1);
+    assert!(discriminator.invalid.is_empty());
+}
+
+#[test]
+fn invalid_observation_stays_visible_and_out_of_current_partitions() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[1].value_state = DiscriminatorValueState::Invalid {
+        reason_ref: "applicability:revision-moved".to_string(),
+    };
+
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let discriminator = enumeration
+        .discriminators
+        .iter()
+        .find(|item| item.discriminator_id == "edit_class")
+        .unwrap();
+    assert!(discriminator.known_partitions.is_empty());
+    assert!(discriminator.unknown.is_empty());
+    assert_eq!(discriminator.invalid.len(), 1);
+}
+
+#[test]
+fn exact_duplicate_observation_identity_rejects() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations.push(batch.observations[0].clone());
+    let error = validate_discriminator_observation_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate discriminator observation id")
+    );
+}
+
+#[test]
+fn conflicting_duplicate_observation_identity_rejects() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let mut conflicting = batch.observations[0].clone();
+    conflicting.value_state = DiscriminatorValueState::Known {
+        value_ref: "observed".to_string(),
+    };
+    batch.observations.push(conflicting);
+    let error = validate_discriminator_observation_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("conflicting discriminator observation id")
+    );
+}
+
+#[test]
+fn missing_source_receipt_rejects() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[0].source_receipt.clear();
+    let error = validate_discriminator_observation_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("source_receipt"));
+}
+
+#[test]
+fn same_value_from_distinct_sources_preserves_each_observation_identity() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let mut repeated = batch.observations[1].clone();
+    repeated.observation_id = "history/oxc-edit-class-v1:second-source".to_string();
+    repeated.source_receipt = "research:cohort-refinement.md#supplied-edit-class".to_string();
+    batch.observations.push(repeated);
+
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let edit_class = enumeration
+        .discriminators
+        .iter()
+        .find(|item| item.discriminator_id == "edit_class")
+        .unwrap();
+    assert_eq!(edit_class.known_partitions.len(), 1);
+    let observations = &edit_class.known_partitions[0].observations;
+    assert_eq!(observations.len(), 2);
+    assert_ne!(
+        observations[0].observation_id,
+        observations[1].observation_id
+    );
+    assert_ne!(
+        observations[0].source_receipt,
+        observations[1].source_receipt
+    );
+}
+
+#[test]
+fn enumeration_order_and_json_round_trip_are_deterministic() {
+    let batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let first = enumerate_discriminator_partitions(&batch).unwrap();
+    let second = enumerate_discriminator_partitions(&batch).unwrap();
+    assert_eq!(first, second);
+
+    let ids = first
+        .discriminators
+        .iter()
+        .map(|item| item.discriminator_id.as_str())
+        .collect::<Vec<_>>();
+    let sorted = ids.iter().copied().collect::<BTreeSet<_>>();
+    assert_eq!(ids, sorted.into_iter().collect::<Vec<_>>());
+
+    let encoded = serde_json::to_vec(&batch).unwrap();
+    let decoded = parse_discriminator_observation_batch(&encoded).unwrap();
+    assert_eq!(decoded, batch);
+}
+
+#[test]
+fn oversized_batch_rejects_before_json_parsing() {
+    let bytes = vec![b' '; MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES + 1];
+    let error = parse_discriminator_observation_batch(&bytes).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}
+
+#[test]
+fn value_spelling_remains_an_opaque_reference() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let DiscriminatorObservation { value_state, .. } = &mut batch.observations[0];
+    *value_state = DiscriminatorValueState::Known {
+        value_ref: "approve_and_merge_everything".to_string(),
+    };
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let partition = &enumeration.discriminators[0].known_partitions[0];
+    assert_eq!(partition.observations.len(), 1);
+}

--- a/tests/known_stale_observation_frontier.rs
+++ b/tests/known_stale_observation_frontier.rs
@@ -1,0 +1,101 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+
+use applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, evaluate_query,
+};
+use discriminator_observation::{
+    DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation,
+    DiscriminatorObservationBatch, DiscriminatorValueState,
+};
+use observation_frontier::{
+    OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierRequest, ObservationFrontierStatus,
+    ObservationRequirement, evaluate_observation_frontiers,
+};
+
+fn known_observation(applicability_ref: &str) -> DiscriminatorObservation {
+    DiscriminatorObservation {
+        observation_id: "obs:edit-class:subject-a".to_string(),
+        discriminator_id: "edit_class".to_string(),
+        subject_ref: "commit:subject-a".to_string(),
+        source_receipt: "receipt:syntax-cohort:subject-a".to_string(),
+        value_state: DiscriminatorValueState::Known {
+            value_ref: "syntax_changed".to_string(),
+        },
+        applicability_ref: Some(applicability_ref.to_string()),
+    }
+}
+
+fn frontier_for(observation: DiscriminatorObservation) -> ObservationFrontierStatus {
+    let request = ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements: vec![ObservationRequirement {
+            discriminator_id: "edit_class".to_string(),
+            subject_ref: "commit:subject-a".to_string(),
+        }],
+        observations: DiscriminatorObservationBatch {
+            schema_version: DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+            observations: vec![observation],
+        },
+    };
+    evaluate_observation_frontiers(&request).unwrap().frontiers[0].status
+}
+
+#[test]
+fn known_value_can_be_called_current_while_shared_applicability_is_invalid() {
+    let applicability = evaluate_query(&ApplicabilityQuery {
+        schema_version: APPLICABILITY_SCHEMA_VERSION,
+        requirements: EvidenceRequirements {
+            repository: Some("owner/repo".to_string()),
+            revision: Some("old-head".to_string()),
+            work: None,
+            scope: None,
+        },
+        context: EvaluationContext {
+            repository: Some("owner/repo".to_string()),
+            revision: Some("new-head".to_string()),
+            work: None,
+            path: None,
+        },
+    })
+    .unwrap();
+    assert_eq!(applicability.status, ApplicabilityStatus::Invalid);
+
+    let status = frontier_for(known_observation(
+        "applicability:owner/repo:old-head->new-head:invalid",
+    ));
+    assert_eq!(status, ObservationFrontierStatus::Current);
+}
+
+#[test]
+fn known_value_can_be_called_current_while_required_current_revision_is_missing() {
+    let applicability = evaluate_query(&ApplicabilityQuery {
+        schema_version: APPLICABILITY_SCHEMA_VERSION,
+        requirements: EvidenceRequirements {
+            repository: Some("owner/repo".to_string()),
+            revision: Some("exact-head".to_string()),
+            work: None,
+            scope: None,
+        },
+        context: EvaluationContext {
+            repository: Some("owner/repo".to_string()),
+            revision: None,
+            work: None,
+            path: None,
+        },
+    })
+    .unwrap();
+    assert_eq!(applicability.status, ApplicabilityStatus::Unknown);
+
+    let status = frontier_for(known_observation(
+        "applicability:owner/repo:exact-head:current-revision-missing",
+    ));
+    assert_eq!(status, ObservationFrontierStatus::Current);
+}

--- a/tests/known_stale_observation_frontier.rs
+++ b/tests/known_stale_observation_frontier.rs
@@ -13,14 +13,18 @@ use applicability::{
 };
 use discriminator_observation::{
     DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation,
-    DiscriminatorObservationBatch, DiscriminatorValueState,
+    DiscriminatorObservationBatch, DiscriminatorValueState, ObservationApplicability,
+    ObservationApplicabilityStatus,
 };
 use observation_frontier::{
     OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierRequest, ObservationFrontierStatus,
     ObservationRequirement, evaluate_observation_frontiers,
 };
 
-fn known_observation(applicability_ref: &str) -> DiscriminatorObservation {
+fn known_observation(
+    applicability_status: ObservationApplicabilityStatus,
+    applicability_ref: &str,
+) -> DiscriminatorObservation {
     DiscriminatorObservation {
         observation_id: "obs:edit-class:subject-a".to_string(),
         discriminator_id: "edit_class".to_string(),
@@ -29,11 +33,16 @@ fn known_observation(applicability_ref: &str) -> DiscriminatorObservation {
         value_state: DiscriminatorValueState::Known {
             value_ref: "syntax_changed".to_string(),
         },
-        applicability_ref: Some(applicability_ref.to_string()),
+        applicability: ObservationApplicability {
+            status: applicability_status,
+            receipt_ref: applicability_ref.to_string(),
+        },
     }
 }
 
-fn frontier_for(observation: DiscriminatorObservation) -> ObservationFrontierStatus {
+fn frontier_for(
+    observation: DiscriminatorObservation,
+) -> observation_frontier::ObservationFrontierReceipt {
     let request = ObservationFrontierRequest {
         schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
         requirements: vec![ObservationRequirement {
@@ -45,11 +54,14 @@ fn frontier_for(observation: DiscriminatorObservation) -> ObservationFrontierSta
             observations: vec![observation],
         },
     };
-    evaluate_observation_frontiers(&request).unwrap().frontiers[0].status
+    evaluate_observation_frontiers(&request)
+        .unwrap()
+        .frontiers
+        .remove(0)
 }
 
 #[test]
-fn known_value_can_be_called_current_while_shared_applicability_is_invalid() {
+fn known_value_with_invalid_shared_applicability_is_not_current() {
     let applicability = evaluate_query(&ApplicabilityQuery {
         schema_version: APPLICABILITY_SCHEMA_VERSION,
         requirements: EvidenceRequirements {
@@ -68,14 +80,21 @@ fn known_value_can_be_called_current_while_shared_applicability_is_invalid() {
     .unwrap();
     assert_eq!(applicability.status, ApplicabilityStatus::Invalid);
 
-    let status = frontier_for(known_observation(
+    let frontier = frontier_for(known_observation(
+        ObservationApplicabilityStatus::Invalid,
         "applicability:owner/repo:old-head->new-head:invalid",
     ));
-    assert_eq!(status, ObservationFrontierStatus::Current);
+    assert_eq!(frontier.status, ObservationFrontierStatus::Invalid);
+    assert!(frontier.current.is_empty());
+    assert_eq!(frontier.invalid.len(), 1);
+    assert_eq!(
+        frontier.invalid[0].known_value_ref.as_deref(),
+        Some("syntax_changed")
+    );
 }
 
 #[test]
-fn known_value_can_be_called_current_while_required_current_revision_is_missing() {
+fn known_value_with_unknown_shared_applicability_is_not_current() {
     let applicability = evaluate_query(&ApplicabilityQuery {
         schema_version: APPLICABILITY_SCHEMA_VERSION,
         requirements: EvidenceRequirements {
@@ -94,8 +113,15 @@ fn known_value_can_be_called_current_while_required_current_revision_is_missing(
     .unwrap();
     assert_eq!(applicability.status, ApplicabilityStatus::Unknown);
 
-    let status = frontier_for(known_observation(
+    let frontier = frontier_for(known_observation(
+        ObservationApplicabilityStatus::Unknown,
         "applicability:owner/repo:exact-head:current-revision-missing",
     ));
-    assert_eq!(status, ObservationFrontierStatus::Current);
+    assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
+    assert!(frontier.current.is_empty());
+    assert_eq!(frontier.unknown.len(), 1);
+    assert_eq!(
+        frontier.unknown[0].known_value_ref.as_deref(),
+        Some("syntax_changed")
+    );
 }

--- a/tests/metamorphic_applicability_probe.rs
+++ b/tests/metamorphic_applicability_probe.rs
@@ -1,0 +1,144 @@
+#![allow(dead_code)]
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+
+use discriminator_observation::{
+    DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation,
+    DiscriminatorObservationBatch, DiscriminatorValueState, ObservationApplicability,
+    ObservationApplicabilityStatus,
+};
+use observation_frontier::{
+    OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierRequest, ObservationFrontierStatus,
+    ObservationRequirement, evaluate_observation_frontiers,
+};
+
+const DISCRIMINATOR: &str = "edit_class";
+const REQUIRED_SUBJECT: &str = "path:src/foo.rs";
+const OTHER_SUBJECT: &str = "path:src/bar.rs";
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum ActionClass {
+    ProceedBounded,
+    RejectStale,
+    RequestDiscriminator,
+}
+
+fn observation(
+    id: &str,
+    subject: &str,
+    status: ObservationApplicabilityStatus,
+    applicability_receipt: &str,
+) -> DiscriminatorObservation {
+    DiscriminatorObservation {
+        observation_id: id.to_string(),
+        discriminator_id: DISCRIMINATOR.to_string(),
+        subject_ref: subject.to_string(),
+        source_receipt: format!("source:{id}"),
+        value_state: DiscriminatorValueState::Known {
+            value_ref: "syntax_changed".to_string(),
+        },
+        applicability: ObservationApplicability {
+            status,
+            receipt_ref: applicability_receipt.to_string(),
+        },
+    }
+}
+
+fn evaluate_action(observations: Vec<DiscriminatorObservation>) -> ActionClass {
+    let request = ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements: vec![ObservationRequirement {
+            discriminator_id: DISCRIMINATOR.to_string(),
+            subject_ref: REQUIRED_SUBJECT.to_string(),
+        }],
+        observations: DiscriminatorObservationBatch {
+            schema_version: DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+            observations,
+        },
+    };
+
+    let evaluation = evaluate_observation_frontiers(&request).unwrap();
+    let frontier = evaluation.frontiers.first().expect("one frontier");
+    match frontier.status {
+        ObservationFrontierStatus::Current => ActionClass::ProceedBounded,
+        ObservationFrontierStatus::Invalid => ActionClass::RejectStale,
+        ObservationFrontierStatus::Unknown | ObservationFrontierStatus::Missing => {
+            ActionClass::RequestDiscriminator
+        }
+    }
+}
+
+#[test]
+fn relevant_applicability_mutation_must_change_the_next_action() {
+    let canonical = evaluate_action(vec![observation(
+        "required",
+        REQUIRED_SUBJECT,
+        ObservationApplicabilityStatus::Applies,
+        "applicability:required:current-head",
+    )]);
+    let mutated = evaluate_action(vec![observation(
+        "required",
+        REQUIRED_SUBJECT,
+        ObservationApplicabilityStatus::Invalid,
+        "applicability:required:moved-head",
+    )]);
+
+    assert_eq!(canonical, ActionClass::ProceedBounded);
+    assert_eq!(mutated, ActionClass::RejectStale);
+    assert_ne!(canonical, mutated);
+}
+
+#[test]
+fn missing_current_applicability_must_request_the_discriminator() {
+    let canonical = evaluate_action(vec![observation(
+        "required",
+        REQUIRED_SUBJECT,
+        ObservationApplicabilityStatus::Applies,
+        "applicability:required:current-head",
+    )]);
+    let mutated = evaluate_action(vec![observation(
+        "required",
+        REQUIRED_SUBJECT,
+        ObservationApplicabilityStatus::Unknown,
+        "applicability:required:missing-current-revision",
+    )]);
+
+    assert_eq!(canonical, ActionClass::ProceedBounded);
+    assert_eq!(mutated, ActionClass::RequestDiscriminator);
+}
+
+#[test]
+fn irrelevant_other_subject_mutation_must_not_perturb_the_action() {
+    let required = observation(
+        "required",
+        REQUIRED_SUBJECT,
+        ObservationApplicabilityStatus::Applies,
+        "applicability:required:current-head",
+    );
+
+    let canonical = evaluate_action(vec![
+        required.clone(),
+        observation(
+            "other",
+            OTHER_SUBJECT,
+            ObservationApplicabilityStatus::Applies,
+            "applicability:other:current-head",
+        ),
+    ]);
+    let mutated = evaluate_action(vec![
+        required,
+        observation(
+            "other",
+            OTHER_SUBJECT,
+            ObservationApplicabilityStatus::Invalid,
+            "applicability:other:moved-head",
+        ),
+    ]);
+
+    assert_eq!(canonical, ActionClass::ProceedBounded);
+    assert_eq!(mutated, ActionClass::ProceedBounded);
+    assert_eq!(canonical, mutated);
+}

--- a/tests/observation_frontier.rs
+++ b/tests/observation_frontier.rs
@@ -10,7 +10,8 @@ mod observation_frontier;
 mod refinement_episode;
 
 use discriminator_observation::{
-    DiscriminatorObservationBatch, DiscriminatorValueState, parse_discriminator_observation_batch,
+    DiscriminatorObservationBatch, DiscriminatorValueState, ObservationApplicabilityStatus,
+    parse_discriminator_observation_batch,
 };
 use observation_frontier::{
     MAX_OBSERVATION_FRONTIER_REQUEST_BYTES, OBSERVATION_FRONTIER_SCHEMA_VERSION,
@@ -68,12 +69,14 @@ fn retained_selected_refinement_discriminators_resolve_current() {
                             &observation.value_state,
                             DiscriminatorValueState::Known { .. }
                         )
+                        && observation.applicability.status
+                            == ObservationApplicabilityStatus::Applies
                 })
                 .collect::<Vec<_>>();
             assert_eq!(
                 matches.len(),
                 1,
-                "retained fixture requires one current subject for {discriminator_id}"
+                "retained fixture requires one current KNOWN+APPLIES subject for {discriminator_id}"
             );
             requirements.push(requirement(discriminator_id, &matches[0].subject_ref));
         }
@@ -127,12 +130,12 @@ fn same_discriminator_on_wrong_subject_does_not_satisfy_requirement() {
 }
 
 #[test]
-fn unknown_matching_observation_produces_unknown_frontier() {
+fn unknown_value_with_applicable_source_produces_unknown_frontier() {
     let mut observations = observation_batch();
     let discriminator_id = observations.observations[0].discriminator_id.clone();
     let subject_ref = observations.observations[0].subject_ref.clone();
     observations.observations[0].value_state = DiscriminatorValueState::Unknown {
-        reason_ref: "applicability:missing-current-revision".to_string(),
+        reason_ref: "classifier:missing-value".to_string(),
     };
 
     let evaluation = evaluate_observation_frontiers(&request(
@@ -143,17 +146,42 @@ fn unknown_matching_observation_produces_unknown_frontier() {
     let frontier = &evaluation.frontiers[0];
     assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
     assert_eq!(frontier.unknown.len(), 1);
-    assert!(frontier.current.is_empty());
+    assert_eq!(
+        frontier.unknown[0].value_unknown_reason_ref.as_deref(),
+        Some("classifier:missing-value")
+    );
 }
 
 #[test]
-fn invalid_matching_observation_produces_invalid_frontier() {
+fn known_value_with_unknown_applicability_produces_unknown_frontier() {
+    let mut observations = observation_batch();
+    let discriminator_id = observations.observations[0].discriminator_id.clone();
+    let subject_ref = observations.observations[0].subject_ref.clone();
+    observations.observations[0].applicability.status = ObservationApplicabilityStatus::Unknown;
+    observations.observations[0].applicability.receipt_ref =
+        "applicability:missing-current-revision".to_string();
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
+    assert_eq!(
+        frontier.unknown[0].known_value_ref.as_deref(),
+        Some("absent")
+    );
+}
+
+#[test]
+fn known_value_with_invalid_applicability_produces_invalid_frontier() {
     let mut observations = observation_batch();
     let discriminator_id = observations.observations[1].discriminator_id.clone();
     let subject_ref = observations.observations[1].subject_ref.clone();
-    observations.observations[1].value_state = DiscriminatorValueState::Invalid {
-        reason_ref: "applicability:revision-moved".to_string(),
-    };
+    observations.observations[1].applicability.status = ObservationApplicabilityStatus::Invalid;
+    observations.observations[1].applicability.receipt_ref =
+        "applicability:revision-moved".to_string();
 
     let evaluation = evaluate_observation_frontiers(&request(
         vec![requirement(&discriminator_id, &subject_ref)],
@@ -162,8 +190,10 @@ fn invalid_matching_observation_produces_invalid_frontier() {
     .unwrap();
     let frontier = &evaluation.frontiers[0];
     assert_eq!(frontier.status, ObservationFrontierStatus::Invalid);
-    assert_eq!(frontier.invalid.len(), 1);
-    assert!(frontier.current.is_empty());
+    assert_eq!(
+        frontier.invalid[0].known_value_ref.as_deref(),
+        Some("syntax_changed")
+    );
 }
 
 #[test]
@@ -172,9 +202,8 @@ fn current_precedes_unknown_while_preserving_both_receipts() {
     let mut unknown = observations.observations[1].clone();
     unknown.observation_id = "history/oxc-edit-class-v1:unknown-second-source".to_string();
     unknown.source_receipt = "research:cohort-refinement.md#unknown-edit-class".to_string();
-    unknown.value_state = DiscriminatorValueState::Unknown {
-        reason_ref: "classifier:missing-source-version".to_string(),
-    };
+    unknown.applicability.status = ObservationApplicabilityStatus::Unknown;
+    unknown.applicability.receipt_ref = "applicability:missing-source-version".to_string();
     let discriminator_id = unknown.discriminator_id.clone();
     let subject_ref = unknown.subject_ref.clone();
     observations.observations.push(unknown);
@@ -196,14 +225,13 @@ fn unknown_precedes_invalid_when_no_current_observation_exists() {
     let mut invalid = observations.observations[0].clone();
     invalid.observation_id = "justification/open-obligation-v1:invalid-second-source".to_string();
     invalid.source_receipt = "research:durable-unknown-obligation.md#stale".to_string();
-    invalid.value_state = DiscriminatorValueState::Invalid {
-        reason_ref: "applicability:head-moved".to_string(),
-    };
+    invalid.applicability.status = ObservationApplicabilityStatus::Invalid;
+    invalid.applicability.receipt_ref = "applicability:head-moved".to_string();
     let discriminator_id = invalid.discriminator_id.clone();
     let subject_ref = invalid.subject_ref.clone();
-    observations.observations[0].value_state = DiscriminatorValueState::Unknown {
-        reason_ref: "applicability:missing-head".to_string(),
-    };
+    observations.observations[0].applicability.status = ObservationApplicabilityStatus::Unknown;
+    observations.observations[0].applicability.receipt_ref =
+        "applicability:missing-head".to_string();
     observations.observations.push(invalid);
 
     let evaluation = evaluate_observation_frontiers(&request(

--- a/tests/observation_frontier.rs
+++ b/tests/observation_frontier.rs
@@ -1,0 +1,283 @@
+#![allow(dead_code)]
+
+use std::collections::BTreeSet;
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+
+use discriminator_observation::{
+    DiscriminatorObservationBatch, DiscriminatorValueState, parse_discriminator_observation_batch,
+};
+use observation_frontier::{
+    MAX_OBSERVATION_FRONTIER_REQUEST_BYTES, OBSERVATION_FRONTIER_SCHEMA_VERSION,
+    ObservationFrontierRequest, ObservationFrontierStatus, ObservationRequirement,
+    evaluate_observation_frontiers, parse_observation_frontier_request,
+};
+use refinement_episode::parse_refinement_episode_batch;
+
+const OBSERVATIONS: &[u8] =
+    include_bytes!("../research/discriminator-observations/cultist-v1.json");
+const REFINEMENTS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+
+fn observation_batch() -> DiscriminatorObservationBatch {
+    parse_discriminator_observation_batch(OBSERVATIONS).unwrap()
+}
+
+fn requirement(discriminator_id: &str, subject_ref: &str) -> ObservationRequirement {
+    ObservationRequirement {
+        discriminator_id: discriminator_id.to_string(),
+        subject_ref: subject_ref.to_string(),
+    }
+}
+
+fn request(
+    requirements: Vec<ObservationRequirement>,
+    observations: DiscriminatorObservationBatch,
+) -> ObservationFrontierRequest {
+    ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements,
+        observations,
+    }
+}
+
+#[test]
+fn retained_selected_refinement_discriminators_resolve_current() {
+    let observations = observation_batch();
+    let refinements = parse_refinement_episode_batch(REFINEMENTS).unwrap();
+    let mut requirements = Vec::new();
+
+    for episode in &refinements.episodes {
+        let selected = episode.selected_transition.as_ref().unwrap();
+        let candidate = episode
+            .candidate_refinements
+            .iter()
+            .find(|candidate| candidate.id == *selected)
+            .unwrap();
+        for discriminator_id in &candidate.discriminator_refs {
+            let matches = observations
+                .observations
+                .iter()
+                .filter(|observation| {
+                    observation.discriminator_id == *discriminator_id
+                        && matches!(
+                            &observation.value_state,
+                            DiscriminatorValueState::Known { .. }
+                        )
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(
+                matches.len(),
+                1,
+                "retained fixture requires one current subject for {discriminator_id}"
+            );
+            requirements.push(requirement(discriminator_id, &matches[0].subject_ref));
+        }
+    }
+
+    let evaluation = evaluate_observation_frontiers(&request(requirements, observations)).unwrap();
+    assert_eq!(evaluation.frontiers.len(), 4);
+    assert!(
+        evaluation
+            .frontiers
+            .iter()
+            .all(|frontier| frontier.status == ObservationFrontierStatus::Current)
+    );
+}
+
+#[test]
+fn removing_one_selected_observation_creates_explicit_missing_frontier() {
+    let mut observations = observation_batch();
+    let removed = observations.observations.remove(0);
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&removed.discriminator_id, &removed.subject_ref)],
+        observations,
+    ))
+    .unwrap();
+
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Missing);
+    assert!(frontier.current.is_empty());
+    assert!(frontier.unknown.is_empty());
+    assert!(frontier.invalid.is_empty());
+}
+
+#[test]
+fn same_discriminator_on_wrong_subject_does_not_satisfy_requirement() {
+    let mut observations = observation_batch();
+    let mut wrong_subject = observations.observations.remove(0);
+    let discriminator_id = wrong_subject.discriminator_id.clone();
+    let required_subject = wrong_subject.subject_ref.clone();
+    wrong_subject.observation_id = "justification/wrong-subject:clearing-presence".to_string();
+    wrong_subject.subject_ref = "refinement:justification/another-obligation".to_string();
+    observations.observations.push(wrong_subject);
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &required_subject)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Missing);
+    assert_eq!(frontier.other_subject.len(), 1);
+}
+
+#[test]
+fn unknown_matching_observation_produces_unknown_frontier() {
+    let mut observations = observation_batch();
+    let discriminator_id = observations.observations[0].discriminator_id.clone();
+    let subject_ref = observations.observations[0].subject_ref.clone();
+    observations.observations[0].value_state = DiscriminatorValueState::Unknown {
+        reason_ref: "applicability:missing-current-revision".to_string(),
+    };
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
+    assert_eq!(frontier.unknown.len(), 1);
+    assert!(frontier.current.is_empty());
+}
+
+#[test]
+fn invalid_matching_observation_produces_invalid_frontier() {
+    let mut observations = observation_batch();
+    let discriminator_id = observations.observations[1].discriminator_id.clone();
+    let subject_ref = observations.observations[1].subject_ref.clone();
+    observations.observations[1].value_state = DiscriminatorValueState::Invalid {
+        reason_ref: "applicability:revision-moved".to_string(),
+    };
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Invalid);
+    assert_eq!(frontier.invalid.len(), 1);
+    assert!(frontier.current.is_empty());
+}
+
+#[test]
+fn current_precedes_unknown_while_preserving_both_receipts() {
+    let mut observations = observation_batch();
+    let mut unknown = observations.observations[1].clone();
+    unknown.observation_id = "history/oxc-edit-class-v1:unknown-second-source".to_string();
+    unknown.source_receipt = "research:cohort-refinement.md#unknown-edit-class".to_string();
+    unknown.value_state = DiscriminatorValueState::Unknown {
+        reason_ref: "classifier:missing-source-version".to_string(),
+    };
+    let discriminator_id = unknown.discriminator_id.clone();
+    let subject_ref = unknown.subject_ref.clone();
+    observations.observations.push(unknown);
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Current);
+    assert_eq!(frontier.current.len(), 1);
+    assert_eq!(frontier.unknown.len(), 1);
+}
+
+#[test]
+fn unknown_precedes_invalid_when_no_current_observation_exists() {
+    let mut observations = observation_batch();
+    let mut invalid = observations.observations[0].clone();
+    invalid.observation_id = "justification/open-obligation-v1:invalid-second-source".to_string();
+    invalid.source_receipt = "research:durable-unknown-obligation.md#stale".to_string();
+    invalid.value_state = DiscriminatorValueState::Invalid {
+        reason_ref: "applicability:head-moved".to_string(),
+    };
+    let discriminator_id = invalid.discriminator_id.clone();
+    let subject_ref = invalid.subject_ref.clone();
+    observations.observations[0].value_state = DiscriminatorValueState::Unknown {
+        reason_ref: "applicability:missing-head".to_string(),
+    };
+    observations.observations.push(invalid);
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
+    assert_eq!(frontier.unknown.len(), 1);
+    assert_eq!(frontier.invalid.len(), 1);
+}
+
+#[test]
+fn duplicate_exact_requirement_rejects() {
+    let observations = observation_batch();
+    let requirement = requirement(
+        &observations.observations[0].discriminator_id,
+        &observations.observations[0].subject_ref,
+    );
+    let error = evaluate_observation_frontiers(&request(
+        vec![requirement.clone(), requirement],
+        observations,
+    ))
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate observation requirement")
+    );
+}
+
+#[test]
+fn frontier_output_order_is_deterministic() {
+    let observations = observation_batch();
+    let requirements = observations
+        .observations
+        .iter()
+        .rev()
+        .map(|observation| requirement(&observation.discriminator_id, &observation.subject_ref))
+        .collect::<Vec<_>>();
+    let evaluation = evaluate_observation_frontiers(&request(requirements, observations)).unwrap();
+    let keys = evaluation
+        .frontiers
+        .iter()
+        .map(|frontier| {
+            (
+                frontier.discriminator_id.as_str(),
+                frontier.subject_ref.as_str(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let sorted = keys.iter().copied().collect::<BTreeSet<_>>();
+    assert_eq!(keys, sorted.into_iter().collect::<Vec<_>>());
+}
+
+#[test]
+fn request_json_round_trip_revalidates_the_frontier_input() {
+    let observations = observation_batch();
+    let request = request(
+        vec![requirement(
+            &observations.observations[0].discriminator_id,
+            &observations.observations[0].subject_ref,
+        )],
+        observations,
+    );
+    let encoded = serde_json::to_vec(&request).unwrap();
+    let decoded = parse_observation_frontier_request(&encoded).unwrap();
+    assert_eq!(decoded, request);
+}
+
+#[test]
+fn oversized_request_rejects_before_json_parsing() {
+    let bytes = vec![b' '; MAX_OBSERVATION_FRONTIER_REQUEST_BYTES + 1];
+    let error = parse_observation_frontier_request(&bytes).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}

--- a/tests/refinement_episode.rs
+++ b/tests/refinement_episode.rs
@@ -1,0 +1,177 @@
+#![allow(dead_code)]
+
+use std::collections::BTreeSet;
+
+#[path = "../src/behavioral_episode.rs"]
+mod behavioral_episode;
+#[path = "../src/behavioral_receipt.rs"]
+mod behavioral_receipt;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+
+use behavioral_episode::parse_behavioral_episode_batch;
+use behavioral_receipt::BehavioralOutcome;
+use refinement_episode::{
+    HeldOutStatus, MAX_REFINEMENT_EPISODE_BATCH_BYTES, RefinementStatus,
+    parse_refinement_episode_batch, validate_refinement_episode_batch,
+};
+
+const CORPUS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+const BEHAVIORAL_CORPUS: &[u8] =
+    include_bytes!("../research/behavioral-episodes/cultist-collaboration-v1.json");
+
+#[test]
+fn retained_cultist_refinement_corpus_preserves_selected_and_rejected_candidates() {
+    let batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    assert_eq!(batch.episodes.len(), 3);
+
+    let justification = &batch.episodes[0];
+    assert_eq!(justification.id, "justification/open-obligation-v1");
+    assert_eq!(
+        justification.selected_transition.as_deref(),
+        Some("allow-open-zero-edge")
+    );
+    assert!(justification.behavioral_episode_ids.is_empty());
+    assert_eq!(
+        justification.candidate_refinements[0].status,
+        RefinementStatus::Weakened
+    );
+
+    let history = &batch.episodes[1];
+    assert_eq!(history.id, "history/oxc-edit-class-v1");
+    assert_eq!(history.candidate_refinements.len(), 3);
+    assert_eq!(
+        history.candidate_refinements[0]
+            .replay_result
+            .held_out_status,
+        HeldOutStatus::Passed
+    );
+    assert!(
+        history
+            .candidate_refinements
+            .iter()
+            .any(|candidate| { candidate.status == RefinementStatus::RejectedNoImprovement })
+    );
+    assert!(
+        history
+            .candidate_refinements
+            .iter()
+            .any(|candidate| { candidate.status == RefinementStatus::RejectedOverfit })
+    );
+
+    let project_memory = &batch.episodes[2];
+    assert_eq!(
+        project_memory.id,
+        "project-memory/primary-case-contract-collision-v1"
+    );
+    assert_eq!(
+        project_memory.candidate_refinements[0].status,
+        RefinementStatus::Split
+    );
+    assert_eq!(
+        project_memory.behavioral_episode_ids,
+        vec!["project-memory:primary-case-contract-collision:9792bfe->df5ae59"]
+    );
+}
+
+#[test]
+fn selected_transition_must_name_a_kept_candidate() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[1].selected_transition = Some("singleton-commit-partition".to_string());
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("rejected status"));
+}
+
+#[test]
+fn kept_candidate_cannot_lose_expected_replay_cases() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[0].candidate_refinements[0]
+        .replay_result
+        .expected_cases_lost = 1;
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("loses expected replay cases"));
+}
+
+#[test]
+fn no_improvement_candidate_cannot_claim_a_resolved_counterexample() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    let candidate = batch.episodes[1]
+        .candidate_refinements
+        .iter_mut()
+        .find(|candidate| candidate.status == RefinementStatus::RejectedNoImprovement)
+        .unwrap();
+    candidate.replay_result.counterexamples_resolved = 1;
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("preserve the baseline replay"));
+}
+
+#[test]
+fn candidate_discriminator_must_be_admitted_by_the_episode() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[0].candidate_refinements[0].discriminator_refs =
+        vec!["invented_discriminator".to_string()];
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("unadmitted discriminator"));
+}
+
+#[test]
+fn behavioral_episode_links_resolve_against_retained_observation_corpus() {
+    let refinement_batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    let behavioral_batch = parse_behavioral_episode_batch(BEHAVIORAL_CORPUS).unwrap();
+    let behavioral_ids = behavioral_batch
+        .episodes
+        .iter()
+        .map(|episode| episode.episode_id.as_str())
+        .collect::<BTreeSet<_>>();
+
+    let linked_ids = refinement_batch
+        .episodes
+        .iter()
+        .flat_map(|episode| episode.behavioral_episode_ids.iter())
+        .collect::<Vec<_>>();
+    assert_eq!(linked_ids.len(), 1);
+    assert!(behavioral_ids.contains(linked_ids[0].as_str()));
+
+    let linked_episode = behavioral_batch
+        .episodes
+        .iter()
+        .find(|episode| episode.episode_id == *linked_ids[0])
+        .unwrap();
+    assert_eq!(
+        linked_episode.receipt.outcome,
+        BehavioralOutcome::ChangedNextAction
+    );
+}
+
+#[test]
+fn behavioral_episode_links_are_optional_and_explicit() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[0].behavioral_episode_ids = vec!["observed:episode-1".to_string()];
+    validate_refinement_episode_batch(&batch).unwrap();
+
+    let encoded = serde_json::to_vec(&batch).unwrap();
+    let decoded = parse_refinement_episode_batch(&encoded).unwrap();
+    assert_eq!(
+        decoded.episodes[0].behavioral_episode_ids,
+        vec!["observed:episode-1"]
+    );
+}
+
+#[test]
+fn duplicate_episode_ids_fail_before_any_aggregate_can_count_them() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[1].id = batch.episodes[0].id.clone();
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate refinement episode id")
+    );
+}
+
+#[test]
+fn oversized_batch_rejects_before_json_parsing() {
+    let bytes = vec![b' '; MAX_REFINEMENT_EPISODE_BATCH_BYTES + 1];
+    let error = parse_refinement_episode_batch(&bytes).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}


### PR DESCRIPTION
Superseded by current-main #277.

The original #224 branch carried the full discriminator-observation/frontier/refinement stack because #210 and its prerequisites were still stacked at the time. Those semantics are now on `main`.

#277 preserves the exact earned child result as one file:

```text
tests/metamorphic_applicability_probe.rs
```

No other branch content needs separate integration.