### PR TITLE
research: seed agent skill failure corpus with explicit claim status

### DIFF
--- a/research/agent-skill-corpus-seed.json
+++ b/research/agent-skill-corpus-seed.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "description": "Reported public Agent Skills issue cases for capability-demand research. Rows are claims until independently reproduced or linked to a verified repair.",
+  "description": "Public Agent Skills issue cases for capability-demand research. Evidence status records how far each reported diagnosis has been independently supported; it does not promote vendor issue claims by editorial confidence.",
   "episodes": [
     {
       "id": "anthropics/skills#556",
@@ -17,8 +17,12 @@
       "source_url": "https://github.com/anthropics/skills/issues/1352",
       "title": "skill-creator: run_eval.py parallel workers cross-match skill UUIDs, producing false-negative trigger rates",
       "reported_boundary": "measurement_misrepresented",
-      "evidence_status": "reported_only",
-      "candidate_discriminator": "compare parallel and isolated/serial trigger evaluation under the same skill description"
+      "evidence_status": "source_mechanism_confirmed",
+      "source_evidence_url": "https://github.com/anthropics/skills/blob/0a64e398ec6bb34a494f0c347e8ccae53a862f8e/skills/skill-creator/scripts/run_eval.py",
+      "source_evidence_blob_sha": "e58c70bea39d5b252a1e819f242bbdcdf20e8b87",
+      "repair_url": "https://github.com/anthropics/skills/pull/1437",
+      "repair_status": "proposed_open",
+      "candidate_discriminator": "compare parallel and isolated/serial trigger evaluation under the same skill description; current source confirms shared project registration, per-query UUID names, parallel execution, and exact per-query UUID matching, but the claimed trigger-rate consequence is not independently replayed here"
     },
     {
       "id": "anthropics/skills#1487",

--- a/research/agent-skill-corpus-seed.json
+++ b/research/agent-skill-corpus-seed.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": 1,
+  "description": "Reported public Agent Skills issue cases for capability-demand research. Rows are claims until independently reproduced or linked to a verified repair.",
+  "episodes": [
+    {
+      "id": "anthropics/skills#556",
+      "ecosystem": "anthropic",
+      "source_url": "https://github.com/anthropics/skills/issues/556",
+      "title": "run_eval.py: claude -p never triggers skills/commands (0% trigger rate across all queries)",
+      "reported_boundary": "measurement_misrepresented",
+      "evidence_status": "reported_only",
+      "candidate_discriminator": "verify the skill is actually exposed and observable before treating zero trigger rate as description/model failure"
+    },
+    {
+      "id": "anthropics/skills#1352",
+      "ecosystem": "anthropic",
+      "source_url": "https://github.com/anthropics/skills/issues/1352",
+      "title": "skill-creator: run_eval.py parallel workers cross-match skill UUIDs, producing false-negative trigger rates",
+      "reported_boundary": "measurement_misrepresented",
+      "evidence_status": "reported_only",
+      "candidate_discriminator": "compare parallel and isolated/serial trigger evaluation under the same skill description"
+    },
+    {
+      "id": "anthropics/skills#1487",
+      "ecosystem": "anthropic",
+      "source_url": "https://github.com/anthropics/skills/issues/1487",
+      "title": "claude-api skill eagerly injects ~156k tokens, exhausting the context window in a single tool call",
+      "reported_boundary": "selection_budget_overreach",
+      "evidence_status": "reported_only",
+      "candidate_discriminator": "measure task-relevant loaded references versus eager payload and next-action preservation under progressive disclosure"
+    },
+    {
+      "id": "anthropics/skills#189",
+      "ecosystem": "anthropic",
+      "source_url": "https://github.com/anthropics/skills/issues/189",
+      "title": "document-skills and example-skills plugins install identical content, causing duplicate skills",
+      "reported_boundary": "selection_budget_overreach",
+      "evidence_status": "reported_only",
+      "candidate_discriminator": "fingerprint loaded skill content and distinguish duplicate bytes from additional decision-relevant evidence"
+    },
+    {
+      "id": "anthropics/skills#1061",
+      "ecosystem": "anthropic",
+      "source_url": "https://github.com/anthropics/skills/issues/1061",
+      "title": "Windows compatibility: skill-creator scripts fail (subprocess PATHEXT, cp1252 encoding, select on pipes)",
+      "reported_boundary": "affordance_miss",
+      "evidence_status": "reported_only",
+      "candidate_discriminator": "run the same eval workflow under declared platform/tool affordances before attributing failure to the worker"
+    },
+    {
+      "id": "anthropics/skills#492",
+      "ecosystem": "anthropic",
+      "source_url": "https://github.com/anthropics/skills/issues/492",
+      "title": "Security: Community skills distributed under anthropic/ namespace enable trust boundary abuse",
+      "reported_boundary": "provenance_identity_gap",
+      "evidence_status": "reported_only",
+      "candidate_discriminator": "bind skill content to verifiable origin identity instead of inferring provenance from a path namespace"
+    },
+    {
+      "id": "anthropics/skills#881",
+      "ecosystem": "anthropic",
+      "source_url": "https://github.com/anthropics/skills/issues/881",
+      "title": "claude-api skill description truncated in Claude Code listings",
+      "reported_boundary": "schema_tooling_drift",
+      "evidence_status": "reported_only",
+      "candidate_discriminator": "compare authored activation metadata with the exact metadata actually exposed to the selector"
+    },
+    {
+      "id": "openai/skills#96",
+      "ecosystem": "openai",
+      "source_url": "https://github.com/openai/skills/issues/96",
+      "title": "gh-address-comments can't find scripts/fetch_comments.py and falls back to GraphQL",
+      "reported_boundary": "context_binding_miss",
+      "evidence_status": "reported_only",
+      "candidate_discriminator": "resolve helper references against an explicit skill root instead of the target repository cwd"
+    },
+    {
+      "id": "openai/skills#526",
+      "ecosystem": "openai",
+      "source_url": "https://github.com/openai/skills/issues/526",
+      "title": "[skill-creator] Document portable Python invocation for non-executable helper scripts",
+      "reported_boundary": "context_binding_miss",
+      "evidence_status": "reported_only",
+      "candidate_discriminator": "execute documented helpers from both skill root and unrelated workspace using explicit interpreter/root coordinates"
+    },
+    {
+      "id": "openai/skills#519",
+      "ecosystem": "openai",
+      "source_url": "https://github.com/openai/skills/issues/519",
+      "title": "quick_validate.py fails on UTF-8 SKILL.md under Windows CP949",
+      "reported_boundary": "affordance_miss",
+      "evidence_status": "reported_only",
+      "candidate_discriminator": "replay validation under a non-UTF-8 locale and an explicit UTF-8 reader while holding skill bytes fixed"
+    },
+    {
+      "id": "openai/skills#518",
+      "ecosystem": "openai",
+      "source_url": "https://github.com/openai/skills/issues/518",
+      "title": "skill-creator validator fails when PyYAML is not available globally",
+      "reported_boundary": "affordance_miss",
+      "evidence_status": "reported_only",
+      "candidate_discriminator": "inventory required runtime dependencies before treating validator non-execution as skill/model failure"
+    },
+    {
+      "id": "openai/skills#131",
+      "ecosystem": "openai",
+      "source_url": "https://github.com/openai/skills/issues/131",
+      "title": "Should skill installs record origin metadata to enable safe updates?",
+      "reported_boundary": "provenance_identity_gap",
+      "evidence_status": "reported_only",
+      "candidate_discriminator": "record exact repo/ref/commit origin so installed skill identity can be compared across updates"
+    },
+    {
+      "id": "openai/skills#420",
+      "ecosystem": "openai",
+      "source_url": "https://github.com/openai/skills/issues/420",
+      "title": "skill-installer and skill-creator still default to ~/.codex/skills while current docs point users toward ~/.agents/skills",
+      "reported_boundary": "schema_tooling_drift",
+      "evidence_status": "reported_only",
+      "candidate_discriminator": "compare documented install root, tool-computed root, and runtime discovery precedence as separate identities"
+    },
+    {
+      "id": "openai/skills#187",
+      "ecosystem": "openai",
+      "source_url": "https://github.com/openai/skills/issues/187",
+      "title": "Allow compatibility property in frontmatter for consistency with Agent Skills Specification",
+      "reported_boundary": "schema_tooling_drift",
+      "evidence_status": "reported_only",
+      "candidate_discriminator": "compare validator-admitted frontmatter fields against the exact declared specification version"
+    }
+  ]
+}

--- a/research/agent-skill-corpus-seed.json
+++ b/research/agent-skill-corpus-seed.json
@@ -18,10 +18,16 @@
       "title": "skill-creator: run_eval.py parallel workers cross-match skill UUIDs, producing false-negative trigger rates",
       "reported_boundary": "measurement_misrepresented",
       "evidence_status": "source_mechanism_confirmed",
-      "source_evidence_url": "https://github.com/anthropics/skills/blob/0a64e398ec6bb34a494f0c347e8ccae53a862f8e/skills/skill-creator/scripts/run_eval.py",
-      "source_evidence_blob_sha": "e58c70bea39d5b252a1e819f242bbdcdf20e8b87",
-      "repair_url": "https://github.com/anthropics/skills/pull/1437",
-      "repair_status": "proposed_open",
+      "source_evidence": [
+        {
+          "url": "https://github.com/anthropics/skills/blob/0a64e398ec6bb34a494f0c347e8ccae53a862f8e/skills/skill-creator/scripts/run_eval.py",
+          "blob_sha": "e58c70bea39d5b252a1e819f242bbdcdf20e8b87"
+        }
+      ],
+      "repair": {
+        "url": "https://github.com/anthropics/skills/pull/1437",
+        "status": "proposed_open"
+      },
       "candidate_discriminator": "compare parallel and isolated/serial trigger evaluation under the same skill description; current source confirms shared project registration, per-query UUID names, parallel execution, and exact per-query UUID matching, but the claimed trigger-rate consequence is not independently replayed here"
     },
     {
@@ -75,8 +81,18 @@
       "source_url": "https://github.com/openai/skills/issues/96",
       "title": "gh-address-comments can't find scripts/fetch_comments.py and falls back to GraphQL",
       "reported_boundary": "context_binding_miss",
-      "evidence_status": "reported_only",
-      "candidate_discriminator": "resolve helper references against an explicit skill root instead of the target repository cwd"
+      "evidence_status": "source_mechanism_confirmed",
+      "source_evidence": [
+        {
+          "url": "https://github.com/openai/skills/blob/49f948faa9258a0c61caceaf225e179651397431/skills/.curated/gh-address-comments/SKILL.md",
+          "blob_sha": "0ee19e080dc9f0b082157080d1e65511ddc49e7e"
+        },
+        {
+          "url": "https://github.com/openai/skills/blob/49f948faa9258a0c61caceaf225e179651397431/skills/.curated/gh-address-comments/scripts/fetch_comments.py",
+          "blob_sha": "09b9c01c50d9202bd6455ce36887e08be92ac1ae"
+        }
+      ],
+      "candidate_discriminator": "current skill instructions use the unbound relative reference scripts/fetch_comments.py while the helper is bundled under the skill directory; replay from target-repository cwd versus an explicitly bound skill root is still required to confirm the reported runtime failure"
     },
     {
       "id": "openai/skills#526",

--- a/tests/agent_skill_corpus_seed.rs
+++ b/tests/agent_skill_corpus_seed.rs
@@ -20,14 +20,24 @@ struct Episode {
     reported_boundary: ReportedBoundary,
     evidence_status: EvidenceStatus,
     #[serde(default)]
-    source_evidence_url: Option<String>,
+    source_evidence: Vec<SourceEvidence>,
     #[serde(default)]
-    source_evidence_blob_sha: Option<String>,
-    #[serde(default)]
-    repair_url: Option<String>,
-    #[serde(default)]
-    repair_status: Option<RepairStatus>,
+    repair: Option<RepairEvidence>,
     candidate_discriminator: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SourceEvidence {
+    url: String,
+    blob_sha: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RepairEvidence {
+    url: String,
+    status: RepairStatus,
 }
 
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Deserialize)]
@@ -68,6 +78,12 @@ fn is_lower_hex_sha(value: &str) -> bool {
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
+fn exact_blob_commit<'a>(url: &'a str, prefix: &str) -> Option<&'a str> {
+    let rest = url.strip_prefix(prefix)?;
+    let (commit, _) = rest.split_once('/')?;
+    is_lower_hex_sha(commit).then_some(commit)
+}
+
 #[test]
 fn agent_skill_seed_is_bounded_cross_ecosystem_and_keeps_evidence_state_explicit() {
     let corpus: Corpus =
@@ -82,7 +98,7 @@ fn agent_skill_seed_is_bounded_cross_ecosystem_and_keeps_evidence_state_explicit
     let mut ids = BTreeSet::new();
     let mut ecosystems = BTreeSet::new();
     let mut boundaries = BTreeSet::new();
-    let mut source_confirmed = 0usize;
+    let mut source_confirmed_ecosystems = BTreeSet::new();
 
     for episode in &corpus.episodes {
         assert!(
@@ -127,30 +143,28 @@ fn agent_skill_seed_is_bounded_cross_ecosystem_and_keeps_evidence_state_explicit
 
         match episode.evidence_status {
             EvidenceStatus::ReportedOnly => {
-                assert!(episode.source_evidence_url.is_none());
-                assert!(episode.source_evidence_blob_sha.is_none());
-                assert!(episode.repair_url.is_none());
-                assert!(episode.repair_status.is_none());
+                assert!(episode.source_evidence.is_empty());
+                assert!(episode.repair.is_none());
             }
             EvidenceStatus::SourceMechanismConfirmed => {
-                source_confirmed += 1;
-                let source_evidence_url = episode
-                    .source_evidence_url
-                    .as_deref()
-                    .expect("confirmed mechanism has exact source URL");
-                let source_evidence_blob_sha = episode
-                    .source_evidence_blob_sha
-                    .as_deref()
-                    .expect("confirmed mechanism has source blob SHA");
-                assert!(source_evidence_url.starts_with(blob_prefix));
-                assert!(is_lower_hex_sha(source_evidence_blob_sha));
+                source_confirmed_ecosystems.insert(episode.ecosystem);
+                assert!(
+                    !episode.source_evidence.is_empty(),
+                    "confirmed mechanism needs exact source evidence"
+                );
+                for evidence in &episode.source_evidence {
+                    assert!(
+                        exact_blob_commit(&evidence.url, blob_prefix).is_some(),
+                        "source evidence URL lacks exact commit: {}",
+                        evidence.url
+                    );
+                    assert!(is_lower_hex_sha(&evidence.blob_sha));
+                }
 
-                let repair_url = episode
-                    .repair_url
-                    .as_deref()
-                    .expect("confirmed mechanism records known repair proposal");
-                assert!(repair_url.starts_with(pull_prefix));
-                assert_eq!(episode.repair_status, Some(RepairStatus::ProposedOpen));
+                if let Some(repair) = &episode.repair {
+                    assert!(repair.url.starts_with(pull_prefix));
+                    assert_eq!(repair.status, RepairStatus::ProposedOpen);
+                }
             }
         }
     }
@@ -164,8 +178,9 @@ fn agent_skill_seed_is_bounded_cross_ecosystem_and_keeps_evidence_state_explicit
         boundaries.len() >= 5,
         "seed should test multiple candidate failure species"
     );
-    assert!(
-        source_confirmed >= 1,
-        "at least one reported diagnosis should graduate through source evidence"
+    assert_eq!(
+        source_confirmed_ecosystems.len(),
+        2,
+        "at least one diagnosis in each sampled ecosystem should graduate through exact source evidence"
     );
 }

--- a/tests/agent_skill_corpus_seed.rs
+++ b/tests/agent_skill_corpus_seed.rs
@@ -1,0 +1,101 @@
+use std::collections::BTreeSet;
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Corpus {
+    schema_version: u32,
+    description: String,
+    episodes: Vec<Episode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Episode {
+    id: String,
+    ecosystem: Ecosystem,
+    source_url: String,
+    title: String,
+    reported_boundary: ReportedBoundary,
+    evidence_status: EvidenceStatus,
+    candidate_discriminator: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Ecosystem {
+    Anthropic,
+    Openai,
+}
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ReportedBoundary {
+    MeasurementMisrepresented,
+    SelectionBudgetOverreach,
+    ContextBindingMiss,
+    AffordanceMiss,
+    ProvenanceIdentityGap,
+    SchemaToolingDrift,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum EvidenceStatus {
+    ReportedOnly,
+}
+
+#[test]
+fn reported_agent_skill_seed_is_bounded_cross_ecosystem_and_explicitly_unverified() {
+    let corpus: Corpus = serde_json::from_slice(include_bytes!(
+        "../research/agent-skill-corpus-seed.json"
+    ))
+    .expect("valid corpus JSON");
+
+    assert_eq!(corpus.schema_version, 1);
+    assert!(corpus.description.contains("claims"));
+    assert!(corpus.episodes.len() >= 12);
+    assert!(corpus.episodes.len() <= 64);
+
+    let mut ids = BTreeSet::new();
+    let mut ecosystems = BTreeSet::new();
+    let mut boundaries = BTreeSet::new();
+
+    for episode in &corpus.episodes {
+        assert!(ids.insert(episode.id.as_str()), "duplicate id {}", episode.id);
+        ecosystems.insert(episode.ecosystem);
+        boundaries.insert(episode.reported_boundary);
+
+        assert_eq!(episode.evidence_status, EvidenceStatus::ReportedOnly);
+        assert!(!episode.title.trim().is_empty());
+        assert!(!episode.candidate_discriminator.trim().is_empty());
+
+        let expected_prefix = match episode.ecosystem {
+            Ecosystem::Anthropic => "https://github.com/anthropics/skills/issues/",
+            Ecosystem::Openai => "https://github.com/openai/skills/issues/",
+        };
+        assert!(
+            episode.source_url.starts_with(expected_prefix),
+            "unexpected source URL {}",
+            episode.source_url
+        );
+
+        let issue_number = episode
+            .id
+            .rsplit_once('#')
+            .map(|(_, number)| number)
+            .expect("id contains issue number");
+        assert!(
+            episode.source_url.ends_with(issue_number),
+            "source URL does not match id {}",
+            episode.id
+        );
+    }
+
+    assert_eq!(ecosystems.len(), 2, "seed must span both sampled ecosystems");
+    assert!(
+        boundaries.len() >= 5,
+        "seed should test multiple candidate failure species"
+    );
+}

--- a/tests/agent_skill_corpus_seed.rs
+++ b/tests/agent_skill_corpus_seed.rs
@@ -19,6 +19,14 @@ struct Episode {
     title: String,
     reported_boundary: ReportedBoundary,
     evidence_status: EvidenceStatus,
+    #[serde(default)]
+    source_evidence_url: Option<String>,
+    #[serde(default)]
+    source_evidence_blob_sha: Option<String>,
+    #[serde(default)]
+    repair_url: Option<String>,
+    #[serde(default)]
+    repair_status: Option<RepairStatus>,
     candidate_discriminator: String,
 }
 
@@ -44,39 +52,64 @@ enum ReportedBoundary {
 #[serde(rename_all = "snake_case")]
 enum EvidenceStatus {
     ReportedOnly,
+    SourceMechanismConfirmed,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RepairStatus {
+    ProposedOpen,
+}
+
+fn is_lower_hex_sha(value: &str) -> bool {
+    value.len() == 40
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
 #[test]
-fn reported_agent_skill_seed_is_bounded_cross_ecosystem_and_explicitly_unverified() {
-    let corpus: Corpus = serde_json::from_slice(include_bytes!(
-        "../research/agent-skill-corpus-seed.json"
-    ))
-    .expect("valid corpus JSON");
+fn agent_skill_seed_is_bounded_cross_ecosystem_and_keeps_evidence_state_explicit() {
+    let corpus: Corpus =
+        serde_json::from_slice(include_bytes!("../research/agent-skill-corpus-seed.json"))
+            .expect("valid corpus JSON");
 
     assert_eq!(corpus.schema_version, 1);
-    assert!(corpus.description.contains("claims"));
+    assert!(corpus.description.contains("Evidence status"));
     assert!(corpus.episodes.len() >= 12);
     assert!(corpus.episodes.len() <= 64);
 
     let mut ids = BTreeSet::new();
     let mut ecosystems = BTreeSet::new();
     let mut boundaries = BTreeSet::new();
+    let mut source_confirmed = 0usize;
 
     for episode in &corpus.episodes {
-        assert!(ids.insert(episode.id.as_str()), "duplicate id {}", episode.id);
+        assert!(
+            ids.insert(episode.id.as_str()),
+            "duplicate id {}",
+            episode.id
+        );
         ecosystems.insert(episode.ecosystem);
         boundaries.insert(episode.reported_boundary);
 
-        assert_eq!(episode.evidence_status, EvidenceStatus::ReportedOnly);
         assert!(!episode.title.trim().is_empty());
         assert!(!episode.candidate_discriminator.trim().is_empty());
 
-        let expected_prefix = match episode.ecosystem {
-            Ecosystem::Anthropic => "https://github.com/anthropics/skills/issues/",
-            Ecosystem::Openai => "https://github.com/openai/skills/issues/",
+        let (issue_prefix, blob_prefix, pull_prefix) = match episode.ecosystem {
+            Ecosystem::Anthropic => (
+                "https://github.com/anthropics/skills/issues/",
+                "https://github.com/anthropics/skills/blob/",
+                "https://github.com/anthropics/skills/pull/",
+            ),
+            Ecosystem::Openai => (
+                "https://github.com/openai/skills/issues/",
+                "https://github.com/openai/skills/blob/",
+                "https://github.com/openai/skills/pull/",
+            ),
         };
         assert!(
-            episode.source_url.starts_with(expected_prefix),
+            episode.source_url.starts_with(issue_prefix),
             "unexpected source URL {}",
             episode.source_url
         );
@@ -91,11 +124,48 @@ fn reported_agent_skill_seed_is_bounded_cross_ecosystem_and_explicitly_unverifie
             "source URL does not match id {}",
             episode.id
         );
+
+        match episode.evidence_status {
+            EvidenceStatus::ReportedOnly => {
+                assert!(episode.source_evidence_url.is_none());
+                assert!(episode.source_evidence_blob_sha.is_none());
+                assert!(episode.repair_url.is_none());
+                assert!(episode.repair_status.is_none());
+            }
+            EvidenceStatus::SourceMechanismConfirmed => {
+                source_confirmed += 1;
+                let source_evidence_url = episode
+                    .source_evidence_url
+                    .as_deref()
+                    .expect("confirmed mechanism has exact source URL");
+                let source_evidence_blob_sha = episode
+                    .source_evidence_blob_sha
+                    .as_deref()
+                    .expect("confirmed mechanism has source blob SHA");
+                assert!(source_evidence_url.starts_with(blob_prefix));
+                assert!(is_lower_hex_sha(source_evidence_blob_sha));
+
+                let repair_url = episode
+                    .repair_url
+                    .as_deref()
+                    .expect("confirmed mechanism records known repair proposal");
+                assert!(repair_url.starts_with(pull_prefix));
+                assert_eq!(episode.repair_status, Some(RepairStatus::ProposedOpen));
+            }
+        }
     }
 
-    assert_eq!(ecosystems.len(), 2, "seed must span both sampled ecosystems");
+    assert_eq!(
+        ecosystems.len(),
+        2,
+        "seed must span both sampled ecosystems"
+    );
     assert!(
         boundaries.len() >= 5,
         "seed should test multiple candidate failure species"
+    );
+    assert!(
+        source_confirmed >= 1,
+        "at least one reported diagnosis should graduate through source evidence"
     );
 }


### PR DESCRIPTION
Starts #225 with a small, typed **reported-only** external corpus and ordinary admission test.

## Why

Agent Skills issue trackers contain unusually direct examples of procedural knowledge being packaged, selected, executed, measured, and repaired. They are useful research feeders only if Cultist does not silently turn issue reports into facts.

## Seed

Adds `research/agent-skill-corpus-seed.json` with 14 public issue identities across:

```text
anthropics/skills
openai/skills
```

Candidate reported boundaries:

```text
measurement_misrepresented
selection_budget_overreach
context_binding_miss
affordance_miss
provenance_identity_gap
schema_tooling_drift
```

Every row is explicitly:

```text
evidence_status = reported_only
```

and carries a short **candidate discriminator** describing what would need to be tested before the episode can support stronger attribution.

## Examples in the seed

- trigger/eval harness reports where zero recall may reflect an unreachable/cross-matched skill instead of model selection failure;
- eager/duplicate skill payload reports as JEI/context-budget pressure;
- helper-path/root ambiguity as ambient-context pressure;
- Windows/dependency assumptions as affordance pressure;
- origin/install-root/spec drift as identity/applicability pressure.

Issue titles and URLs are source identities; issue bodies are not copied into the corpus.

## Admission test

`tests/agent_skill_corpus_seed.rs` requires:

- schema v1;
- 12..64 bounded rows;
- unique episode IDs;
- both sampled ecosystems present;
- at least five failure species;
- every current row remains `reported_only`;
- source URL namespace matches ecosystem;
- issue number in source URL matches the typed episode ID;
- non-empty title and candidate discriminator.

This test validates the research carrier, **not the vendor issue claims**.

## Next evidence states

Do not mutate `reported_only` by editorial confidence. A future episode should advance only with explicit evidence such as:

```text
reported_only
-> reproduced
-> repair_linked
-> counterfactual_replayed
```

Exact vocabulary remains research-local until real episodes need it.

## Boundary

- research corpus only; no product CLI/analyzer behavior;
- external repos are feeders, not specifications;
- no vendor-specific trigger semantics promoted to Cultist rules;
- no private skill data;
- no claim that issue author diagnosis is correct;
- provenance/security separate from authority;
- candidate boundary is a hypothesis until reproduced.

Refs #29 #41 #106 #115 #123 #134 #137 #146 #148 #215 #223 #225.