### PR TITLE
research: prove ephemeral clone identity can mis-score semantic trigger

### DIFF
--- a/tests/skill_eval_identity_aliasing.rs
+++ b/tests/skill_eval_identity_aliasing.rs
@@ -1,0 +1,158 @@
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct Registration {
+    execution_id: &'static str,
+    semantic_fingerprint: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum SemanticScore {
+    ExactIdentity,
+    EquivalentEvaluatorClone,
+    DifferentSemantics,
+    UnknownIdentity,
+}
+
+fn exact_identity_score(expected_execution_id: &str, triggered_execution_id: &str) -> bool {
+    expected_execution_id == triggered_execution_id
+}
+
+fn semantic_score(
+    registrations: &[Registration],
+    expected_execution_id: &str,
+    triggered_execution_id: &str,
+) -> SemanticScore {
+    let by_id = registrations
+        .iter()
+        .map(|registration| (registration.execution_id, registration))
+        .collect::<BTreeMap<_, _>>();
+
+    let Some(expected) = by_id.get(expected_execution_id) else {
+        return SemanticScore::UnknownIdentity;
+    };
+    let Some(triggered) = by_id.get(triggered_execution_id) else {
+        return SemanticScore::UnknownIdentity;
+    };
+
+    if expected.execution_id == triggered.execution_id {
+        SemanticScore::ExactIdentity
+    } else if expected.semantic_fingerprint == triggered.semantic_fingerprint {
+        SemanticScore::EquivalentEvaluatorClone
+    } else {
+        SemanticScore::DifferentSemantics
+    }
+}
+
+fn clone(id: &'static str, semantic_fingerprint: &'static str) -> Registration {
+    Registration {
+        execution_id: id,
+        semantic_fingerprint,
+    }
+}
+
+#[test]
+fn exact_id_scoring_can_false_negative_an_evaluator_owned_equivalent_clone() {
+    let registrations = [
+        clone("skill-a-uuid-1111", "semantic-candidate-v1"),
+        clone("skill-a-uuid-2222", "semantic-candidate-v1"),
+    ];
+
+    assert!(!exact_identity_score(
+        "skill-a-uuid-1111",
+        "skill-a-uuid-2222"
+    ));
+    assert_eq!(
+        semantic_score(
+            &registrations,
+            "skill-a-uuid-1111",
+            "skill-a-uuid-2222"
+        ),
+        SemanticScore::EquivalentEvaluatorClone
+    );
+}
+
+#[test]
+fn exact_id_scoring_remains_correct_when_the_expected_clone_is_triggered() {
+    let registrations = [clone("skill-a-uuid-1111", "semantic-candidate-v1")];
+
+    assert!(exact_identity_score(
+        "skill-a-uuid-1111",
+        "skill-a-uuid-1111"
+    ));
+    assert_eq!(
+        semantic_score(
+            &registrations,
+            "skill-a-uuid-1111",
+            "skill-a-uuid-1111"
+        ),
+        SemanticScore::ExactIdentity
+    );
+}
+
+#[test]
+fn different_semantics_do_not_get_equivalence_credit_merely_for_sharing_a_namespace() {
+    let registrations = [
+        clone("skill-a-uuid-1111", "semantic-candidate-v1"),
+        clone("skill-b-uuid-2222", "different-candidate-v1"),
+    ];
+
+    assert!(!exact_identity_score(
+        "skill-a-uuid-1111",
+        "skill-b-uuid-2222"
+    ));
+    assert_eq!(
+        semantic_score(
+            &registrations,
+            "skill-a-uuid-1111",
+            "skill-b-uuid-2222"
+        ),
+        SemanticScore::DifferentSemantics
+    );
+}
+
+#[test]
+fn unregistered_trigger_identity_is_not_guessed_as_an_equivalent_clone() {
+    let registrations = [clone("skill-a-uuid-1111", "semantic-candidate-v1")];
+
+    assert!(!exact_identity_score(
+        "skill-a-uuid-1111",
+        "skill-a-uuid-9999"
+    ));
+    assert_eq!(
+        semantic_score(
+            &registrations,
+            "skill-a-uuid-1111",
+            "skill-a-uuid-9999"
+        ),
+        SemanticScore::UnknownIdentity
+    );
+}
+
+#[test]
+fn evaluator_clone_equivalence_is_local_and_does_not_create_durable_semantic_lineage() {
+    let first_run = [clone("skill-a-uuid-1111", "semantic-candidate-v1")];
+    let later_run = [clone("skill-a-uuid-3333", "semantic-candidate-v2")];
+
+    assert_eq!(
+        semantic_score(
+            &first_run,
+            "skill-a-uuid-1111",
+            "skill-a-uuid-1111"
+        ),
+        SemanticScore::ExactIdentity
+    );
+    assert_eq!(
+        semantic_score(
+            &later_run,
+            "skill-a-uuid-3333",
+            "skill-a-uuid-3333"
+        ),
+        SemanticScore::ExactIdentity
+    );
+
+    assert_ne!(
+        first_run[0].semantic_fingerprint,
+        later_run[0].semantic_fingerprint
+    );
+}

--- a/tests/skill_eval_identity_aliasing.rs
+++ b/tests/skill_eval_identity_aliasing.rs
@@ -63,11 +63,7 @@ fn exact_id_scoring_can_false_negative_an_evaluator_owned_equivalent_clone() {
         "skill-a-uuid-2222"
     ));
     assert_eq!(
-        semantic_score(
-            &registrations,
-            "skill-a-uuid-1111",
-            "skill-a-uuid-2222"
-        ),
+        semantic_score(&registrations, "skill-a-uuid-1111", "skill-a-uuid-2222"),
         SemanticScore::EquivalentEvaluatorClone
     );
 }
