### PR TITLE
research: reconstruct a proxy-to-authoritative semantic revision

### DIFF
--- a/examples/proxy_revision.rs
+++ b/examples/proxy_revision.rs
@@ -1,0 +1,61 @@
+#[path = "../src/project_memory.rs"]
+mod project_memory;
+#[path = "../src/proxy_revision.rs"]
+mod proxy_revision;
+
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use project_memory::{MAX_PROJECT_MEMORY_BYTES, parse_project_memory_packet};
+use proxy_revision::{MAX_PROXY_REVISION_BYTES, evaluate_proxy_revision, parse_proxy_revision_claim};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("proxy-revision: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut args = std::env::args().skip(1);
+    let memory_path = args.next().ok_or_else(|| usage_error())?;
+    let claim_path = args.next().ok_or_else(|| usage_error())?;
+    if args.next().is_some() {
+        return Err(usage_error().into());
+    }
+
+    let memory_bytes = read_bounded(&memory_path, MAX_PROJECT_MEMORY_BYTES)?;
+    let claim_bytes = read_bounded(&claim_path, MAX_PROXY_REVISION_BYTES)?;
+    let memory = parse_project_memory_packet(&memory_bytes).map_err(invalid_data)?;
+    memory.summary().map_err(invalid_data)?;
+    let claim = parse_proxy_revision_claim(&claim_bytes).map_err(invalid_data)?;
+    let evaluation = evaluate_proxy_revision(&memory, &claim).map_err(invalid_data)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}
+
+fn read_bounded(path: impl AsRef<Path>, maximum: usize) -> Result<Vec<u8>, Box<dyn Error>> {
+    let path = path.as_ref();
+    let metadata = fs::metadata(path)?;
+    if metadata.len() > maximum as u64 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{} exceeds {maximum} bytes", path.display()),
+        )
+        .into());
+    }
+    Ok(fs::read(path)?)
+}
+
+fn usage_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "usage: proxy_revision PROJECT_MEMORY.json PROXY_REVISION_CLAIM.json",
+    )
+}
+
+fn invalid_data(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}

--- a/examples/proxy_revision.rs
+++ b/examples/proxy_revision.rs
@@ -9,7 +9,9 @@ use std::io;
 use std::path::Path;
 
 use project_memory::{MAX_PROJECT_MEMORY_BYTES, parse_project_memory_packet};