@@ -81,11 +77,7 @@ fn exact_id_scoring_remains_correct_when_the_expected_clone_is_triggered() {
         "skill-a-uuid-1111"
     ));
     assert_eq!(
-        semantic_score(
-            &registrations,
-            "skill-a-uuid-1111",
-            "skill-a-uuid-1111"
-        ),
+        semantic_score(&registrations, "skill-a-uuid-1111", "skill-a-uuid-1111"),
         SemanticScore::ExactIdentity
     );
 }
@@ -102,11 +94,7 @@ fn different_semantics_do_not_get_equivalence_credit_merely_for_sharing_a_namesp
         "skill-b-uuid-2222"
     ));
     assert_eq!(
-        semantic_score(
-            &registrations,
-            "skill-a-uuid-1111",
-            "skill-b-uuid-2222"
-        ),
+        semantic_score(&registrations, "skill-a-uuid-1111", "skill-b-uuid-2222"),
         SemanticScore::DifferentSemantics
     );
 }
@@ -120,11 +108,7 @@ fn unregistered_trigger_identity_is_not_guessed_as_an_equivalent_clone() {
         "skill-a-uuid-9999"
     ));
     assert_eq!(
-        semantic_score(
-            &registrations,
-            "skill-a-uuid-1111",
-            "skill-a-uuid-9999"
-        ),
+        semantic_score(&registrations, "skill-a-uuid-1111", "skill-a-uuid-9999"),
         SemanticScore::UnknownIdentity
     );
 }
@@ -135,19 +119,11 @@ fn evaluator_clone_equivalence_is_local_and_does_not_create_durable_semantic_lin
     let later_run = [clone("skill-a-uuid-3333", "semantic-candidate-v2")];
 
     assert_eq!(
-        semantic_score(
-            &first_run,
-            "skill-a-uuid-1111",
-            "skill-a-uuid-1111"
-        ),
+        semantic_score(&first_run, "skill-a-uuid-1111", "skill-a-uuid-1111"),
         SemanticScore::ExactIdentity
     );
     assert_eq!(
-        semantic_score(
-            &later_run,
-            "skill-a-uuid-3333",
-            "skill-a-uuid-3333"
-        ),
+        semantic_score(&later_run, "skill-a-uuid-3333", "skill-a-uuid-3333"),
         SemanticScore::ExactIdentity
     );
 


### PR DESCRIPTION
Progresses #225/#215 with one deterministic measurement counterexample inspired by the source-confirmed `anthropics/skills#1352` episode.

## Question

When an evaluator itself creates multiple registrations from the **same semantic candidate** solely for parallel execution, can exact synthetic-ID scoring report a false negative even though an equivalent evaluator-owned clone was triggered?

## Test-only model

One registration has:

```text
execution_id
semantic_fingerprint
```

Two scorers are compared:

```text
exact_identity_score
  expected synthetic ID == triggered synthetic ID

semantic_score
  exact identity
  equivalent evaluator clone
  different semantics
  unknown identity
```

## Counterexample

```text
A
  id = skill-a-uuid-1111
  semantic = candidate-v1

B
  id = skill-a-uuid-2222
  semantic = candidate-v1

triggered = B
expected by worker A = A
```

Then:

```text
exact ID score = false
semantic evaluator score = EquivalentEvaluatorClone
```

That proves the exact-ID boolean is not a complete measure of the intended semantic event **inside an evaluator-owned same-candidate clone cohort**.

## Negative controls

- triggering the exact expected clone scores exact success;
- a sibling registration with different semantic fingerprint receives no equivalence credit;
- an unregistered triggered ID is `UnknownIdentity`, not guessed equivalent;
- a later run with changed semantic fingerprint is not granted durable semantic lineage merely because the human-readable skill name resembles the earlier run.

## External source relation

The public Anthropic source snapshot retained in #226 shows one shared project command directory, per-query UUID command names, parallel queries, and exact UUID matching. Open repair PR `anthropics/skills#1437` proposes per-query project isolation so siblings are no longer concurrently visible.

This PR does **not** reproduce Claude's reported trigger behavior or claim Anthropic's issue diagnosis is fully proven. It extracts and tests the general evaluator identity distinction only.

## Product implication

Before recording a `model/skill failed to trigger` capability observation, ask whether the evaluator is scoring:

```text
behavioral semantics
or
one ephemeral execution identity created by the harness
```

This composes with #127: snapshot/execution identity and semantic lineage are different jobs.

## Boundary

- test only; no product CLI/schema change;
- evaluator-owned equivalence is local, not universal content-based skill identity;
- no model call, no trigger-rate claim;
- semantic fingerprint is a synthetic fixture fact, not inferred from arbitrary prose;
- no provider/vendor behavior promoted to Cultist policy.

Refs #127 #137 #146 #215 #218 #223 #225 #226.