-use proxy_revision::{MAX_PROXY_REVISION_BYTES, evaluate_proxy_revision, parse_proxy_revision_claim};
+use proxy_revision::{
+    MAX_PROXY_REVISION_BYTES, evaluate_proxy_revision, parse_proxy_revision_claim,
+};
 
 fn main() {
     if let Err(error) = run() {
@@ -20,8 +22,8 @@ fn main() {
 
 fn run() -> Result<(), Box<dyn Error>> {
     let mut args = std::env::args().skip(1);
-    let memory_path = args.next().ok_or_else(|| usage_error())?;
-    let claim_path = args.next().ok_or_else(|| usage_error())?;
+    let memory_path = args.next().ok_or_else(usage_error)?;
+    let claim_path = args.next().ok_or_else(usage_error)?;
     if args.next().is_some() {
         return Err(usage_error().into());
     }

--- a/research/project-memory/stensibly-1604-1605.json
+++ b/research/project-memory/stensibly-1604-1605.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "repository": "teamleaderleo/stensibly",
+  "anchor": {
+    "kind": "pull_request",
+    "number": 1605
+  },
+  "artifacts": [
+    {
+      "reference": {
+        "kind": "pull_request",
+        "number": 1604
+      },
+      "title": "Emit durable handoff and completion activity",
+      "state": "closed",
+      "created_at": "2026-08-16T09:42:36Z",
+      "closed_at": "2026-08-16T09:46:52Z",
+      "revision": {
+        "head_sha": "bcf5fdc5f322a92a7bb3ea4e1b9227c4c3194f97",
+        "base_sha": "34c8bcbb06bfa41738a60390057a417ee748b8b5",
+        "merged": true
+      },
+      "changed_paths": [
+        "convex/itemTransitionActivity.test.ts",
+        "convex/items.ts",
+        "convex/lib/claimActivity.ts",
+        "convex/lib/ledgerEventActivity.ts"
+      ],
+      "evidence_text": "## Purpose\n\nContinue #1149 from durable claim lifecycle activity into two ordinary item transitions that carry the highest project-history value: handoff and completion.\n\n#1600/#1602 made claim responsibility changes appear automatically in the durable activity store. This slice makes `work.handed_off` and `item.completed` join that same timeline inside the exact Convex transaction that commits the item transition.\n\n## Change\n\n- extract the canonical ledger-event → durable activity projection from the claim-only helper into one Convex-private `ledgerEventActivity` helper;\n- keep claim activity as a thin `responsibility` wrapper so #1600/#1602 semantics stay on the same persistence implementation;\n- project `work.handed_off` as `ledger_event` + `handoff` / `observed`;\n- project `item.completed` as `ledger_event` + `completed` / `succeeded`;\n- retain the exact transition event as source identity and hash its canonical event bytes without copying summary, next-action, target-actor, or completion prose into activity;\n- retain the responsibility generation being ended when it is positive;\n- omit responsibility generation for valid generation-0 transitions instead of inventing a claim that never existed;\n- keep block/unblock outside this slice.\n\n## Atomicity / replay\n\nThe activity append occurs after the canonical item event is appended and before the mutation returns, inside the same Convex transaction. If durable activity cannot commit, the item patch and transition event roll back with it. Existing transition idempotency replay returns without a second event or activity observation.\n\n## Proof\n\nFocused Convex controls cover:\n\n- claim → handoff → new claim → completion as one exact four-record activity timeline;\n- exact source classes, source event IDs, activity classes/states, and responsibility generations;\n- immediate handoff and completion replay creating no duplicate deliveries/observations;\n- handoff summary, next action, target actor, and completion summary absent from durable activity bytes;\n- direct completion from generation 0 yielding `completed/succeeded` with `responsibilityGeneration: null`;\n- actor IDs outside the activity identifier grammar remaining content-minimised;\n- forced activity append-order exhaustion rolling completion and `item.completed` back together.\n\nExisting claim producer/lifecycle suites continue to exercise the same generic projection through the claim wrapper.\n\n## Boundary\n\nHandoff/completion producer only. No block/unblock producer, provider producer, Project Activity live API/UI, Work Pulse live adapter, notification, prioritisation, new worker call, provider effect, or authority change.\n\nRefs #1149, #1602, #1600, #1593, #1592, #1586.\n\n— Keel · automatic item transition lane",
+      "evidence_complete": true
+    },
+    {
+      "reference": {
+        "kind": "pull_request",
+        "number": 1605
+      },
+      "title": "Emit durable block and unblock activity",
+      "state": "closed",
+      "created_at": "2026-08-16T09:52:37Z",
+      "closed_at": "2026-08-16T09:58:14Z",
+      "revision": {
+        "head_sha": "82bf8831ae45867e8d990e73f17b062c1a95f62c",
+        "base_sha": "6769bdc9f4a5d0d6070f8d6f17c36fdb7821788f",
+        "merged": true
+      },
+      "changed_paths": [
+        "convex/itemBlockActivity.test.ts",
+        "convex/items.ts"
+      ],
+      "evidence_text": "## Purpose\n\nFinish the ordinary item-state producer lane for #1149 by projecting block/unblock transitions into the same durable automatic activity store, while correcting one subtle responsibility-generation assumption exposed by this continuation.\n\n#1604 attached positive `claimGeneration` to handoff/completion activity. The counter also advances on unclaimed semantic transitions, so positivity alone does not prove a live responsibility. This slice binds `responsibilityGeneration` to actual live claim evidence instead.\n\n## Change\n\n- all four item transitions now use one ledger-event activity mapping after their canonical event commits:\n  - `item.completed` → `completed / succeeded`;\n  - `work.handed_off` → `handoff / observed`;\n  - `work.blocked` → `blocked / blocked`;\n  - `work.unblocked` → `progress_evidence / observed`;\n- source class remains `ledger_event`, with exact canonical event ID/fingerprint and zero retained transition prose;\n- `responsibilityGeneration` is included only when the item carries a live, unexpired claim held by the acting actor at transition time;\n- unclaimed transitions stay responsibility-null even when the monotonic claim-generation counter is positive because earlier semantic transitions advanced it;\n- block/unblock activity commits in the same Convex transaction as the item patch and canonical event.\n\n## Proof\n\nFocused Convex controls cover:\n\n- an entirely unclaimed block → unblock → handoff → completion chain advancing claim generation from 0 to 4 while all four activity observations keep `responsibilityGeneration: null`;\n- exact block/unblock/handoff/completion source events and activity class/state mappings;\n- exact semantic replay creating no duplicate deliveries/observations;\n- block reason, next actions, handoff summary, and completion summary absent from durable activity bytes;\n- blocking a real live claim retaining the exact responsibility generation being ended;\n- forced activity append-order exhaustion rolling the block item patch and `work.blocked` event back together;\n- existing #1604 claimed handoff/completion controls continue to prove responsibility generation is retained when a real live claim exists.\n\n## Boundary\n\nItem transition producer semantics only. No provider producer, Project Activity live API/UI, Work Pulse live adapter, notification, prioritisation, new worker call, provider effect, or authority change.\n\nRefs #1149, #1604, #1602, #1600, #1593, #1592, #1586.\n\n— Keel · automatic blocked-work lane",
+      "evidence_complete": true
+    }
+  ],
+  "edges": []
+}

--- a/research/proxy-revision/stensibly-1604-1605.json
+++ b/research/proxy-revision/stensibly-1604-1605.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "repository": "teamleaderleo/stensibly",
+  "candidate_id": "stensibly-responsibility-generation-proxy-revision",
+  "semantic_axis_id": "responsibility_generation_evidence",
+  "prior_value_ref": "positive_expected_generation",
+  "replacement_value_ref": "live_unexpired_claim_for_actor",
+  "predecessor": {
+    "kind": "pull_request",
+    "number": 1604
+  },
+  "successor": {
+    "kind": "pull_request",
+    "number": 1605
+  },
+  "shared_path": "convex/items.ts",
+  "predecessor_source_evidence": "- retain the responsibility generation being ended when it is positive;\n- omit responsibility generation for valid generation-0 transitions instead of inventing a claim that never existed;",
+  "successor_counterexample_evidence": "#1604 attached positive `claimGeneration` to handoff/completion activity. The counter also advances on unclaimed semantic transitions, so positivity alone does not prove a live responsibility. This slice binds `responsibilityGeneration` to actual live claim evidence instead.",
+  "successor_replacement_evidence": "- `responsibilityGeneration` is included only when the item carries a live, unexpired claim held by the acting actor at transition time;\n- unclaimed transitions stay responsibility-null even when the monotonic claim-generation counter is positive because earlier semantic transitions advanced it;",
+  "proxy_rule_marker": "retain the responsibility generation being ended when it is positive",
+  "counterexample_marker": "The counter also advances on unclaimed semantic transitions",
+  "replacement_rule_marker": "`responsibilityGeneration` is included only when the item carries a live, unexpired claim held by the acting actor at transition time"
+}

--- a/research/proxy-semantic-revision.md
+++ b/research/proxy-semantic-revision.md
@@ -112,7 +112,7 @@ replacement_rule_missing
 observed_proxy_revision
 ```
 
-The retained case should evaluate to:
+The retained case evaluates to:
 
 ```text
 status                           observed_proxy_revision
@@ -147,6 +147,42 @@ cargo run --example proxy_revision -- \
   research/project-memory/stensibly-1604-1605.json \
   research/proxy-revision/stensibly-1604-1605.json
 ```
+
+## Executed current-main receipt
+
+The semantic code + retained evidence head was:
+
+```text
+head:       8d7c5ed05077e242e8013b78cf7cf91d52b89834
+main:       6edf32f07138579d87abf5210e84c71e94c1d431
+merge view: c25ab8817bfc0528edecb19a7b41679291abd474
+```
+
+GitHub Actions receipt:
+
+```text
+CI run:                    32259077612  success
+Generated provenance run:  32259077595  success
+```
+
+The merge-view CI passed:
+
+```text
+rustfmt
+all-target Clippy with -D warnings
+project-memory lineage controls
+GitHub review-memory adapter controls
+GitHub issue-closure adapter controls
+external GitHub reference controls
+full Rust tests
+repository scan text + JSON dogfood
+bounded history text + JSON dogfood
+CI test-filter text + JSON dogfood
+positive/control CI-filter fixtures
+pull-request diff text + JSON dogfood
+```
+
+The retained proxy-revision tests passed all ten adversarial controls above. The only change after this semantic receipt is the durable receipt prose in this research note.
 
 ## Product direction
 

--- a/research/proxy-semantic-revision.md
+++ b/research/proxy-semantic-revision.md
@@ -1,0 +1,163 @@
+# Reconstructing a proxy-to-authoritative semantic revision
+
+Stensibly preserves a compact historical case where a useful correlated field acquired stronger meaning than it could actually support, then a successor supplied a concrete counterexample and replaced the proxy with a narrower predicate.
+
+Human-facing external links use `redirect.github.com`:
+
+- [Stensibly PR #1604](https://redirect.github.com/teamleaderleo/stensibly/pull/1604)
+- [Stensibly PR #1605](https://redirect.github.com/teamleaderleo/stensibly/pull/1605)
+
+Provider/source text inside retained project-memory evidence remains exact.
+
+## Prior rule
+
+Merged PR #1604 added handoff/completion activity projection and explicitly stated:
+
+```text
+retain the responsibility generation being ended when it is positive
+omit responsibility generation for valid generation-0 transitions
+```
+
+Its `convex/items.ts` patch implemented that rule directly:
+
+```text
+expectedGeneration == 0
+  -> omit responsibilityGeneration
+
+expectedGeneration > 0
+  -> responsibilityGeneration = expectedGeneration
+```
+
+That was an accepted historical repository behavior, not a hypothetical belief reconstructed from chronology.
+
+## Counterexample
+
+Merged PR #1605 explicitly names #1604 and says:
+
+```text
+#1604 attached positive claimGeneration to handoff/completion activity
+counter also advances on unclaimed semantic transitions
+positivity alone does not prove a live responsibility
+```
+
+The focused control is particularly strong: an entirely unclaimed block → unblock → handoff → completion sequence advances `claimGeneration` from 0 to 4 while all four activity observations keep `responsibilityGeneration: null`.
+
+So the old proxy fails on a reachable, executable state:
+
+```text
+claimGeneration > 0
+```
+
+can coexist with:
+
+```text
+no live responsibility
+```
+
+## Replacement predicate
+
+PR #1605 then replaces the proxy with a narrower source-owned rule:
+
+```text
+include responsibilityGeneration only when
+  the item has a live claim
+  held by the acting actor
+  whose claim has not expired
+```
+
+The same `convex/items.ts` transition path changes from `expectedGeneration > 0` gating to `liveResponsibilityGeneration(item, actorExternalId, now)`.
+
+This is a useful semantic revision shape:
+
+```text
+accepted proxy
+-> concrete counterexample
+-> proxy loses authority for that inference
+-> narrower authoritative predicate
+```
+
+The historical record supports that local revision. It does not establish a universal rule about every monotonic counter or correlated field.
+
+## Retained packet
+
+`research/project-memory/stensibly-1604-1605.json` preserves both exact merged PRs, exact head/base coordinates, complete retained PR text, and changed paths. It carries zero relationship edges deliberately.
+
+The specialized claim in `research/proxy-revision/stensibly-1604-1605.json` must establish the semantic relationship from source evidence instead of inheriting a generic project-memory edge.
+
+Required evidence:
+
+```text
+predecessor #1604 is merged
+successor #1605 is merged
+successor counterexample text explicitly names #1604
+both touch convex/items.ts
+predecessor excerpt states the proxy rule
+successor excerpt states the counterexample
+successor excerpt states the replacement predicate
+prior/replacement semantic values differ
+```
+
+## Evaluation states
+
+The research evaluator can return:
+
+```text
+predecessor_unmerged
+successor_unmerged
+successor_does_not_name_predecessor
+no_shared_implementation_path
+prior_proxy_rule_missing
+counterexample_missing
+replacement_rule_missing
+observed_proxy_revision
+```
+
+The retained case should evaluate to:
+
+```text
+status                           observed_proxy_revision
+semantic axis                    responsibility_generation_evidence
+prior value                      positive_expected_generation
+replacement value                live_unexpired_claim_for_actor
+predecessor                      #1604
+successor                        #1605
+shared path                      convex/items.ts
+automatic generalization authority false
+```
+
+## Adversarial controls
+
+The ordinary Rust suite requires:
+
+1. unmerged #1604 stays `predecessor_unmerged`;
+2. unmerged #1605 stays `successor_unmerged`;
+3. successor evidence that never names #1604 stays `successor_does_not_name_predecessor`;
+4. removing `convex/items.ts` from either side stays `no_shared_implementation_path`;
+5. a missing predecessor rule marker stays `prior_proxy_rule_missing`;
+6. a missing successor counterexample marker stays `counterexample_missing`;
+7. a missing replacement marker stays `replacement_rule_missing`;
+8. identical prior/replacement semantic values reject;
+9. invented source excerpts reject against retained project-memory text;
+10. claim input is bounded before JSON parsing.
+
+## Replay
+
+```text
+cargo run --example proxy_revision -- \
+  research/project-memory/stensibly-1604-1605.json \
+  research/proxy-revision/stensibly-1604-1605.json
+```
+
+## Product direction
+
+Together with the merged lesson-promotion replay, this gives project memory two different temporal semantics:
+
+```text
+repeated same-class repairs -> later common guard
+
+accepted proxy -> counterexample -> narrower predicate
+```
+
+Both are historical evidence packets first. A later worker can use them to avoid rediscovering already-rejected assumptions, while any prospective generalization still needs its own evidence and acceptance event.
+
+Refs #6 #18 #41 #74 #222.

--- a/src/proxy_revision.rs
+++ b/src/proxy_revision.rs
@@ -1,0 +1,313 @@
+use serde::{Deserialize, Serialize};
+
+use crate::project_memory::{ArtifactKind, ArtifactRef, ProjectArtifact, ProjectMemoryPacket};
+
+pub const PROXY_REVISION_SCHEMA_VERSION: u32 = 1;
+pub const MAX_PROXY_REVISION_BYTES: usize = 128 * 1024;
+const MAX_ID_BYTES: usize = 256;
+const MAX_MARKER_BYTES: usize = 1024;
+const MAX_SOURCE_EVIDENCE_BYTES: usize = 8 * 1024;
+const MAX_PATH_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProxyRevisionClaim {
+    pub schema_version: u32,
+    pub repository: String,
+    pub candidate_id: String,
+    pub semantic_axis_id: String,
+    pub prior_value_ref: String,
+    pub replacement_value_ref: String,
+    pub predecessor: ArtifactRef,
+    pub successor: ArtifactRef,
+    pub shared_path: String,
+    pub predecessor_source_evidence: String,
+    pub successor_counterexample_evidence: String,
+    pub successor_replacement_evidence: String,
+    pub proxy_rule_marker: String,
+    pub counterexample_marker: String,
+    pub replacement_rule_marker: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProxyRevisionStatus {
+    PredecessorUnmerged,
+    SuccessorUnmerged,
+    SuccessorDoesNotNamePredecessor,
+    NoSharedImplementationPath,
+    PriorProxyRuleMissing,
+    CounterexampleMissing,
+    ReplacementRuleMissing,
+    ObservedProxyRevision,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ProxyRevisionEvaluation {
+    pub schema_version: u32,
+    pub repository: String,
+    pub candidate_id: String,
+    pub status: ProxyRevisionStatus,
+    pub semantic_axis_id: String,
+    pub prior_value_ref: String,
+    pub replacement_value_ref: String,
+    pub predecessor: ArtifactRef,
+    pub successor: ArtifactRef,
+    pub shared_path: String,
+    pub automatic_generalization_authority: bool,
+}
+
+pub fn parse_proxy_revision_claim(bytes: &[u8]) -> Result<ProxyRevisionClaim, String> {
+    if bytes.len() > MAX_PROXY_REVISION_BYTES {
+        return Err(format!(
+            "proxy-revision claim exceeds {} bytes",
+            MAX_PROXY_REVISION_BYTES
+        ));
+    }
+    let claim: ProxyRevisionClaim = serde_json::from_slice(bytes)
+        .map_err(|error| format!("invalid proxy-revision JSON: {error}"))?;
+    claim.validate_shape()?;
+    Ok(claim)
+}
+
+pub fn evaluate_proxy_revision(
+    memory: &ProjectMemoryPacket,
+    claim: &ProxyRevisionClaim,
+) -> Result<ProxyRevisionEvaluation, String> {
+    memory.validate()?;
+    claim.validate_shape()?;
+    if memory.repository != claim.repository {
+        return Err(format!(
+            "proxy-revision repository `{}` disagrees with project-memory repository `{}`",
+            claim.repository, memory.repository
+        ));
+    }
+
+    let predecessor = artifact(memory, claim.predecessor)?;
+    let successor = artifact(memory, claim.successor)?;
+    validate_exact_source_excerpt(
+        predecessor,
+        &claim.predecessor_source_evidence,
+        claim.predecessor,
+    )?;
+    validate_exact_source_excerpt(
+        successor,
+        &claim.successor_counterexample_evidence,
+        claim.successor,
+    )?;
+    validate_exact_source_excerpt(
+        successor,
+        &claim.successor_replacement_evidence,
+        claim.successor,
+    )?;
+
+    let predecessor_merged = merged(predecessor);
+    let successor_merged = merged(successor);
+    let predecessor_marker = format!("#{}", claim.predecessor.number);
+
+    let status = if !predecessor_merged {
+        ProxyRevisionStatus::PredecessorUnmerged
+    } else if !successor_merged {
+        ProxyRevisionStatus::SuccessorUnmerged
+    } else if !claim
+        .successor_counterexample_evidence
+        .contains(&predecessor_marker)
+    {
+        ProxyRevisionStatus::SuccessorDoesNotNamePredecessor
+    } else if !predecessor.changed_paths.contains(&claim.shared_path)
+        || !successor.changed_paths.contains(&claim.shared_path)
+    {
+        ProxyRevisionStatus::NoSharedImplementationPath
+    } else if !claim
+        .predecessor_source_evidence
+        .contains(&claim.proxy_rule_marker)
+    {
+        ProxyRevisionStatus::PriorProxyRuleMissing
+    } else if !claim
+        .successor_counterexample_evidence
+        .contains(&claim.counterexample_marker)
+    {
+        ProxyRevisionStatus::CounterexampleMissing
+    } else if !claim
+        .successor_replacement_evidence
+        .contains(&claim.replacement_rule_marker)
+    {
+        ProxyRevisionStatus::ReplacementRuleMissing
+    } else {
+        ProxyRevisionStatus::ObservedProxyRevision
+    };
+
+    Ok(ProxyRevisionEvaluation {
+        schema_version: PROXY_REVISION_SCHEMA_VERSION,
+        repository: claim.repository.clone(),
+        candidate_id: claim.candidate_id.clone(),
+        status,
+        semantic_axis_id: claim.semantic_axis_id.clone(),
+        prior_value_ref: claim.prior_value_ref.clone(),
+        replacement_value_ref: claim.replacement_value_ref.clone(),
+        predecessor: claim.predecessor,
+        successor: claim.successor,
+        shared_path: claim.shared_path.clone(),
+        automatic_generalization_authority: false,
+    })
+}
+
+impl ProxyRevisionClaim {
+    fn validate_shape(&self) -> Result<(), String> {
+        if self.schema_version != PROXY_REVISION_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported proxy-revision schema version {}",
+                self.schema_version
+            ));
+        }
+        validate_repository(&self.repository)?;
+        validate_single_line(&self.candidate_id, "candidate_id", MAX_ID_BYTES)?;
+        validate_single_line(&self.semantic_axis_id, "semantic_axis_id", MAX_ID_BYTES)?;
+        validate_single_line(&self.prior_value_ref, "prior_value_ref", MAX_ID_BYTES)?;
+        validate_single_line(
+            &self.replacement_value_ref,
+            "replacement_value_ref",
+            MAX_ID_BYTES,
+        )?;
+        if self.prior_value_ref == self.replacement_value_ref {
+            return Err("proxy-revision prior and replacement values must differ".to_string());
+        }
+        validate_pr_ref(self.predecessor, "predecessor")?;
+        validate_pr_ref(self.successor, "successor")?;
+        if self.predecessor == self.successor {
+            return Err("proxy-revision predecessor and successor must differ".to_string());
+        }
+        validate_repository_path(&self.shared_path)?;
+        validate_source_evidence(
+            &self.predecessor_source_evidence,
+            "predecessor_source_evidence",
+        )?;
+        validate_source_evidence(
+            &self.successor_counterexample_evidence,
+            "successor_counterexample_evidence",
+        )?;
+        validate_source_evidence(
+            &self.successor_replacement_evidence,
+            "successor_replacement_evidence",
+        )?;
+        validate_marker(&self.proxy_rule_marker, "proxy_rule_marker")?;
+        validate_marker(&self.counterexample_marker, "counterexample_marker")?;
+        validate_marker(&self.replacement_rule_marker, "replacement_rule_marker")?;
+        Ok(())
+    }
+}
+
+fn artifact(
+    memory: &ProjectMemoryPacket,
+    reference: ArtifactRef,
+) -> Result<&ProjectArtifact, String> {
+    memory
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.reference == reference)
+        .ok_or_else(|| {
+            format!(
+                "proxy-revision artifact {} is absent from project memory",
+                display_ref(reference)
+            )
+        })
+}
+
+fn validate_exact_source_excerpt(
+    artifact: &ProjectArtifact,
+    evidence: &str,
+    reference: ArtifactRef,
+) -> Result<(), String> {
+    if !artifact.evidence_text.contains(evidence) {
+        return Err(format!(
+            "proxy-revision evidence for {} is absent from retained project-memory text",
+            display_ref(reference)
+        ));
+    }
+    Ok(())
+}
+
+fn merged(artifact: &ProjectArtifact) -> bool {
+    artifact
+        .revision
+        .as_ref()
+        .is_some_and(|revision| revision.merged)
+}
+
+fn validate_pr_ref(reference: ArtifactRef, label: &str) -> Result<(), String> {
+    if reference.kind != ArtifactKind::PullRequest || reference.number == 0 {
+        return Err(format!("{label} must be a positive pull-request reference"));
+    }
+    Ok(())
+}
+
+fn validate_source_evidence(value: &str, label: &str) -> Result<(), String> {
+    if value.is_empty() || value.len() > MAX_SOURCE_EVIDENCE_BYTES || value.contains('\0') {
+        return Err(format!("{label} is empty, malformed, or too long"));
+    }
+    Ok(())
+}
+
+fn validate_marker(value: &str, label: &str) -> Result<(), String> {
+    if value.is_empty()
+        || value.len() > MAX_MARKER_BYTES
+        || value.contains('\0')
+        || value.bytes().any(|byte| matches!(byte, b'\n' | b'\r'))
+    {
+        return Err(format!("{label} is empty, malformed, or too long"));
+    }
+    Ok(())
+}
+
+fn validate_single_line(value: &str, label: &str, maximum: usize) -> Result<(), String> {
+    if value.is_empty()
+        || value.len() > maximum
+        || value.contains('\0')
+        || value.bytes().any(|byte| matches!(byte, b'\n' | b'\r'))
+    {
+        return Err(format!("{label} is empty, malformed, or too long"));
+    }
+    Ok(())
+}
+
+fn validate_repository(value: &str) -> Result<(), String> {
+    let Some((owner, repository)) = value.split_once('/') else {
+        return Err("repository must be canonical owner/name".to_string());
+    };
+    if owner.is_empty()
+        || repository.is_empty()
+        || repository.contains('/')
+        || !owner.bytes().all(valid_repository_char)
+        || !repository.bytes().all(valid_repository_char)
+    {
+        return Err("repository must be canonical owner/name".to_string());
+    }
+    Ok(())
+}
+
+fn valid_repository_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')
+}
+
+fn validate_repository_path(path: &str) -> Result<(), String> {
+    if path.is_empty()
+        || path.len() > MAX_PATH_BYTES
+        || path.starts_with('/')
+        || path.contains('\\')
+        || path.contains('\0')
+        || path
+            .split('/')
+            .any(|component| component.is_empty() || matches!(component, "." | ".."))
+    {
+        return Err(format!("non-canonical repository-relative path `{path}`"));
+    }
+    Ok(())
+}
+
+fn display_ref(reference: ArtifactRef) -> String {
+    let kind = match reference.kind {
+        ArtifactKind::PullRequest => "pr",
+        ArtifactKind::Issue => "issue",
+    };
+    format!("{kind}#{}", reference.number)
+}

--- a/tests/proxy_revision.rs
+++ b/tests/proxy_revision.rs
@@ -1,7 +1,7 @@
-#[path = "../src/proxy_revision.rs"]
-mod proxy_revision;
 #[path = "../src/project_memory.rs"]
 mod project_memory;
+#[path = "../src/proxy_revision.rs"]
+mod proxy_revision;
 
 use project_memory::{ArtifactKind, ArtifactRef, parse_project_memory_packet};
 use proxy_revision::{
@@ -34,7 +34,10 @@ fn retained_stensibly_episode_is_an_observed_proxy_revision() {
     let (memory, claim) = inputs();
     let evaluation = evaluate_proxy_revision(&memory, &claim).unwrap();
 
-    assert_eq!(evaluation.status, ProxyRevisionStatus::ObservedProxyRevision);
+    assert_eq!(
+        evaluation.status,
+        ProxyRevisionStatus::ObservedProxyRevision
+    );
     assert_eq!(evaluation.predecessor, pr(1604));
     assert_eq!(evaluation.successor, pr(1605));
     assert_eq!(evaluation.shared_path, "convex/items.ts");
@@ -117,7 +120,10 @@ fn predecessor_must_state_the_proxy_rule() {
     claim.proxy_rule_marker = "claim generation always proves responsibility".to_string();
 
     let evaluation = evaluate_proxy_revision(&memory, &claim).unwrap();
-    assert_eq!(evaluation.status, ProxyRevisionStatus::PriorProxyRuleMissing);
+    assert_eq!(
+        evaluation.status,
+        ProxyRevisionStatus::PriorProxyRuleMissing
+    );
 }
 
 #[test]
@@ -126,7 +132,10 @@ fn successor_must_state_the_counterexample() {
     claim.counterexample_marker = "counterexample missing from retained source".to_string();
 
     let evaluation = evaluate_proxy_revision(&memory, &claim).unwrap();
-    assert_eq!(evaluation.status, ProxyRevisionStatus::CounterexampleMissing);
+    assert_eq!(
+        evaluation.status,
+        ProxyRevisionStatus::CounterexampleMissing
+    );
 }
 
 #[test]
@@ -135,7 +144,10 @@ fn successor_must_state_the_replacement_rule() {
     claim.replacement_rule_marker = "replacement rule missing from retained source".to_string();
 
     let evaluation = evaluate_proxy_revision(&memory, &claim).unwrap();
-    assert_eq!(evaluation.status, ProxyRevisionStatus::ReplacementRuleMissing);
+    assert_eq!(
+        evaluation.status,
+        ProxyRevisionStatus::ReplacementRuleMissing
+    );
 }
 
 #[test]

--- a/tests/proxy_revision.rs
+++ b/tests/proxy_revision.rs
@@ -1,0 +1,165 @@
+#[path = "../src/proxy_revision.rs"]
+mod proxy_revision;
+#[path = "../src/project_memory.rs"]
+mod project_memory;
+
+use project_memory::{ArtifactKind, ArtifactRef, parse_project_memory_packet};
+use proxy_revision::{
+    MAX_PROXY_REVISION_BYTES, ProxyRevisionStatus, evaluate_proxy_revision,
+    parse_proxy_revision_claim,
+};
+
+const MEMORY: &[u8] = include_bytes!("../research/project-memory/stensibly-1604-1605.json");
+const CLAIM: &[u8] = include_bytes!("../research/proxy-revision/stensibly-1604-1605.json");
+
+fn inputs() -> (
+    project_memory::ProjectMemoryPacket,
+    proxy_revision::ProxyRevisionClaim,
+) {
+    let memory = parse_project_memory_packet(MEMORY).unwrap();
+    memory.summary().unwrap();
+    let claim = parse_proxy_revision_claim(CLAIM).unwrap();
+    (memory, claim)
+}
+
+fn pr(number: u64) -> ArtifactRef {
+    ArtifactRef {
+        kind: ArtifactKind::PullRequest,
+        number,
+    }
+}
+
+#[test]
+fn retained_stensibly_episode_is_an_observed_proxy_revision() {
+    let (memory, claim) = inputs();
+    let evaluation = evaluate_proxy_revision(&memory, &claim).unwrap();
+
+    assert_eq!(evaluation.status, ProxyRevisionStatus::ObservedProxyRevision);
+    assert_eq!(evaluation.predecessor, pr(1604));
+    assert_eq!(evaluation.successor, pr(1605));
+    assert_eq!(evaluation.shared_path, "convex/items.ts");
+    assert_eq!(evaluation.prior_value_ref, "positive_expected_generation");
+    assert_eq!(
+        evaluation.replacement_value_ref,
+        "live_unexpired_claim_for_actor"
+    );
+    assert!(!evaluation.automatic_generalization_authority);
+}
+
+#[test]
+fn unmerged_predecessor_is_not_an_observed_revision() {
+    let (mut memory, claim) = inputs();
+    memory
+        .artifacts
+        .iter_mut()
+        .find(|artifact| artifact.reference == pr(1604))
+        .unwrap()
+        .revision
+        .as_mut()
+        .unwrap()
+        .merged = false;
+
+    let evaluation = evaluate_proxy_revision(&memory, &claim).unwrap();
+    assert_eq!(evaluation.status, ProxyRevisionStatus::PredecessorUnmerged);
+}
+
+#[test]
+fn unmerged_successor_is_not_an_observed_revision() {
+    let (mut memory, claim) = inputs();
+    memory
+        .artifacts
+        .iter_mut()
+        .find(|artifact| artifact.reference == pr(1605))
+        .unwrap()
+        .revision
+        .as_mut()
+        .unwrap()
+        .merged = false;
+
+    let evaluation = evaluate_proxy_revision(&memory, &claim).unwrap();
+    assert_eq!(evaluation.status, ProxyRevisionStatus::SuccessorUnmerged);
+}
+
+#[test]
+fn successor_must_explicitly_name_the_predecessor() {
+    let (memory, mut claim) = inputs();
+    claim.successor_counterexample_evidence =
+        "Finish the ordinary item-state producer lane for #1149 by projecting block/unblock transitions into the same durable automatic activity store, while correcting one subtle responsibility-generation assumption exposed by this continuation.".to_string();
+
+    let evaluation = evaluate_proxy_revision(&memory, &claim).unwrap();
+    assert_eq!(
+        evaluation.status,
+        ProxyRevisionStatus::SuccessorDoesNotNamePredecessor
+    );
+}
+
+#[test]
+fn both_artifacts_must_touch_the_shared_implementation_path() {
+    let (mut memory, claim) = inputs();
+    memory
+        .artifacts
+        .iter_mut()
+        .find(|artifact| artifact.reference == pr(1605))
+        .unwrap()
+        .changed_paths
+        .retain(|path| path != "convex/items.ts");
+
+    let evaluation = evaluate_proxy_revision(&memory, &claim).unwrap();
+    assert_eq!(
+        evaluation.status,
+        ProxyRevisionStatus::NoSharedImplementationPath
+    );
+}
+
+#[test]
+fn predecessor_must_state_the_proxy_rule() {
+    let (memory, mut claim) = inputs();
+    claim.proxy_rule_marker = "claim generation always proves responsibility".to_string();
+
+    let evaluation = evaluate_proxy_revision(&memory, &claim).unwrap();
+    assert_eq!(evaluation.status, ProxyRevisionStatus::PriorProxyRuleMissing);
+}
+
+#[test]
+fn successor_must_state_the_counterexample() {
+    let (memory, mut claim) = inputs();
+    claim.counterexample_marker = "counterexample missing from retained source".to_string();
+
+    let evaluation = evaluate_proxy_revision(&memory, &claim).unwrap();
+    assert_eq!(evaluation.status, ProxyRevisionStatus::CounterexampleMissing);
+}
+
+#[test]
+fn successor_must_state_the_replacement_rule() {
+    let (memory, mut claim) = inputs();
+    claim.replacement_rule_marker = "replacement rule missing from retained source".to_string();
+
+    let evaluation = evaluate_proxy_revision(&memory, &claim).unwrap();
+    assert_eq!(evaluation.status, ProxyRevisionStatus::ReplacementRuleMissing);
+}
+
+#[test]
+fn prior_and_replacement_values_must_differ() {
+    let (memory, mut claim) = inputs();
+    claim.replacement_value_ref = claim.prior_value_ref.clone();
+
+    let error = evaluate_proxy_revision(&memory, &claim).unwrap_err();
+    assert!(error.contains("prior and replacement values must differ"));
+}
+
+#[test]
+fn invented_predecessor_source_excerpt_is_rejected() {
+    let (memory, mut claim) = inputs();
+    claim.predecessor_source_evidence =
+        "This historical rule definitely meant something stronger.".to_string();
+
+    let error = evaluate_proxy_revision(&memory, &claim).unwrap_err();
+    assert!(error.contains("absent from retained project-memory text"));
+}
+
+#[test]
+fn claim_input_is_bounded_before_json_parse() {
+    let bytes = vec![b' '; MAX_PROXY_REVISION_BYTES + 1];
+    let error = parse_proxy_revision_claim(&bytes).unwrap_err();
+    assert!(error.contains("exceeds"));
+}


### PR DESCRIPTION
## Goal

Progress #41 with a second temporal project-memory species beside merged #222: an accepted proxy rule, an exact counterexample, and a narrower successor predicate on the same implementation path.

Human-facing source refs use `redirect.github.com`:

- [Stensibly #1604](https://redirect.github.com/teamleaderleo/stensibly/pull/1604)
- [Stensibly #1605](https://redirect.github.com/teamleaderleo/stensibly/pull/1605)

## Historical episode

Merged #1604 explicitly stated:

```text
retain the responsibility generation being ended when it is positive
omit responsibility generation for valid generation-0 transitions
```

Its `convex/items.ts` patch implemented the proxy as:

```text
expectedGeneration == 0 -> omit responsibilityGeneration
expectedGeneration > 0  -> retain expectedGeneration
```

Merged #1605 explicitly names #1604 and supplies the counterexample:

```text
the counter also advances on unclaimed semantic transitions
positivity alone does not prove a live responsibility
```

It replaces that proxy with:

```text
responsibilityGeneration only when the item has a live, unexpired claim held by the acting actor
```

Both exact PRs change `convex/items.ts`.

## Retained memory and evaluation

`research/project-memory/stensibly-1604-1605.json` preserves the two exact merged PRs with complete source text, exact head/base coordinates, and changed paths. It deliberately contains zero relationship edges.

The specialized claim must independently establish:

```text
successor explicitly names predecessor
shared implementation path
predecessor states prior proxy rule
successor states concrete counterexample
successor states replacement predicate
prior/replacement semantic values differ
```

Executed retained result:

```text
status             observed_proxy_revision
semantic axis      responsibility_generation_evidence
prior value        positive_expected_generation
replacement value  live_unexpired_claim_for_actor
predecessor        #1604
successor          #1605
shared path        convex/items.ts
automatic generalization authority = false
```

## Adversarial controls

The ordinary Rust suite covers:

- unmerged predecessor;
- unmerged successor;
- successor text that does not name #1604;
- missing shared implementation path;
- missing prior proxy marker;
- missing counterexample marker;
- missing replacement marker;
- equal prior/replacement semantic values;
- invented retained-source excerpts;
- bounded input before JSON parsing.

## Executed current-main receipts

Semantic code/evidence head:

```text
head:       8d7c5ed05077e242e8013b78cf7cf91d52b89834
main:       6edf32f07138579d87abf5210e84c71e94c1d431
merge view: c25ab8817bfc0528edecb19a7b41679291abd474
CI:         32259077612 success
provenance: 32259077595 success
```

Final head adds only durable receipt prose in `research/proxy-semantic-revision.md`:

```text
head:       700c07b0f656cb008f88708dd5eaca53abca8ece
CI:         32259338878 success
provenance: 32259339543 success
```

Both merge-view CI runs passed formatter, all-target Clippy with warnings denied, full tests, project-memory adapter controls, external GitHub reference controls, and normal Cultist repository/history/CI/diff dogfood.

## Replay

```text
cargo run --example proxy_revision -- \
  research/project-memory/stensibly-1604-1605.json \
  research/proxy-revision/stensibly-1604-1605.json
```

## Boundary

Research-only:

- `src/proxy_revision.rs`
- `tests/proxy_revision.rs`
- `examples/proxy_revision.rs`
- `research/project-memory/stensibly-1604-1605.json`
- `research/proxy-revision/stensibly-1604-1605.json`
- `research/proxy-semantic-revision.md`

No product CLI/report-schema change; no provider/network call; no automatic generalization; no chronology-derived causal edge. Retained provider text remains exact evidence while human-facing documentation uses redirect GitHub links.

The final merge view is current `main@6edf32f07138579d87abf5210e84c71e94c1d431` plus this six-file research lane.

Progresses #41
Refs #6 #18 #74 #222.