### PR TITLE
research: bind selected refinements to exact observation subjects

### DIFF
--- a/.github/workflows/rust-edit-class-observation.yml
+++ b/.github/workflows/rust-edit-class-observation.yml
@@ -1,0 +1,234 @@
+name: Rust edit-class observation carrier
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/rust-edit-class-observation.yml"
+      - "examples/rust_syntax_cohort.rs"
+      - "examples/rust_edit_class_observation.rs"
+      - "src/rust_edit_class_source.rs"
+      - "src/observation_probe_bridge.rs"
+      - "src/observation_frontier.rs"
+      - "src/discriminator_observation.rs"
+      - "src/evidence_planner.rs"
+      - "tests/rust_edit_class_source.rs"
+
+permissions:
+  contents: read
+
+jobs:
+  oxc-edit-class-loop:
+    if: github.event_name == 'workflow_dispatch' || github.head_ref == 'research/rust-edit-class-observation-loop'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Cultist
+        uses: actions/checkout@v4
+        with:
+          path: cultist
+
+      - name: Install stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Build source and generic readers
+        run: |
+          cargo build --release \
+            --example rust_edit_class_observation \
+            --example observation_probe_plan \
+            --example observation_frontiers \
+            --manifest-path cultist/Cargo.toml
+
+      - name: Checkout pinned Oxc history
+        uses: actions/checkout@v4
+        with:
+          repository: oxc-project/oxc
+          ref: 8783524015b1e6ff1c39ccf426df0bb07cbbc588
+          fetch-depth: 200
+          persist-credentials: false
+          path: target
+
+      - name: Verify pinned head and resolve latest focused rules commit
+        id: focus
+        run: |
+          set -euo pipefail
+          pinned=8783524015b1e6ff1c39ccf426df0bb07cbbc588
+          anchor=crates/oxc_linter/src/rules.rs
+          test "$(git -C target rev-parse HEAD)" = "$pinned"
+          test -f "target/$anchor"
+
+          focused="$(git -C target log --no-merges -1 --format='%H' -- "$anchor")"
+          test -n "$focused"
+          test "$focused" != "$pinned"
+          parent="$(git -C target rev-parse "$focused^")"
+          test -n "$parent"
+          test -n "$(git -C target diff-tree --no-commit-id --name-only -r "$focused" -- "$anchor")"
+
+          echo "focused_sha=$focused" >> "$GITHUB_OUTPUT"
+          echo "focused_parent=$parent" >> "$GITHUB_OUTPUT"
+          echo "Pinned repository head: $pinned"
+          echo "Latest focused rules.rs commit: $focused"
+          git -C target show --no-patch --format='%H %s' "$focused"
+
+      - name: Assert pinned repository head is not an edit-class observation
+        run: |
+          set -euo pipefail
+          "$PWD/cultist/target/release/examples/rust_edit_class_observation" \
+            "$PWD/target" \
+            oxc-project/oxc \
+            8783524015b1e6ff1c39ccf426df0bb07cbbc588 \
+            crates/oxc_linter/src/rules.rs \
+            > head-control.json
+          cat head-control.json
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          result = json.loads(Path("head-control.json").read_text())
+          observation = result["observation"]
+          assert result["current_head"] == "8783524015b1e6ff1c39ccf426df0bb07cbbc588", result
+          assert observation["value_state"]["state"] == "unknown", observation
+          assert "anchor-unchanged" in observation["value_state"]["reason_ref"], observation
+          assert observation["applicability"]["status"] == "applies", observation
+          PY
+
+      - name: Checkout latest focused rules commit
+        env:
+          FOCUSED_SHA: ${{ steps.focus.outputs.focused_sha }}
+        run: |
+          set -euo pipefail
+          git -C target checkout -q "$FOCUSED_SHA"
+          test "$(git -C target rev-parse HEAD)" = "$FOCUSED_SHA"
+          test -f target/crates/oxc_linter/src/rules.rs
+
+      - name: Collect focused source-owned bridge and observation
+        env:
+          FOCUSED_SHA: ${{ steps.focus.outputs.focused_sha }}
+        run: |
+          set -euo pipefail
+          "$PWD/cultist/target/release/examples/rust_edit_class_observation" \
+            "$PWD/target" \
+            oxc-project/oxc \
+            "$FOCUSED_SHA" \
+            crates/oxc_linter/src/rules.rs \
+            > source-result.json
+          cat source-result.json
+
+      - name: Plan missing observation through generic bridge
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          source = json.loads(Path("source-result.json").read_text())
+          subject_ref = source["observation"]["subject_ref"]
+          revision = source["subject"]["revision"]
+          path = source["subject"]["path"]
+          request = {
+              "schema_version": 1,
+              "frontier": {
+                  "discriminator_id": "edit_class",
+                  "subject_ref": subject_ref,
+                  "status": "missing",
+                  "current": [],
+                  "unknown": [],
+                  "invalid": [],
+                  "other_subject": [],
+              },
+              "bridges": [source["bridge"]],
+              "context": {
+                  "repository": "oxc-project/oxc",
+                  "revision": revision,
+                  "path": path,
+              },
+              "probes": [source["probe"]],
+              "allow_effectful": False,
+              "policy": "conservative",
+          }
+          Path("plan-request.json").write_text(json.dumps(request), encoding="utf-8")
+          PY
+
+          "$PWD/cultist/target/release/examples/observation_probe_plan" \
+            < plan-request.json \
+            > plan.json
+          cat plan.json
+
+      - name: Feed produced observation back into frontier
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          source = json.loads(Path("source-result.json").read_text())
+          subject_ref = source["observation"]["subject_ref"]
+          request = {
+              "schema_version": 2,
+              "requirements": [{
+                  "discriminator_id": "edit_class",
+                  "subject_ref": subject_ref,
+              }],
+              "observations": {
+                  "schema_version": 2,
+                  "observations": [source["observation"]],
+              },
+          }
+          Path("frontier-request.json").write_text(json.dumps(request), encoding="utf-8")
+          PY
+
+          "$PWD/cultist/target/release/examples/observation_frontiers" \
+            < frontier-request.json \
+            > frontier.json
+          cat frontier.json
+
+      - name: Assert retained Oxc focused closed loop
+        env:
+          FOCUSED_SHA: ${{ steps.focus.outputs.focused_sha }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          focused = os.environ["FOCUSED_SHA"]
+          path = "crates/oxc_linter/src/rules.rs"
+          expected_subject = f"oxc-project/oxc@{focused}:{path}"
+
+          source = json.loads(Path("source-result.json").read_text())
+          observation = source["observation"]
+          assert source["current_head"] == focused, source
+          assert observation["discriminator_id"] == "edit_class", observation
+          assert observation["subject_ref"] == expected_subject, observation
+          assert observation["value_state"] == {
+              "state": "known",
+              "value_ref": "syntax_changed",
+          }, observation
+          assert observation["applicability"]["status"] == "applies", observation
+          assert source["bridge"]["observation_subject_ref"] == expected_subject, source
+          assert source["bridge"]["probe_discriminator"]["kind"] == "rust_edit_class", source
+          assert source["probe"]["effect"] == "read_only", source
+          assert source["probe"]["requirements"]["scope"] == {
+              "mode": "exact",
+              "path": path,
+          }, source
+
+          plan = json.loads(Path("plan.json").read_text())
+          assert plan["status"] == "planned", plan
+          assert plan["frontier_status"] == "missing", plan
+          assert plan["evidence_plan"]["status"] == "selected", plan
+          assert plan["evidence_plan"]["selected"]["id"] == source["probe"]["id"], plan
+
+          frontier = json.loads(Path("frontier.json").read_text())
+          receipt = frontier["frontiers"][0]
+          assert receipt["status"] == "current", receipt
+          assert receipt["current"][0]["value_ref"] == "syntax_changed", receipt
+          print(json.dumps({
+              "pinned_head_control": "unknown:anchor-unchanged",
+              "focused_sha": focused,
+              "subject_ref": expected_subject,
+              "planned_probe": plan["evidence_plan"]["selected"]["id"],
+              "value_ref": receipt["current"][0]["value_ref"],
+              "frontier": receipt["status"],
+          }, indent=2, sort_keys=True))
+          PY

--- a/examples/discriminator_observations.rs
+++ b/examples/discriminator_observations.rs
@@ -1,0 +1,37 @@
+#![allow(dead_code)]
+
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+
+use discriminator_observation::{
+    MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES, enumerate_discriminator_partitions,
+    parse_discriminator_observation_batch,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("discriminator-observations: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES {
+        return Err(format!(
+            "discriminator observation batch exceeds the {MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let batch = parse_discriminator_observation_batch(&bytes)?;
+    let enumeration = enumerate_discriminator_partitions(&batch)?;
+    println!("{}", serde_json::to_string_pretty(&enumeration)?);
+    Ok(())
+}

--- a/examples/durable_unknown.rs
+++ b/examples/durable_unknown.rs
@@ -1,0 +1,45 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+use serde::Deserialize;
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/justification.rs"]
+mod justification;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+
+use applicability::EvaluationContext;
+use durable_obligation::{ClearingEvidenceReceipt, DurableObligation, evaluate_obligation};
+
+const MAX_INPUT_BYTES: u64 = 1024 * 1024;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvaluationInput {
+    obligation: DurableObligation,
+    #[serde(default)]
+    receipts: Vec<ClearingEvidenceReceipt>,
+    context: EvaluationContext,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut input = Vec::new();
+    io::stdin()
+        .take(MAX_INPUT_BYTES + 1)
+        .read_to_end(&mut input)?;
+    if input.len() as u64 > MAX_INPUT_BYTES {
+        return Err("durable unknown input exceeds 1 MiB".into());
+    }
+
+    let request: EvaluationInput = serde_json::from_slice(&input)?;
+    let evaluation = evaluate_obligation(
+        &request.obligation,
+        &request.receipts,
+        &request.context,
+    )?;
+    serde_json::to_writer_pretty(io::stdout().lock(), &evaluation)?;
+    println!();
+    Ok(())
+}

--- a/examples/durable_unknown.rs
+++ b/examples/durable_unknown.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::error::Error;
 use std::io::{self, Read};
 
@@ -5,10 +7,10 @@ use serde::Deserialize;
 
 #[path = "../src/applicability.rs"]
 mod applicability;
-#[path = "../src/justification.rs"]
-mod justification;
 #[path = "../src/durable_obligation.rs"]
 mod durable_obligation;
+#[path = "../src/justification.rs"]
+mod justification;
 
 use applicability::EvaluationContext;
 use durable_obligation::{ClearingEvidenceReceipt, DurableObligation, evaluate_obligation};
@@ -34,11 +36,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let request: EvaluationInput = serde_json::from_slice(&input)?;
-    let evaluation = evaluate_obligation(
-        &request.obligation,
-        &request.receipts,
-        &request.context,
-    )?;
+    let evaluation = evaluate_obligation(&request.obligation, &request.receipts, &request.context)?;
     serde_json::to_writer_pretty(io::stdout().lock(), &evaluation)?;
     println!();
     Ok(())

--- a/examples/evidence_plan.rs
+++ b/examples/evidence_plan.rs
@@ -1,0 +1,33 @@
+#![allow(dead_code)]
+
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[path = "../src/justification.rs"]
+mod justification;
+
+use evidence_planner::{ProbePlanRequest, plan_evidence};
+
+const MAX_INPUT_BYTES: u64 = 1024 * 1024;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut input = Vec::new();
+    io::stdin()
+        .take(MAX_INPUT_BYTES + 1)
+        .read_to_end(&mut input)?;
+    if input.len() as u64 > MAX_INPUT_BYTES {
+        return Err("evidence planner input exceeds 1 MiB".into());
+    }
+
+    let request: ProbePlanRequest = serde_json::from_slice(&input)?;
+    let plan = plan_evidence(&request)?;
+    serde_json::to_writer_pretty(io::stdout().lock(), &plan)?;
+    println!();
+    Ok(())
+}

--- a/examples/justification_graph.rs
+++ b/examples/justification_graph.rs
@@ -1,0 +1,63 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+use serde::Deserialize;
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/justification.rs"]
+mod justification;
+
+use applicability::EvaluationContext;
+use justification::{JustificationGraph, evaluate_graph, reevaluate_graph};
+
+const MAX_INPUT_BYTES: u64 = 1024 * 1024;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvaluationInput {
+    graph: JustificationGraph,
+    context: EvaluationContext,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReevaluationInput {
+    graph: JustificationGraph,
+    before_context: EvaluationContext,
+    after_context: EvaluationContext,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    let mut input = Vec::new();
+    io::stdin()
+        .take(MAX_INPUT_BYTES + 1)
+        .read_to_end(&mut input)?;
+    if input.len() as u64 > MAX_INPUT_BYTES {
+        return Err("justification input exceeds 1 MiB".into());
+    }
+
+    match args.as_slice() {
+        [] => {
+            let request: EvaluationInput = serde_json::from_slice(&input)?;
+            let evaluation = evaluate_graph(&request.graph, &request.context)?;
+            serde_json::to_writer_pretty(io::stdout().lock(), &evaluation)?;
+        }
+        [flag] if flag == "--reevaluate" => {
+            let request: ReevaluationInput = serde_json::from_slice(&input)?;
+            let receipt = reevaluate_graph(
+                &request.graph,
+                &request.before_context,
+                &request.after_context,
+            )?;
+            serde_json::to_writer_pretty(io::stdout().lock(), &receipt)?;
+        }
+        _ => {
+            return Err("usage: cultist_justification [--reevaluate] < request.json".into());
+        }
+    }
+
+    println!();
+    Ok(())
+}

--- a/examples/justification_graph.rs
+++ b/examples/justification_graph.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::error::Error;
 use std::io::{self, Read};
 

--- a/examples/observation_frontiers.rs
+++ b/examples/observation_frontiers.rs
@@ -1,0 +1,39 @@
+#![allow(dead_code)]
+
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+
+use observation_frontier::{
+    MAX_OBSERVATION_FRONTIER_REQUEST_BYTES, evaluate_observation_frontiers,
+    parse_observation_frontier_request,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("observation-frontiers: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_OBSERVATION_FRONTIER_REQUEST_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_OBSERVATION_FRONTIER_REQUEST_BYTES {
+        return Err(format!(
+            "observation frontier request exceeds the {MAX_OBSERVATION_FRONTIER_REQUEST_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let request = parse_observation_frontier_request(&bytes)?;
+    let evaluation = evaluate_observation_frontiers(&request)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}

--- a/examples/observation_probe_plan.rs
+++ b/examples/observation_probe_plan.rs
@@ -8,14 +8,14 @@ mod applicability;
 #[path = "../src/discriminator_observation.rs"]
 mod discriminator_observation;
 #[allow(dead_code)]
-#[path = "../src/justification.rs"]
-mod justification;
-#[allow(dead_code)]
 #[path = "../src/durable_obligation.rs"]
 mod durable_obligation;
 #[allow(dead_code)]
 #[path = "../src/evidence_planner.rs"]
 mod evidence_planner;
+#[allow(dead_code)]
+#[path = "../src/justification.rs"]
+mod justification;
 #[allow(dead_code)]
 #[path = "../src/observation_frontier.rs"]
 mod observation_frontier;

--- a/examples/observation_probe_plan.rs
+++ b/examples/observation_probe_plan.rs
@@ -1,0 +1,54 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+#[allow(dead_code)]
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[allow(dead_code)]
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[allow(dead_code)]
+#[path = "../src/justification.rs"]
+mod justification;
+#[allow(dead_code)]
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[allow(dead_code)]
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[allow(dead_code)]
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[allow(dead_code)]
+#[path = "../src/observation_probe_bridge.rs"]
+mod observation_probe_bridge;
+
+use observation_probe_bridge::{
+    MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES, parse_observation_probe_plan_request,
+    plan_observation_probe,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("observation-probe-plan: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES {
+        return Err(format!(
+            "observation probe plan request exceeds the {MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let request = parse_observation_probe_plan_request(&bytes)?;
+    let plan = plan_observation_probe(&request)?;
+    println!("{}", serde_json::to_string_pretty(&plan)?);
+    Ok(())
+}

--- a/examples/refinement_episodes.rs
+++ b/examples/refinement_episodes.rs
@@ -1,0 +1,33 @@
+#![allow(dead_code)]
+
+use std::error::Error;
+use std::io::{self, Read};
+
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+
+use refinement_episode::{MAX_REFINEMENT_EPISODE_BATCH_BYTES, parse_refinement_episode_batch};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("refinement-episodes: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_REFINEMENT_EPISODE_BATCH_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_REFINEMENT_EPISODE_BATCH_BYTES {
+        return Err(format!(
+            "refinement episode batch exceeds the {MAX_REFINEMENT_EPISODE_BATCH_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let batch = parse_refinement_episode_batch(&bytes)?;
+    println!("{}", serde_json::to_string_pretty(&batch)?);
+    Ok(())
+}

--- a/examples/refinement_observation_requirements.rs
+++ b/examples/refinement_observation_requirements.rs
@@ -1,0 +1,45 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+#[allow(dead_code)]
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[allow(dead_code)]
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[allow(dead_code)]
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+#[allow(dead_code)]
+#[path = "../src/refinement_observation_requirement.rs"]
+mod refinement_observation_requirement;
+
+use refinement_observation_requirement::{
+    MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES,
+    evaluate_selected_observation_requirements, parse_refinement_observation_requirement_request,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("refinement-observation-requirements: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES {
+        return Err(format!(
+            "refinement observation requirement request exceeds the {MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let request = parse_refinement_observation_requirement_request(&bytes)?;
+    let evaluation = evaluate_selected_observation_requirements(&request)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}

--- a/examples/rust_edit_class_observation.rs
+++ b/examples/rust_edit_class_observation.rs
@@ -1,0 +1,68 @@
+use std::env;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+#[allow(dead_code)]
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[allow(dead_code)]
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[allow(dead_code)]
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[allow(dead_code)]
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[allow(dead_code)]
+#[path = "../src/justification.rs"]
+mod justification;
+#[allow(dead_code)]
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[allow(dead_code)]
+#[path = "../src/observation_probe_bridge.rs"]
+mod observation_probe_bridge;
+#[allow(dead_code)]
+#[path = "../src/rust_edit_class_source.rs"]
+mod rust_edit_class_source;
+
+use rust_edit_class_source::{RustEditClassSubject, collect_rust_edit_class_source};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("rust-edit-class-observation: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut args = env::args().skip(1);
+    let root = PathBuf::from(
+        args.next()
+            .ok_or("usage: rust_edit_class_observation REPO_ROOT REPOSITORY REVISION FILE")?,
+    );
+    let repository = args
+        .next()
+        .ok_or("usage: rust_edit_class_observation REPO_ROOT REPOSITORY REVISION FILE")?;
+    let revision = args
+        .next()
+        .ok_or("usage: rust_edit_class_observation REPO_ROOT REPOSITORY REVISION FILE")?;
+    let path = args
+        .next()
+        .ok_or("usage: rust_edit_class_observation REPO_ROOT REPOSITORY REVISION FILE")?;
+    if args.next().is_some() {
+        return Err("usage: rust_edit_class_observation REPO_ROOT REPOSITORY REVISION FILE".into());
+    }
+
+    let result = collect_rust_edit_class_source(
+        Path::new(&root),
+        &RustEditClassSubject {
+            repository,
+            revision,
+            path,
+        },
+    )?;
+    println!("{}", serde_json::to_string_pretty(&result)?);
+    Ok(())
+}

--- a/examples/rust_syntax_cohort.rs
+++ b/examples/rust_syntax_cohort.rs
@@ -20,7 +20,7 @@ struct Commit {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum RustEditClass {
+pub(crate) enum RustEditClass {
     SyntaxChanged,
     CommentsOrWhitespaceOnly,
     Unclassified,
@@ -230,7 +230,7 @@ fn commit_metadata(root: &Path, sha: &str) -> Result<(String, BTreeSet<PathBuf>)
     Ok((subject.trim().to_string(), paths))
 }
 
-fn classify_rust_edit(root: &Path, sha: &str, anchor: &Path) -> RustEditClass {
+pub(crate) fn classify_rust_edit(root: &Path, sha: &str, anchor: &Path) -> RustEditClass {
     let after = source_at_revision(root, sha, anchor);
     let before = source_at_revision(root, &format!("{sha}^"), anchor);
     let (Some(before), Some(after)) = (before, after) else {

--- a/research/discriminator-observations.md
+++ b/research/discriminator-observations.md
@@ -141,6 +141,31 @@ cargo run --example discriminator_observations \
 
 The reader validates the supplied observation batch and prints generic current/unknown/invalid partition receipts.
 
+## Executed GitHub receipt
+
+Draft PR #187 was compacted to one semantic commit on #179's exact green receipt head.
+
+Exact semantic head:
+
+```text
+bea8b42be1d372096c64e41c7dce37cb363b8f1a
+```
+
+GitHub Actions CI run `32248518562` / run number `1266` completed successfully. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work preflight;
+- full `cargo test`, including selected #179 discriminator coverage, KNOWN/UNKNOWN/INVALID partition behavior, duplicate/conflict identity controls, distinct-source identity preservation, deterministic round trip, and opaque value semantics;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The first CI attempt failed only at rustfmt before Clippy or tests. The exact formatter delta was applied, then the branch was compacted back to the single semantic commit above before the successful run.
+
+Because #187 is stacked on #179 rather than `main`, the PR executes the ordinary CI workflow; the generated-provenance PR workflow is not part of this stacked carrier's gate.
+
 ## Boundary
 
 - research-only reference seam;
@@ -153,7 +178,7 @@ The reader validates the supplied observation batch and prints generic current/u
 
 ## Next discriminator
 
-If this three-family reference seam survives CI, the next useful experiment is deliberately tiny:
+The three-family reference seam survived CI. The next useful experiment is deliberately tiny:
 
 ```text
 #179 candidate needs discriminator D
@@ -161,9 +186,9 @@ If this three-family reference seam survives CI, the next useful experiment is d
 -> return explicit missing-observation frontier
 ```
 
-Then compare that frontier with #145's probe-capability planning. A useful composition would let #145 select a source-owned probe capable of producing observation D without making #185 execute it.
+Compare that frontier with #145's probe-capability planning while keeping their vocabularies separate. #185 identifies the missing generic observation reference; a source adapter must map that need to #145's `{kind,target}` clearing/probe contract. The generic layer must not assume that a matching string means a probe can produce the observation.
 
-If the bridge requires family-specific probe semantics inside #185, keep the bridge in adapters and preserve the reference module as the narrow boundary earned here.
+A useful composition would let #145 select a source-owned probe capable of producing observation D while #185 remains a read-only reference/partition layer. If the bridge requires family-specific probe semantics inside #185, keep the bridge in adapters and preserve the reference module as the narrow boundary earned here.
 
 North star:
 

--- a/research/discriminator-observations.md
+++ b/research/discriminator-observations.md
@@ -1,0 +1,170 @@
+# Source-owned discriminator observation references
+
+Tracking: #185. Stacked on the green #179 / #148 refinement-episode carrier.
+
+## Question
+
+Can three very different analyzer families expose one tiny typed reference seam for already-earned discriminator observations without moving their domain evaluators into the analyzer-refinement layer?
+
+V0 deliberately models **references to observations**, not the logic that produces them.
+
+## Observation contract
+
+```text
+DiscriminatorObservation
+  observation_id
+  discriminator_id
+  subject_ref
+  source_receipt
+  value_state
+    known { value_ref }
+    unknown { reason_ref }
+    invalid { reason_ref }
+  applicability_ref?
+```
+
+The fields mean:
+
+- `observation_id` — identity of this supplied observation event/object;
+- `discriminator_id` — which distinction the source analyzer says this observation answers;
+- `subject_ref` — exact source-owned subject identity;
+- `source_receipt` — where the value/status came from;
+- `value_ref` — opaque supplied partition value when current;
+- `reason_ref` — source-owned explanation reference for UNKNOWN/INVALID;
+- `applicability_ref` — optional exact reference to the source applicability/coordinate receipt.
+
+The generic layer parses none of those reference strings for semantic meaning.
+
+## Enumeration contract
+
+`enumerate_discriminator_partitions` groups only KNOWN observations by:
+
+```text
+discriminator_id
+  -> value_ref
+     -> current observation receipts[]
+```
+
+UNKNOWN and INVALID observations remain separate inspectable lists under the same discriminator and never enter current partitions.
+
+Each current partition keeps every observation identity, subject, source receipt, and applicability reference. Equal values from two source receipts therefore remain two observations rather than being silently deduplicated into one evidence event.
+
+## Retained three-family corpus
+
+`research/discriminator-observations/cultist-v1.json` supplies one current observation for every discriminator used by the selected transitions in #179.
+
+### A. Justification / durable UNKNOWN
+
+```text
+discriminator_id = clearing_evidence_presence
+value_ref        = absent
+source           = #159 exact durable-obligation head
+```
+
+The reference layer does not decide whether `absent` means OPEN or whether the subject remains applicable. #159/#123 own those semantics.
+
+### B. Historical companion refinement
+
+```text
+discriminator_id = edit_class
+value_ref        = syntax_changed
+source           = retained Oxc syntax-cohort replay
+```
+
+The reference layer does not tokenize Rust or decide that exact commit identity is overfit. Those results remain in the source research and #168.
+
+### C. Project-memory contract refinement
+
+```text
+discriminator_id = primary_case_evidence_form
+value_ref        = primary_case_issue_block
+
+discriminator_id = same_repository_issue_target
+value_ref        = same_repository_issue
+
+source           = #174 exact repair head
+```
+
+The reference layer does not parse `Primary case:`, GitHub URLs, repositories, issue numbers, or relation types. #174/project-memory validation owns those checks.
+
+## Composition with #179
+
+The strongest first control is cross-object rather than family-specific:
+
+```text
+for every selected transition in the retained #179 corpus:
+  for every discriminator_ref used by that selected candidate:
+    a current KNOWN discriminator observation must exist
+```
+
+The test uses only exact discriminator IDs and supplied observation state. It does not execute the source analyzers.
+
+This proves the narrow seam #185 is asking for: #179 can consume current source-owned discriminator references without learning how those discriminators were produced.
+
+## Adversarial controls
+
+The standard test harness requires:
+
+- KNOWN observations enumerate deterministically by discriminator/value;
+- UNKNOWN stays visible and out of current partitions;
+- INVALID stays visible and out of current partitions;
+- exact duplicate observation identity rejects;
+- same observation identity with changed semantics rejects as a conflict;
+- missing source receipt rejects;
+- same value from distinct source receipts preserves both observation identities;
+- batch/enum JSON round trips and ordering remain deterministic;
+- oversized input rejects before JSON parsing;
+- an alarming value spelling such as `approve_and_merge_everything` remains an opaque value reference and grants no authority/disposition.
+
+## What V0 intentionally cannot do
+
+This module does not decide:
+
+```text
+which discriminator to acquire
+whether a partition is causal
+whether a partition is overfit
+whether a candidate improves replay
+whether evidence is strong enough
+whether a source observation is authorized
+what action/disposition follows
+```
+
+Those questions remain in #145, #168, #179, applicability, or the originating analyzer.
+
+## Research reader
+
+```text
+cargo run --example discriminator_observations \
+  < research/discriminator-observations/cultist-v1.json
+```
+
+The reader validates the supplied observation batch and prints generic current/unknown/invalid partition receipts.
+
+## Boundary
+
+- research-only reference seam;
+- no universal fact ontology;
+- no source analyzer duplication;
+- no string parsing for semantic authority;
+- no behavioral identity conflation;
+- no automatic analyzer refinement/promotion;
+- no product CLI/report-schema change.
+
+## Next discriminator
+
+If this three-family reference seam survives CI, the next useful experiment is deliberately tiny:
+
+```text
+#179 candidate needs discriminator D
+#185 has zero current KNOWN observations for D
+-> return explicit missing-observation frontier
+```
+
+Then compare that frontier with #145's probe-capability planning. A useful composition would let #145 select a source-owned probe capable of producing observation D without making #185 execute it.
+
+If the bridge requires family-specific probe semantics inside #185, keep the bridge in adapters and preserve the reference module as the narrow boundary earned here.
+
+North star:
+
+> Exchange references to analyzer-earned distinctions; keep the knowledge of how those distinctions are proved with the analyzer that owns them.

--- a/research/discriminator-observations/cultist-v1.json
+++ b/research/discriminator-observations/cultist-v1.json
@@ -18,15 +18,15 @@
     {
       "observation_id": "history/oxc-edit-class-v1:current-edit-class",
       "discriminator_id": "edit_class",
-      "subject_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588:crates/oxc_linter/src/rules.rs",
-      "source_receipt": "research:rust-syntax-cohort-replay.md",
+      "subject_ref": "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs",
+      "source_receipt": "github-actions:run/32257998359#focused-oxc-edit-class",
       "value_state": {
         "state": "known",
         "value_ref": "syntax_changed"
       },
       "applicability": {
         "status": "applies",
-        "receipt_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588"
+        "receipt_ref": "github-actions:run/32257998359#focused-oxc-applicability"
       }
     },
     {

--- a/research/discriminator-observations/cultist-v1.json
+++ b/research/discriminator-observations/cultist-v1.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "observations": [
+    {
+      "observation_id": "justification/open-obligation-v1:clearing-evidence-presence",
+      "discriminator_id": "clearing_evidence_presence",
+      "subject_ref": "refinement:justification/open-obligation-v1",
+      "source_receipt": "github:pull/159@1c1a0086a199168fd0e21445d103936183063dc7",
+      "value_state": {
+        "state": "known",
+        "value_ref": "absent"
+      },
+      "applicability_ref": "research:durable-unknown-obligation.md#evaluation"
+    },
+    {
+      "observation_id": "history/oxc-edit-class-v1:current-edit-class",
+      "discriminator_id": "edit_class",
+      "subject_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588:crates/oxc_linter/src/rules.rs",
+      "source_receipt": "research:rust-syntax-cohort-replay.md",
+      "value_state": {
+        "state": "known",
+        "value_ref": "syntax_changed"
+      },
+      "applicability_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588"
+    },
+    {
+      "observation_id": "project-memory/primary-case-contract-collision-v1:evidence-form",
+      "discriminator_id": "primary_case_evidence_form",
+      "subject_ref": "refinement:project-memory/primary-case-contract-collision-v1",
+      "source_receipt": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca",
+      "value_state": {
+        "state": "known",
+        "value_ref": "primary_case_issue_block"
+      },
+      "applicability_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+    },
+    {
+      "observation_id": "project-memory/primary-case-contract-collision-v1:target-relation",
+      "discriminator_id": "same_repository_issue_target",
+      "subject_ref": "refinement:project-memory/primary-case-contract-collision-v1",
+      "source_receipt": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca",
+      "value_state": {
+        "state": "known",
+        "value_ref": "same_repository_issue"
+      },
+      "applicability_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+    }
+  ]
+}

--- a/research/discriminator-observations/cultist-v1.json
+++ b/research/discriminator-observations/cultist-v1.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "observations": [
     {
       "observation_id": "justification/open-obligation-v1:clearing-evidence-presence",
@@ -10,7 +10,10 @@
         "state": "known",
         "value_ref": "absent"
       },
-      "applicability_ref": "research:durable-unknown-obligation.md#evaluation"
+      "applicability": {
+        "status": "applies",
+        "receipt_ref": "research:durable-unknown-obligation.md#evaluation"
+      }
     },
     {
       "observation_id": "history/oxc-edit-class-v1:current-edit-class",
@@ -21,7 +24,10 @@
         "state": "known",
         "value_ref": "syntax_changed"
       },
-      "applicability_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588"
+      "applicability": {
+        "status": "applies",
+        "receipt_ref": "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588"
+      }
     },
     {
       "observation_id": "project-memory/primary-case-contract-collision-v1:evidence-form",
@@ -32,7 +38,10 @@
         "state": "known",
         "value_ref": "primary_case_issue_block"
       },
-      "applicability_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+      "applicability": {
+        "status": "applies",
+        "receipt_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+      }
     },
     {
       "observation_id": "project-memory/primary-case-contract-collision-v1:target-relation",
@@ -43,7 +52,10 @@
         "state": "known",
         "value_ref": "same_repository_issue"
       },
-      "applicability_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+      "applicability": {
+        "status": "applies",
+        "receipt_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca#project-memory-validation"
+      }
     }
   ]
 }

--- a/research/durable-unknown-obligation.md
+++ b/research/durable-unknown-obligation.md
@@ -17,6 +17,8 @@ Encoding a prospective clearing edge as if evidence already existed would confus
 
 This carrier therefore treats **the open durable record** and **arrived clearing receipts** as separate things.
 
+That counterexample was fed back into #141/#156 as well: an obligation node may now remain open with zero clearing edges instead of requiring a fabricated future evidence object.
+
 ## v0 record
 
 ```text
@@ -77,6 +79,30 @@ The stacked carrier tests:
 - record round-trips with completed evidence references for fresh-worker handoff;
 - a clearing condition must actually answer the declared missing discriminator.
 
+## Executed GitHub receipt
+
+Draft stacked PR #159 ran against exact parent #156 head:
+
+```text
+parent  9beaeaab2bece20a4e0bb9c880f510f740bf8cfb
+child   fd37861d73e966ed64538c60cc00bf32f8f928b2
+```
+
+GitHub Actions CI run `32243607858` / run number `1045` completed successfully on the stacked PR merge ref. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work heads-up;
+- full `cargo test` including the durable-obligation harness;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The PR-only push-diff step remained skipped by workflow context.
+
+The first current-stack CI attempt was a useful mechanical control: rustfmt rejected handwritten formatting in the new research files. Applying the exact formatter diff plus a fixture-local dead-code allowance for the standalone example allowed the next run to reach and pass Clippy/tests.
+
 ## Boundary
 
 - discriminator `{kind,target}` is a research key, not a final universal evidence ontology;
@@ -89,3 +115,5 @@ The stacked carrier tests:
 ## Next discriminator
 
 The next useful experiment is #145: given this typed missing discriminator and a bounded set of available probe capabilities, select the cheapest admitted probe capable of producing a matching receipt. That experiment should consume this object rather than restating the missing question in prose.
+
+Keep planning forecasts separate from observed performance receipts. Current `PerfCounters` measure work after execution; a planner cost is an admitted forecast before execution and can later be calibrated against measured counters where the dimensions overlap.

--- a/research/durable-unknown-obligation.md
+++ b/research/durable-unknown-obligation.md
@@ -1,0 +1,91 @@
+# Durable UNKNOWN obligation research receipt
+
+Tracking: #144. Stacked on the #141 justification-graph carrier.
+
+## Dogfood discriminator from #141
+
+The first justification graph required every obligation node to have a clearing edge. That is convenient for evaluating a graph containing known candidate evidence, but it fails the central durable-handoff case:
+
+```text
+worker finishes bounded investigation
+-> material discriminator remains missing
+-> clearing evidence does not exist yet
+-> preserve the open obligation for the next worker
+```
+
+Encoding a prospective clearing edge as if evidence already existed would confuse an expected future observation with an observed evidence object.
+
+This carrier therefore treats **the open durable record** and **arrived clearing receipts** as separate things.
+
+## v0 record
+
+```text
+DurableObligation
+  id
+  question
+  exact subject applicability requirements
+  established_evidence[]
+  missing_discriminator { kind, target }
+  clearing_conditions[]
+```
+
+A clearing condition names an exact typed discriminator plus exact applicability requirements. A supplied receipt must match both before it can participate in clearing.
+
+`established_evidence` is intentionally a bounded list of evidence IDs in this experiment. It preserves completed investigation for handoff without granting those strings authority or semantic lineage.
+
+## Evaluation
+
+The record and every candidate receipt reuse the shared applicability evaluator.
+
+```text
+subject APPLIES
+  + matching clearing receipt APPLIES
+    -> CLEARED
+
+subject APPLIES
+  + no matching/current clearing receipt
+    -> OPEN
+
+subject APPLIES
+  + matching receipt applicability UNKNOWN
+    -> UNKNOWN
+
+subject applicability UNKNOWN
+    -> UNKNOWN
+
+subject INVALID because the exact coordinate moved
+    -> REOPEN_REQUIRED
+```
+
+A semantically adjacent receipt with another discriminator kind remains unmatched even when it names the same target/revision.
+
+## Why `REOPEN_REQUIRED` exists
+
+An obligation captured for exact head A cannot silently become the obligation for head B. Head movement invalidates the old subject coordinate. The next worker/orchestrator can compile a fresh obligation for B while preserving the old record as a historical handoff receipt.
+
+This keeps reopening distinct from pretending the stale obligation is still current.
+
+## Standard-suite controls
+
+The stacked carrier tests:
+
+- open obligation with zero clearing evidence;
+- exact matching receipt clears;
+- exact subject head movement produces `reopen_required`;
+- missing current coordinate remains `unknown`;
+- semantically adjacent receipt does not clear;
+- record round-trips with completed evidence references for fresh-worker handoff;
+- a clearing condition must actually answer the declared missing discriminator.
+
+## Boundary
+
+- discriminator `{kind,target}` is a research key, not a final universal evidence ontology;
+- receipt requirements use exact v1 matching against the clearing condition before applicability evaluation;
+- richer subject/predicate envelopes belong to #147;
+- probe discovery/cost belongs to #145;
+- this record grants no mutation, review, merge, or deployment authority;
+- solved records can remain as history, while current use always rechecks applicability.
+
+## Next discriminator
+
+The next useful experiment is #145: given this typed missing discriminator and a bounded set of available probe capabilities, select the cheapest admitted probe capable of producing a matching receipt. That experiment should consume this object rather than restating the missing question in prose.

--- a/research/evidence-acquisition-planner.md
+++ b/research/evidence-acquisition-planner.md
@@ -1,0 +1,133 @@
+# Evidence acquisition planner research receipt
+
+Tracking: #145. Stacked on #144/#159 and #141/#156.
+
+## Question
+
+Given one material durable `UNKNOWN`, can Cultist select the smallest admitted evidence probe capable of changing that exact answer without confusing cheap evidence with sufficient evidence or granting permission to perform effects?
+
+## Earned input from #144
+
+The planner consumes the durable record directly:
+
+```text
+DurableObligation
+  subject applicability
+  missing_discriminator { kind, target }
+  clearing_conditions[]
+```
+
+It does not reparse the question prose to decide what evidence is needed.
+
+A candidate probe declares:
+
+```text
+id
+produces { kind, target }
+requirements
+probe effect class
+forecast cost
+```
+
+A probe is capable only when its produced discriminator exactly matches the obligation's missing discriminator and its exact output requirements match an admitted clearing condition.
+
+This is deliberately stronger than vocabulary overlap. A historical companion probe can be cheap and useful while remaining incapable of clearing an `exact-head target_test_result` obligation.
+
+## Candidate states
+
+Each probe receives one inspectable status:
+
+```text
+eligible
+incapable
+incompatible_clearing_condition
+invalid_coordinate
+missing_context
+effect_authority_required
+```
+
+The whole plan is:
+
+```text
+selected
+blocked
+unresolved
+stale_obligation
+```
+
+`unresolved` means no admitted probe can currently answer the obligation. It is a valid research-frontier result.
+
+`stale_obligation` means the durable obligation's own subject coordinate moved; the planner refuses to select new work against an obsolete question and requires a fresh obligation first.
+
+## Effect boundary
+
+Probe effect class is explicit:
+
+```text
+read_only
+external_read
+effectful
+```
+
+An effectful probe may be the only capable next discriminator. The planner can identify that fact while returning `blocked / effect_authority_required` when the caller has not admitted effectful work.
+
+Selection therefore answers:
+
+> Which admitted probe would be appropriate if its effect class is allowed?
+
+It does not itself execute the probe or mint execution authority.
+
+## Forecast cost versus measured performance
+
+V0 `ProbeCost` is a pre-execution forecast:
+
+```text
+git_subprocesses
+rust_files_parsed
+remote_requests
+effectful_executions
+```
+
+Current `PerfCounters` on main are post-execution observations. Keep those concepts separate. A later calibration experiment can compare forecast and measured dimensions where they overlap.
+
+The first explicit policy is `conservative`:
+
+1. prefer read-only over external-read over effectful probes;
+2. then fewer remote requests;
+3. then fewer Git subprocesses;
+4. then fewer Rust files parsed;
+5. then fewer effectful executions;
+6. stable probe ID breaks exact ties.
+
+No hidden scalar cost score is produced.
+
+## Initial controls
+
+The carrier tests:
+
+- a cheaper historical probe is skipped when it cannot produce the required discriminator;
+- a stale exact-test probe cannot satisfy a current-head clearing condition;
+- the exact-head target execution probe is selected when effectful work is admitted;
+- the same capable probe returns `blocked` when effect authority is absent;
+- conservative policy prefers an eligible external read before an eligible effectful alternative;
+- no capable probe produces explicit `unresolved`;
+- missing current obligation context produces `blocked` instead of guessing;
+- moved obligation subject produces `stale_obligation` before probe selection;
+- simulated execution of the selected probe can emit the exact typed receipt that #144 evaluates from `open -> cleared`;
+- malformed effect/cost declarations fail explicitly.
+
+## Boundary
+
+- candidate capability comes from typed probe declarations, never prose keyword inference;
+- planning does not strengthen the epistemic kind of the evidence produced;
+- historical co-change remains association evidence even when it is the cheapest probe;
+- selection is deterministic under the declared policy;
+- a selected effectful probe remains unexecuted until an external caller/orchestrator grants that action;
+- no model, network request, test command, or repository mutation occurs inside the planner;
+- planner output is research-only and does not change the product CLI/report schema.
+
+## Next discriminator
+
+If this carrier survives CI, replay one real Cultist research frontier where two probes can answer the same typed discriminator at different costs. Then compare forecast work with existing performance receipts after execution.
+
+A second follow-up should test whether probe prerequisites need their own typed relation beyond output applicability. Keep v0 small until a real probe requires a prerequisite that cannot be represented by the current obligation/context coordinates.

--- a/research/evidence-acquisition-planner.md
+++ b/research/evidence-acquisition-planner.md
@@ -77,6 +77,8 @@ Selection therefore answers:
 
 It does not itself execute the probe or mint execution authority.
 
+A `SelectedProbe` remains an **expected evidence contract** until the probe actually runs and produces a separate observed receipt. The planner cannot clear its own obligation merely by selecting a capable probe.
+
 ## Forecast cost versus measured performance
 
 V0 `ProbeCost` is a pre-execution forecast:
@@ -116,6 +118,35 @@ The carrier tests:
 - simulated execution of the selected probe can emit the exact typed receipt that #144 evaluates from `open -> cleared`;
 - malformed effect/cost declarations fail explicitly.
 
+## Executed GitHub receipt
+
+Draft stacked PR #164 ran against exact parent #159 head:
+
+```text
+parent  1c1a0086a199168fd0e21445d103936183063dc7
+child   179a2b45267b36d9dfd92eddca93f70aac1744d4
+```
+
+GitHub Actions CI run `32244269156` / run number `1083` completed successfully on the stacked PR merge ref. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work heads-up;
+- full `cargo test` including the evidence-planner harness;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The PR-only push-diff step remained skipped by workflow context.
+
+Two preceding runs were useful controls:
+
+1. run `32243927421` exposed handwritten rustfmt differences before semantic validation;
+2. run `32244049236` passed format/Clippy and all planner semantics except one test assertion that expected the plural phrase `effectful executions` while the intentional validation error used singular `effectful execution`.
+
+The second failure changed only the test's string expectation. The planner contract stayed unchanged, and the next full run passed.
+
 ## Boundary
 
 - candidate capability comes from typed probe declarations, never prose keyword inference;
@@ -123,11 +154,12 @@ The carrier tests:
 - historical co-change remains association evidence even when it is the cheapest probe;
 - selection is deterministic under the declared policy;
 - a selected effectful probe remains unexecuted until an external caller/orchestrator grants that action;
+- selection produces an expected receipt contract, not observed clearing evidence;
 - no model, network request, test command, or repository mutation occurs inside the planner;
 - planner output is research-only and does not change the product CLI/report schema.
 
 ## Next discriminator
 
-If this carrier survives CI, replay one real Cultist research frontier where two probes can answer the same typed discriminator at different costs. Then compare forecast work with existing performance receipts after execution.
+Replay one real Cultist research frontier where two probes can answer the same typed discriminator at different costs. Then compare forecast work with existing performance receipts after execution.
 
 A second follow-up should test whether probe prerequisites need their own typed relation beyond output applicability. Keep v0 small until a real probe requires a prerequisite that cannot be represented by the current obligation/context coordinates.

--- a/research/justification-graph.md
+++ b/research/justification-graph.md
@@ -62,6 +62,8 @@ cleared
   at least one clearing evidence object applies
 ```
 
+An open obligation is valid with **zero clearing edges**. The immediately stacked #144 experiment exposed this as a necessary case: a durable missing discriminator can exist before any clearing evidence object has arrived. Requiring a clearing edge would manufacture prospective evidence as if it had already been observed.
+
 When exact-head clearing evidence later becomes INVALID after revision movement, the obligation reopens.
 
 ## Reevaluation receipt
@@ -84,10 +86,38 @@ The carrier includes controls for:
 - one invalidated support + one independent support -> claim remains supported;
 - sole invalidated support -> claim becomes unknown;
 - counterexample and limit receipts remain visible;
+- an obligation can remain open before any clearing evidence exists;
 - exact-head clearing evidence clears an obligation and head movement reopens it;
 - reevaluation names only targets downstream of changed evidence;
 - UNKNOWN dependency prevents a supported projection;
 - relation/target mismatch rejects rather than inventing cyclic/general graph semantics.
+
+## Executed GitHub receipt
+
+Draft PR #156 ran the ordinary repository gates after the open-obligation correction and fixture-only Clippy containment.
+
+Exact head under test:
+
+```text
+9399f29ebcb96e5b306e88b6ad12c0189f0e6f62
+```
+
+GitHub Actions CI run `32243151354` / run number `1018` completed successfully on the PR merge ref. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work heads-up;
+- full `cargo test` including the justification integration harness;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The PR-only push-diff step remained skipped by workflow context.
+
+Generated provenance review dogfood run `32243151304` / run number `160` also completed successfully for the same head.
+
+Two earlier CI attempts were useful mechanical controls rather than semantic failures: the first exposed rustfmt differences; the second reached Clippy and exposed one fixture-only unused applicability constant through the standalone example. Both were repaired before this executed receipt.
 
 ## Boundary
 
@@ -101,12 +131,12 @@ The carrier includes controls for:
 
 ## Next discriminator after this carrier
 
-If the controls hold, the next useful question is whether real Cultist evidence needs **alternative derivation groups** such as:
+The first follow-up is already concrete through #144: preserve open obligations and their future clearing conditions without pretending expected evidence is observed evidence.
+
+Beyond that, the next useful truth-maintenance question is whether real Cultist evidence needs **alternative derivation groups** such as:
 
 ```text
 (E1 AND E2) OR E3 -> C1
 ```
 
 before justification edges deserve canonical IR representation. Keep the v0 bipartite model until a real replay demonstrates that richer derivation semantics change the justified next action.
-
-CI/executed-run details should be appended after the carrier runs on GitHub.

--- a/research/justification-graph.md
+++ b/research/justification-graph.md
@@ -1,0 +1,112 @@
+# Justification graph research receipt
+
+Tracking: #141.
+
+## Question
+
+When one evidence object becomes invalid or unknown at a new repository/work/revision coordinate, can Cultist identify exactly which conclusions need reconsideration while preserving independent support, counterexamples, limits, and explicit clearing conditions?
+
+## v0 model
+
+The first carrier deliberately uses a typed bipartite graph:
+
+```text
+EvidenceNode
+  -> ClaimNode
+  -> relation: support | counterexample | limit | dependency
+
+EvidenceNode
+  -> ObligationNode
+  -> relation: clearing
+```
+
+Evidence nodes carry the existing `EvidenceRequirements` coordinate contract. Evaluation delegates applicability to the shared evaluator from #123/#124/#130.
+
+This means v0 has no claim-to-claim or obligation-to-claim edges. Cycles are excluded by representation instead of being accepted and then interpreted heuristically.
+
+## Semantics under test
+
+### Independent support
+
+```text
+E1 --support--> C1
+E2 --support--> C1
+```
+
+If `E1` becomes INVALID while `E2` still APPLIES, `C1` remains `supported` and both receipts stay visible.
+
+If the sole support becomes INVALID or UNKNOWN, the claim returns to `unknown`. The graph never turns missing applicable justification into a false claim.
+
+### Dependencies
+
+A dependency is a hard prerequisite in this v0 experiment. Any INVALID or UNKNOWN dependency keeps the claim justification `unknown` even when an ordinary support receipt still applies.
+
+This is intentionally narrower than a general logical justification language. Alternative dependency sets / AND-OR derivations remain future research.
+
+### Counterexamples and limits
+
+Applicable `counterexample` and `limit` edges remain explicit receipts. They do not automatically negate a supported claim or grant a stronger disposition. A downstream JEI/review/projection consumer can decide how those roles affect the current action while preserving the evidence that changes what may be concluded.
+
+### Clearing obligations
+
+An obligation is:
+
+```text
+open
+  no clearing evidence currently applies
+
+unknown
+  candidate clearing evidence has UNKNOWN applicability
+
+cleared
+  at least one clearing evidence object applies
+```
+
+When exact-head clearing evidence later becomes INVALID after revision movement, the obligation reopens.
+
+## Reevaluation receipt
+
+`reevaluate_graph(before_context, after_context)` evaluates evidence applicability at both coordinates and emits only:
+
+```text
+changed evidence applicability
+-> affected claim/obligation targets
+```
+
+An unrelated claim whose evidence coordinate did not change is absent from the affected-target receipt.
+
+This is the first discriminator for a future truth-maintenance engine: invalidate/reconsider downstream conclusions instead of treating the entire packet as one stale blob.
+
+## Adversarial controls in the standard test suite
+
+The carrier includes controls for:
+
+- one invalidated support + one independent support -> claim remains supported;
+- sole invalidated support -> claim becomes unknown;
+- counterexample and limit receipts remain visible;
+- exact-head clearing evidence clears an obligation and head movement reopens it;
+- reevaluation names only targets downstream of changed evidence;
+- UNKNOWN dependency prevents a supported projection;
+- relation/target mismatch rejects rather than inventing cyclic/general graph semantics.
+
+## Boundary
+
+- claim provenance remains separate from justification relation;
+- applicability remains separate from epistemic strength and authority;
+- v0 graph identity is local to the exact research object;
+- no stable semantic lineage is inferred from IDs;
+- no mutation, merge, deployment, or review authority is granted;
+- no model is required;
+- no `AnalysisReport` schema change is proposed by this carrier.
+
+## Next discriminator after this carrier
+
+If the controls hold, the next useful question is whether real Cultist evidence needs **alternative derivation groups** such as:
+
+```text
+(E1 AND E2) OR E3 -> C1
+```
+
+before justification edges deserve canonical IR representation. Keep the v0 bipartite model until a real replay demonstrates that richer derivation semantics change the justified next action.
+
+CI/executed-run details should be appended after the carrier runs on GitHub.

--- a/research/observation-frontiers.md
+++ b/research/observation-frontiers.md
@@ -1,0 +1,134 @@
+# Missing discriminator observation frontiers
+
+Tracking: #190 Phase A. Stacked on #187/#185 and #179/#148.
+
+## Question
+
+When a selected refinement requires discriminator `D` for exact subject `S`, can Cultist state whether a usable source-owned observation currently exists without running the source analyzer or guessing from another subject?
+
+Phase A adds only the read-only frontier.
+
+## Exact requirement identity
+
+```text
+ObservationRequirement
+  discriminator_id
+  subject_ref
+```
+
+A requirement is satisfied only by observations with the exact same pair.
+
+This deliberately prevents a source observation such as:
+
+```text
+edit_class = syntax_changed
+subject = file A
+```
+
+from satisfying the same discriminator for file B.
+
+Observations with the same discriminator and another subject stay visible under `other_subject`; they never satisfy the requested frontier.
+
+## Frontier states
+
+```text
+current
+  >= 1 matching KNOWN observation
+
+unknown
+  zero matching KNOWN
+  >= 1 matching UNKNOWN
+
+invalid
+  zero matching KNOWN/UNKNOWN
+  >= 1 matching INVALID
+
+missing
+  zero matching observations
+```
+
+All matching receipts remain visible even when a higher-precedence state wins. For example:
+
+```text
+KNOWN + UNKNOWN
+  -> current
+  -> preserve both current and unknown receipts
+
+UNKNOWN + INVALID
+  -> unknown
+  -> preserve both unknown and invalid receipts
+```
+
+The precedence represents current usability, not evidence strength:
+
+```text
+current > unknown > invalid > missing
+```
+
+## Composition controls
+
+The first standard-suite control derives exact requirements from the retained #179 selected transitions plus #187 observation corpus. All four selected discriminator requirements resolve `current`.
+
+Then adversarial controls mutate the same supplied observations:
+
+- remove one selected observation -> explicit `missing`;
+- keep the discriminator but move it to another subject -> `missing` + `other_subject` receipt;
+- change matching observation to UNKNOWN -> `unknown`;
+- change matching observation to INVALID -> `invalid`;
+- add UNKNOWN beside KNOWN -> `current`, preserving both;
+- add INVALID beside UNKNOWN -> `unknown`, preserving both;
+- duplicate exact requirements reject;
+- frontier order is deterministic;
+- request JSON round trip revalidates the embedded observation batch;
+- input above 512 KiB rejects before JSON parsing.
+
+## Bounded research reader
+
+```text
+cargo run --example observation_frontiers < request.json
+```
+
+The request embeds the bounded #185 observation batch and a bounded requirement list. The reader validates and prints only frontier receipts.
+
+## Boundary
+
+Phase A performs zero acquisition work:
+
+- no source analyzer execution;
+- no probe capability lookup;
+- no mapping from `discriminator_id` to #145 `{kind,target}`;
+- no evidence-strength or authority inference;
+- no action/disposition decision;
+- no duplicate applicability evaluator.
+
+UNKNOWN/INVALID reason and applicability references remain source-owned strings. The frontier carries them; it does not interpret them.
+
+## Phase B discriminator
+
+After Phase A survives CI, test one explicit source-owned adapter mapping:
+
+```text
+missing observation D@S
+-> adapter receipt
+   observation discriminator D
+   observation subject S
+   #145 probe discriminator {kind,target}
+   clearing requirements
+-> existing #145 planner
+```
+
+Negative control:
+
+```text
+similarly named probe
++ no explicit adapter mapping
+-> frontier remains unresolved for acquisition
+```
+
+Effect authorization remains #145's existing responsibility.
+
+The bridge should be a separate carrier because #190 currently spans two independent research stacks: #179/#187 frontier semantics and #159/#164 probe planning. Proving Phase A first avoids copying #145 types into this read-only layer just to make the stacks meet.
+
+North star:
+
+> Name the exact missing analyzer observation before deciding which evidence work, if any, can produce it.

--- a/research/observation-frontiers.md
+++ b/research/observation-frontiers.md
@@ -90,6 +90,43 @@ cargo run --example observation_frontiers < request.json
 
 The request embeds the bounded #185 observation batch and a bounded requirement list. The reader validates and prints only frontier receipts.
 
+## Executed GitHub receipt
+
+Draft PR #194 was compacted to one semantic commit on #187's exact green receipt head.
+
+Exact semantic head:
+
+```text
+b54ed3213994c96ec818ef36bb9728b0dc1f7eb6
+```
+
+GitHub Actions CI run `32249440070` / run number `1293` completed successfully. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work preflight;
+- full `cargo test`, including current coverage for all four selected #179/#187 requirements, explicit missing after observation removal, wrong-subject isolation, UNKNOWN/INVALID states, mixed-state receipt preservation and precedence, duplicate requirement rejection, deterministic ordering, bounded request parsing, and JSON round trip;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The first CI attempt stopped at rustfmt before Clippy or tests. The exact formatter delta was applied, then the branch was compacted back to the single semantic commit above before the successful run.
+
+The central Phase A result is now executable:
+
+```text
+same discriminator + wrong subject
+  -> other_subject receipt remains visible
+  -> exact required frontier stays missing
+```
+
+and mixed source states preserve their receipts while current usability follows:
+
+```text
+current > unknown > invalid > missing
+```
+
 ## Boundary
 
 Phase A performs zero acquisition work:
@@ -105,7 +142,7 @@ UNKNOWN/INVALID reason and applicability references remain source-owned strings.
 
 ## Phase B discriminator
 
-After Phase A survives CI, test one explicit source-owned adapter mapping:
+Phase A survived CI. The next experiment can test one explicit source-owned adapter mapping:
 
 ```text
 missing observation D@S
@@ -127,7 +164,7 @@ similarly named probe
 
 Effect authorization remains #145's existing responsibility.
 
-The bridge should be a separate carrier because #190 currently spans two independent research stacks: #179/#187 frontier semantics and #159/#164 probe planning. Proving Phase A first avoids copying #145 types into this read-only layer just to make the stacks meet.
+The bridge should be a separate carrier because #190 currently spans two independent research stacks: #179/#187 frontier semantics and #159/#164 probe planning. Phase A now gives that bridge a precise input without copying #145 types into the read-only frontier layer.
 
 North star:
 

--- a/research/observation-probe-bridge.md
+++ b/research/observation-probe-bridge.md
@@ -119,7 +119,28 @@ The reader revalidates the bounded request before planning.
 
 ## Execution receipt
 
-Pending the first GitHub CI run on the combined Phase B carrier.
+The explicit composition base was created by merging green #164 evidence-planner head `3284895e50831811af53d60a9436e0d4ffb3c267` into a branch pinned to #210 v2 frontier head `7b5c4e5add71356e2d58ac234680e26ed0fc8ba9`. The merge commit is `32cef81ac5e57c4d8285cce00fd644265a67e5fd`.
+
+The first Phase B CI attempt stopped only at `cargo fmt --check`; the formatter delta changed line wrapping and module ordering only.
+
+Formatted semantic head:
+
+```text
+959d1712235a4f7c7e1f48e524baeecbcf1df0a3
+```
+
+GitHub Actions CI run `32256195538` / run number `1453` completed successfully. It passed:
+
+- `cargo fmt --check`;
+- strict Clippy;
+- active-work preflight;
+- full `cargo test`, including mapped/unmapped/wrong-subject/current/UNKNOWN/INVALID/missing-context/effect-authority bridge controls;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON and positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+Main advanced independently while this ran, but the intervening five main commits changed only CI/reference-policy tooling and `AGENTS.md`; they did not touch the observation/frontier/planner/bridge files.
 
 North star:
 

--- a/research/observation-probe-bridge.md
+++ b/research/observation-probe-bridge.md
@@ -1,0 +1,126 @@
+# Observation frontier to probe bridge
+
+Tracking: #190 Phase B. Composes the green #210 v2 observation/frontier semantics with the green #164 evidence planner.
+
+## Question
+
+When a selected analyzer refinement needs one current observation `D@S`, and the v2 frontier says that observation is missing, unknown, or invalid, how can Cultist ask the existing #145 planner for bounded evidence work without assuming the observation discriminator vocabulary and probe vocabulary are identical?
+
+## Source-owned mapping
+
+V0 adds one explicit record:
+
+```text
+ObservationProbeBridge
+  bridge_id
+  observation_discriminator_id
+  observation_subject_ref
+  probe_discriminator
+    kind
+    target
+  clearing_requirements
+  source_receipt
+```
+
+The bridge is supplied evidence that one #145 probe discriminator and one exact clearing coordinate are admitted producers for the required observation.
+
+No mapping is inferred from:
+
+- equal or similar strings;
+- the known/old observation value;
+- path ancestry;
+- probe cost;
+- chronology;
+- source-receipt prose.
+
+One exact `D@S` may have at most one admitted v0 bridge. Multiple competing mappings remain a future source-selection question instead of becoming hidden generic ranking.
+
+## Composition
+
+For a noncurrent frontier with one exact bridge, the adapter creates one ordinary `DurableObligation`:
+
+```text
+missing_discriminator = bridge.probe_discriminator
+subject               = bridge.clearing_requirements
+clearing condition     = same discriminator + same requirements
+```
+
+It then calls the existing #164 planner unchanged.
+
+The planner still owns:
+
+- capability matching;
+- exact clearing-condition matching;
+- applicability/current-context checks;
+- conservative cost ordering;
+- read-only / external-read / effectful boundaries;
+- selected / blocked / unresolved / stale outcomes.
+
+The bridge grants zero execution authority.
+
+## V2 currentness boundary
+
+#201 proved the old observation model could represent:
+
+```text
+KNOWN old value
++ INVALID or UNKNOWN applicability
+-> CURRENT frontier
+```
+
+#210 repaired that. This bridge consumes the repaired frontier directly:
+
+```text
+CURRENT
+  -> already_current; no acquisition plan
+
+MISSING / UNKNOWN / INVALID
+  -> exact bridge lookup
+  -> existing evidence planner
+```
+
+A retained old value under an INVALID frontier may justify planning a current-head refresh, but the bridge does not reclassify that old observation. The returned bridge plan preserves the original frontier status until a source actually emits a new current observation.
+
+## Controls
+
+The standard test carrier covers:
+
+1. exact mapped source probe is selected while a cheaper similarly named probe is `incapable`;
+2. similarly named probe with no explicit bridge leaves the frontier `no_admitted_mapping`;
+3. bridge for another subject cannot map the required frontier;
+4. CURRENT frontier produces no acquisition plan;
+5. UNKNOWN value at an applicable coordinate can select deeper evidence work;
+6. INVALID old value can select a current-head refresh while the frontier remains INVALID;
+7. missing current revision stays blocked through the existing planner;
+8. effectful mapped probe remains `effect_authority_required` when authority is absent;
+9. duplicate exact `D@S` mappings reject;
+10. incoherent frontier receipts reject before planning;
+11. request JSON round-trip and a 1 MiB input bound are explicit.
+
+## Reader
+
+```text
+cargo run --example observation_probe_plan < request.json
+```
+
+The reader revalidates the bounded request before planning.
+
+## Boundary
+
+- research only;
+- no source analyzer execution;
+- no implicit `discriminator_id == probe.kind` convention;
+- no conversion from `value_ref` to evidence strength;
+- no generic source relevance score;
+- no effect authorization;
+- no automatic claim that a planned probe cleared the observation;
+- source adapters own the mapping receipt;
+- #145 planner semantics remain unchanged.
+
+## Execution receipt
+
+Pending the first GitHub CI run on the combined Phase B carrier.
+
+North star:
+
+> Turn a noncurrent observation into bounded investigation only when the source explicitly proves which admitted probe can produce the current observation.

--- a/research/refinement-episodes.md
+++ b/research/refinement-episodes.md
@@ -1,0 +1,243 @@
+# Counterexample-guided analyzer refinement episodes
+
+Tracking: #148. Built after #141/#144, #142/#168, project-memory contract refinement #174, and the behavioral episode work in #137/#175/#178.
+
+## Question
+
+Can Cultist preserve analyzer-research transitions as bounded, replayable records while leaving domain facts and predicates with the analyzers that produced them?
+
+V0 answers only the bookkeeping layer.
+
+## Episode contract
+
+```text
+RefinementEpisode
+  id
+  family
+  hypothesis_before
+  counterexample_refs[]
+  admitted_discriminators[]
+  candidate_refinements[]
+  selected_transition?
+  source_receipts[]
+  behavioral_episode_ids[]
+```
+
+Each candidate carries:
+
+```text
+hypothesis_after
+admitted discriminator refs
+source replay receipts
+replay_result
+  expected_cases_retained
+  counterexamples_resolved
+  expected_cases_lost
+  counterexamples_remaining
+  held_out_status
+status
+  retained
+  weakened
+  split
+  rejected_no_improvement
+  rejected_overfit
+  rejected_lost_expected_case
+```
+
+The replay counts are supplied by exact source receipts. This layer does zero Rust edit classification, obligation applicability, historical co-change analysis, project-memory relation parsing, or domain predicate evaluation.
+
+## Meta-level invariants
+
+The validator checks only properties the refinement ledger itself owns:
+
+- episode, candidate, discriminator, and reference identities are bounded and unique where required;
+- every candidate discriminator reference names one discriminator admitted by the episode;
+- a selected transition names an existing `retained`, `weakened`, or `split` candidate;
+- kept candidates retain every expected replay case, resolve at least one counterexample, and cannot carry a failed held-out result;
+- `rejected_no_improvement` resolves zero counterexamples and loses zero expected cases;
+- `rejected_lost_expected_case` records at least one lost expected case;
+- rejected-overfit status stays a supplied source conclusion because overfit criteria belong to the source experiment;
+- behavioral episode IDs remain optional explicit links to already-observed #165 episodes.
+
+The last point composes with #175: a research transition can link to observed receiver episodes and descriptive summaries while deterministic replay remains independently inspectable.
+
+## Retained episode A: justification / open obligation
+
+The first episode records the refinement discovered by stacking #144 on #141.
+
+```text
+H0
+  every obligation requires >= 1 observed clearing edge
+
+counterexample
+  a durable material UNKNOWN can exist before clearing evidence arrives
+
+selected transition
+  allow zero-edge OPEN obligations
+  keep typed clearing receipts when evidence later arrives
+```
+
+Source receipts point at the #156/#159 research heads and CI. The meta replay records expected cases retained, the counterexample resolved, and zero expected cases lost.
+
+No behavioral episode is attached because this was a deterministic semantic refinement rather than an observed receiver episode.
+
+## Retained episode B: Oxc edit-class cohort
+
+The second episode records the already-executed Oxc result:
+
+```text
+raw forward cohort
+  99 support / 1 counterexample
+
+edit_class = syntax_changed
+  99 support / 0 counterexamples
+```
+
+The selected `edit_class` refinement is `weakened` because it narrows the original file-change hypothesis.
+
+Two rejected candidates remain beside it:
+
+```text
+reverse edit-class control
+  94 support / 6 counterexamples
+  -> rejected_no_improvement
+
+exact commit identity partition
+  one-current-observation cohort
+  -> rejected_overfit
+```
+
+The source receipts preserve the full Rust syntax cohort replay, #168's generic refinement evaluator, its green CI run, and the earlier held-out generated-companion product proof.
+
+## Retained episode C: project-memory Primary case contract
+
+The third episode came from a real producer/consumer collision between merged #166 and #167.
+
+```text
+H0
+  current project-memory relation admission composes with collector evidence
+
+#166 consumer
+  strict single-line relation admission + exact target mention
+
+#167 producer
+  Primary case:\nURL issue evidence block
+
+counterexample
+  both landed with zero path overlap
+  current-main packet no longer passed the consumer contract
+```
+
+#174 split the admission rule instead of weakening every relation edge:
+
+```text
+ordinary relationship prose
+  -> existing strict single-line classifier
+
+exact Primary case block
+  -> separate validated path
+     exact label
+     admitted GitHub origin
+     packet repository match
+     canonical positive issue number
+     relation = related
+     declared target match
+```
+
+The source replay admits the two intended Primary case forms, resolves the integration counterexample, loses zero expected cases, and passed #174 CI/provenance on head `e1196c553ab496df13a230535de997f30c2d63ca`.
+
+This episode also carries the real #178 behavioral episode:
+
+```text
+project-memory:primary-case-contract-collision:9792bfe->df5ae59
+```
+
+The standard refinement test resolves that ID against the retained #165 behavioral batch and requires its observed outcome to be `changed_next_action`.
+
+## Why rejected candidates stay in the object
+
+Keeping only the winner would erase the research path. The durable episode instead records:
+
+```text
+what broad claim existed
+which counterexample challenged it
+which discriminators were admitted
+which candidate survived
+which tempting candidates failed
+which exact receipts justify those statuses
+```
+
+That gives a future worker enough information to resume the research question without reconstructing the discarded alternatives from prose or chronology.
+
+## Behavioral boundary
+
+`behavioral_episode_ids[]` is an explicit optional join to merged #165 observation identity.
+
+Episodes A and B stay empty because no observed worker episode has been collected for those exact research transitions. Episode C links one already-retained #178 observation and verifies that the ID exists in the behavioral corpus.
+
+A deterministic replay result never manufactures a behavioral receipt. Behavioral identity and deterministic refinement identity remain separate records joined by explicit ID only when an observation exists.
+
+## Research reader
+
+```text
+cargo run --example refinement_episodes \
+  < research/refinement-episodes/cultist-v1.json
+```
+
+The reader validates the bounded batch and reprints the typed records.
+
+## Initial executed GitHub receipt
+
+The first two-family version of draft PR #179 passed on exact head:
+
+```text
+f4d92b05e061a99e262a1ef1eb2f2be424686359
+```
+
+GitHub Actions CI run `32247329835` / run number `1222` completed successfully, including format, strict Clippy, active-work preflight, full tests, repository/history/CI-filter/diff dogfood. Generated provenance review run `32247329697` / run number `219` also passed.
+
+The first CI attempt failed only at rustfmt before Clippy or tests. The formatter delta was applied verbatim, and the standalone reader received fixture-local dead-code containment.
+
+The three-family extension is rebuilt directly on main after merged #178 so the behavioral join is tested against the current retained observation corpus. Record its exact execution separately after the new head runs.
+
+## Boundary
+
+- research-only ledger;
+- no analyzer predicate language;
+- no automatic discriminator enumeration;
+- no scalar research score;
+- no automatic promotion/demotion;
+- no chronology-derived causality;
+- no fabricated behavioral evidence;
+- exact source receipts remain the authority for domain replay claims.
+
+## Next discriminator
+
+Three independent families now fit the ledger, but they expose different fact-production mechanisms:
+
+```text
+justification
+  typed clearing-evidence presence
+
+historical companion
+  supplied Rust edit class
+
+project memory
+  exact evidence-form + target/repository contract
+```
+
+That diversity argues for one more restraint: episode count alone does not earn automatic candidate enumeration. The next useful question is whether these source analyzers can expose a common **discriminator reference interface** without moving their domain logic into #148.
+
+A small future experiment can ask each source family for only:
+
+```text
+discriminator id
+source receipt
+current supplied value / applicability
+```
+
+and then test whether the refinement ledger can enumerate candidates over those references while still delegating semantics to the source evaluator. If the adapters need family-specific execution logic, keep enumeration outside the meta-layer.
+
+North star:
+
+> Preserve every analyzer refinement as an inspectable transition from broad hypothesis through counterexample and replay, including the rejected alternatives that explain why the surviving rule earned its narrower claim.

--- a/research/refinement-episodes.md
+++ b/research/refinement-episodes.md
@@ -186,7 +186,7 @@ cargo run --example refinement_episodes \
 
 The reader validates the bounded batch and reprints the typed records.
 
-## Initial executed GitHub receipt
+## Executed GitHub receipts
 
 The first two-family version of draft PR #179 passed on exact head:
 
@@ -194,11 +194,28 @@ The first two-family version of draft PR #179 passed on exact head:
 f4d92b05e061a99e262a1ef1eb2f2be424686359
 ```
 
-GitHub Actions CI run `32247329835` / run number `1222` completed successfully, including format, strict Clippy, active-work preflight, full tests, repository/history/CI-filter/diff dogfood. Generated provenance review run `32247329697` / run number `219` also passed.
+CI run `32247329835` / run number `1222` and generated provenance review run `32247329697` / run number `219` completed successfully. The first CI attempt had failed only at rustfmt before Clippy or tests; the formatter delta was applied verbatim and the standalone reader received fixture-local dead-code containment.
 
-The first CI attempt failed only at rustfmt before Clippy or tests. The formatter delta was applied verbatim, and the standalone reader received fixture-local dead-code containment.
+The three-family carrier was then rebuilt as one commit on merged #178 main so its behavioral join resolves against the current retained observation corpus.
 
-The three-family extension is rebuilt directly on main after merged #178 so the behavioral join is tested against the current retained observation corpus. Record its exact execution separately after the new head runs.
+Exact three-family semantic head:
+
+```text
+dbb39fb729df762ffefcf97d024e52fd647832cf
+```
+
+GitHub Actions CI run `32247721374` / run number `1235` completed successfully. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work preflight;
+- full `cargo test`, including the three retained refinement episodes, rejected-candidate controls, and the cross-corpus #178 behavioral ID/outcome assertion;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+Generated provenance review dogfood run `32247721348` / run number `223` also completed successfully on the same three-family head.
 
 ## Boundary
 

--- a/research/refinement-episodes/cultist-v1.json
+++ b/research/refinement-episodes/cultist-v1.json
@@ -1,0 +1,209 @@
+{
+  "schema_version": 1,
+  "episodes": [
+    {
+      "id": "justification/open-obligation-v1",
+      "family": "justification",
+      "hypothesis_before": {
+        "id": "requires-clearing-edge",
+        "statement": "Every obligation node requires at least one observed clearing edge."
+      },
+      "counterexample_refs": [
+        "github:issue/144#open-before-clearing-evidence"
+      ],
+      "admitted_discriminators": [
+        {
+          "id": "clearing_evidence_presence",
+          "source_ref": "github:pull/159@1c1a0086a199168fd0e21445d103936183063dc7"
+        }
+      ],
+      "candidate_refinements": [
+        {
+          "id": "allow-open-zero-edge",
+          "hypothesis_after": {
+            "id": "observed-clearing-edge-is-optional",
+            "statement": "An obligation may remain open before clearing evidence arrives; observed clearing edges remain typed receipts when present."
+          },
+          "discriminator_refs": [
+            "clearing_evidence_presence"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 7,
+            "counterexamples_resolved": 1,
+            "expected_cases_lost": 0,
+            "counterexamples_remaining": 0,
+            "held_out_status": "not_run"
+          },
+          "status": "weakened",
+          "source_receipts": [
+            "github:pull/156@9beaeaab2bece20a4e0bb9c880f510f740bf8cfb",
+            "github:pull/159@1c1a0086a199168fd0e21445d103936183063dc7",
+            "github-actions:run/32243719268"
+          ]
+        }
+      ],
+      "selected_transition": "allow-open-zero-edge",
+      "source_receipts": [
+        "research:justification-graph.md",
+        "research:durable-unknown-obligation.md"
+      ],
+      "behavioral_episode_ids": []
+    },
+    {
+      "id": "history/oxc-edit-class-v1",
+      "family": "historical_companion",
+      "hypothesis_before": {
+        "id": "raw-source-change-cohort",
+        "statement": "Every source-file change belongs to one historical companion cohort for evaluating the generated-file expectation."
+      },
+      "counterexample_refs": [
+        "oxc:5e113baf716b9f3781331b268b4142d23cac0541#docs-license-notices"
+      ],
+      "admitted_discriminators": [
+        {
+          "id": "edit_class",
+          "source_ref": "research:rust-syntax-cohort-replay.md"
+        },
+        {
+          "id": "commit_identity",
+          "source_ref": "github:pull/168@b8c6457de8d05a38a662289962fc11a124d32861"
+        }
+      ],
+      "candidate_refinements": [
+        {
+          "id": "syntax-changing-current-cohort",
+          "hypothesis_after": {
+            "id": "syntax-changing-source-cohort",
+            "statement": "Evaluate the forward generated-companion expectation inside the supplied Rust syntax-changing edit cohort."
+          },
+          "discriminator_refs": [
+            "edit_class"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 99,
+            "counterexamples_resolved": 1,
+            "expected_cases_lost": 0,
+            "counterexamples_remaining": 0,
+            "held_out_status": "passed"
+          },
+          "status": "weakened",
+          "source_receipts": [
+            "research:rust-syntax-cohort-replay.md",
+            "github:pull/168@b8c6457de8d05a38a662289962fc11a124d32861",
+            "github-actions:run/32245110401",
+            "github:pull/72"
+          ]
+        },
+        {
+          "id": "reverse-edit-class-control",
+          "hypothesis_after": {
+            "id": "reverse-syntax-cohort-improves",
+            "statement": "Applying the same edit-class discriminator to generated-to-source history should remove reverse-direction counterexamples."
+          },
+          "discriminator_refs": [
+            "edit_class"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 94,
+            "counterexamples_resolved": 0,
+            "expected_cases_lost": 0,
+            "counterexamples_remaining": 6,
+            "held_out_status": "passed"
+          },
+          "status": "rejected_no_improvement",
+          "source_receipts": [
+            "research:rust-syntax-cohort-replay.md",
+            "github:pull/168@b8c6457de8d05a38a662289962fc11a124d32861"
+          ]
+        },
+        {
+          "id": "singleton-commit-partition",
+          "hypothesis_after": {
+            "id": "exact-commit-is-cohort",
+            "statement": "Use exact commit identity as the discriminator so the current observation defines its own cohort."
+          },
+          "discriminator_refs": [
+            "commit_identity"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 1,
+            "counterexamples_resolved": 1,
+            "expected_cases_lost": 98,
+            "counterexamples_remaining": 0,
+            "held_out_status": "not_run"
+          },
+          "status": "rejected_overfit",
+          "source_receipts": [
+            "github:pull/168@b8c6457de8d05a38a662289962fc11a124d32861"
+          ]
+        }
+      ],
+      "selected_transition": "syntax-changing-current-cohort",
+      "source_receipts": [
+        "research:history-companion-replay.md",
+        "research:rust-syntax-cohort-replay.md",
+        "research:cohort-refinement.md"
+      ],
+      "behavioral_episode_ids": []
+    },
+    {
+      "id": "project-memory/primary-case-contract-collision-v1",
+      "family": "project_memory",
+      "hypothesis_before": {
+        "id": "single-line-admission-covers-collector-evidence",
+        "statement": "The existing project-memory relation admission contract composes with every explicit relationship evidence form emitted by current collectors."
+      },
+      "counterexample_refs": [
+        "github:issue/172#primary-case-multiline-contract-collision"
+      ],
+      "admitted_discriminators": [
+        {
+          "id": "primary_case_evidence_form",
+          "source_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca"
+        },
+        {
+          "id": "same_repository_issue_target",
+          "source_ref": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca"
+        }
+      ],
+      "candidate_refinements": [
+        {
+          "id": "split-primary-case-admission",
+          "hypothesis_after": {
+            "id": "typed-primary-case-admission",
+            "statement": "Keep ordinary relation evidence on the strict single-line grammar and admit only the exact same-repository Primary case issue block through a separate validated path."
+          },
+          "discriminator_refs": [
+            "primary_case_evidence_form",
+            "same_repository_issue_target"
+          ],
+          "replay_result": {
+            "expected_cases_retained": 2,
+            "counterexamples_resolved": 1,
+            "expected_cases_lost": 0,
+            "counterexamples_remaining": 0,
+            "held_out_status": "passed"
+          },
+          "status": "split",
+          "source_receipts": [
+            "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca",
+            "github-actions:run/32246042100",
+            "github-actions:run/32246042091"
+          ]
+        }
+      ],
+      "selected_transition": "split-primary-case-admission",
+      "source_receipts": [
+        "github:pull/166",
+        "github:pull/167",
+        "github:issue/172",
+        "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca",
+        "github:pull/178@22fa1d9405737ae6868d9b1f6643b4107c6f058a",
+        "research:behavioral-receipts/project-memory-primary-case-collision-174.json"
+      ],
+      "behavioral_episode_ids": [
+        "project-memory:primary-case-contract-collision:9792bfe->df5ae59"
+      ]
+    }
+  ]
+}

--- a/research/refinement-observation-requirements.md
+++ b/research/refinement-observation-requirements.md
@@ -1,0 +1,189 @@
+# Exact refinement observation requirements
+
+Tracking: #227. Builds on #179, #185, #210, #221, and the green wrong-subject control in #228.
+
+## Trigger
+
+#228 proved an executable mismatch between two already-earned semantics.
+
+The Oxc selected refinement says only:
+
+```text
+discriminator_refs = ["edit_class"]
+```
+
+When its exact current observation is replaced by a KNOWN+APPLIES `edit_class` for another subject, the existing #187-style ID-only coverage still says the selected candidate has current `edit_class` evidence.
+
+The exact #210 frontier for the earned Oxc subject simultaneously says:
+
+```text
+MISSING
+other_subject = [wrong edit_class observation]
+```
+
+The refinement candidate therefore needs an explicit way to say which source observation requirement applies to this candidate/application.
+
+## Why the subject stays outside the discriminator definition
+
+The Oxc `edit_class` discriminator is a reusable classifier, not a fact with one intrinsic subject. The same discriminator appears in both the selected forward cohort candidate and the rejected reverse control, and the #54 source producer classifies many different commits.
+
+Adding one subject directly to the admitted discriminator would conflate:
+
+```text
+what classifier/refinement dimension exists
+```
+
+with:
+
+```text
+which exact observation subject this candidate currently needs
+```
+
+V0 keeps those separate.
+
+## Source-owned mapping
+
+`src/refinement_observation_requirement.rs` adds one bounded receipt:
+
+```text
+RefinementObservationRequirementMapping
+  id
+  episode_id
+  candidate_id
+  discriminator_id
+  subject_ref
+  source_receipt
+```
+
+The tuple:
+
+```text
+(episode_id, candidate_id, discriminator_id)
+```
+
+may have at most one v0 subject mapping. The source receipt owns the claim that this exact candidate/discriminator needs this exact observation subject.
+
+The mapping must reference:
+
+- an existing refinement episode;
+- an existing candidate in that episode;
+- a discriminator actually named by that candidate.
+
+No subject is inferred from the current observation corpus.
+
+## Selected requirement compilation
+
+For each episode with a selected transition, the evaluator resolves the selected candidate's discriminator refs through the source-owned mappings and emits ordinary #210:
+
+```text
+ObservationRequirement
+  discriminator_id
+  subject_ref
+```
+
+It also preserves the exact mapping receipts used.
+
+Missing mapping stays explicit:
+
+```text
+missing_discriminator_refs[]
+```
+
+An empty mapping set therefore produces zero resolved requirements and exposes every selected discriminator ref as missing mapping evidence. The evaluator never searches the observation corpus for a convenient current subject.
+
+## Retained three-family mappings
+
+The first corpus covers every selected #179 candidate.
+
+### Justification
+
+```text
+justification/open-obligation-v1
+allow-open-zero-edge
+clearing_evidence_presence
+-> refinement:justification/open-obligation-v1
+```
+
+### Oxc
+
+```text
+history/oxc-edit-class-v1
+syntax-changing-current-cohort
+edit_class
+-> oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs
+```
+
+This is the exact focused source observation earned by #221.
+
+### Project memory
+
+```text
+project-memory/primary-case-contract-collision-v1
+split-primary-case-admission
+primary_case_evidence_form
+same_repository_issue_target
+-> refinement:project-memory/primary-case-contract-collision-v1
+```
+
+The two discriminator requirements share the same episode-local subject while remaining separate exact requirements.
+
+## Controls
+
+The standard test carrier requires:
+
+1. all three selected candidates compile with zero missing mappings;
+2. every compiled requirement is CURRENT in the retained v2 observation corpus;
+3. wrong-subject Oxc `edit_class` leaves the compiled exact requirement MISSING;
+4. removing the Oxc mapping exposes `edit_class` under `missing_discriminator_refs` even when observations exist elsewhere;
+5. a mapping for a discriminator absent from the candidate rejects;
+6. multiple subject mappings for one exact episode/candidate/discriminator reject;
+7. the same reusable discriminator may have a different mapping for another candidate without changing the selected candidate mapping;
+8. request round-trip and a 512 KiB input bound are explicit;
+9. an empty mapping batch is valid and exposes every selected requirement as unresolved mapping evidence.
+
+## Reader
+
+```text
+cargo run --example refinement_observation_requirements < request.json
+```
+
+The request carries the validated refinement episode batch plus the source-owned mapping batch. The reader revalidates both before compiling selected exact requirements.
+
+## Boundary
+
+- research only;
+- #179 replay ledger schema remains unchanged;
+- mapping subject identity grants no observation value, evidence strength, or authority;
+- #210 frontier currentness remains unchanged;
+- #216 probe mapping remains a later acquisition step after an exact observation requirement exists;
+- no implicit first/current observation selection;
+- no automatic refinement promotion.
+
+## Execution receipt
+
+The first CI attempt stopped at `cargo fmt --check`; the formatter delta changed wrapping/order only. The next run reached Clippy and exposed a standalone-reader dependency: `observation_frontier.rs` imports `discriminator_observation`, so the research example needed that sibling module in its crate root. Adding that import changed no mapping semantics.
+
+Formatted semantic head:
+
+```text
+95f614c079de09358f1865bab34399235a512844
+```
+
+GitHub Actions CI run `32259965516` / run number `1597` completed successfully. It passed:
+
+- `cargo fmt --check`;
+- strict Clippy;
+- active-work preflight;
+- full tests, including all three retained selected-family requirement mappings;
+- exact retained D@S requirements CURRENT;
+- wrong-subject Oxc edit class MISSING with `other_subject` receipt;
+- missing mapping explicit despite other current observations;
+- duplicate/invalid mapping controls;
+- deterministic round-trip and input bound;
+- repository/history/CI-filter/diff dogfood.
+
+The result preserves the chosen boundary: refinement candidates keep reusable discriminator IDs, while source-owned candidate/application receipts bind those IDs to exact observation subjects before currentness or acquisition is evaluated.
+
+North star:
+
+> Let the refinement ledger say which discriminator a candidate uses, and let explicit source evidence say which exact observation subject this candidate currently requires.

--- a/research/refinement-observation-requirements/cultist-v1.json
+++ b/research/refinement-observation-requirements/cultist-v1.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "mappings": [
+    {
+      "id": "justification/open-obligation-v1:allow-open-zero-edge:clearing-evidence-presence",
+      "episode_id": "justification/open-obligation-v1",
+      "candidate_id": "allow-open-zero-edge",
+      "discriminator_id": "clearing_evidence_presence",
+      "subject_ref": "refinement:justification/open-obligation-v1",
+      "source_receipt": "github:pull/159@1c1a0086a199168fd0e21445d103936183063dc7"
+    },
+    {
+      "id": "history/oxc-edit-class-v1:syntax-changing-current-cohort:edit-class",
+      "episode_id": "history/oxc-edit-class-v1",
+      "candidate_id": "syntax-changing-current-cohort",
+      "discriminator_id": "edit_class",
+      "subject_ref": "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs",
+      "source_receipt": "github-actions:run/32257998359#focused-oxc-edit-class"
+    },
+    {
+      "id": "project-memory/primary-case-contract-collision-v1:split-primary-case-admission:evidence-form",
+      "episode_id": "project-memory/primary-case-contract-collision-v1",
+      "candidate_id": "split-primary-case-admission",
+      "discriminator_id": "primary_case_evidence_form",
+      "subject_ref": "refinement:project-memory/primary-case-contract-collision-v1",
+      "source_receipt": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca"
+    },
+    {
+      "id": "project-memory/primary-case-contract-collision-v1:split-primary-case-admission:target-relation",
+      "episode_id": "project-memory/primary-case-contract-collision-v1",
+      "candidate_id": "split-primary-case-admission",
+      "discriminator_id": "same_repository_issue_target",
+      "subject_ref": "refinement:project-memory/primary-case-contract-collision-v1",
+      "source_receipt": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca"
+    }
+  ]
+}

--- a/research/rust-edit-class-observation-loop.md
+++ b/research/rust-edit-class-observation-loop.md
@@ -1,0 +1,269 @@
+# Rust edit-class observation acquisition loop
+
+Tracking: #220, building on #54, #185, #210, and #216.
+
+## Question
+
+Can one retained analyzer family complete the full deterministic loop:
+
+```text
+noncurrent source discriminator
+-> explicit source bridge
+-> existing evidence planner
+-> source probe execution
+-> v2 current observation
+-> current frontier
+```
+
+without copying source semantics into the generic bridge or planner?
+
+The first carrier uses the Oxc `edit_class` discriminator because #54 already earned a deterministic producer: select a focused non-merge commit that changes one Rust anchor, compare that anchor with its first parent, tokenize both versions with `proc_macro2`, recursively remove doc attributes, and classify whether lexical Rust syntax changed.
+
+## Reuse boundary
+
+`examples/rust_syntax_cohort.rs` remains the owning classifier. This carrier changes only visibility of:
+
+```text
+RustEditClass
+classify_rust_edit(...)
+```
+
+so the source adapter can call that exact implementation. The token/fingerprint/classification logic is unchanged.
+
+## Focused-commit admission
+
+The first public carrier exposed an important precondition that had been implicit in #54.
+
+#54 never called the classifier on arbitrary repository heads. It first selected commits from:
+
+```text
+git log --no-merges -- anchor.rs
+```
+
+then classified each selected commit against its first parent.
+
+Calling the raw token comparator at pinned Oxc repository head:
+
+```text
+8783524015b1e6ff1c39ccf426df0bb07cbbc588
+```
+
+produced equal `rules.rs` token streams because that repository commit does not change `crates/oxc_linter/src/rules.rs`. Without an explicit focus check, unchanged-anchor equality was indistinguishable from a comment/docs/whitespace-only edit.
+
+The source adapter now admits a value only when:
+
+```text
+revision has exactly one parent
++ exact anchor path changed in that revision
+```
+
+Otherwise it emits value UNKNOWN with one of:
+
+```text
+rust-edit-class:not-single-parent:...
+rust-edit-class:anchor-unchanged:...
+```
+
+This keeps repository/head applicability separate from whether an `edit_class` observation exists for the anchor at that commit.
+
+## Source contract
+
+`src/rust_edit_class_source.rs` owns one source-specific record:
+
+```text
+RustEditClassSubject
+  repository
+  exact 40-hex revision
+  normalized repository-relative .rs path
+```
+
+Collection emits:
+
+```text
+RustEditClassSourceResult
+  subject
+  current_head
+  bridge
+  probe
+  observation
+```
+
+### Bridge
+
+The adapter explicitly maps:
+
+```text
+edit_class @ repository@revision:path
+-> probe kind rust_edit_class
+-> target same exact subject ref
+-> repository + revision + exact-path clearing requirements
+```
+
+The bridge carries a source receipt. No generic string equality convention is introduced.
+
+### Probe
+
+The admitted probe is read-only and forecasts the source work performed by the focused first-parent classifier:
+
+```text
+git subprocesses: 5
+Rust files parsed: 2
+remote requests: 0
+effectful executions: 0
+```
+
+The existing #145 planner remains responsible for capability, clearing-coordinate applicability, cost, and effect authority.
+
+### Observation
+
+For an admitted focused commit, the adapter maps only the existing classifier result:
+
+```text
+SyntaxChanged
+  -> KNOWN syntax_changed
+
+CommentsOrWhitespaceOnly
+  -> KNOWN comments_or_docs_only
+
+Unclassified
+  -> UNKNOWN with exact source reason receipt
+```
+
+A root/merge/unrelated-anchor revision stays UNKNOWN before this mapping.
+
+Current applicability is evaluated through the shared #123 evaluator against:
+
+```text
+required
+  repository
+  exact revision
+  exact file path
+
+current
+  repository label
+  git rev-parse HEAD
+  exact file path
+```
+
+A moved checkout can therefore preserve an old known edit class while applicability becomes INVALID. It cannot claim the old classification is current.
+
+Every emitted observation is revalidated through the v2 #210/#185 observation batch contract before return.
+
+## Local deterministic controls
+
+`tests/rust_edit_class_source.rs` creates temporary local Git repositories and exercises the actual retained classifier:
+
+1. lexical Rust code change -> KNOWN `syntax_changed` + APPLIES;
+2. comment-only change -> KNOWN `comments_or_docs_only` + APPLIES;
+3. root commit with no single parent -> value UNKNOWN + APPLIES;
+4. unrelated repository commit that leaves the anchor unchanged -> value UNKNOWN `anchor-unchanged` + APPLIES;
+5. previously known syntax edit after HEAD advances -> KNOWN old value + INVALID;
+6. exact source bridge/probe is planned by #216/#145;
+7. inserting the produced observation changes the exact v2 frontier from MISSING to CURRENT;
+8. emitted observation round-trips through v2 validation;
+9. traversing/non-Rust paths and non-exact revisions fail closed.
+
+## Retained public Oxc carrier
+
+The workflow pins the historical repository window at:
+
+```text
+oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588
+anchor: crates/oxc_linter/src/rules.rs
+```
+
+It keeps that repository head as the negative control:
+
+```text
+8783524...
+anchor unchanged
+-> value UNKNOWN / anchor-unchanged
+-> applicability APPLIES to the exact repo/head/path coordinate
+```
+
+Within that pinned history, the workflow resolves the latest actual focused anchor commit through the same admission species as #54:
+
+```text
+228e8e0f85c0e7aeded02c5e27fd810004d3b41a
+fix(linter): resolve inactive React compiler rules (#25830)
+```
+
+The workflow then executes three independent readers in sequence on that exact focused commit:
+
+```text
+rust_edit_class_observation
+  -> source bridge + probe + KNOWN syntax_changed observation
+
+observation_probe_plan
+  -> MISSING frontier + exact source bridge
+  -> selected read-only probe
+
+observation_frontiers
+  -> produced observation
+  -> CURRENT edit_class frontier
+```
+
+The resulting source subject is:
+
+```text
+oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs
+```
+
+This corrects the inherited #185 retained observation coordinate. The pinned repository head remains the historical cohort window and explicit unchanged-anchor negative control; the actual `edit_class=syntax_changed` observation belongs to the focused file-touching commit.
+
+## Boundary
+
+- research only;
+- Rust lexical syntax class is not behavioral equivalence;
+- edit class does not prove generator ownership or regeneration intent;
+- source observation values grant no evidence strength or action authority;
+- the generic #216 bridge/planner/frontier remain unchanged;
+- source execution produces evidence, not a claim that any higher-level refinement should be promoted;
+- the public carrier preserves both exact repository-window and exact focused-commit coordinates.
+
+## Execution receipt
+
+The first public carrier run `32257281636` / run number `1` compiled all readers, collected a source result, selected the bridge probe, and fed the result to a CURRENT frontier. Its final assertion failed because arbitrary pinned repository head `8783524...` emitted `comments_or_docs_only`; inspection showed the anchor did not change in that commit. This failure produced the focused-commit admission repair above.
+
+After adding explicit single-parent + anchor-changed admission, public carrier run:
+
+```text
+GitHub Actions run: 32257998359
+workflow run number: 7
+result: success
+```
+
+proved both controls:
+
+```text
+pinned repository head 8783524...
+  -> UNKNOWN anchor-unchanged
+
+focused rules.rs commit 228e8e0f85c0...
+  -> KNOWN syntax_changed
+  -> applicability APPLIES
+  -> exact read-only probe selected
+  -> final frontier CURRENT
+```
+
+The emitted focused observation, bridge, selected probe, and final frontier all use the exact `228e8e0f...:rules.rs` subject coordinate.
+
+After correcting the inherited #185 observation corpus and recording the receipt, the branch's current semantic state passed:
+
+```text
+ordinary CI
+  run: 32258258665
+  run number: 1533
+  result: success
+
+public Oxc carrier
+  run: 32258258680
+  run number: 9
+  result: success
+```
+
+Ordinary CI passed format, strict Clippy, active-work preflight, the full local Git/source/bridge/frontier suite, and repository/history/CI-filter/diff dogfood. The public carrier again reproduced the pinned-head UNKNOWN control and focused-commit `syntax_changed -> selected probe -> CURRENT frontier` loop.
+
+North star:
+
+> Let one real source discriminator complete the investigation loop while every handoff remains typed, exact-coordinate, and replayable.

--- a/research/typed-observation-applicability.md
+++ b/research/typed-observation-applicability.md
@@ -1,0 +1,122 @@
+# Typed discriminator applicability repair
+
+Tracking: #195. Stacked on the green #201 negative control over #194/#187.
+
+## Counterexample that earned the repair
+
+#201 composes the real shared applicability evaluator with the v1 discriminator observation and observation frontier types.
+
+It proves both of these states were admitted:
+
+```text
+value_state = KNOWN(syntax_changed)
+shared applicability = INVALID after exact-head movement
+frontier = CURRENT
+```
+
+and:
+
+```text
+value_state = KNOWN(syntax_changed)
+shared applicability = UNKNOWN because current revision is missing
+frontier = CURRENT
+```
+
+#201 head `1614cc2ae82df50ec3c8b5c4a9e428ad01c1d50f` passed CI run `32250242114` / #1341, so the ambiguity was executable.
+
+The cause is precise: v1 carries only an opaque `applicability_ref`, while generic currentness is decided entirely from `value_state=KNOWN`.
+
+## Disposition: separate axes
+
+The repair chooses #195 Model B.
+
+V2 discriminator observations carry two independent supplied facts:
+
+```text
+value_state
+  known { value_ref }
+  unknown { reason_ref }
+
+applicability
+  status = applies | unknown | invalid
+  receipt_ref
+```
+
+`INVALID` leaves the value-knowledge axis. Stale/coordinate invalidity belongs to applicability.
+
+The generic module still performs no Git/repository/source-domain applicability evaluation. A source adapter supplies the typed applicability state plus the exact receipt that earned it.
+
+## Shared combination rule
+
+One source-owned helper combines the two axes for both generic consumers:
+
+```text
+applicability INVALID
+  -> INVALID
+  preserve known old value when present
+
+applicability UNKNOWN
+  -> UNKNOWN
+  preserve known old value when present
+
+applicability APPLIES + value UNKNOWN
+  -> UNKNOWN
+
+applicability APPLIES + value KNOWN
+  -> CURRENT
+```
+
+Both discriminator partition enumeration and observation frontier evaluation call this same classifier. The rule therefore cannot drift between #187 and #194.
+
+## Wire/version change
+
+Because the v1 observation meaning allowed KNOWN to outrun applicability, this is an incompatible research wire change:
+
+```text
+DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION: 1 -> 2
+OBSERVATION_FRONTIER_SCHEMA_VERSION:        1 -> 2
+```
+
+The retained three-family observation corpus is rewritten to v2 and gives every current observation an explicit `applicability.status = applies` plus its source receipt.
+
+## Adversarial controls
+
+The repaired standard harness requires:
+
+- retained selected #179 discriminators are current only through `KNOWN + APPLIES`;
+- value UNKNOWN with APPLIES remains unknown;
+- known value + applicability UNKNOWN remains unknown and preserves the known value;
+- known value + applicability INVALID remains invalid and preserves the known value;
+- missing applicability receipt rejects;
+- duplicate/conflicting observation identity controls remain intact;
+- equal values from different source receipts remain distinct observations;
+- opaque value spelling still grants zero authority/disposition;
+- #194 wrong-subject isolation and mixed-state precedence remain intact;
+- the exact #201 moved-head and missing-current-revision cases now produce INVALID/UNKNOWN frontiers instead of CURRENT.
+
+## Phase B consequence
+
+#190 probe planning must consume the repaired frontier semantics.
+
+A historical known value can remain useful as a receipt while current acquisition still proceeds:
+
+```text
+KNOWN old value
++ applicability INVALID
+-> frontier INVALID
+-> source adapter may propose current evidence acquisition
+```
+
+The known value is preserved in the noncurrent receipt; it simply cannot suppress current work.
+
+## Boundary
+
+- source adapters supply applicability state; generic modules do not execute the shared evaluator;
+- applicability receipt strings remain opaque references after the typed state is supplied;
+- no implicit mapping to #145 probe capability;
+- no evidence strength, authority, or disposition is inferred from either axis;
+- v1 receipts remain retained as the historical counterexample/earlier experiment.
+
+North star:
+
+> Preserve what was learned from stale evidence while making current usability an explicit typed fact that stale knowledge cannot silently override.

--- a/research/typed-observation-applicability.md
+++ b/research/typed-observation-applicability.md
@@ -94,6 +94,45 @@ The repaired standard harness requires:
 - #194 wrong-subject isolation and mixed-state precedence remain intact;
 - the exact #201 moved-head and missing-current-revision cases now produce INVALID/UNKNOWN frontiers instead of CURRENT.
 
+## Executed GitHub receipt
+
+The v2 repair was compacted to one semantic commit directly on #201's exact green counterexample head.
+
+Exact semantic head:
+
+```text
+5c84155eb1616b6774f0c5ac764f17ac5d61fa9b
+```
+
+GitHub Actions CI run `32251969947` / run number `1417` completed successfully. The job passed:
+
+- `cargo fmt --check`;
+- `cargo clippy --all-targets -- -D warnings`;
+- active-work preflight;
+- full `cargo test`, including the v2 discriminator enumeration controls, exact-subject frontier controls, and the two #201 closure tests using the real shared applicability evaluator;
+- repository text/JSON dogfood;
+- history text/JSON dogfood;
+- CI test-filter inventory text/JSON plus positive/control fixtures;
+- pull-request diff text/JSON dogfood.
+
+The first repair attempt stopped only at rustfmt before Clippy or tests. The exact formatter deltas touched the three v2 test files only. After those mechanical edits, the intermediate head passed the full gate; the branch was then compacted back to the one semantic commit above and revalidated through CI #1417.
+
+Because #210 is a stacked research PR, the ordinary CI workflow is its authoritative gate; generated-provenance PR dogfood is not part of this stack's trigger set.
+
+The central closure is now executable:
+
+```text
+KNOWN old value + applicability INVALID
+  -> frontier INVALID
+  -> known old value preserved
+
+KNOWN old value + applicability UNKNOWN
+  -> frontier UNKNOWN
+  -> known old value preserved
+```
+
+Stale knowledge can no longer suppress a current observation frontier.
+
 ## Phase B consequence
 
 #190 probe planning must consume the repaired frontier semantics.

--- a/src/discriminator_observation.rs
+++ b/src/discriminator_observation.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-pub const DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION: u32 = 1;
+pub const DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION: u32 = 2;
 pub const MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES: usize = 256 * 1024;
 const MAX_OBSERVATIONS: usize = 1024;
 const MAX_ID_BYTES: usize = 512;
@@ -25,8 +25,7 @@ pub struct DiscriminatorObservation {
     pub subject_ref: String,
     pub source_receipt: String,
     pub value_state: DiscriminatorValueState,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub applicability: ObservationApplicability,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -34,7 +33,21 @@ pub struct DiscriminatorObservation {
 pub enum DiscriminatorValueState {
     Known { value_ref: String },
     Unknown { reason_ref: String },
-    Invalid { reason_ref: String },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationApplicability {
+    pub status: ObservationApplicabilityStatus,
+    pub receipt_ref: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationApplicabilityStatus {
+    Applies,
+    Unknown,
+    Invalid,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -66,8 +79,7 @@ pub struct CurrentObservationReceipt {
     pub observation_id: String,
     pub subject_ref: String,
     pub source_receipt: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub applicability_ref: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -76,9 +88,29 @@ pub struct NonCurrentObservationReceipt {
     pub observation_id: String,
     pub subject_ref: String,
     pub source_receipt: String,
-    pub reason_ref: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub known_value_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_unknown_reason_ref: Option<String>,
+    pub applicability_ref: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ObservationCurrentness<'a> {
+    Current {
+        value_ref: &'a str,
+        applicability_ref: &'a str,
+    },
+    Unknown {
+        known_value_ref: Option<&'a str>,
+        value_unknown_reason_ref: Option<&'a str>,
+        applicability_ref: &'a str,
+    },
+    Invalid {
+        known_value_ref: Option<&'a str>,
+        value_unknown_reason_ref: Option<&'a str>,
+        applicability_ref: &'a str,
+    },
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -156,6 +188,39 @@ pub fn validate_discriminator_observation_batch(
     Ok(())
 }
 
+pub fn classify_observation_currentness(
+    observation: &DiscriminatorObservation,
+) -> ObservationCurrentness<'_> {
+    let (known_value_ref, value_unknown_reason_ref) = match &observation.value_state {
+        DiscriminatorValueState::Known { value_ref } => (Some(value_ref.as_str()), None),
+        DiscriminatorValueState::Unknown { reason_ref } => (None, Some(reason_ref.as_str())),
+    };
+
+    match observation.applicability.status {
+        ObservationApplicabilityStatus::Invalid => ObservationCurrentness::Invalid {
+            known_value_ref,
+            value_unknown_reason_ref,
+            applicability_ref: &observation.applicability.receipt_ref,
+        },
+        ObservationApplicabilityStatus::Unknown => ObservationCurrentness::Unknown {
+            known_value_ref,
+            value_unknown_reason_ref,
+            applicability_ref: &observation.applicability.receipt_ref,
+        },
+        ObservationApplicabilityStatus::Applies => match known_value_ref {
+            Some(value_ref) => ObservationCurrentness::Current {
+                value_ref,
+                applicability_ref: &observation.applicability.receipt_ref,
+            },
+            None => ObservationCurrentness::Unknown {
+                known_value_ref: None,
+                value_unknown_reason_ref,
+                applicability_ref: &observation.applicability.receipt_ref,
+            },
+        },
+    }
+}
+
 pub fn enumerate_discriminator_partitions(
     batch: &DiscriminatorObservationBatch,
 ) -> Result<DiscriminatorEnumeration, DiscriminatorObservationError> {
@@ -173,24 +238,42 @@ pub fn enumerate_discriminator_partitions(
         let builder = builders
             .entry(observation.discriminator_id.clone())
             .or_default();
-        match &observation.value_state {
-            DiscriminatorValueState::Known { value_ref } => {
+        match classify_observation_currentness(observation) {
+            ObservationCurrentness::Current {
+                value_ref,
+                applicability_ref,
+            } => {
                 builder
                     .known
-                    .entry(value_ref.clone())
+                    .entry(value_ref.to_string())
                     .or_default()
-                    .push(current_receipt(observation));
+                    .push(CurrentObservationReceipt {
+                        observation_id: observation.observation_id.clone(),
+                        subject_ref: observation.subject_ref.clone(),
+                        source_receipt: observation.source_receipt.clone(),
+                        applicability_ref: applicability_ref.to_string(),
+                    });
             }
-            DiscriminatorValueState::Unknown { reason_ref } => {
-                builder
-                    .unknown
-                    .push(non_current_receipt(observation, reason_ref));
-            }
-            DiscriminatorValueState::Invalid { reason_ref } => {
-                builder
-                    .invalid
-                    .push(non_current_receipt(observation, reason_ref));
-            }
+            ObservationCurrentness::Unknown {
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            } => builder.unknown.push(non_current_receipt(
+                observation,
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            )),
+            ObservationCurrentness::Invalid {
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            } => builder.invalid.push(non_current_receipt(
+                observation,
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            )),
         }
     }
 
@@ -230,25 +313,19 @@ pub fn enumerate_discriminator_partitions(
     })
 }
 
-fn current_receipt(observation: &DiscriminatorObservation) -> CurrentObservationReceipt {
-    CurrentObservationReceipt {
-        observation_id: observation.observation_id.clone(),
-        subject_ref: observation.subject_ref.clone(),
-        source_receipt: observation.source_receipt.clone(),
-        applicability_ref: observation.applicability_ref.clone(),
-    }
-}
-
 fn non_current_receipt(
     observation: &DiscriminatorObservation,
-    reason_ref: &str,
+    known_value_ref: Option<&str>,
+    value_unknown_reason_ref: Option<&str>,
+    applicability_ref: &str,
 ) -> NonCurrentObservationReceipt {
     NonCurrentObservationReceipt {
         observation_id: observation.observation_id.clone(),
         subject_ref: observation.subject_ref.clone(),
         source_receipt: observation.source_receipt.clone(),
-        reason_ref: reason_ref.to_string(),
-        applicability_ref: observation.applicability_ref.clone(),
+        known_value_ref: known_value_ref.map(str::to_string),
+        value_unknown_reason_ref: value_unknown_reason_ref.map(str::to_string),
+        applicability_ref: applicability_ref.to_string(),
     }
 }
 
@@ -267,18 +344,19 @@ fn validate_observation(
         "source_receipt",
         MAX_REFERENCE_BYTES,
     )?;
-    if let Some(applicability_ref) = &observation.applicability_ref {
-        validate_atom(applicability_ref, "applicability_ref", MAX_REFERENCE_BYTES)?;
-    }
     match &observation.value_state {
         DiscriminatorValueState::Known { value_ref } => {
-            validate_atom(value_ref, "value_ref", MAX_REFERENCE_BYTES)
+            validate_atom(value_ref, "value_ref", MAX_REFERENCE_BYTES)?;
         }
-        DiscriminatorValueState::Unknown { reason_ref }
-        | DiscriminatorValueState::Invalid { reason_ref } => {
-            validate_atom(reason_ref, "reason_ref", MAX_REFERENCE_BYTES)
+        DiscriminatorValueState::Unknown { reason_ref } => {
+            validate_atom(reason_ref, "value reason_ref", MAX_REFERENCE_BYTES)?;
         }
     }
+    validate_atom(
+        &observation.applicability.receipt_ref,
+        "applicability receipt_ref",
+        MAX_REFERENCE_BYTES,
+    )
 }
 
 fn validate_atom(

--- a/src/discriminator_observation.rs
+++ b/src/discriminator_observation.rs
@@ -1,0 +1,300 @@
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+pub const DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION: u32 = 1;
+pub const MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES: usize = 256 * 1024;
+const MAX_OBSERVATIONS: usize = 1024;
+const MAX_ID_BYTES: usize = 512;
+const MAX_REFERENCE_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorObservationBatch {
+    pub schema_version: u32,
+    pub observations: Vec<DiscriminatorObservation>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorObservation {
+    pub observation_id: String,
+    pub discriminator_id: String,
+    pub subject_ref: String,
+    pub source_receipt: String,
+    pub value_state: DiscriminatorValueState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DiscriminatorValueState {
+    Known { value_ref: String },
+    Unknown { reason_ref: String },
+    Invalid { reason_ref: String },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorEnumeration {
+    pub schema_version: u32,
+    pub discriminators: Vec<EnumeratedDiscriminator>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EnumeratedDiscriminator {
+    pub discriminator_id: String,
+    pub known_partitions: Vec<KnownPartition>,
+    pub unknown: Vec<NonCurrentObservationReceipt>,
+    pub invalid: Vec<NonCurrentObservationReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct KnownPartition {
+    pub value_ref: String,
+    pub observations: Vec<CurrentObservationReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CurrentObservationReceipt {
+    pub observation_id: String,
+    pub subject_ref: String,
+    pub source_receipt: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct NonCurrentObservationReceipt {
+    pub observation_id: String,
+    pub subject_ref: String,
+    pub source_receipt: String,
+    pub reason_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DiscriminatorObservationError {
+    message: String,
+}
+
+impl DiscriminatorObservationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for DiscriminatorObservationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for DiscriminatorObservationError {}
+
+pub fn parse_discriminator_observation_batch(
+    bytes: &[u8],
+) -> Result<DiscriminatorObservationBatch, DiscriminatorObservationError> {
+    if bytes.len() > MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES {
+        return Err(DiscriminatorObservationError::new(format!(
+            "discriminator observation batch exceeds the {MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES}-byte limit"
+        )));
+    }
+    let batch: DiscriminatorObservationBatch = serde_json::from_slice(bytes).map_err(|error| {
+        DiscriminatorObservationError::new(format!(
+            "invalid discriminator observation JSON: {error}"
+        ))
+    })?;
+    validate_discriminator_observation_batch(&batch)?;
+    Ok(batch)
+}
+
+pub fn validate_discriminator_observation_batch(
+    batch: &DiscriminatorObservationBatch,
+) -> Result<(), DiscriminatorObservationError> {
+    if batch.schema_version != DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION {
+        return Err(DiscriminatorObservationError::new(format!(
+            "unsupported discriminator observation schema {}; expected {DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION}",
+            batch.schema_version
+        )));
+    }
+    if batch.observations.is_empty() || batch.observations.len() > MAX_OBSERVATIONS {
+        return Err(DiscriminatorObservationError::new(
+            "discriminator observation batch must contain a bounded non-empty observation set",
+        ));
+    }
+
+    let mut seen = BTreeMap::<String, DiscriminatorObservation>::new();
+    for observation in &batch.observations {
+        validate_observation(observation)?;
+        if let Some(existing) = seen.get(&observation.observation_id) {
+            let message = if existing == observation {
+                format!(
+                    "duplicate discriminator observation id {}",
+                    observation.observation_id
+                )
+            } else {
+                format!(
+                    "conflicting discriminator observation id {}",
+                    observation.observation_id
+                )
+            };
+            return Err(DiscriminatorObservationError::new(message));
+        }
+        seen.insert(observation.observation_id.clone(), observation.clone());
+    }
+    Ok(())
+}
+
+pub fn enumerate_discriminator_partitions(
+    batch: &DiscriminatorObservationBatch,
+) -> Result<DiscriminatorEnumeration, DiscriminatorObservationError> {
+    validate_discriminator_observation_batch(batch)?;
+
+    #[derive(Default)]
+    struct Builder {
+        known: BTreeMap<String, Vec<CurrentObservationReceipt>>,
+        unknown: Vec<NonCurrentObservationReceipt>,
+        invalid: Vec<NonCurrentObservationReceipt>,
+    }
+
+    let mut builders = BTreeMap::<String, Builder>::new();
+    for observation in &batch.observations {
+        let builder = builders
+            .entry(observation.discriminator_id.clone())
+            .or_default();
+        match &observation.value_state {
+            DiscriminatorValueState::Known { value_ref } => {
+                builder
+                    .known
+                    .entry(value_ref.clone())
+                    .or_default()
+                    .push(current_receipt(observation));
+            }
+            DiscriminatorValueState::Unknown { reason_ref } => {
+                builder
+                    .unknown
+                    .push(non_current_receipt(observation, reason_ref));
+            }
+            DiscriminatorValueState::Invalid { reason_ref } => {
+                builder
+                    .invalid
+                    .push(non_current_receipt(observation, reason_ref));
+            }
+        }
+    }
+
+    let discriminators = builders
+        .into_iter()
+        .map(|(discriminator_id, mut builder)| {
+            let known_partitions = builder
+                .known
+                .into_iter()
+                .map(|(value_ref, mut observations)| {
+                    observations
+                        .sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+                    KnownPartition {
+                        value_ref,
+                        observations,
+                    }
+                })
+                .collect();
+            builder
+                .unknown
+                .sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+            builder
+                .invalid
+                .sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+            EnumeratedDiscriminator {
+                discriminator_id,
+                known_partitions,
+                unknown: builder.unknown,
+                invalid: builder.invalid,
+            }
+        })
+        .collect();
+
+    Ok(DiscriminatorEnumeration {
+        schema_version: DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+        discriminators,
+    })
+}
+
+fn current_receipt(observation: &DiscriminatorObservation) -> CurrentObservationReceipt {
+    CurrentObservationReceipt {
+        observation_id: observation.observation_id.clone(),
+        subject_ref: observation.subject_ref.clone(),
+        source_receipt: observation.source_receipt.clone(),
+        applicability_ref: observation.applicability_ref.clone(),
+    }
+}
+
+fn non_current_receipt(
+    observation: &DiscriminatorObservation,
+    reason_ref: &str,
+) -> NonCurrentObservationReceipt {
+    NonCurrentObservationReceipt {
+        observation_id: observation.observation_id.clone(),
+        subject_ref: observation.subject_ref.clone(),
+        source_receipt: observation.source_receipt.clone(),
+        reason_ref: reason_ref.to_string(),
+        applicability_ref: observation.applicability_ref.clone(),
+    }
+}
+
+fn validate_observation(
+    observation: &DiscriminatorObservation,
+) -> Result<(), DiscriminatorObservationError> {
+    validate_atom(&observation.observation_id, "observation_id", MAX_ID_BYTES)?;
+    validate_atom(
+        &observation.discriminator_id,
+        "discriminator_id",
+        MAX_ID_BYTES,
+    )?;
+    validate_atom(&observation.subject_ref, "subject_ref", MAX_REFERENCE_BYTES)?;
+    validate_atom(
+        &observation.source_receipt,
+        "source_receipt",
+        MAX_REFERENCE_BYTES,
+    )?;
+    if let Some(applicability_ref) = &observation.applicability_ref {
+        validate_atom(applicability_ref, "applicability_ref", MAX_REFERENCE_BYTES)?;
+    }
+    match &observation.value_state {
+        DiscriminatorValueState::Known { value_ref } => {
+            validate_atom(value_ref, "value_ref", MAX_REFERENCE_BYTES)
+        }
+        DiscriminatorValueState::Unknown { reason_ref }
+        | DiscriminatorValueState::Invalid { reason_ref } => {
+            validate_atom(reason_ref, "reason_ref", MAX_REFERENCE_BYTES)
+        }
+    }
+}
+
+fn validate_atom(
+    value: &str,
+    field: &str,
+    max_bytes: usize,
+) -> Result<(), DiscriminatorObservationError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > max_bytes
+        || value.contains('\0')
+        || value.contains(['\n', '\r'])
+    {
+        return Err(DiscriminatorObservationError::new(format!(
+            "{field} must be bounded canonical single-line text"
+        )));
+    }
+    Ok(())
+}

--- a/src/durable_obligation.rs
+++ b/src/durable_obligation.rs
@@ -1,0 +1,428 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, evaluate_query,
+};
+use crate::justification::RelationReceipt;
+
+pub const DURABLE_OBLIGATION_SCHEMA_VERSION: u32 = 1;
+const MAX_ID_BYTES: usize = 256;
+const MAX_TEXT_BYTES: usize = 4096;
+const MAX_ESTABLISHED_EVIDENCE: usize = 256;
+const MAX_CLEARING_CONDITIONS: usize = 64;
+const MAX_RECEIPTS: usize = 512;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DurableObligation {
+    pub schema_version: u32,
+    pub id: String,
+    pub question: String,
+    pub subject: EvidenceRequirements,
+    pub established_evidence: Vec<String>,
+    pub missing_discriminator: DiscriminatorKey,
+    pub clearing_conditions: Vec<ClearingCondition>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorKey {
+    pub kind: String,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClearingCondition {
+    pub discriminator: DiscriminatorKey,
+    pub requirements: EvidenceRequirements,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClearingEvidenceReceipt {
+    pub id: String,
+    pub discriminator: DiscriminatorKey,
+    pub requirements: EvidenceRequirements,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DurableObligationStatus {
+    Open,
+    Cleared,
+    Unknown,
+    ReopenRequired,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DurableObligationEvaluation {
+    pub schema_version: u32,
+    pub id: String,
+    pub status: DurableObligationStatus,
+    pub subject_applicability: ApplicabilityStatus,
+    pub clearing: RelationReceipt,
+    pub unmatched_receipts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DurableObligationError {
+    message: String,
+}
+
+impl DurableObligationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for DurableObligationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for DurableObligationError {}
+
+pub fn evaluate_obligation(
+    obligation: &DurableObligation,
+    receipts: &[ClearingEvidenceReceipt],
+    context: &EvaluationContext,
+) -> Result<DurableObligationEvaluation, DurableObligationError> {
+    validate_obligation(obligation)?;
+    validate_receipts(receipts)?;
+
+    let subject_applicability = evaluate_requirements(&obligation.subject, context, "subject")?;
+    let mut clearing = RelationReceipt::default();
+    let mut unmatched_receipts = Vec::new();
+
+    for receipt in receipts {
+        let Some(condition) = obligation.clearing_conditions.iter().find(|condition| {
+            condition.discriminator == receipt.discriminator
+                && condition.requirements == receipt.requirements
+        }) else {
+            unmatched_receipts.push(receipt.id.clone());
+            continue;
+        };
+
+        debug_assert_eq!(condition.requirements, receipt.requirements);
+        let applicability = evaluate_requirements(
+            &receipt.requirements,
+            context,
+            &format!("clearing receipt {}", receipt.id),
+        )?;
+        push_receipt(&mut clearing, receipt.id.clone(), applicability);
+    }
+
+    clearing.applies.sort();
+    clearing.invalid.sort();
+    clearing.unknown.sort();
+    unmatched_receipts.sort();
+
+    let status = match subject_applicability {
+        ApplicabilityStatus::Invalid => DurableObligationStatus::ReopenRequired,
+        ApplicabilityStatus::Unknown => DurableObligationStatus::Unknown,
+        ApplicabilityStatus::Applies if !clearing.applies.is_empty() => {
+            DurableObligationStatus::Cleared
+        }
+        ApplicabilityStatus::Applies if !clearing.unknown.is_empty() => {
+            DurableObligationStatus::Unknown
+        }
+        ApplicabilityStatus::Applies => DurableObligationStatus::Open,
+    };
+
+    Ok(DurableObligationEvaluation {
+        schema_version: DURABLE_OBLIGATION_SCHEMA_VERSION,
+        id: obligation.id.clone(),
+        status,
+        subject_applicability,
+        clearing,
+        unmatched_receipts,
+    })
+}
+
+fn evaluate_requirements(
+    requirements: &EvidenceRequirements,
+    context: &EvaluationContext,
+    label: &str,
+) -> Result<ApplicabilityStatus, DurableObligationError> {
+    let evaluation = evaluate_query(&ApplicabilityQuery {
+        schema_version: APPLICABILITY_SCHEMA_VERSION,
+        requirements: requirements.clone(),
+        context: context.clone(),
+    })
+    .map_err(|error| {
+        DurableObligationError::new(format!("{label} applicability failed: {error}"))
+    })?;
+    Ok(evaluation.status)
+}
+
+fn validate_obligation(obligation: &DurableObligation) -> Result<(), DurableObligationError> {
+    if obligation.schema_version != DURABLE_OBLIGATION_SCHEMA_VERSION {
+        return Err(DurableObligationError::new(format!(
+            "unsupported durable obligation schema {}; expected {DURABLE_OBLIGATION_SCHEMA_VERSION}",
+            obligation.schema_version
+        )));
+    }
+
+    validate_id(&obligation.id, "obligation id")?;
+    validate_text(&obligation.question, "obligation question")?;
+    validate_discriminator(&obligation.missing_discriminator)?;
+    require_coordinates(&obligation.subject, "obligation subject")?;
+
+    if obligation.established_evidence.len() > MAX_ESTABLISHED_EVIDENCE {
+        return Err(DurableObligationError::new(
+            "established evidence exceeds the admitted boundary",
+        ));
+    }
+    let mut established = BTreeSet::new();
+    for id in &obligation.established_evidence {
+        validate_id(id, "established evidence id")?;
+        if !established.insert(id.clone()) {
+            return Err(DurableObligationError::new(format!(
+                "duplicate established evidence id {id}"
+            )));
+        }
+    }
+
+    if obligation.clearing_conditions.is_empty()
+        || obligation.clearing_conditions.len() > MAX_CLEARING_CONDITIONS
+    {
+        return Err(DurableObligationError::new(
+            "durable obligation must declare a bounded non-empty clearing condition set",
+        ));
+    }
+
+    let mut conditions = BTreeSet::new();
+    for condition in &obligation.clearing_conditions {
+        validate_discriminator(&condition.discriminator)?;
+        require_coordinates(&condition.requirements, "clearing condition requirements")?;
+        let key = (
+            condition.discriminator.clone(),
+            serde_json::to_string(&condition.requirements).map_err(|error| {
+                DurableObligationError::new(format!(
+                    "failed to canonicalize clearing requirements: {error}"
+                ))
+            })?,
+        );
+        if !conditions.insert(key) {
+            return Err(DurableObligationError::new(
+                "duplicate durable obligation clearing condition",
+            ));
+        }
+    }
+
+    if !obligation
+        .clearing_conditions
+        .iter()
+        .any(|condition| condition.discriminator == obligation.missing_discriminator)
+    {
+        return Err(DurableObligationError::new(
+            "at least one clearing condition must answer the missing discriminator",
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_receipts(receipts: &[ClearingEvidenceReceipt]) -> Result<(), DurableObligationError> {
+    if receipts.len() > MAX_RECEIPTS {
+        return Err(DurableObligationError::new(
+            "clearing receipts exceed the admitted boundary",
+        ));
+    }
+
+    let mut ids = BTreeSet::new();
+    for receipt in receipts {
+        validate_id(&receipt.id, "clearing receipt id")?;
+        validate_discriminator(&receipt.discriminator)?;
+        require_coordinates(&receipt.requirements, "clearing receipt requirements")?;
+        if !ids.insert(receipt.id.clone()) {
+            return Err(DurableObligationError::new(format!(
+                "duplicate clearing receipt id {}",
+                receipt.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn require_coordinates(
+    requirements: &EvidenceRequirements,
+    label: &str,
+) -> Result<(), DurableObligationError> {
+    if requirements.repository.is_none()
+        && requirements.revision.is_none()
+        && requirements.work.is_none()
+        && requirements.scope.is_none()
+    {
+        return Err(DurableObligationError::new(format!(
+            "{label} must carry at least one applicability coordinate"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_discriminator(discriminator: &DiscriminatorKey) -> Result<(), DurableObligationError> {
+    validate_id(&discriminator.kind, "discriminator kind")?;
+    validate_text(&discriminator.target, "discriminator target")
+}
+
+fn validate_id(value: &str, field: &str) -> Result<(), DurableObligationError> {
+    if value.is_empty() || value.trim() != value || value.len() > MAX_ID_BYTES || value.contains('\0') {
+        return Err(DurableObligationError::new(format!(
+            "{field} must be a bounded canonical identifier"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, field: &str) -> Result<(), DurableObligationError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_TEXT_BYTES
+        || value.contains('\0')
+    {
+        return Err(DurableObligationError::new(format!(
+            "{field} must be bounded non-empty text"
+        )));
+    }
+    Ok(())
+}
+
+fn push_receipt(receipt: &mut RelationReceipt, id: String, status: ApplicabilityStatus) {
+    match status {
+        ApplicabilityStatus::Applies => receipt.applies.push(id),
+        ApplicabilityStatus::Invalid => receipt.invalid.push(id),
+        ApplicabilityStatus::Unknown => receipt.unknown.push(id),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn requirements(repository: &str, revision: Option<&str>) -> EvidenceRequirements {
+        EvidenceRequirements {
+            repository: Some(repository.to_string()),
+            revision: revision.map(str::to_string),
+            work: None,
+            scope: None,
+        }
+    }
+
+    fn discriminator() -> DiscriminatorKey {
+        DiscriminatorKey {
+            kind: "target_test_result".to_string(),
+            target: "cargo test target_t".to_string(),
+        }
+    }
+
+    fn obligation() -> DurableObligation {
+        DurableObligation {
+            schema_version: DURABLE_OBLIGATION_SCHEMA_VERSION,
+            id: "U17".to_string(),
+            question: "Does target T pass at this exact head?".to_string(),
+            subject: requirements("owner/repo", Some("head-a")),
+            established_evidence: vec!["E-history".to_string(), "E-guidance".to_string()],
+            missing_discriminator: discriminator(),
+            clearing_conditions: vec![ClearingCondition {
+                discriminator: discriminator(),
+                requirements: requirements("owner/repo", Some("head-a")),
+            }],
+        }
+    }
+
+    fn context(revision: Option<&str>) -> EvaluationContext {
+        EvaluationContext {
+            repository: Some("owner/repo".to_string()),
+            revision: revision.map(str::to_string),
+            work: None,
+            path: None,
+        }
+    }
+
+    fn receipt(revision: &str) -> ClearingEvidenceReceipt {
+        ClearingEvidenceReceipt {
+            id: format!("test-{revision}"),
+            discriminator: discriminator(),
+            requirements: requirements("owner/repo", Some(revision)),
+        }
+    }
+
+    #[test]
+    fn durable_unknown_can_exist_before_any_clearing_evidence_arrives() {
+        let evaluation = evaluate_obligation(&obligation(), &[], &context(Some("head-a"))).unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Open);
+        assert!(evaluation.clearing.applies.is_empty());
+    }
+
+    #[test]
+    fn exact_matching_receipt_clears_the_obligation() {
+        let evaluation = evaluate_obligation(
+            &obligation(),
+            &[receipt("head-a")],
+            &context(Some("head-a")),
+        )
+        .unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Cleared);
+        assert_eq!(evaluation.clearing.applies, vec!["test-head-a"]);
+    }
+
+    #[test]
+    fn moved_subject_coordinate_requires_reopen() {
+        let evaluation = evaluate_obligation(
+            &obligation(),
+            &[receipt("head-a")],
+            &context(Some("head-b")),
+        )
+        .unwrap();
+        assert_eq!(
+            evaluation.status,
+            DurableObligationStatus::ReopenRequired
+        );
+        assert_eq!(evaluation.subject_applicability, ApplicabilityStatus::Invalid);
+        assert_eq!(evaluation.clearing.invalid, vec!["test-head-a"]);
+    }
+
+    #[test]
+    fn missing_current_coordinate_remains_unknown() {
+        let evaluation = evaluate_obligation(&obligation(), &[], &context(None)).unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Unknown);
+        assert_eq!(evaluation.subject_applicability, ApplicabilityStatus::Unknown);
+    }
+
+    #[test]
+    fn semantically_adjacent_receipt_does_not_clear() {
+        let mut wrong = receipt("head-a");
+        wrong.discriminator.kind = "target_test_listing".to_string();
+        let evaluation = evaluate_obligation(&obligation(), &[wrong], &context(Some("head-a"))).unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Open);
+        assert_eq!(evaluation.unmatched_receipts, vec!["test-head-a"]);
+    }
+
+    #[test]
+    fn durable_record_round_trips_for_fresh_worker_handoff() {
+        let record = obligation();
+        let encoded = serde_json::to_string(&record).unwrap();
+        let decoded: DurableObligation = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, record);
+        assert_eq!(decoded.established_evidence, vec!["E-history", "E-guidance"]);
+    }
+
+    #[test]
+    fn clearing_condition_must_answer_declared_missing_discriminator() {
+        let mut record = obligation();
+        record.clearing_conditions[0].discriminator.kind = "provider_current".to_string();
+        let error = evaluate_obligation(&record, &[], &context(Some("head-a"))).unwrap_err();
+        assert!(error.to_string().contains("answer the missing discriminator"));
+    }
+}

--- a/src/durable_obligation.rs
+++ b/src/durable_obligation.rs
@@ -277,7 +277,11 @@ fn validate_discriminator(discriminator: &DiscriminatorKey) -> Result<(), Durabl
 }
 
 fn validate_id(value: &str, field: &str) -> Result<(), DurableObligationError> {
-    if value.is_empty() || value.trim() != value || value.len() > MAX_ID_BYTES || value.contains('\0') {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_ID_BYTES
+        || value.contains('\0')
+    {
         return Err(DurableObligationError::new(format!(
             "{field} must be a bounded canonical identifier"
         )));
@@ -385,11 +389,11 @@ mod tests {
             &context(Some("head-b")),
         )
         .unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::ReopenRequired);
         assert_eq!(
-            evaluation.status,
-            DurableObligationStatus::ReopenRequired
+            evaluation.subject_applicability,
+            ApplicabilityStatus::Invalid
         );
-        assert_eq!(evaluation.subject_applicability, ApplicabilityStatus::Invalid);
         assert_eq!(evaluation.clearing.invalid, vec!["test-head-a"]);
     }
 
@@ -397,14 +401,18 @@ mod tests {
     fn missing_current_coordinate_remains_unknown() {
         let evaluation = evaluate_obligation(&obligation(), &[], &context(None)).unwrap();
         assert_eq!(evaluation.status, DurableObligationStatus::Unknown);
-        assert_eq!(evaluation.subject_applicability, ApplicabilityStatus::Unknown);
+        assert_eq!(
+            evaluation.subject_applicability,
+            ApplicabilityStatus::Unknown
+        );
     }
 
     #[test]
     fn semantically_adjacent_receipt_does_not_clear() {
         let mut wrong = receipt("head-a");
         wrong.discriminator.kind = "target_test_listing".to_string();
-        let evaluation = evaluate_obligation(&obligation(), &[wrong], &context(Some("head-a"))).unwrap();
+        let evaluation =
+            evaluate_obligation(&obligation(), &[wrong], &context(Some("head-a"))).unwrap();
         assert_eq!(evaluation.status, DurableObligationStatus::Open);
         assert_eq!(evaluation.unmatched_receipts, vec!["test-head-a"]);
     }
@@ -415,7 +423,10 @@ mod tests {
         let encoded = serde_json::to_string(&record).unwrap();
         let decoded: DurableObligation = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded, record);
-        assert_eq!(decoded.established_evidence, vec!["E-history", "E-guidance"]);
+        assert_eq!(
+            decoded.established_evidence,
+            vec!["E-history", "E-guidance"]
+        );
     }
 
     #[test]
@@ -423,6 +434,10 @@ mod tests {
         let mut record = obligation();
         record.clearing_conditions[0].discriminator.kind = "provider_current".to_string();
         let error = evaluate_obligation(&record, &[], &context(Some("head-a"))).unwrap_err();
-        assert!(error.to_string().contains("answer the missing discriminator"));
+        assert!(
+            error
+                .to_string()
+                .contains("answer the missing discriminator")
+        );
     }
 }

--- a/src/evidence_planner.rs
+++ b/src/evidence_planner.rs
@@ -683,6 +683,6 @@ mod tests {
         ))
         .unwrap_err();
 
-        assert!(error.to_string().contains("effectful executions"));
+        assert!(error.to_string().contains("effectful execution"));
     }
 }

--- a/src/evidence_planner.rs
+++ b/src/evidence_planner.rs
@@ -1,0 +1,687 @@
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, evaluate_query,
+};
+use crate::durable_obligation::{
+    DiscriminatorKey, DurableObligation, DurableObligationStatus, evaluate_obligation,
+};
+
+pub const EVIDENCE_PLANNER_SCHEMA_VERSION: u32 = 1;
+const MAX_PROBES: usize = 128;
+const MAX_ID_BYTES: usize = 256;
+const MAX_TEXT_BYTES: usize = 4096;
+const MAX_COST_UNIT: u32 = 1_000_000;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProbePlanRequest {
+    pub schema_version: u32,
+    pub obligation: DurableObligation,
+    pub context: EvaluationContext,
+    pub probes: Vec<EvidenceProbe>,
+    pub allow_effectful: bool,
+    pub policy: ProbeSelectionPolicy,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceProbe {
+    pub id: String,
+    pub produces: DiscriminatorKey,
+    pub requirements: EvidenceRequirements,
+    pub effect: ProbeEffect,
+    pub cost: ProbeCost,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeEffect {
+    ReadOnly,
+    ExternalRead,
+    Effectful,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProbeCost {
+    pub git_subprocesses: u32,
+    pub rust_files_parsed: u32,
+    pub remote_requests: u32,
+    pub effectful_executions: u32,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeSelectionPolicy {
+    Conservative,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeCandidateStatus {
+    Eligible,
+    Incapable,
+    IncompatibleClearingCondition,
+    InvalidCoordinate,
+    MissingContext,
+    EffectAuthorityRequired,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProbeCandidateReceipt {
+    pub id: String,
+    pub status: ProbeCandidateStatus,
+    pub effect: ProbeEffect,
+    pub cost: ProbeCost,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidencePlanStatus {
+    Selected,
+    Blocked,
+    Unresolved,
+    StaleObligation,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SelectedProbe {
+    pub id: String,
+    pub produces: DiscriminatorKey,
+    pub requirements: EvidenceRequirements,
+    pub effect: ProbeEffect,
+    pub cost: ProbeCost,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidencePlan {
+    pub schema_version: u32,
+    pub obligation_id: String,
+    pub obligation_status: DurableObligationStatus,
+    pub status: EvidencePlanStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected: Option<SelectedProbe>,
+    pub candidates: Vec<ProbeCandidateReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct EvidencePlannerError {
+    message: String,
+}
+
+impl EvidencePlannerError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for EvidencePlannerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for EvidencePlannerError {}
+
+pub fn plan_evidence(request: &ProbePlanRequest) -> Result<EvidencePlan, EvidencePlannerError> {
+    validate_request(request)?;
+
+    let obligation_evaluation = evaluate_obligation(&request.obligation, &[], &request.context)
+        .map_err(|error| {
+            EvidencePlannerError::new(format!("obligation evaluation failed: {error}"))
+        })?;
+
+    if obligation_evaluation.status == DurableObligationStatus::ReopenRequired {
+        return Ok(EvidencePlan {
+            schema_version: EVIDENCE_PLANNER_SCHEMA_VERSION,
+            obligation_id: request.obligation.id.clone(),
+            obligation_status: obligation_evaluation.status,
+            status: EvidencePlanStatus::StaleObligation,
+            selected: None,
+            candidates: Vec::new(),
+        });
+    }
+
+    let mut candidates = request
+        .probes
+        .iter()
+        .map(|probe| {
+            evaluate_candidate(
+                &request.obligation,
+                &request.context,
+                request.allow_effectful,
+                probe,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    candidates.sort_by(|left, right| left.receipt.id.cmp(&right.receipt.id));
+
+    let selected_probe = candidates
+        .iter()
+        .filter(|candidate| candidate.receipt.status == ProbeCandidateStatus::Eligible)
+        .map(|candidate| candidate.probe)
+        .min_by(|left, right| compare_probe_cost(left, right, request.policy));
+
+    let status = if selected_probe.is_some() {
+        EvidencePlanStatus::Selected
+    } else if obligation_evaluation.status == DurableObligationStatus::Unknown
+        || candidates.iter().any(|candidate| {
+            matches!(
+                candidate.receipt.status,
+                ProbeCandidateStatus::MissingContext
+                    | ProbeCandidateStatus::EffectAuthorityRequired
+            )
+        })
+    {
+        EvidencePlanStatus::Blocked
+    } else {
+        EvidencePlanStatus::Unresolved
+    };
+
+    let selected = selected_probe.map(|probe| SelectedProbe {
+        id: probe.id.clone(),
+        produces: probe.produces.clone(),
+        requirements: probe.requirements.clone(),
+        effect: probe.effect,
+        cost: probe.cost,
+    });
+
+    Ok(EvidencePlan {
+        schema_version: EVIDENCE_PLANNER_SCHEMA_VERSION,
+        obligation_id: request.obligation.id.clone(),
+        obligation_status: obligation_evaluation.status,
+        status,
+        selected,
+        candidates: candidates
+            .into_iter()
+            .map(|candidate| candidate.receipt)
+            .collect(),
+    })
+}
+
+struct CandidateEvaluation<'a> {
+    probe: &'a EvidenceProbe,
+    receipt: ProbeCandidateReceipt,
+}
+
+fn evaluate_candidate<'a>(
+    obligation: &DurableObligation,
+    context: &EvaluationContext,
+    allow_effectful: bool,
+    probe: &'a EvidenceProbe,
+) -> Result<CandidateEvaluation<'a>, EvidencePlannerError> {
+    let status = if probe.produces != obligation.missing_discriminator {
+        ProbeCandidateStatus::Incapable
+    } else if !obligation.clearing_conditions.iter().any(|condition| {
+        condition.discriminator == probe.produces && condition.requirements == probe.requirements
+    }) {
+        ProbeCandidateStatus::IncompatibleClearingCondition
+    } else {
+        let applicability = evaluate_query(&ApplicabilityQuery {
+            schema_version: APPLICABILITY_SCHEMA_VERSION,
+            requirements: probe.requirements.clone(),
+            context: context.clone(),
+        })
+        .map_err(|error| {
+            EvidencePlannerError::new(format!(
+                "probe {} applicability failed: {error}",
+                probe.id
+            ))
+        })?;
+
+        match applicability.status {
+            ApplicabilityStatus::Invalid => ProbeCandidateStatus::InvalidCoordinate,
+            ApplicabilityStatus::Unknown => ProbeCandidateStatus::MissingContext,
+            ApplicabilityStatus::Applies
+                if probe.effect == ProbeEffect::Effectful && !allow_effectful =>
+            {
+                ProbeCandidateStatus::EffectAuthorityRequired
+            }
+            ApplicabilityStatus::Applies => ProbeCandidateStatus::Eligible,
+        }
+    };
+
+    Ok(CandidateEvaluation {
+        probe,
+        receipt: ProbeCandidateReceipt {
+            id: probe.id.clone(),
+            status,
+            effect: probe.effect,
+            cost: probe.cost,
+        },
+    })
+}
+
+fn compare_probe_cost(
+    left: &EvidenceProbe,
+    right: &EvidenceProbe,
+    policy: ProbeSelectionPolicy,
+) -> Ordering {
+    match policy {
+        ProbeSelectionPolicy::Conservative => conservative_cost_key(left)
+            .cmp(&conservative_cost_key(right))
+            .then_with(|| left.id.cmp(&right.id)),
+    }
+}
+
+fn conservative_cost_key(probe: &EvidenceProbe) -> (u8, u32, u32, u32, u32) {
+    (
+        effect_rank(probe.effect),
+        probe.cost.remote_requests,
+        probe.cost.git_subprocesses,
+        probe.cost.rust_files_parsed,
+        probe.cost.effectful_executions,
+    )
+}
+
+fn effect_rank(effect: ProbeEffect) -> u8 {
+    match effect {
+        ProbeEffect::ReadOnly => 0,
+        ProbeEffect::ExternalRead => 1,
+        ProbeEffect::Effectful => 2,
+    }
+}
+
+fn validate_request(request: &ProbePlanRequest) -> Result<(), EvidencePlannerError> {
+    if request.schema_version != EVIDENCE_PLANNER_SCHEMA_VERSION {
+        return Err(EvidencePlannerError::new(format!(
+            "unsupported evidence planner schema {}; expected {EVIDENCE_PLANNER_SCHEMA_VERSION}",
+            request.schema_version
+        )));
+    }
+    if request.probes.len() > MAX_PROBES {
+        return Err(EvidencePlannerError::new(
+            "probe inventory exceeds the admitted boundary",
+        ));
+    }
+
+    let mut ids = BTreeSet::new();
+    for probe in &request.probes {
+        validate_probe(probe)?;
+        if !ids.insert(probe.id.clone()) {
+            return Err(EvidencePlannerError::new(format!(
+                "duplicate probe id {}",
+                probe.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_probe(probe: &EvidenceProbe) -> Result<(), EvidencePlannerError> {
+    validate_id(&probe.id, "probe id")?;
+    validate_id(&probe.produces.kind, "probe discriminator kind")?;
+    validate_text(&probe.produces.target, "probe discriminator target")?;
+    require_coordinates(&probe.requirements)?;
+    validate_cost(probe)?;
+    Ok(())
+}
+
+fn validate_cost(probe: &EvidenceProbe) -> Result<(), EvidencePlannerError> {
+    let costs = [
+        probe.cost.git_subprocesses,
+        probe.cost.rust_files_parsed,
+        probe.cost.remote_requests,
+        probe.cost.effectful_executions,
+    ];
+    if costs.into_iter().any(|cost| cost > MAX_COST_UNIT) {
+        return Err(EvidencePlannerError::new(format!(
+            "probe {} cost exceeds the admitted boundary",
+            probe.id
+        )));
+    }
+
+    match probe.effect {
+        ProbeEffect::ReadOnly
+            if probe.cost.remote_requests != 0 || probe.cost.effectful_executions != 0 =>
+        {
+            Err(EvidencePlannerError::new(format!(
+                "read-only probe {} cannot forecast remote requests or effectful executions",
+                probe.id
+            )))
+        }
+        ProbeEffect::ExternalRead if probe.cost.remote_requests == 0 => {
+            Err(EvidencePlannerError::new(format!(
+                "external-read probe {} must forecast at least one remote request",
+                probe.id
+            )))
+        }
+        ProbeEffect::ExternalRead if probe.cost.effectful_executions != 0 => {
+            Err(EvidencePlannerError::new(format!(
+                "external-read probe {} cannot forecast effectful executions",
+                probe.id
+            )))
+        }
+        ProbeEffect::Effectful if probe.cost.effectful_executions == 0 => {
+            Err(EvidencePlannerError::new(format!(
+                "effectful probe {} must forecast at least one effectful execution",
+                probe.id
+            )))
+        }
+        _ => Ok(()),
+    }
+}
+
+fn require_coordinates(requirements: &EvidenceRequirements) -> Result<(), EvidencePlannerError> {
+    if requirements.repository.is_none()
+        && requirements.revision.is_none()
+        && requirements.work.is_none()
+        && requirements.scope.is_none()
+    {
+        return Err(EvidencePlannerError::new(
+            "probe requirements must carry at least one applicability coordinate",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_id(value: &str, field: &str) -> Result<(), EvidencePlannerError> {
+    if value.is_empty() || value.trim() != value || value.len() > MAX_ID_BYTES || value.contains('\0') {
+        return Err(EvidencePlannerError::new(format!(
+            "{field} must be a bounded canonical identifier"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, field: &str) -> Result<(), EvidencePlannerError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_TEXT_BYTES
+        || value.contains('\0')
+    {
+        return Err(EvidencePlannerError::new(format!(
+            "{field} must be bounded non-empty text"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::durable_obligation::{
+        ClearingCondition, ClearingEvidenceReceipt, DURABLE_OBLIGATION_SCHEMA_VERSION,
+    };
+
+    fn requirements(revision: Option<&str>) -> EvidenceRequirements {
+        EvidenceRequirements {
+            repository: Some("owner/repo".to_string()),
+            revision: revision.map(str::to_string),
+            work: None,
+            scope: None,
+        }
+    }
+
+    fn discriminator(kind: &str) -> DiscriminatorKey {
+        DiscriminatorKey {
+            kind: kind.to_string(),
+            target: "cargo test target_t".to_string(),
+        }
+    }
+
+    fn obligation() -> DurableObligation {
+        DurableObligation {
+            schema_version: DURABLE_OBLIGATION_SCHEMA_VERSION,
+            id: "U17".to_string(),
+            question: "Does target T pass at this exact head?".to_string(),
+            subject: requirements(Some("head-a")),
+            established_evidence: vec!["E-history".to_string()],
+            missing_discriminator: discriminator("target_test_result"),
+            clearing_conditions: vec![ClearingCondition {
+                discriminator: discriminator("target_test_result"),
+                requirements: requirements(Some("head-a")),
+            }],
+        }
+    }
+
+    fn context(revision: Option<&str>) -> EvaluationContext {
+        EvaluationContext {
+            repository: Some("owner/repo".to_string()),
+            revision: revision.map(str::to_string),
+            work: None,
+            path: None,
+        }
+    }
+
+    fn probe(
+        id: &str,
+        kind: &str,
+        revision: Option<&str>,
+        effect: ProbeEffect,
+        cost: ProbeCost,
+    ) -> EvidenceProbe {
+        EvidenceProbe {
+            id: id.to_string(),
+            produces: discriminator(kind),
+            requirements: requirements(revision),
+            effect,
+            cost,
+        }
+    }
+
+    fn request(probes: Vec<EvidenceProbe>, allow_effectful: bool) -> ProbePlanRequest {
+        ProbePlanRequest {
+            schema_version: EVIDENCE_PLANNER_SCHEMA_VERSION,
+            obligation: obligation(),
+            context: context(Some("head-a")),
+            probes,
+            allow_effectful,
+            policy: ProbeSelectionPolicy::Conservative,
+        }
+    }
+
+    #[test]
+    fn selects_capable_exact_head_probe_and_skips_cheaper_incapable_work() {
+        let plan = plan_evidence(&request(
+            vec![
+                probe(
+                    "history",
+                    "historical_companion",
+                    Some("head-a"),
+                    ProbeEffect::ReadOnly,
+                    ProbeCost {
+                        git_subprocesses: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+                probe(
+                    "stale-test",
+                    "target_test_result",
+                    Some("old-head"),
+                    ProbeEffect::Effectful,
+                    ProbeCost {
+                        effectful_executions: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+                probe(
+                    "exact-test",
+                    "target_test_result",
+                    Some("head-a"),
+                    ProbeEffect::Effectful,
+                    ProbeCost {
+                        effectful_executions: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+            ],
+            true,
+        ))
+        .unwrap();
+
+        assert_eq!(plan.status, EvidencePlanStatus::Selected);
+        assert_eq!(plan.selected.as_ref().unwrap().id, "exact-test");
+        assert_eq!(plan.candidates[0].id, "exact-test");
+        assert_eq!(plan.candidates[0].status, ProbeCandidateStatus::Eligible);
+        assert_eq!(plan.candidates[1].status, ProbeCandidateStatus::Incapable);
+        assert_eq!(
+            plan.candidates[2].status,
+            ProbeCandidateStatus::IncompatibleClearingCondition
+        );
+    }
+
+    #[test]
+    fn effectful_capability_can_be_selected_without_granting_execution_authority() {
+        let plan = plan_evidence(&request(
+            vec![probe(
+                "exact-test",
+                "target_test_result",
+                Some("head-a"),
+                ProbeEffect::Effectful,
+                ProbeCost {
+                    effectful_executions: 1,
+                    ..ProbeCost::default()
+                },
+            )],
+            false,
+        ))
+        .unwrap();
+
+        assert_eq!(plan.status, EvidencePlanStatus::Blocked);
+        assert!(plan.selected.is_none());
+        assert_eq!(
+            plan.candidates[0].status,
+            ProbeCandidateStatus::EffectAuthorityRequired
+        );
+    }
+
+    #[test]
+    fn conservative_policy_prefers_read_only_capability_before_effectful_probe() {
+        let mut record = obligation();
+        record.missing_discriminator = discriminator("provider_current");
+        record.clearing_conditions[0].discriminator = discriminator("provider_current");
+
+        let mut request = request(
+            vec![
+                probe(
+                    "remote-current",
+                    "provider_current",
+                    Some("head-a"),
+                    ProbeEffect::ExternalRead,
+                    ProbeCost {
+                        remote_requests: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+                probe(
+                    "effectful-current",
+                    "provider_current",
+                    Some("head-a"),
+                    ProbeEffect::Effectful,
+                    ProbeCost {
+                        effectful_executions: 1,
+                        ..ProbeCost::default()
+                    },
+                ),
+            ],
+            true,
+        );
+        request.obligation = record;
+
+        let plan = plan_evidence(&request).unwrap();
+        assert_eq!(plan.selected.as_ref().unwrap().id, "remote-current");
+    }
+
+    #[test]
+    fn no_capable_probe_leaves_an_explicit_unresolved_frontier() {
+        let plan = plan_evidence(&request(
+            vec![probe(
+                "history",
+                "historical_companion",
+                Some("head-a"),
+                ProbeEffect::ReadOnly,
+                ProbeCost {
+                    git_subprocesses: 1,
+                    ..ProbeCost::default()
+                },
+            )],
+            true,
+        ))
+        .unwrap();
+
+        assert_eq!(plan.status, EvidencePlanStatus::Unresolved);
+        assert!(plan.selected.is_none());
+        assert_eq!(plan.candidates[0].status, ProbeCandidateStatus::Incapable);
+    }
+
+    #[test]
+    fn missing_current_coordinate_blocks_planning_instead_of_guessing() {
+        let mut request = request(Vec::new(), true);
+        request.context = context(None);
+
+        let plan = plan_evidence(&request).unwrap();
+        assert_eq!(plan.status, EvidencePlanStatus::Blocked);
+        assert_eq!(plan.obligation_status, DurableObligationStatus::Unknown);
+    }
+
+    #[test]
+    fn moved_obligation_subject_requires_reopen_before_new_probe_selection() {
+        let mut request = request(Vec::new(), true);
+        request.context = context(Some("head-b"));
+
+        let plan = plan_evidence(&request).unwrap();
+        assert_eq!(plan.status, EvidencePlanStatus::StaleObligation);
+        assert_eq!(
+            plan.obligation_status,
+            DurableObligationStatus::ReopenRequired
+        );
+    }
+
+    #[test]
+    fn selected_probe_can_produce_a_receipt_that_clears_the_same_obligation() {
+        let request = request(
+            vec![probe(
+                "exact-test",
+                "target_test_result",
+                Some("head-a"),
+                ProbeEffect::Effectful,
+                ProbeCost {
+                    effectful_executions: 1,
+                    ..ProbeCost::default()
+                },
+            )],
+            true,
+        );
+        let plan = plan_evidence(&request).unwrap();
+        let selected = plan.selected.unwrap();
+
+        let receipt = ClearingEvidenceReceipt {
+            id: "executed-test-receipt".to_string(),
+            discriminator: selected.produces,
+            requirements: selected.requirements,
+        };
+        let evaluation = evaluate_obligation(&request.obligation, &[receipt], &request.context)
+            .unwrap();
+        assert_eq!(evaluation.status, DurableObligationStatus::Cleared);
+    }
+
+    #[test]
+    fn malformed_effect_forecast_fails_explicitly() {
+        let error = plan_evidence(&request(
+            vec![probe(
+                "bad-test",
+                "target_test_result",
+                Some("head-a"),
+                ProbeEffect::Effectful,
+                ProbeCost::default(),
+            )],
+            true,
+        ))
+        .unwrap_err();
+
+        assert!(error.to_string().contains("effectful executions"));
+    }
+}

--- a/src/evidence_planner.rs
+++ b/src/evidence_planner.rs
@@ -235,10 +235,7 @@ fn evaluate_candidate<'a>(
             context: context.clone(),
         })
         .map_err(|error| {
-            EvidencePlannerError::new(format!(
-                "probe {} applicability failed: {error}",
-                probe.id
-            ))
+            EvidencePlannerError::new(format!("probe {} applicability failed: {error}", probe.id))
         })?;
 
         match applicability.status {
@@ -388,7 +385,11 @@ fn require_coordinates(requirements: &EvidenceRequirements) -> Result<(), Eviden
 }
 
 fn validate_id(value: &str, field: &str) -> Result<(), EvidencePlannerError> {
-    if value.is_empty() || value.trim() != value || value.len() > MAX_ID_BYTES || value.contains('\0') {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_ID_BYTES
+        || value.contains('\0')
+    {
         return Err(EvidencePlannerError::new(format!(
             "{field} must be a bounded canonical identifier"
         )));
@@ -663,8 +664,8 @@ mod tests {
             discriminator: selected.produces,
             requirements: selected.requirements,
         };
-        let evaluation = evaluate_obligation(&request.obligation, &[receipt], &request.context)
-            .unwrap();
+        let evaluation =
+            evaluate_obligation(&request.obligation, &[receipt], &request.context).unwrap();
         assert_eq!(evaluation.status, DurableObligationStatus::Cleared);
     }
 

--- a/src/justification.rs
+++ b/src/justification.rs
@@ -414,7 +414,6 @@ fn validate_graph(graph: &JustificationGraph) -> Result<(), JustificationError> 
 
     let mut edge_keys = BTreeSet::new();
     let mut supported_claims = BTreeSet::new();
-    let mut clearable_obligations = BTreeSet::new();
     for edge in &graph.edges {
         if !evidence_ids.contains(&edge.evidence_id) {
             return Err(JustificationError::new(format!(
@@ -445,7 +444,6 @@ fn validate_graph(graph: &JustificationGraph) -> Result<(), JustificationError> 
                         "edge references unknown obligation {id}"
                     )));
                 }
-                clearable_obligations.insert(id.clone());
             }
             (JustificationTarget::Obligation(id), relation) => {
                 return Err(JustificationError::new(format!(
@@ -454,11 +452,7 @@ fn validate_graph(graph: &JustificationGraph) -> Result<(), JustificationError> 
             }
         }
 
-        let key = (
-            edge.evidence_id.clone(),
-            edge.target.clone(),
-            edge.relation,
-        );
+        let key = (edge.evidence_id.clone(), edge.target.clone(), edge.relation);
         if !edge_keys.insert(key) {
             return Err(JustificationError::new("duplicate justification edge"));
         }
@@ -467,11 +461,6 @@ fn validate_graph(graph: &JustificationGraph) -> Result<(), JustificationError> 
     if let Some(id) = claim_ids.difference(&supported_claims).next() {
         return Err(JustificationError::new(format!(
             "claim {id} has no support edge"
-        )));
-    }
-    if let Some(id) = obligation_ids.difference(&clearable_obligations).next() {
-        return Err(JustificationError::new(format!(
-            "obligation {id} has no clearing edge"
         )));
     }
 
@@ -598,7 +587,10 @@ mod tests {
         };
 
         let evaluation = evaluate_graph(&graph, &context("owner/repo", Some("new-head"))).unwrap();
-        assert_eq!(evaluation.claims[0].status, ClaimJustificationStatus::Supported);
+        assert_eq!(
+            evaluation.claims[0].status,
+            ClaimJustificationStatus::Supported
+        );
         assert_eq!(evaluation.claims[0].support.applies, vec!["E2"]);
         assert_eq!(evaluation.claims[0].support.invalid, vec!["E1"]);
     }
@@ -614,7 +606,10 @@ mod tests {
         };
 
         let evaluation = evaluate_graph(&graph, &context("owner/repo", Some("new-head"))).unwrap();
-        assert_eq!(evaluation.claims[0].status, ClaimJustificationStatus::Unknown);
+        assert_eq!(
+            evaluation.claims[0].status,
+            ClaimJustificationStatus::Unknown
+        );
         assert_eq!(evaluation.claims[0].support.invalid, vec!["E1"]);
     }
 
@@ -649,6 +644,24 @@ mod tests {
         assert_eq!(claim.status, ClaimJustificationStatus::Supported);
         assert_eq!(claim.counterexamples.applies, vec!["E2"]);
         assert_eq!(claim.limits.applies, vec!["E3"]);
+    }
+
+    #[test]
+    fn open_obligation_can_exist_before_clearing_evidence_arrives() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: Vec::new(),
+            claims: Vec::new(),
+            obligations: vec![ObligationNode {
+                id: "U0".to_string(),
+                question: "which exact evidence clears this?".to_string(),
+            }],
+            edges: Vec::new(),
+        };
+
+        let evaluation = evaluate_graph(&graph, &context("owner/repo", Some("head"))).unwrap();
+        assert_eq!(evaluation.obligations[0].status, ObligationStatus::Open);
+        assert!(evaluation.obligations[0].clearing.applies.is_empty());
     }
 
     #[test]
@@ -725,7 +738,10 @@ mod tests {
         };
 
         let evaluation = evaluate_graph(&graph, &context("owner/repo", None)).unwrap();
-        assert_eq!(evaluation.claims[0].status, ClaimJustificationStatus::Unknown);
+        assert_eq!(
+            evaluation.claims[0].status,
+            ClaimJustificationStatus::Unknown
+        );
         assert_eq!(evaluation.claims[0].dependencies.unknown, vec!["E2"]);
     }
 

--- a/src/justification.rs
+++ b/src/justification.rs
@@ -1,0 +1,752 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, evaluate_query,
+};
+
+pub const JUSTIFICATION_SCHEMA_VERSION: u32 = 1;
+const MAX_NODES: usize = 1024;
+const MAX_EDGES: usize = 4096;
+const MAX_ID_BYTES: usize = 256;
+const MAX_TEXT_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct JustificationGraph {
+    pub schema_version: u32,
+    pub evidence: Vec<EvidenceNode>,
+    pub claims: Vec<ClaimNode>,
+    pub obligations: Vec<ObligationNode>,
+    pub edges: Vec<JustificationEdge>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceNode {
+    pub id: String,
+    pub requirements: EvidenceRequirements,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClaimNode {
+    pub id: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObligationNode {
+    pub id: String,
+    pub question: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
+#[serde(tag = "kind", content = "id", rename_all = "snake_case")]
+pub enum JustificationTarget {
+    Claim(String),
+    Obligation(String),
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JustificationRelation {
+    Support,
+    Counterexample,
+    Limit,
+    Dependency,
+    Clearing,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct JustificationEdge {
+    pub evidence_id: String,
+    pub target: JustificationTarget,
+    pub relation: JustificationRelation,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct JustificationEvaluation {
+    pub schema_version: u32,
+    pub evidence: Vec<EvidenceEvaluation>,
+    pub claims: Vec<ClaimEvaluation>,
+    pub obligations: Vec<ObligationEvaluation>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceEvaluation {
+    pub id: String,
+    pub applicability: ApplicabilityStatus,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimJustificationStatus {
+    Supported,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RelationReceipt {
+    pub applies: Vec<String>,
+    pub invalid: Vec<String>,
+    pub unknown: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClaimEvaluation {
+    pub id: String,
+    pub status: ClaimJustificationStatus,
+    pub support: RelationReceipt,
+    pub counterexamples: RelationReceipt,
+    pub limits: RelationReceipt,
+    pub dependencies: RelationReceipt,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObligationStatus {
+    Open,
+    Cleared,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObligationEvaluation {
+    pub id: String,
+    pub status: ObligationStatus,
+    pub clearing: RelationReceipt,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceTransition {
+    pub id: String,
+    pub before: ApplicabilityStatus,
+    pub after: ApplicabilityStatus,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReevaluationReceipt {
+    pub schema_version: u32,
+    pub evidence_transitions: Vec<EvidenceTransition>,
+    pub affected_targets: Vec<JustificationTarget>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct JustificationError {
+    message: String,
+}
+
+impl JustificationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for JustificationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for JustificationError {}
+
+pub fn evaluate_graph(
+    graph: &JustificationGraph,
+    context: &EvaluationContext,
+) -> Result<JustificationEvaluation, JustificationError> {
+    validate_graph(graph)?;
+    let evidence_status = evaluate_evidence(graph, context)?;
+
+    let mut claim_receipts: BTreeMap<String, ClaimReceipts> = graph
+        .claims
+        .iter()
+        .map(|claim| (claim.id.clone(), ClaimReceipts::default()))
+        .collect();
+    let mut obligation_receipts: BTreeMap<String, RelationReceipt> = graph
+        .obligations
+        .iter()
+        .map(|obligation| (obligation.id.clone(), RelationReceipt::default()))
+        .collect();
+
+    for edge in &graph.edges {
+        let status = evidence_status[&edge.evidence_id];
+        match (&edge.target, edge.relation) {
+            (JustificationTarget::Claim(id), JustificationRelation::Support) => {
+                claim_receipts
+                    .get_mut(id)
+                    .expect("validated claim target")
+                    .support
+                    .push(edge.evidence_id.clone(), status);
+            }
+            (JustificationTarget::Claim(id), JustificationRelation::Counterexample) => {
+                claim_receipts
+                    .get_mut(id)
+                    .expect("validated claim target")
+                    .counterexamples
+                    .push(edge.evidence_id.clone(), status);
+            }
+            (JustificationTarget::Claim(id), JustificationRelation::Limit) => {
+                claim_receipts
+                    .get_mut(id)
+                    .expect("validated claim target")
+                    .limits
+                    .push(edge.evidence_id.clone(), status);
+            }
+            (JustificationTarget::Claim(id), JustificationRelation::Dependency) => {
+                claim_receipts
+                    .get_mut(id)
+                    .expect("validated claim target")
+                    .dependencies
+                    .push(edge.evidence_id.clone(), status);
+            }
+            (JustificationTarget::Obligation(id), JustificationRelation::Clearing) => {
+                obligation_receipts
+                    .get_mut(id)
+                    .expect("validated obligation target")
+                    .push(edge.evidence_id.clone(), status);
+            }
+            _ => unreachable!("validated relation/target pairing"),
+        }
+    }
+
+    let evidence = evidence_status
+        .iter()
+        .map(|(id, applicability)| EvidenceEvaluation {
+            id: id.clone(),
+            applicability: *applicability,
+        })
+        .collect();
+
+    let claims = graph
+        .claims
+        .iter()
+        .map(|claim| {
+            let mut receipts = claim_receipts
+                .remove(&claim.id)
+                .expect("claim accumulator exists");
+            receipts.sort();
+
+            let dependencies_block = !receipts.dependencies.invalid.is_empty()
+                || !receipts.dependencies.unknown.is_empty();
+            let status = if !dependencies_block && !receipts.support.applies.is_empty() {
+                ClaimJustificationStatus::Supported
+            } else {
+                ClaimJustificationStatus::Unknown
+            };
+
+            ClaimEvaluation {
+                id: claim.id.clone(),
+                status,
+                support: receipts.support,
+                counterexamples: receipts.counterexamples,
+                limits: receipts.limits,
+                dependencies: receipts.dependencies,
+            }
+        })
+        .collect();
+
+    let obligations = graph
+        .obligations
+        .iter()
+        .map(|obligation| {
+            let mut clearing = obligation_receipts
+                .remove(&obligation.id)
+                .expect("obligation accumulator exists");
+            clearing.sort();
+            let status = if !clearing.applies.is_empty() {
+                ObligationStatus::Cleared
+            } else if !clearing.unknown.is_empty() {
+                ObligationStatus::Unknown
+            } else {
+                ObligationStatus::Open
+            };
+
+            ObligationEvaluation {
+                id: obligation.id.clone(),
+                status,
+                clearing,
+            }
+        })
+        .collect();
+
+    Ok(JustificationEvaluation {
+        schema_version: JUSTIFICATION_SCHEMA_VERSION,
+        evidence,
+        claims,
+        obligations,
+    })
+}
+
+pub fn reevaluate_graph(
+    graph: &JustificationGraph,
+    before: &EvaluationContext,
+    after: &EvaluationContext,
+) -> Result<ReevaluationReceipt, JustificationError> {
+    validate_graph(graph)?;
+    let before_status = evaluate_evidence(graph, before)?;
+    let after_status = evaluate_evidence(graph, after)?;
+
+    let mut changed = BTreeSet::new();
+    let mut evidence_transitions = Vec::new();
+    for (id, before) in &before_status {
+        let after = after_status[id];
+        if *before != after {
+            changed.insert(id.clone());
+            evidence_transitions.push(EvidenceTransition {
+                id: id.clone(),
+                before: *before,
+                after,
+            });
+        }
+    }
+
+    let affected_targets = graph
+        .edges
+        .iter()
+        .filter(|edge| changed.contains(&edge.evidence_id))
+        .map(|edge| edge.target.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    Ok(ReevaluationReceipt {
+        schema_version: JUSTIFICATION_SCHEMA_VERSION,
+        evidence_transitions,
+        affected_targets,
+    })
+}
+
+fn evaluate_evidence(
+    graph: &JustificationGraph,
+    context: &EvaluationContext,
+) -> Result<BTreeMap<String, ApplicabilityStatus>, JustificationError> {
+    graph
+        .evidence
+        .iter()
+        .map(|evidence| {
+            let query = ApplicabilityQuery {
+                schema_version: APPLICABILITY_SCHEMA_VERSION,
+                requirements: evidence.requirements.clone(),
+                context: context.clone(),
+            };
+            let evaluation = evaluate_query(&query).map_err(|error| {
+                JustificationError::new(format!(
+                    "evidence {} applicability failed: {error}",
+                    evidence.id
+                ))
+            })?;
+            Ok((evidence.id.clone(), evaluation.status))
+        })
+        .collect()
+}
+
+fn validate_graph(graph: &JustificationGraph) -> Result<(), JustificationError> {
+    if graph.schema_version != JUSTIFICATION_SCHEMA_VERSION {
+        return Err(JustificationError::new(format!(
+            "unsupported justification schema {}; expected {JUSTIFICATION_SCHEMA_VERSION}",
+            graph.schema_version
+        )));
+    }
+
+    let total_nodes = graph.evidence.len() + graph.claims.len() + graph.obligations.len();
+    if total_nodes > MAX_NODES || graph.edges.len() > MAX_EDGES {
+        return Err(JustificationError::new(
+            "justification graph exceeds the admitted node/edge boundary",
+        ));
+    }
+
+    let mut evidence_ids = BTreeSet::new();
+    for evidence in &graph.evidence {
+        validate_id(&evidence.id, "evidence id")?;
+        if !evidence_ids.insert(evidence.id.clone()) {
+            return Err(JustificationError::new(format!(
+                "duplicate evidence id {}",
+                evidence.id
+            )));
+        }
+        if requirements_are_empty(&evidence.requirements) {
+            return Err(JustificationError::new(format!(
+                "evidence {} must carry at least one applicability requirement",
+                evidence.id
+            )));
+        }
+    }
+
+    let mut claim_ids = BTreeSet::new();
+    for claim in &graph.claims {
+        validate_id(&claim.id, "claim id")?;
+        validate_text(&claim.message, "claim message")?;
+        if !claim_ids.insert(claim.id.clone()) {
+            return Err(JustificationError::new(format!(
+                "duplicate claim id {}",
+                claim.id
+            )));
+        }
+    }
+
+    let mut obligation_ids = BTreeSet::new();
+    for obligation in &graph.obligations {
+        validate_id(&obligation.id, "obligation id")?;
+        validate_text(&obligation.question, "obligation question")?;
+        if !obligation_ids.insert(obligation.id.clone()) {
+            return Err(JustificationError::new(format!(
+                "duplicate obligation id {}",
+                obligation.id
+            )));
+        }
+    }
+
+    let mut edge_keys = BTreeSet::new();
+    let mut supported_claims = BTreeSet::new();
+    let mut clearable_obligations = BTreeSet::new();
+    for edge in &graph.edges {
+        if !evidence_ids.contains(&edge.evidence_id) {
+            return Err(JustificationError::new(format!(
+                "edge references unknown evidence {}",
+                edge.evidence_id
+            )));
+        }
+
+        match (&edge.target, edge.relation) {
+            (JustificationTarget::Claim(id), JustificationRelation::Clearing) => {
+                return Err(JustificationError::new(format!(
+                    "clearing relation cannot target claim {id}"
+                )));
+            }
+            (JustificationTarget::Claim(id), relation) => {
+                if !claim_ids.contains(id) {
+                    return Err(JustificationError::new(format!(
+                        "edge references unknown claim {id}"
+                    )));
+                }
+                if relation == JustificationRelation::Support {
+                    supported_claims.insert(id.clone());
+                }
+            }
+            (JustificationTarget::Obligation(id), JustificationRelation::Clearing) => {
+                if !obligation_ids.contains(id) {
+                    return Err(JustificationError::new(format!(
+                        "edge references unknown obligation {id}"
+                    )));
+                }
+                clearable_obligations.insert(id.clone());
+            }
+            (JustificationTarget::Obligation(id), relation) => {
+                return Err(JustificationError::new(format!(
+                    "{relation:?} relation cannot target obligation {id}"
+                )));
+            }
+        }
+
+        let key = (
+            edge.evidence_id.clone(),
+            edge.target.clone(),
+            edge.relation,
+        );
+        if !edge_keys.insert(key) {
+            return Err(JustificationError::new("duplicate justification edge"));
+        }
+    }
+
+    if let Some(id) = claim_ids.difference(&supported_claims).next() {
+        return Err(JustificationError::new(format!(
+            "claim {id} has no support edge"
+        )));
+    }
+    if let Some(id) = obligation_ids.difference(&clearable_obligations).next() {
+        return Err(JustificationError::new(format!(
+            "obligation {id} has no clearing edge"
+        )));
+    }
+
+    Ok(())
+}
+
+fn requirements_are_empty(requirements: &EvidenceRequirements) -> bool {
+    requirements.repository.is_none()
+        && requirements.revision.is_none()
+        && requirements.work.is_none()
+        && requirements.scope.is_none()
+}
+
+fn validate_id(id: &str, field: &str) -> Result<(), JustificationError> {
+    if id.is_empty() || id.trim() != id || id.len() > MAX_ID_BYTES || id.contains('\0') {
+        return Err(JustificationError::new(format!(
+            "{field} must be a bounded canonical identifier"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, field: &str) -> Result<(), JustificationError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_TEXT_BYTES
+        || value.contains('\0')
+    {
+        return Err(JustificationError::new(format!(
+            "{field} must be bounded non-empty text"
+        )));
+    }
+    Ok(())
+}
+
+impl RelationReceipt {
+    fn push(&mut self, evidence_id: String, status: ApplicabilityStatus) {
+        match status {
+            ApplicabilityStatus::Applies => self.applies.push(evidence_id),
+            ApplicabilityStatus::Invalid => self.invalid.push(evidence_id),
+            ApplicabilityStatus::Unknown => self.unknown.push(evidence_id),
+        }
+    }
+
+    fn sort(&mut self) {
+        self.applies.sort();
+        self.invalid.sort();
+        self.unknown.sort();
+    }
+}
+
+#[derive(Debug, Default)]
+struct ClaimReceipts {
+    support: RelationReceipt,
+    counterexamples: RelationReceipt,
+    limits: RelationReceipt,
+    dependencies: RelationReceipt,
+}
+
+impl ClaimReceipts {
+    fn sort(&mut self) {
+        self.support.sort();
+        self.counterexamples.sort();
+        self.limits.sort();
+        self.dependencies.sort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn requirements(repository: Option<&str>, revision: Option<&str>) -> EvidenceRequirements {
+        EvidenceRequirements {
+            repository: repository.map(str::to_string),
+            revision: revision.map(str::to_string),
+            work: None,
+            scope: None,
+        }
+    }
+
+    fn evidence(id: &str, requirements: EvidenceRequirements) -> EvidenceNode {
+        EvidenceNode {
+            id: id.to_string(),
+            requirements,
+        }
+    }
+
+    fn claim(id: &str) -> ClaimNode {
+        ClaimNode {
+            id: id.to_string(),
+            message: format!("claim {id}"),
+        }
+    }
+
+    fn support(evidence_id: &str, claim_id: &str) -> JustificationEdge {
+        JustificationEdge {
+            evidence_id: evidence_id.to_string(),
+            target: JustificationTarget::Claim(claim_id.to_string()),
+            relation: JustificationRelation::Support,
+        }
+    }
+
+    fn context(repository: &str, revision: Option<&str>) -> EvaluationContext {
+        EvaluationContext {
+            repository: Some(repository.to_string()),
+            revision: revision.map(str::to_string),
+            work: None,
+            path: None,
+        }
+    }
+
+    #[test]
+    fn independent_support_survives_one_invalidated_receipt() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: vec![
+                evidence("E1", requirements(None, Some("old-head"))),
+                evidence("E2", requirements(Some("owner/repo"), None)),
+            ],
+            claims: vec![claim("C1")],
+            obligations: Vec::new(),
+            edges: vec![support("E1", "C1"), support("E2", "C1")],
+        };
+
+        let evaluation = evaluate_graph(&graph, &context("owner/repo", Some("new-head"))).unwrap();
+        assert_eq!(evaluation.claims[0].status, ClaimJustificationStatus::Supported);
+        assert_eq!(evaluation.claims[0].support.applies, vec!["E2"]);
+        assert_eq!(evaluation.claims[0].support.invalid, vec!["E1"]);
+    }
+
+    #[test]
+    fn sole_invalidated_support_returns_claim_to_unknown() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: vec![evidence("E1", requirements(None, Some("old-head")))],
+            claims: vec![claim("C1")],
+            obligations: Vec::new(),
+            edges: vec![support("E1", "C1")],
+        };
+
+        let evaluation = evaluate_graph(&graph, &context("owner/repo", Some("new-head"))).unwrap();
+        assert_eq!(evaluation.claims[0].status, ClaimJustificationStatus::Unknown);
+        assert_eq!(evaluation.claims[0].support.invalid, vec!["E1"]);
+    }
+
+    #[test]
+    fn counterexamples_and_limits_remain_visible_without_collapsing_support() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: vec![
+                evidence("E1", requirements(Some("owner/repo"), None)),
+                evidence("E2", requirements(Some("owner/repo"), None)),
+                evidence("E3", requirements(Some("owner/repo"), None)),
+            ],
+            claims: vec![claim("C1")],
+            obligations: Vec::new(),
+            edges: vec![
+                support("E1", "C1"),
+                JustificationEdge {
+                    evidence_id: "E2".to_string(),
+                    target: JustificationTarget::Claim("C1".to_string()),
+                    relation: JustificationRelation::Counterexample,
+                },
+                JustificationEdge {
+                    evidence_id: "E3".to_string(),
+                    target: JustificationTarget::Claim("C1".to_string()),
+                    relation: JustificationRelation::Limit,
+                },
+            ],
+        };
+
+        let evaluation = evaluate_graph(&graph, &context("owner/repo", Some("head"))).unwrap();
+        let claim = &evaluation.claims[0];
+        assert_eq!(claim.status, ClaimJustificationStatus::Supported);
+        assert_eq!(claim.counterexamples.applies, vec!["E2"]);
+        assert_eq!(claim.limits.applies, vec!["E3"]);
+    }
+
+    #[test]
+    fn exact_clearing_evidence_resolves_obligation_and_reopens_after_head_moves() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: vec![evidence("E1", requirements(None, Some("exact-head")))],
+            claims: Vec::new(),
+            obligations: vec![ObligationNode {
+                id: "U1".to_string(),
+                question: "run exact target execution?".to_string(),
+            }],
+            edges: vec![JustificationEdge {
+                evidence_id: "E1".to_string(),
+                target: JustificationTarget::Obligation("U1".to_string()),
+                relation: JustificationRelation::Clearing,
+            }],
+        };
+
+        let cleared = evaluate_graph(&graph, &context("owner/repo", Some("exact-head"))).unwrap();
+        assert_eq!(cleared.obligations[0].status, ObligationStatus::Cleared);
+
+        let reopened = evaluate_graph(&graph, &context("owner/repo", Some("new-head"))).unwrap();
+        assert_eq!(reopened.obligations[0].status, ObligationStatus::Open);
+        assert_eq!(reopened.obligations[0].clearing.invalid, vec!["E1"]);
+    }
+
+    #[test]
+    fn reevaluation_names_only_targets_downstream_of_changed_evidence() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: vec![
+                evidence("E1", requirements(None, Some("old-head"))),
+                evidence("E2", requirements(Some("owner/repo"), None)),
+            ],
+            claims: vec![claim("C1"), claim("C2")],
+            obligations: Vec::new(),
+            edges: vec![support("E1", "C1"), support("E2", "C2")],
+        };
+
+        let receipt = reevaluate_graph(
+            &graph,
+            &context("owner/repo", Some("old-head")),
+            &context("owner/repo", Some("new-head")),
+        )
+        .unwrap();
+
+        assert_eq!(receipt.evidence_transitions.len(), 1);
+        assert_eq!(receipt.evidence_transitions[0].id, "E1");
+        assert_eq!(
+            receipt.affected_targets,
+            vec![JustificationTarget::Claim("C1".to_string())]
+        );
+    }
+
+    #[test]
+    fn dependency_unknown_prevents_supported_projection() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: vec![
+                evidence("E1", requirements(Some("owner/repo"), None)),
+                evidence("E2", requirements(None, Some("exact-head"))),
+            ],
+            claims: vec![claim("C1")],
+            obligations: Vec::new(),
+            edges: vec![
+                support("E1", "C1"),
+                JustificationEdge {
+                    evidence_id: "E2".to_string(),
+                    target: JustificationTarget::Claim("C1".to_string()),
+                    relation: JustificationRelation::Dependency,
+                },
+            ],
+        };
+
+        let evaluation = evaluate_graph(&graph, &context("owner/repo", None)).unwrap();
+        assert_eq!(evaluation.claims[0].status, ClaimJustificationStatus::Unknown);
+        assert_eq!(evaluation.claims[0].dependencies.unknown, vec!["E2"]);
+    }
+
+    #[test]
+    fn typed_targets_keep_v0_graph_acyclic_and_reject_relation_mismatch() {
+        let graph = JustificationGraph {
+            schema_version: JUSTIFICATION_SCHEMA_VERSION,
+            evidence: vec![evidence("E1", requirements(Some("owner/repo"), None))],
+            claims: Vec::new(),
+            obligations: vec![ObligationNode {
+                id: "U1".to_string(),
+                question: "resolve?".to_string(),
+            }],
+            edges: vec![JustificationEdge {
+                evidence_id: "E1".to_string(),
+                target: JustificationTarget::Obligation("U1".to_string()),
+                relation: JustificationRelation::Support,
+            }],
+        };
+
+        let error = evaluate_graph(&graph, &context("owner/repo", Some("head"))).unwrap_err();
+        assert!(error.to_string().contains("cannot target obligation"));
+    }
+}

--- a/src/observation_frontier.rs
+++ b/src/observation_frontier.rs
@@ -5,11 +5,11 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 use crate::discriminator_observation::{
-    DiscriminatorObservation, DiscriminatorObservationBatch, DiscriminatorValueState,
-    validate_discriminator_observation_batch,
+    DiscriminatorObservation, DiscriminatorObservationBatch, ObservationCurrentness,
+    classify_observation_currentness, validate_discriminator_observation_batch,
 };
 
-pub const OBSERVATION_FRONTIER_SCHEMA_VERSION: u32 = 1;
+pub const OBSERVATION_FRONTIER_SCHEMA_VERSION: u32 = 2;
 pub const MAX_OBSERVATION_FRONTIER_REQUEST_BYTES: usize = 512 * 1024;
 const MAX_REQUIREMENTS: usize = 256;
 const MAX_ID_BYTES: usize = 512;
@@ -64,8 +64,7 @@ pub struct CurrentObservationReceipt {
     pub observation_id: String,
     pub source_receipt: String,
     pub value_ref: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub applicability_ref: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -73,15 +72,17 @@ pub struct CurrentObservationReceipt {
 pub struct NonCurrentObservationReceipt {
     pub observation_id: String,
     pub source_receipt: String,
-    pub reason_ref: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub applicability_ref: Option<String>,
+    pub known_value_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_unknown_reason_ref: Option<String>,
+    pub applicability_ref: String,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ObservationValueStateKind {
-    Known,
+pub enum ObservationCurrentnessKind {
+    Current,
     Unknown,
     Invalid,
 }
@@ -92,7 +93,7 @@ pub struct OtherSubjectObservationReceipt {
     pub observation_id: String,
     pub subject_ref: String,
     pub source_receipt: String,
-    pub state: ObservationValueStateKind,
+    pub state: ObservationCurrentnessKind,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -166,41 +167,47 @@ fn evaluate_requirement(
         .iter()
         .filter(|observation| observation.discriminator_id == requirement.discriminator_id)
     {
+        let currentness = classify_observation_currentness(observation);
         if observation.subject_ref != requirement.subject_ref {
             other_subject.push(OtherSubjectObservationReceipt {
                 observation_id: observation.observation_id.clone(),
                 subject_ref: observation.subject_ref.clone(),
                 source_receipt: observation.source_receipt.clone(),
-                state: value_state_kind(&observation.value_state),
+                state: currentness_kind(currentness),
             });
             continue;
         }
 
-        match &observation.value_state {
-            DiscriminatorValueState::Known { value_ref } => {
-                current.push(CurrentObservationReceipt {
-                    observation_id: observation.observation_id.clone(),
-                    source_receipt: observation.source_receipt.clone(),
-                    value_ref: value_ref.clone(),
-                    applicability_ref: observation.applicability_ref.clone(),
-                });
-            }
-            DiscriminatorValueState::Unknown { reason_ref } => {
-                unknown.push(NonCurrentObservationReceipt {
-                    observation_id: observation.observation_id.clone(),
-                    source_receipt: observation.source_receipt.clone(),
-                    reason_ref: reason_ref.clone(),
-                    applicability_ref: observation.applicability_ref.clone(),
-                });
-            }
-            DiscriminatorValueState::Invalid { reason_ref } => {
-                invalid.push(NonCurrentObservationReceipt {
-                    observation_id: observation.observation_id.clone(),
-                    source_receipt: observation.source_receipt.clone(),
-                    reason_ref: reason_ref.clone(),
-                    applicability_ref: observation.applicability_ref.clone(),
-                });
-            }
+        match currentness {
+            ObservationCurrentness::Current {
+                value_ref,
+                applicability_ref,
+            } => current.push(CurrentObservationReceipt {
+                observation_id: observation.observation_id.clone(),
+                source_receipt: observation.source_receipt.clone(),
+                value_ref: value_ref.to_string(),
+                applicability_ref: applicability_ref.to_string(),
+            }),
+            ObservationCurrentness::Unknown {
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            } => unknown.push(non_current_receipt(
+                observation,
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            )),
+            ObservationCurrentness::Invalid {
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            } => invalid.push(non_current_receipt(
+                observation,
+                known_value_ref,
+                value_unknown_reason_ref,
+                applicability_ref,
+            )),
         }
     }
 
@@ -230,11 +237,26 @@ fn evaluate_requirement(
     }
 }
 
-fn value_state_kind(value_state: &DiscriminatorValueState) -> ObservationValueStateKind {
-    match value_state {
-        DiscriminatorValueState::Known { .. } => ObservationValueStateKind::Known,
-        DiscriminatorValueState::Unknown { .. } => ObservationValueStateKind::Unknown,
-        DiscriminatorValueState::Invalid { .. } => ObservationValueStateKind::Invalid,
+fn currentness_kind(currentness: ObservationCurrentness<'_>) -> ObservationCurrentnessKind {
+    match currentness {
+        ObservationCurrentness::Current { .. } => ObservationCurrentnessKind::Current,
+        ObservationCurrentness::Unknown { .. } => ObservationCurrentnessKind::Unknown,
+        ObservationCurrentness::Invalid { .. } => ObservationCurrentnessKind::Invalid,
+    }
+}
+
+fn non_current_receipt(
+    observation: &DiscriminatorObservation,
+    known_value_ref: Option<&str>,
+    value_unknown_reason_ref: Option<&str>,
+    applicability_ref: &str,
+) -> NonCurrentObservationReceipt {
+    NonCurrentObservationReceipt {
+        observation_id: observation.observation_id.clone(),
+        source_receipt: observation.source_receipt.clone(),
+        known_value_ref: known_value_ref.map(str::to_string),
+        value_unknown_reason_ref: value_unknown_reason_ref.map(str::to_string),
+        applicability_ref: applicability_ref.to_string(),
     }
 }
 

--- a/src/observation_frontier.rs
+++ b/src/observation_frontier.rs
@@ -1,0 +1,295 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::discriminator_observation::{
+    DiscriminatorObservation, DiscriminatorObservationBatch, DiscriminatorValueState,
+    validate_discriminator_observation_batch,
+};
+
+pub const OBSERVATION_FRONTIER_SCHEMA_VERSION: u32 = 1;
+pub const MAX_OBSERVATION_FRONTIER_REQUEST_BYTES: usize = 512 * 1024;
+const MAX_REQUIREMENTS: usize = 256;
+const MAX_ID_BYTES: usize = 512;
+const MAX_REFERENCE_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationFrontierRequest {
+    pub schema_version: u32,
+    pub requirements: Vec<ObservationRequirement>,
+    pub observations: DiscriminatorObservationBatch,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationRequirement {
+    pub discriminator_id: String,
+    pub subject_ref: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationFrontierStatus {
+    Current,
+    Unknown,
+    Invalid,
+    Missing,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationFrontierEvaluation {
+    pub schema_version: u32,
+    pub frontiers: Vec<ObservationFrontierReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationFrontierReceipt {
+    pub discriminator_id: String,
+    pub subject_ref: String,
+    pub status: ObservationFrontierStatus,
+    pub current: Vec<CurrentObservationReceipt>,
+    pub unknown: Vec<NonCurrentObservationReceipt>,
+    pub invalid: Vec<NonCurrentObservationReceipt>,
+    pub other_subject: Vec<OtherSubjectObservationReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CurrentObservationReceipt {
+    pub observation_id: String,
+    pub source_receipt: String,
+    pub value_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct NonCurrentObservationReceipt {
+    pub observation_id: String,
+    pub source_receipt: String,
+    pub reason_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applicability_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationValueStateKind {
+    Known,
+    Unknown,
+    Invalid,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OtherSubjectObservationReceipt {
+    pub observation_id: String,
+    pub subject_ref: String,
+    pub source_receipt: String,
+    pub state: ObservationValueStateKind,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ObservationFrontierError {
+    message: String,
+}
+
+impl ObservationFrontierError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ObservationFrontierError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for ObservationFrontierError {}
+
+pub fn parse_observation_frontier_request(
+    bytes: &[u8],
+) -> Result<ObservationFrontierRequest, ObservationFrontierError> {
+    if bytes.len() > MAX_OBSERVATION_FRONTIER_REQUEST_BYTES {
+        return Err(ObservationFrontierError::new(format!(
+            "observation frontier request exceeds the {MAX_OBSERVATION_FRONTIER_REQUEST_BYTES}-byte limit"
+        )));
+    }
+    let request: ObservationFrontierRequest = serde_json::from_slice(bytes).map_err(|error| {
+        ObservationFrontierError::new(format!("invalid observation frontier JSON: {error}"))
+    })?;
+    validate_request(&request)?;
+    Ok(request)
+}
+
+pub fn evaluate_observation_frontiers(
+    request: &ObservationFrontierRequest,
+) -> Result<ObservationFrontierEvaluation, ObservationFrontierError> {
+    validate_request(request)?;
+
+    let mut frontiers = request
+        .requirements
+        .iter()
+        .map(|requirement| evaluate_requirement(requirement, &request.observations.observations))
+        .collect::<Vec<_>>();
+    frontiers.sort_by(|left, right| {
+        left.discriminator_id
+            .cmp(&right.discriminator_id)
+            .then_with(|| left.subject_ref.cmp(&right.subject_ref))
+    });
+
+    Ok(ObservationFrontierEvaluation {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        frontiers,
+    })
+}
+
+fn evaluate_requirement(
+    requirement: &ObservationRequirement,
+    observations: &[DiscriminatorObservation],
+) -> ObservationFrontierReceipt {
+    let mut current = Vec::new();
+    let mut unknown = Vec::new();
+    let mut invalid = Vec::new();
+    let mut other_subject = Vec::new();
+
+    for observation in observations
+        .iter()
+        .filter(|observation| observation.discriminator_id == requirement.discriminator_id)
+    {
+        if observation.subject_ref != requirement.subject_ref {
+            other_subject.push(OtherSubjectObservationReceipt {
+                observation_id: observation.observation_id.clone(),
+                subject_ref: observation.subject_ref.clone(),
+                source_receipt: observation.source_receipt.clone(),
+                state: value_state_kind(&observation.value_state),
+            });
+            continue;
+        }
+
+        match &observation.value_state {
+            DiscriminatorValueState::Known { value_ref } => {
+                current.push(CurrentObservationReceipt {
+                    observation_id: observation.observation_id.clone(),
+                    source_receipt: observation.source_receipt.clone(),
+                    value_ref: value_ref.clone(),
+                    applicability_ref: observation.applicability_ref.clone(),
+                });
+            }
+            DiscriminatorValueState::Unknown { reason_ref } => {
+                unknown.push(NonCurrentObservationReceipt {
+                    observation_id: observation.observation_id.clone(),
+                    source_receipt: observation.source_receipt.clone(),
+                    reason_ref: reason_ref.clone(),
+                    applicability_ref: observation.applicability_ref.clone(),
+                });
+            }
+            DiscriminatorValueState::Invalid { reason_ref } => {
+                invalid.push(NonCurrentObservationReceipt {
+                    observation_id: observation.observation_id.clone(),
+                    source_receipt: observation.source_receipt.clone(),
+                    reason_ref: reason_ref.clone(),
+                    applicability_ref: observation.applicability_ref.clone(),
+                });
+            }
+        }
+    }
+
+    current.sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+    unknown.sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+    invalid.sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+    other_subject.sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+
+    let status = if !current.is_empty() {
+        ObservationFrontierStatus::Current
+    } else if !unknown.is_empty() {
+        ObservationFrontierStatus::Unknown
+    } else if !invalid.is_empty() {
+        ObservationFrontierStatus::Invalid
+    } else {
+        ObservationFrontierStatus::Missing
+    };
+
+    ObservationFrontierReceipt {
+        discriminator_id: requirement.discriminator_id.clone(),
+        subject_ref: requirement.subject_ref.clone(),
+        status,
+        current,
+        unknown,
+        invalid,
+        other_subject,
+    }
+}
+
+fn value_state_kind(value_state: &DiscriminatorValueState) -> ObservationValueStateKind {
+    match value_state {
+        DiscriminatorValueState::Known { .. } => ObservationValueStateKind::Known,
+        DiscriminatorValueState::Unknown { .. } => ObservationValueStateKind::Unknown,
+        DiscriminatorValueState::Invalid { .. } => ObservationValueStateKind::Invalid,
+    }
+}
+
+fn validate_request(request: &ObservationFrontierRequest) -> Result<(), ObservationFrontierError> {
+    if request.schema_version != OBSERVATION_FRONTIER_SCHEMA_VERSION {
+        return Err(ObservationFrontierError::new(format!(
+            "unsupported observation frontier schema {}; expected {OBSERVATION_FRONTIER_SCHEMA_VERSION}",
+            request.schema_version
+        )));
+    }
+    if request.requirements.is_empty() || request.requirements.len() > MAX_REQUIREMENTS {
+        return Err(ObservationFrontierError::new(
+            "observation frontier requirements must be bounded and non-empty",
+        ));
+    }
+    validate_discriminator_observation_batch(&request.observations).map_err(|error| {
+        ObservationFrontierError::new(format!("observation batch validation failed: {error}"))
+    })?;
+
+    let mut seen = BTreeSet::new();
+    for requirement in &request.requirements {
+        validate_atom(
+            &requirement.discriminator_id,
+            "requirement discriminator_id",
+            MAX_ID_BYTES,
+        )?;
+        validate_atom(
+            &requirement.subject_ref,
+            "requirement subject_ref",
+            MAX_REFERENCE_BYTES,
+        )?;
+        if !seen.insert(requirement.clone()) {
+            return Err(ObservationFrontierError::new(format!(
+                "duplicate observation requirement {} @ {}",
+                requirement.discriminator_id, requirement.subject_ref
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_atom(
+    value: &str,
+    field: &str,
+    max_bytes: usize,
+) -> Result<(), ObservationFrontierError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > max_bytes
+        || value.contains('\0')
+        || value.contains(['\n', '\r'])
+    {
+        return Err(ObservationFrontierError::new(format!(
+            "{field} must be bounded canonical single-line text"
+        )));
+    }
+    Ok(())
+}

--- a/src/observation_probe_bridge.rs
+++ b/src/observation_probe_bridge.rs
@@ -1,0 +1,324 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::applicability::{EvaluationContext, EvidenceRequirements};
+use crate::durable_obligation::{
+    ClearingCondition, DURABLE_OBLIGATION_SCHEMA_VERSION, DiscriminatorKey, DurableObligation,
+};
+use crate::evidence_planner::{
+    EVIDENCE_PLANNER_SCHEMA_VERSION, EvidencePlan, EvidenceProbe, ProbePlanRequest,
+    ProbeSelectionPolicy, plan_evidence,
+};
+use crate::observation_frontier::{ObservationFrontierReceipt, ObservationFrontierStatus};
+
+pub const OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION: u32 = 1;
+pub const MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES: usize = 1024 * 1024;
+const MAX_BRIDGES: usize = 128;
+const MAX_ID_BYTES: usize = 256;
+const MAX_REFERENCE_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationProbeBridge {
+    pub bridge_id: String,
+    pub observation_discriminator_id: String,
+    pub observation_subject_ref: String,
+    pub probe_discriminator: DiscriminatorKey,
+    pub clearing_requirements: EvidenceRequirements,
+    pub source_receipt: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationProbePlanRequest {
+    pub schema_version: u32,
+    pub frontier: ObservationFrontierReceipt,
+    pub bridges: Vec<ObservationProbeBridge>,
+    pub context: EvaluationContext,
+    pub probes: Vec<EvidenceProbe>,
+    pub allow_effectful: bool,
+    pub policy: ProbeSelectionPolicy,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationProbePlanStatus {
+    AlreadyCurrent,
+    NoAdmittedMapping,
+    Planned,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationProbePlan {
+    pub schema_version: u32,
+    pub observation_discriminator_id: String,
+    pub observation_subject_ref: String,
+    pub frontier_status: ObservationFrontierStatus,
+    pub status: ObservationProbePlanStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bridge_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bridge_source_receipt: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence_plan: Option<EvidencePlan>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ObservationProbeBridgeError {
+    message: String,
+}
+
+impl ObservationProbeBridgeError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ObservationProbeBridgeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for ObservationProbeBridgeError {}
+
+pub fn parse_observation_probe_plan_request(
+    bytes: &[u8],
+) -> Result<ObservationProbePlanRequest, ObservationProbeBridgeError> {
+    if bytes.len() > MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES {
+        return Err(ObservationProbeBridgeError::new(format!(
+            "observation probe plan request exceeds the {MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES}-byte limit"
+        )));
+    }
+    let request: ObservationProbePlanRequest = serde_json::from_slice(bytes).map_err(|error| {
+        ObservationProbeBridgeError::new(format!("invalid observation probe plan JSON: {error}"))
+    })?;
+    validate_request(&request)?;
+    Ok(request)
+}
+
+pub fn plan_observation_probe(
+    request: &ObservationProbePlanRequest,
+) -> Result<ObservationProbePlan, ObservationProbeBridgeError> {
+    validate_request(request)?;
+
+    let frontier = &request.frontier;
+    if frontier.status == ObservationFrontierStatus::Current {
+        return Ok(base_plan(
+            frontier,
+            ObservationProbePlanStatus::AlreadyCurrent,
+        ));
+    }
+
+    let matching = request
+        .bridges
+        .iter()
+        .filter(|bridge| bridge_matches_frontier(bridge, frontier))
+        .collect::<Vec<_>>();
+
+    let Some(bridge) = matching.first().copied() else {
+        return Ok(base_plan(
+            frontier,
+            ObservationProbePlanStatus::NoAdmittedMapping,
+        ));
+    };
+
+    let obligation = DurableObligation {
+        schema_version: DURABLE_OBLIGATION_SCHEMA_VERSION,
+        id: format!("observation-bridge:{}", bridge.bridge_id),
+        question: format!("Acquire current observation through bridge {}", bridge.bridge_id),
+        subject: bridge.clearing_requirements.clone(),
+        established_evidence: Vec::new(),
+        missing_discriminator: bridge.probe_discriminator.clone(),
+        clearing_conditions: vec![ClearingCondition {
+            discriminator: bridge.probe_discriminator.clone(),
+            requirements: bridge.clearing_requirements.clone(),
+        }],
+    };
+
+    let evidence_plan = plan_evidence(&ProbePlanRequest {
+        schema_version: EVIDENCE_PLANNER_SCHEMA_VERSION,
+        obligation,
+        context: request.context.clone(),
+        probes: request.probes.clone(),
+        allow_effectful: request.allow_effectful,
+        policy: request.policy,
+    })
+    .map_err(|error| {
+        ObservationProbeBridgeError::new(format!("evidence planning failed: {error}"))
+    })?;
+
+    Ok(ObservationProbePlan {
+        schema_version: OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION,
+        observation_discriminator_id: frontier.discriminator_id.clone(),
+        observation_subject_ref: frontier.subject_ref.clone(),
+        frontier_status: frontier.status,
+        status: ObservationProbePlanStatus::Planned,
+        bridge_id: Some(bridge.bridge_id.clone()),
+        bridge_source_receipt: Some(bridge.source_receipt.clone()),
+        evidence_plan: Some(evidence_plan),
+    })
+}
+
+fn base_plan(
+    frontier: &ObservationFrontierReceipt,
+    status: ObservationProbePlanStatus,
+) -> ObservationProbePlan {
+    ObservationProbePlan {
+        schema_version: OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION,
+        observation_discriminator_id: frontier.discriminator_id.clone(),
+        observation_subject_ref: frontier.subject_ref.clone(),
+        frontier_status: frontier.status,
+        status,
+        bridge_id: None,
+        bridge_source_receipt: None,
+        evidence_plan: None,
+    }
+}
+
+fn bridge_matches_frontier(
+    bridge: &ObservationProbeBridge,
+    frontier: &ObservationFrontierReceipt,
+) -> bool {
+    bridge.observation_discriminator_id == frontier.discriminator_id
+        && bridge.observation_subject_ref == frontier.subject_ref
+}
+
+fn validate_request(
+    request: &ObservationProbePlanRequest,
+) -> Result<(), ObservationProbeBridgeError> {
+    if request.schema_version != OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION {
+        return Err(ObservationProbeBridgeError::new(format!(
+            "unsupported observation probe bridge schema {}; expected {OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION}",
+            request.schema_version
+        )));
+    }
+    validate_frontier(&request.frontier)?;
+    if request.bridges.len() > MAX_BRIDGES {
+        return Err(ObservationProbeBridgeError::new(
+            "observation probe bridges exceed the admitted boundary",
+        ));
+    }
+
+    let mut bridge_ids = BTreeSet::new();
+    let mut mappings = BTreeSet::new();
+    for bridge in &request.bridges {
+        validate_bridge(bridge)?;
+        if !bridge_ids.insert(bridge.bridge_id.clone()) {
+            return Err(ObservationProbeBridgeError::new(format!(
+                "duplicate observation probe bridge id {}",
+                bridge.bridge_id
+            )));
+        }
+        let mapping = (
+            bridge.observation_discriminator_id.clone(),
+            bridge.observation_subject_ref.clone(),
+        );
+        if !mappings.insert(mapping) {
+            return Err(ObservationProbeBridgeError::new(format!(
+                "multiple admitted bridges for observation {} @ {}",
+                bridge.observation_discriminator_id, bridge.observation_subject_ref
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_frontier(frontier: &ObservationFrontierReceipt) -> Result<(), ObservationProbeBridgeError> {
+    validate_atom(
+        &frontier.discriminator_id,
+        "frontier discriminator_id",
+        MAX_ID_BYTES,
+    )?;
+    validate_atom(
+        &frontier.subject_ref,
+        "frontier subject_ref",
+        MAX_REFERENCE_BYTES,
+    )?;
+
+    let coherent = match frontier.status {
+        ObservationFrontierStatus::Current => !frontier.current.is_empty(),
+        ObservationFrontierStatus::Unknown => {
+            frontier.current.is_empty() && !frontier.unknown.is_empty()
+        }
+        ObservationFrontierStatus::Invalid => {
+            frontier.current.is_empty()
+                && frontier.unknown.is_empty()
+                && !frontier.invalid.is_empty()
+        }
+        ObservationFrontierStatus::Missing => {
+            frontier.current.is_empty()
+                && frontier.unknown.is_empty()
+                && frontier.invalid.is_empty()
+        }
+    };
+    if !coherent {
+        return Err(ObservationProbeBridgeError::new(
+            "observation frontier status disagrees with its current/unknown/invalid receipts",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_bridge(bridge: &ObservationProbeBridge) -> Result<(), ObservationProbeBridgeError> {
+    validate_atom(&bridge.bridge_id, "bridge id", MAX_ID_BYTES)?;
+    validate_atom(
+        &bridge.observation_discriminator_id,
+        "bridge observation_discriminator_id",
+        MAX_ID_BYTES,
+    )?;
+    validate_atom(
+        &bridge.observation_subject_ref,
+        "bridge observation_subject_ref",
+        MAX_REFERENCE_BYTES,
+    )?;
+    validate_atom(
+        &bridge.probe_discriminator.kind,
+        "bridge probe discriminator kind",
+        MAX_ID_BYTES,
+    )?;
+    validate_atom(
+        &bridge.probe_discriminator.target,
+        "bridge probe discriminator target",
+        MAX_REFERENCE_BYTES,
+    )?;
+    validate_atom(
+        &bridge.source_receipt,
+        "bridge source_receipt",
+        MAX_REFERENCE_BYTES,
+    )?;
+    if bridge.clearing_requirements.repository.is_none()
+        && bridge.clearing_requirements.revision.is_none()
+        && bridge.clearing_requirements.work.is_none()
+        && bridge.clearing_requirements.scope.is_none()
+    {
+        return Err(ObservationProbeBridgeError::new(
+            "bridge clearing_requirements must carry at least one applicability coordinate",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_atom(
+    value: &str,
+    field: &str,
+    max_bytes: usize,
+) -> Result<(), ObservationProbeBridgeError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > max_bytes
+        || value.contains('\0')
+        || value.contains(['\n', '\r'])
+    {
+        return Err(ObservationProbeBridgeError::new(format!(
+            "{field} must be bounded canonical single-line text"
+        )));
+    }
+    Ok(())
+}

--- a/src/observation_probe_bridge.rs
+++ b/src/observation_probe_bridge.rs
@@ -132,7 +132,10 @@ pub fn plan_observation_probe(
     let obligation = DurableObligation {
         schema_version: DURABLE_OBLIGATION_SCHEMA_VERSION,
         id: format!("observation-bridge:{}", bridge.bridge_id),
-        question: format!("Acquire current observation through bridge {}", bridge.bridge_id),
+        question: format!(
+            "Acquire current observation through bridge {}",
+            bridge.bridge_id
+        ),
         subject: bridge.clearing_requirements.clone(),
         established_evidence: Vec::new(),
         missing_discriminator: bridge.probe_discriminator.clone(),
@@ -230,7 +233,9 @@ fn validate_request(
     Ok(())
 }
 
-fn validate_frontier(frontier: &ObservationFrontierReceipt) -> Result<(), ObservationProbeBridgeError> {
+fn validate_frontier(
+    frontier: &ObservationFrontierReceipt,
+) -> Result<(), ObservationProbeBridgeError> {
     validate_atom(
         &frontier.discriminator_id,
         "frontier discriminator_id",

--- a/src/refinement_episode.rs
+++ b/src/refinement_episode.rs
@@ -1,0 +1,362 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+pub const REFINEMENT_EPISODE_SCHEMA_VERSION: u32 = 1;
+pub const MAX_REFINEMENT_EPISODE_BATCH_BYTES: usize = 256 * 1024;
+const MAX_EPISODES: usize = 128;
+const MAX_CANDIDATES: usize = 64;
+const MAX_REFERENCES: usize = 256;
+const MAX_ID_BYTES: usize = 512;
+const MAX_TEXT_BYTES: usize = 8 * 1024;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementEpisodeBatch {
+    pub schema_version: u32,
+    pub episodes: Vec<RefinementEpisode>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementEpisode {
+    pub id: String,
+    pub family: String,
+    pub hypothesis_before: ResearchHypothesis,
+    pub counterexample_refs: Vec<String>,
+    pub admitted_discriminators: Vec<DiscriminatorRef>,
+    pub candidate_refinements: Vec<CandidateRefinement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_transition: Option<String>,
+    pub source_receipts: Vec<String>,
+    #[serde(default)]
+    pub behavioral_episode_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResearchHypothesis {
+    pub id: String,
+    pub statement: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscriminatorRef {
+    pub id: String,
+    pub source_ref: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CandidateRefinement {
+    pub id: String,
+    pub hypothesis_after: ResearchHypothesis,
+    pub discriminator_refs: Vec<String>,
+    pub replay_result: ReplayResult,
+    pub status: RefinementStatus,
+    pub source_receipts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReplayResult {
+    pub expected_cases_retained: usize,
+    pub counterexamples_resolved: usize,
+    pub expected_cases_lost: usize,
+    pub counterexamples_remaining: usize,
+    pub held_out_status: HeldOutStatus,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HeldOutStatus {
+    NotRun,
+    Passed,
+    Failed,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefinementStatus {
+    Retained,
+    Weakened,
+    Split,
+    RejectedNoImprovement,
+    RejectedOverfit,
+    RejectedLostExpectedCase,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RefinementEpisodeError {
+    message: String,
+}
+
+impl RefinementEpisodeError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for RefinementEpisodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for RefinementEpisodeError {}
+
+pub fn parse_refinement_episode_batch(
+    bytes: &[u8],
+) -> Result<RefinementEpisodeBatch, RefinementEpisodeError> {
+    if bytes.len() > MAX_REFINEMENT_EPISODE_BATCH_BYTES {
+        return Err(RefinementEpisodeError::new(format!(
+            "refinement episode batch exceeds the {MAX_REFINEMENT_EPISODE_BATCH_BYTES}-byte limit"
+        )));
+    }
+    let batch: RefinementEpisodeBatch = serde_json::from_slice(bytes).map_err(|error| {
+        RefinementEpisodeError::new(format!("invalid refinement episode JSON: {error}"))
+    })?;
+    validate_refinement_episode_batch(&batch)?;
+    Ok(batch)
+}
+
+pub fn validate_refinement_episode_batch(
+    batch: &RefinementEpisodeBatch,
+) -> Result<(), RefinementEpisodeError> {
+    if batch.schema_version != REFINEMENT_EPISODE_SCHEMA_VERSION {
+        return Err(RefinementEpisodeError::new(format!(
+            "unsupported refinement episode schema {}; expected {REFINEMENT_EPISODE_SCHEMA_VERSION}",
+            batch.schema_version
+        )));
+    }
+    if batch.episodes.is_empty() || batch.episodes.len() > MAX_EPISODES {
+        return Err(RefinementEpisodeError::new(
+            "refinement episode batch must contain a bounded non-empty episode set",
+        ));
+    }
+
+    let mut episode_ids = BTreeSet::new();
+    for episode in &batch.episodes {
+        validate_episode(episode)?;
+        if !episode_ids.insert(episode.id.clone()) {
+            return Err(RefinementEpisodeError::new(format!(
+                "duplicate refinement episode id {}",
+                episode.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_episode(episode: &RefinementEpisode) -> Result<(), RefinementEpisodeError> {
+    validate_atom(&episode.id, "episode id", MAX_ID_BYTES)?;
+    validate_atom(&episode.family, "episode family", MAX_ID_BYTES)?;
+    validate_hypothesis(&episode.hypothesis_before, "hypothesis_before")?;
+    validate_reference_set(&episode.counterexample_refs, "counterexample_refs", false)?;
+    validate_reference_set(&episode.source_receipts, "source_receipts", false)?;
+    validate_reference_set(
+        &episode.behavioral_episode_ids,
+        "behavioral_episode_ids",
+        true,
+    )?;
+
+    if episode.admitted_discriminators.is_empty()
+        || episode.admitted_discriminators.len() > MAX_REFERENCES
+    {
+        return Err(RefinementEpisodeError::new(
+            "admitted_discriminators must be bounded and non-empty",
+        ));
+    }
+    let mut discriminator_ids = BTreeSet::new();
+    for discriminator in &episode.admitted_discriminators {
+        validate_atom(&discriminator.id, "discriminator id", MAX_ID_BYTES)?;
+        validate_atom(
+            &discriminator.source_ref,
+            "discriminator source_ref",
+            MAX_TEXT_BYTES,
+        )?;
+        if !discriminator_ids.insert(discriminator.id.clone()) {
+            return Err(RefinementEpisodeError::new(format!(
+                "duplicate admitted discriminator {}",
+                discriminator.id
+            )));
+        }
+    }
+
+    if episode.candidate_refinements.is_empty()
+        || episode.candidate_refinements.len() > MAX_CANDIDATES
+    {
+        return Err(RefinementEpisodeError::new(
+            "candidate_refinements must be bounded and non-empty",
+        ));
+    }
+    let mut candidate_ids = BTreeSet::new();
+    for candidate in &episode.candidate_refinements {
+        validate_candidate(candidate, &discriminator_ids)?;
+        if !candidate_ids.insert(candidate.id.clone()) {
+            return Err(RefinementEpisodeError::new(format!(
+                "duplicate candidate refinement id {}",
+                candidate.id
+            )));
+        }
+    }
+
+    if let Some(selected) = &episode.selected_transition {
+        validate_atom(selected, "selected_transition", MAX_ID_BYTES)?;
+        let candidate = episode
+            .candidate_refinements
+            .iter()
+            .find(|candidate| candidate.id == *selected)
+            .ok_or_else(|| {
+                RefinementEpisodeError::new(format!(
+                    "selected transition {selected} is absent from candidate_refinements"
+                ))
+            })?;
+        if !matches!(
+            candidate.status,
+            RefinementStatus::Retained | RefinementStatus::Weakened | RefinementStatus::Split
+        ) {
+            return Err(RefinementEpisodeError::new(format!(
+                "selected transition {selected} has rejected status {:?}",
+                candidate.status
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_candidate(
+    candidate: &CandidateRefinement,
+    admitted_discriminators: &BTreeSet<String>,
+) -> Result<(), RefinementEpisodeError> {
+    validate_atom(&candidate.id, "candidate id", MAX_ID_BYTES)?;
+    validate_hypothesis(&candidate.hypothesis_after, "hypothesis_after")?;
+    validate_reference_set(
+        &candidate.discriminator_refs,
+        "candidate discriminator_refs",
+        false,
+    )?;
+    validate_reference_set(
+        &candidate.source_receipts,
+        "candidate source_receipts",
+        false,
+    )?;
+
+    for discriminator in &candidate.discriminator_refs {
+        if !admitted_discriminators.contains(discriminator) {
+            return Err(RefinementEpisodeError::new(format!(
+                "candidate {} references unadmitted discriminator {discriminator}",
+                candidate.id
+            )));
+        }
+    }
+
+    match candidate.status {
+        RefinementStatus::Retained | RefinementStatus::Weakened | RefinementStatus::Split => {
+            if candidate.replay_result.expected_cases_lost != 0 {
+                return Err(RefinementEpisodeError::new(format!(
+                    "kept candidate {} loses expected replay cases",
+                    candidate.id
+                )));
+            }
+            if candidate.replay_result.counterexamples_resolved == 0 {
+                return Err(RefinementEpisodeError::new(format!(
+                    "kept candidate {} resolves no counterexample",
+                    candidate.id
+                )));
+            }
+            if candidate.replay_result.held_out_status == HeldOutStatus::Failed {
+                return Err(RefinementEpisodeError::new(format!(
+                    "kept candidate {} has failed held-out replay",
+                    candidate.id
+                )));
+            }
+        }
+        RefinementStatus::RejectedNoImprovement => {
+            if candidate.replay_result.counterexamples_resolved != 0
+                || candidate.replay_result.expected_cases_lost != 0
+            {
+                return Err(RefinementEpisodeError::new(format!(
+                    "rejected_no_improvement candidate {} must preserve the baseline replay",
+                    candidate.id
+                )));
+            }
+        }
+        RefinementStatus::RejectedLostExpectedCase => {
+            if candidate.replay_result.expected_cases_lost == 0 {
+                return Err(RefinementEpisodeError::new(format!(
+                    "rejected_lost_expected_case candidate {} must lose at least one expected case",
+                    candidate.id
+                )));
+            }
+        }
+        RefinementStatus::RejectedOverfit => {}
+    }
+
+    Ok(())
+}
+
+fn validate_hypothesis(
+    hypothesis: &ResearchHypothesis,
+    field: &str,
+) -> Result<(), RefinementEpisodeError> {
+    validate_atom(&hypothesis.id, &format!("{field} id"), MAX_ID_BYTES)?;
+    validate_text(
+        &hypothesis.statement,
+        &format!("{field} statement"),
+        MAX_TEXT_BYTES,
+    )
+}
+
+fn validate_reference_set(
+    values: &[String],
+    field: &str,
+    allow_empty: bool,
+) -> Result<(), RefinementEpisodeError> {
+    if (!allow_empty && values.is_empty()) || values.len() > MAX_REFERENCES {
+        return Err(RefinementEpisodeError::new(format!(
+            "{field} must be within the admitted reference bound"
+        )));
+    }
+    let mut seen = BTreeSet::new();
+    for value in values {
+        validate_atom(value, field, MAX_TEXT_BYTES)?;
+        if !seen.insert(value.clone()) {
+            return Err(RefinementEpisodeError::new(format!(
+                "{field} contains duplicate reference {value}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_atom(value: &str, field: &str, max_bytes: usize) -> Result<(), RefinementEpisodeError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > max_bytes
+        || value.contains('\0')
+        || value.contains(['\n', '\r'])
+    {
+        return Err(RefinementEpisodeError::new(format!(
+            "{field} must be bounded canonical single-line text"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, field: &str, max_bytes: usize) -> Result<(), RefinementEpisodeError> {
+    if value.is_empty() || value.trim() != value || value.len() > max_bytes || value.contains('\0')
+    {
+        return Err(RefinementEpisodeError::new(format!(
+            "{field} must be bounded non-empty text"
+        )));
+    }
+    Ok(())
+}

--- a/src/refinement_observation_requirement.rs
+++ b/src/refinement_observation_requirement.rs
@@ -1,0 +1,291 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::observation_frontier::ObservationRequirement;
+use crate::refinement_episode::{RefinementEpisodeBatch, validate_refinement_episode_batch};
+
+pub const REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION: u32 = 1;
+pub const MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES: usize = 512 * 1024;
+const MAX_MAPPINGS: usize = 512;
+const MAX_ID_BYTES: usize = 512;
+const MAX_REFERENCE_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementObservationRequirementMapping {
+    pub id: String,
+    pub episode_id: String,
+    pub candidate_id: String,
+    pub discriminator_id: String,
+    pub subject_ref: String,
+    pub source_receipt: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementObservationRequirementBatch {
+    pub schema_version: u32,
+    pub mappings: Vec<RefinementObservationRequirementMapping>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementObservationRequirementRequest {
+    pub schema_version: u32,
+    pub refinements: RefinementEpisodeBatch,
+    pub mappings: RefinementObservationRequirementBatch,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SelectedRefinementObservationRequirements {
+    pub episode_id: String,
+    pub candidate_id: String,
+    pub requirements: Vec<ObservationRequirement>,
+    pub mappings: Vec<RefinementObservationRequirementMapping>,
+    pub missing_discriminator_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementObservationRequirementEvaluation {
+    pub schema_version: u32,
+    pub selected: Vec<SelectedRefinementObservationRequirements>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RefinementObservationRequirementError {
+    message: String,
+}
+
+impl RefinementObservationRequirementError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for RefinementObservationRequirementError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for RefinementObservationRequirementError {}
+
+pub fn parse_refinement_observation_requirement_request(
+    bytes: &[u8],
+) -> Result<RefinementObservationRequirementRequest, RefinementObservationRequirementError> {
+    if bytes.len() > MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES {
+        return Err(RefinementObservationRequirementError::new(format!(
+            "refinement observation requirement request exceeds the {MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES}-byte limit"
+        )));
+    }
+    let request: RefinementObservationRequirementRequest =
+        serde_json::from_slice(bytes).map_err(|error| {
+            RefinementObservationRequirementError::new(format!(
+                "invalid refinement observation requirement JSON: {error}"
+            ))
+        })?;
+    validate_request(&request)?;
+    Ok(request)
+}
+
+pub fn evaluate_selected_observation_requirements(
+    request: &RefinementObservationRequirementRequest,
+) -> Result<RefinementObservationRequirementEvaluation, RefinementObservationRequirementError> {
+    validate_request(request)?;
+
+    let mut selected = Vec::new();
+    for episode in &request.refinements.episodes {
+        let Some(selected_id) = episode.selected_transition.as_ref() else {
+            continue;
+        };
+        let candidate = episode
+            .candidate_refinements
+            .iter()
+            .find(|candidate| candidate.id == *selected_id)
+            .ok_or_else(|| {
+                RefinementObservationRequirementError::new(format!(
+                    "selected candidate {selected_id} is missing from episode {}",
+                    episode.id
+                ))
+            })?;
+
+        let mut requirements = Vec::new();
+        let mut mappings = Vec::new();
+        let mut missing_discriminator_refs = Vec::new();
+        for discriminator_id in &candidate.discriminator_refs {
+            if let Some(mapping) = request.mappings.mappings.iter().find(|mapping| {
+                mapping.episode_id == episode.id
+                    && mapping.candidate_id == candidate.id
+                    && mapping.discriminator_id == *discriminator_id
+            }) {
+                requirements.push(ObservationRequirement {
+                    discriminator_id: discriminator_id.clone(),
+                    subject_ref: mapping.subject_ref.clone(),
+                });
+                mappings.push(mapping.clone());
+            } else {
+                missing_discriminator_refs.push(discriminator_id.clone());
+            }
+        }
+
+        requirements.sort_by(|left, right| {
+            left.discriminator_id
+                .cmp(&right.discriminator_id)
+                .then_with(|| left.subject_ref.cmp(&right.subject_ref))
+        });
+        mappings.sort_by(|left, right| left.id.cmp(&right.id));
+        missing_discriminator_refs.sort();
+        selected.push(SelectedRefinementObservationRequirements {
+            episode_id: episode.id.clone(),
+            candidate_id: candidate.id.clone(),
+            requirements,
+            mappings,
+            missing_discriminator_refs,
+        });
+    }
+    selected.sort_by(|left, right| left.episode_id.cmp(&right.episode_id));
+
+    Ok(RefinementObservationRequirementEvaluation {
+        schema_version: REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION,
+        selected,
+    })
+}
+
+fn validate_request(
+    request: &RefinementObservationRequirementRequest,
+) -> Result<(), RefinementObservationRequirementError> {
+    if request.schema_version != REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION {
+        return Err(RefinementObservationRequirementError::new(format!(
+            "unsupported refinement observation requirement schema {}; expected {REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION}",
+            request.schema_version
+        )));
+    }
+    validate_refinement_episode_batch(&request.refinements).map_err(|error| {
+        RefinementObservationRequirementError::new(format!(
+            "invalid refinement episode batch: {error}"
+        ))
+    })?;
+    validate_mapping_batch(&request.mappings)?;
+    validate_mapping_references(&request.refinements, &request.mappings)
+}
+
+fn validate_mapping_batch(
+    batch: &RefinementObservationRequirementBatch,
+) -> Result<(), RefinementObservationRequirementError> {
+    if batch.schema_version != REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION {
+        return Err(RefinementObservationRequirementError::new(format!(
+            "unsupported refinement observation mapping schema {}; expected {REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION}",
+            batch.schema_version
+        )));
+    }
+    if batch.mappings.len() > MAX_MAPPINGS {
+        return Err(RefinementObservationRequirementError::new(
+            "refinement observation mappings exceed the admitted boundary",
+        ));
+    }
+
+    let mut ids = BTreeSet::new();
+    let mut keys = BTreeSet::new();
+    for mapping in &batch.mappings {
+        validate_atom(&mapping.id, "mapping id", MAX_ID_BYTES)?;
+        validate_atom(&mapping.episode_id, "mapping episode_id", MAX_ID_BYTES)?;
+        validate_atom(&mapping.candidate_id, "mapping candidate_id", MAX_ID_BYTES)?;
+        validate_atom(
+            &mapping.discriminator_id,
+            "mapping discriminator_id",
+            MAX_ID_BYTES,
+        )?;
+        validate_atom(
+            &mapping.subject_ref,
+            "mapping subject_ref",
+            MAX_REFERENCE_BYTES,
+        )?;
+        validate_atom(
+            &mapping.source_receipt,
+            "mapping source_receipt",
+            MAX_REFERENCE_BYTES,
+        )?;
+        if !ids.insert(mapping.id.clone()) {
+            return Err(RefinementObservationRequirementError::new(format!(
+                "duplicate refinement observation mapping id {}",
+                mapping.id
+            )));
+        }
+        let key = (
+            mapping.episode_id.clone(),
+            mapping.candidate_id.clone(),
+            mapping.discriminator_id.clone(),
+        );
+        if !keys.insert(key) {
+            return Err(RefinementObservationRequirementError::new(format!(
+                "multiple subject mappings for refinement {} / {} / {}",
+                mapping.episode_id, mapping.candidate_id, mapping.discriminator_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_mapping_references(
+    refinements: &RefinementEpisodeBatch,
+    mappings: &RefinementObservationRequirementBatch,
+) -> Result<(), RefinementObservationRequirementError> {
+    for mapping in &mappings.mappings {
+        let episode = refinements
+            .episodes
+            .iter()
+            .find(|episode| episode.id == mapping.episode_id)
+            .ok_or_else(|| {
+                RefinementObservationRequirementError::new(format!(
+                    "mapping {} references missing episode {}",
+                    mapping.id, mapping.episode_id
+                ))
+            })?;
+        let candidate = episode
+            .candidate_refinements
+            .iter()
+            .find(|candidate| candidate.id == mapping.candidate_id)
+            .ok_or_else(|| {
+                RefinementObservationRequirementError::new(format!(
+                    "mapping {} references missing candidate {} in episode {}",
+                    mapping.id, mapping.candidate_id, mapping.episode_id
+                ))
+            })?;
+        if !candidate
+            .discriminator_refs
+            .iter()
+            .any(|discriminator| discriminator == &mapping.discriminator_id)
+        {
+            return Err(RefinementObservationRequirementError::new(format!(
+                "mapping {} discriminator {} is not required by candidate {}",
+                mapping.id, mapping.discriminator_id, mapping.candidate_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_atom(
+    value: &str,
+    field: &str,
+    max_bytes: usize,
+) -> Result<(), RefinementObservationRequirementError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > max_bytes
+        || value.contains('\0')
+        || value.contains(['\n', '\r'])
+    {
+        return Err(RefinementObservationRequirementError::new(format!(
+            "{field} must be bounded canonical single-line text"
+        )));
+    }
+    Ok(())
+}

--- a/src/rust_edit_class_source.rs
+++ b/src/rust_edit_class_source.rs
@@ -1,0 +1,339 @@
+use std::error::Error;
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use crate::applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, PathScope, PathScopeMode, evaluate_query,
+};
+use crate::discriminator_observation::{
+    DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation,
+    DiscriminatorObservationBatch, DiscriminatorValueState, ObservationApplicability,
+    ObservationApplicabilityStatus, validate_discriminator_observation_batch,
+};
+use crate::durable_obligation::DiscriminatorKey;
+use crate::evidence_planner::{EvidenceProbe, ProbeCost, ProbeEffect};
+use crate::observation_probe_bridge::ObservationProbeBridge;
+
+#[allow(dead_code)]
+#[path = "../examples/rust_syntax_cohort.rs"]
+mod rust_syntax_cohort;
+
+use rust_syntax_cohort::{RustEditClass, classify_rust_edit};
+
+pub const RUST_EDIT_CLASS_DISCRIMINATOR_ID: &str = "edit_class";
+pub const RUST_EDIT_CLASS_PROBE_KIND: &str = "rust_edit_class";
+const MAX_REPOSITORY_BYTES: usize = 256;
+const MAX_PATH_BYTES: usize = 2048;
+const SHA_BYTES: usize = 40;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustEditClassSubject {
+    pub repository: String,
+    pub revision: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustEditClassSourceResult {
+    pub subject: RustEditClassSubject,
+    pub current_head: String,
+    pub bridge: ObservationProbeBridge,
+    pub probe: EvidenceProbe,
+    pub observation: DiscriminatorObservation,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RustEditClassSourceError {
+    message: String,
+}
+
+impl RustEditClassSourceError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for RustEditClassSourceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for RustEditClassSourceError {}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum FocusAdmission {
+    Focused,
+    NotSingleParent,
+    AnchorUnchanged,
+}
+
+pub fn collect_rust_edit_class_source(
+    root: &Path,
+    subject: &RustEditClassSubject,
+) -> Result<RustEditClassSourceResult, RustEditClassSourceError> {
+    validate_subject(subject)?;
+    let root = root.canonicalize().map_err(|error| {
+        RustEditClassSourceError::new(format!("cannot canonicalize repository root: {error}"))
+    })?;
+    let current_head = git_head(&root)?;
+    let path = PathBuf::from(&subject.path);
+    let subject_ref = subject_ref(subject);
+    let requirements = exact_requirements(subject);
+    let context = EvaluationContext {
+        repository: Some(subject.repository.clone()),
+        revision: Some(current_head.clone()),
+        work: None,
+        path: Some(subject.path.clone()),
+    };
+    let applicability = evaluate_query(&ApplicabilityQuery {
+        schema_version: APPLICABILITY_SCHEMA_VERSION,
+        requirements: requirements.clone(),
+        context,
+    })
+    .map_err(|error| {
+        RustEditClassSourceError::new(format!("edit-class applicability failed: {error}"))
+    })?;
+
+    let value_state = match focus_admission(&root, &subject.revision, &path)? {
+        FocusAdmission::Focused => match classify_rust_edit(&root, &subject.revision, &path) {
+            RustEditClass::SyntaxChanged => DiscriminatorValueState::Known {
+                value_ref: "syntax_changed".to_string(),
+            },
+            RustEditClass::CommentsOrWhitespaceOnly => DiscriminatorValueState::Known {
+                value_ref: "comments_or_docs_only".to_string(),
+            },
+            RustEditClass::Unclassified => DiscriminatorValueState::Unknown {
+                reason_ref: format!("rust-edit-class:unclassified:{subject_ref}"),
+            },
+        },
+        FocusAdmission::NotSingleParent => DiscriminatorValueState::Unknown {
+            reason_ref: format!("rust-edit-class:not-single-parent:{subject_ref}"),
+        },
+        FocusAdmission::AnchorUnchanged => DiscriminatorValueState::Unknown {
+            reason_ref: format!("rust-edit-class:anchor-unchanged:{subject_ref}"),
+        },
+    };
+    let applicability_status = match applicability.status {
+        ApplicabilityStatus::Applies => ObservationApplicabilityStatus::Applies,
+        ApplicabilityStatus::Unknown => ObservationApplicabilityStatus::Unknown,
+        ApplicabilityStatus::Invalid => ObservationApplicabilityStatus::Invalid,
+    };
+    let applicability_ref =
+        format!("rust-edit-class:applicability:{subject_ref}:current={current_head}");
+    let source_receipt = format!("rust-syntax-cohort:{subject_ref}");
+    let observation = DiscriminatorObservation {
+        observation_id: format!("rust-edit-class:{subject_ref}"),
+        discriminator_id: RUST_EDIT_CLASS_DISCRIMINATOR_ID.to_string(),
+        subject_ref: subject_ref.clone(),
+        source_receipt,
+        value_state,
+        applicability: ObservationApplicability {
+            status: applicability_status,
+            receipt_ref: applicability_ref,
+        },
+    };
+    validate_discriminator_observation_batch(&DiscriminatorObservationBatch {
+        schema_version: DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+        observations: vec![observation.clone()],
+    })
+    .map_err(|error| {
+        RustEditClassSourceError::new(format!("produced observation failed validation: {error}"))
+    })?;
+
+    let probe_discriminator = DiscriminatorKey {
+        kind: RUST_EDIT_CLASS_PROBE_KIND.to_string(),
+        target: subject_ref.clone(),
+    };
+    let suffix = &subject.revision[..12];
+    let bridge = ObservationProbeBridge {
+        bridge_id: format!("rust-edit-class-{suffix}"),
+        observation_discriminator_id: RUST_EDIT_CLASS_DISCRIMINATOR_ID.to_string(),
+        observation_subject_ref: subject_ref.clone(),
+        probe_discriminator: probe_discriminator.clone(),
+        clearing_requirements: requirements.clone(),
+        source_receipt: format!("rust-edit-class-adapter:{subject_ref}"),
+    };
+    let probe = EvidenceProbe {
+        id: format!("rust-edit-class-{suffix}"),
+        produces: probe_discriminator,
+        requirements,
+        effect: ProbeEffect::ReadOnly,
+        cost: ProbeCost {
+            git_subprocesses: 5,
+            rust_files_parsed: 2,
+            ..ProbeCost::default()
+        },
+    };
+
+    Ok(RustEditClassSourceResult {
+        subject: subject.clone(),
+        current_head,
+        bridge,
+        probe,
+        observation,
+    })
+}
+
+pub fn subject_ref(subject: &RustEditClassSubject) -> String {
+    format!(
+        "{}@{}:{}",
+        subject.repository, subject.revision, subject.path
+    )
+}
+
+fn exact_requirements(subject: &RustEditClassSubject) -> EvidenceRequirements {
+    EvidenceRequirements {
+        repository: Some(subject.repository.clone()),
+        revision: Some(subject.revision.clone()),
+        work: None,
+        scope: Some(PathScope {
+            mode: PathScopeMode::Exact,
+            path: subject.path.clone(),
+        }),
+    }
+}
+
+fn git_head(root: &Path) -> Result<String, RustEditClassSourceError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .map_err(|error| {
+            RustEditClassSourceError::new(format!("cannot execute git rev-parse: {error}"))
+        })?;
+    if !output.status.success() {
+        return Err(RustEditClassSourceError::new(format!(
+            "git rev-parse HEAD failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    let head = String::from_utf8(output.stdout)
+        .map_err(|error| RustEditClassSourceError::new(format!("invalid git head UTF-8: {error}")))?
+        .trim()
+        .to_string();
+    validate_revision(&head, "current git head")?;
+    Ok(head)
+}
+
+fn focus_admission(
+    root: &Path,
+    revision: &str,
+    path: &Path,
+) -> Result<FocusAdmission, RustEditClassSourceError> {
+    let parents = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-list", "--parents", "-n", "1", revision])
+        .output()
+        .map_err(|error| {
+            RustEditClassSourceError::new(format!("cannot inspect edit-class parents: {error}"))
+        })?;
+    if !parents.status.success() {
+        return Err(RustEditClassSourceError::new(format!(
+            "git rev-list failed for {revision}: {}",
+            String::from_utf8_lossy(&parents.stderr)
+        )));
+    }
+    let parents = String::from_utf8(parents.stdout).map_err(|error| {
+        RustEditClassSourceError::new(format!("invalid parent-list UTF-8: {error}"))
+    })?;
+    if parents.split_whitespace().count() != 2 {
+        return Ok(FocusAdmission::NotSingleParent);
+    }
+
+    let changed = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args([
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "-r",
+            revision,
+            "--",
+        ])
+        .arg(path)
+        .output()
+        .map_err(|error| {
+            RustEditClassSourceError::new(format!("cannot inspect edit-class path change: {error}"))
+        })?;
+    if !changed.status.success() {
+        return Err(RustEditClassSourceError::new(format!(
+            "git diff-tree failed for {revision}: {}",
+            String::from_utf8_lossy(&changed.stderr)
+        )));
+    }
+    if String::from_utf8(changed.stdout)
+        .map_err(|error| {
+            RustEditClassSourceError::new(format!("invalid changed-path UTF-8: {error}"))
+        })?
+        .lines()
+        .all(|line| line.trim().is_empty())
+    {
+        return Ok(FocusAdmission::AnchorUnchanged);
+    }
+    Ok(FocusAdmission::Focused)
+}
+
+fn validate_subject(subject: &RustEditClassSubject) -> Result<(), RustEditClassSourceError> {
+    if subject.repository.is_empty()
+        || subject.repository.trim() != subject.repository
+        || subject.repository.len() > MAX_REPOSITORY_BYTES
+        || subject.repository.contains(['\n', '\r', '\0'])
+    {
+        return Err(RustEditClassSourceError::new(
+            "repository must be bounded canonical single-line text",
+        ));
+    }
+    validate_revision(&subject.revision, "subject revision")?;
+    if subject.path.is_empty()
+        || subject.path.trim() != subject.path
+        || subject.path.len() > MAX_PATH_BYTES
+        || subject.path.contains(['\n', '\r', '\0', '\\'])
+    {
+        return Err(RustEditClassSourceError::new(
+            "path must be bounded canonical repository-relative text",
+        ));
+    }
+    let path = Path::new(&subject.path);
+    if path.is_absolute()
+        || path.extension().and_then(|extension| extension.to_str()) != Some("rs")
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(RustEditClassSourceError::new(
+            "path must be a normalized repository-relative Rust source path",
+        ));
+    }
+    let reference = subject_ref(subject);
+    if reference.len() > 480 {
+        return Err(RustEditClassSourceError::new(
+            "edit-class subject reference exceeds the admitted boundary",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_revision(value: &str, label: &str) -> Result<(), RustEditClassSourceError> {
+    if value.len() != SHA_BYTES
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(RustEditClassSourceError::new(format!(
+            "{label} must be an exact lowercase 40-hex Git commit"
+        )));
+    }
+    Ok(())
+}

--- a/tests/discriminator_observation.rs
+++ b/tests/discriminator_observation.rs
@@ -9,8 +9,9 @@ mod refinement_episode;
 
 use discriminator_observation::{
     DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation, DiscriminatorValueState,
-    MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES, enumerate_discriminator_partitions,
-    parse_discriminator_observation_batch, validate_discriminator_observation_batch,
+    MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES, ObservationApplicabilityStatus,
+    enumerate_discriminator_partitions, parse_discriminator_observation_batch,
+    validate_discriminator_observation_batch,
 };
 use refinement_episode::parse_refinement_episode_batch;
 
@@ -49,14 +50,14 @@ fn retained_observations_cover_every_selected_refinement_discriminator() {
             assert_eq!(
                 current.get(discriminator.as_str()),
                 Some(&true),
-                "selected discriminator {discriminator} lacks a current KNOWN observation"
+                "selected discriminator {discriminator} lacks a current KNOWN+APPLIES observation"
             );
         }
     }
 }
 
 #[test]
-fn known_observations_enumerate_by_discriminator_and_value() {
+fn known_applicable_observations_enumerate_by_discriminator_and_value() {
     let batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
     let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
     assert_eq!(
@@ -72,10 +73,10 @@ fn known_observations_enumerate_by_discriminator_and_value() {
 }
 
 #[test]
-fn unknown_observation_stays_visible_and_out_of_current_partitions() {
+fn unknown_value_with_applicable_source_stays_unknown() {
     let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
     batch.observations[0].value_state = DiscriminatorValueState::Unknown {
-        reason_ref: "applicability:missing-current-revision".to_string(),
+        reason_ref: "classifier:missing-value".to_string(),
     };
 
     let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
@@ -86,15 +87,38 @@ fn unknown_observation_stays_visible_and_out_of_current_partitions() {
         .unwrap();
     assert!(discriminator.known_partitions.is_empty());
     assert_eq!(discriminator.unknown.len(), 1);
-    assert!(discriminator.invalid.is_empty());
+    assert_eq!(
+        discriminator.unknown[0].value_unknown_reason_ref.as_deref(),
+        Some("classifier:missing-value")
+    );
 }
 
 #[test]
-fn invalid_observation_stays_visible_and_out_of_current_partitions() {
+fn known_value_with_unknown_applicability_stays_unknown_and_preserves_value() {
     let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
-    batch.observations[1].value_state = DiscriminatorValueState::Invalid {
-        reason_ref: "applicability:revision-moved".to_string(),
-    };
+    batch.observations[0].applicability.status = ObservationApplicabilityStatus::Unknown;
+    batch.observations[0].applicability.receipt_ref =
+        "applicability:missing-current-revision".to_string();
+
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let discriminator = enumeration
+        .discriminators
+        .iter()
+        .find(|item| item.discriminator_id == "clearing_evidence_presence")
+        .unwrap();
+    assert!(discriminator.known_partitions.is_empty());
+    assert_eq!(discriminator.unknown.len(), 1);
+    assert_eq!(
+        discriminator.unknown[0].known_value_ref.as_deref(),
+        Some("absent")
+    );
+}
+
+#[test]
+fn known_value_with_invalid_applicability_stays_invalid_and_preserves_value() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[1].applicability.status = ObservationApplicabilityStatus::Invalid;
+    batch.observations[1].applicability.receipt_ref = "applicability:revision-moved".to_string();
 
     let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
     let discriminator = enumeration
@@ -103,8 +127,11 @@ fn invalid_observation_stays_visible_and_out_of_current_partitions() {
         .find(|item| item.discriminator_id == "edit_class")
         .unwrap();
     assert!(discriminator.known_partitions.is_empty());
-    assert!(discriminator.unknown.is_empty());
     assert_eq!(discriminator.invalid.len(), 1);
+    assert_eq!(
+        discriminator.invalid[0].known_value_ref.as_deref(),
+        Some("syntax_changed")
+    );
 }
 
 #[test]
@@ -141,6 +168,14 @@ fn missing_source_receipt_rejects() {
     batch.observations[0].source_receipt.clear();
     let error = validate_discriminator_observation_batch(&batch).unwrap_err();
     assert!(error.to_string().contains("source_receipt"));
+}
+
+#[test]
+fn missing_applicability_receipt_rejects() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[0].applicability.receipt_ref.clear();
+    let error = validate_discriminator_observation_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("applicability receipt_ref"));
 }
 
 #[test]

--- a/tests/discriminator_observation.rs
+++ b/tests/discriminator_observation.rs
@@ -1,0 +1,210 @@
+#![allow(dead_code)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+
+use discriminator_observation::{
+    DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation, DiscriminatorValueState,
+    MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES, enumerate_discriminator_partitions,
+    parse_discriminator_observation_batch, validate_discriminator_observation_batch,
+};
+use refinement_episode::parse_refinement_episode_batch;
+
+const OBSERVATIONS: &[u8] =
+    include_bytes!("../research/discriminator-observations/cultist-v1.json");
+const REFINEMENTS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+
+#[test]
+fn retained_observations_cover_every_selected_refinement_discriminator() {
+    let observations = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let enumeration = enumerate_discriminator_partitions(&observations).unwrap();
+    let refinements = parse_refinement_episode_batch(REFINEMENTS).unwrap();
+
+    let current = enumeration
+        .discriminators
+        .iter()
+        .map(|discriminator| {
+            (
+                discriminator.discriminator_id.as_str(),
+                !discriminator.known_partitions.is_empty(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    for episode in &refinements.episodes {
+        let selected = episode
+            .selected_transition
+            .as_ref()
+            .expect("retained fixture has selected transition");
+        let candidate = episode
+            .candidate_refinements
+            .iter()
+            .find(|candidate| candidate.id == *selected)
+            .expect("selected candidate exists");
+        for discriminator in &candidate.discriminator_refs {
+            assert_eq!(
+                current.get(discriminator.as_str()),
+                Some(&true),
+                "selected discriminator {discriminator} lacks a current KNOWN observation"
+            );
+        }
+    }
+}
+
+#[test]
+fn known_observations_enumerate_by_discriminator_and_value() {
+    let batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    assert_eq!(
+        enumeration.schema_version,
+        DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION
+    );
+    assert_eq!(enumeration.discriminators.len(), 4);
+    assert!(enumeration.discriminators.iter().all(|discriminator| {
+        discriminator.known_partitions.len() == 1
+            && discriminator.unknown.is_empty()
+            && discriminator.invalid.is_empty()
+    }));
+}
+
+#[test]
+fn unknown_observation_stays_visible_and_out_of_current_partitions() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[0].value_state = DiscriminatorValueState::Unknown {
+        reason_ref: "applicability:missing-current-revision".to_string(),
+    };
+
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let discriminator = enumeration
+        .discriminators
+        .iter()
+        .find(|item| item.discriminator_id == "clearing_evidence_presence")
+        .unwrap();
+    assert!(discriminator.known_partitions.is_empty());
+    assert_eq!(discriminator.unknown.len(), 1);
+    assert!(discriminator.invalid.is_empty());
+}
+
+#[test]
+fn invalid_observation_stays_visible_and_out_of_current_partitions() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[1].value_state = DiscriminatorValueState::Invalid {
+        reason_ref: "applicability:revision-moved".to_string(),
+    };
+
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let discriminator = enumeration
+        .discriminators
+        .iter()
+        .find(|item| item.discriminator_id == "edit_class")
+        .unwrap();
+    assert!(discriminator.known_partitions.is_empty());
+    assert!(discriminator.unknown.is_empty());
+    assert_eq!(discriminator.invalid.len(), 1);
+}
+
+#[test]
+fn exact_duplicate_observation_identity_rejects() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations.push(batch.observations[0].clone());
+    let error = validate_discriminator_observation_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate discriminator observation id")
+    );
+}
+
+#[test]
+fn conflicting_duplicate_observation_identity_rejects() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let mut conflicting = batch.observations[0].clone();
+    conflicting.value_state = DiscriminatorValueState::Known {
+        value_ref: "observed".to_string(),
+    };
+    batch.observations.push(conflicting);
+    let error = validate_discriminator_observation_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("conflicting discriminator observation id")
+    );
+}
+
+#[test]
+fn missing_source_receipt_rejects() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    batch.observations[0].source_receipt.clear();
+    let error = validate_discriminator_observation_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("source_receipt"));
+}
+
+#[test]
+fn same_value_from_distinct_sources_preserves_each_observation_identity() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let mut repeated = batch.observations[1].clone();
+    repeated.observation_id = "history/oxc-edit-class-v1:second-source".to_string();
+    repeated.source_receipt = "research:cohort-refinement.md#supplied-edit-class".to_string();
+    batch.observations.push(repeated);
+
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let edit_class = enumeration
+        .discriminators
+        .iter()
+        .find(|item| item.discriminator_id == "edit_class")
+        .unwrap();
+    assert_eq!(edit_class.known_partitions.len(), 1);
+    let observations = &edit_class.known_partitions[0].observations;
+    assert_eq!(observations.len(), 2);
+    assert_ne!(
+        observations[0].observation_id,
+        observations[1].observation_id
+    );
+    assert_ne!(
+        observations[0].source_receipt,
+        observations[1].source_receipt
+    );
+}
+
+#[test]
+fn enumeration_order_and_json_round_trip_are_deterministic() {
+    let batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let first = enumerate_discriminator_partitions(&batch).unwrap();
+    let second = enumerate_discriminator_partitions(&batch).unwrap();
+    assert_eq!(first, second);
+
+    let ids = first
+        .discriminators
+        .iter()
+        .map(|item| item.discriminator_id.as_str())
+        .collect::<Vec<_>>();
+    let sorted = ids.iter().copied().collect::<BTreeSet<_>>();
+    assert_eq!(ids, sorted.into_iter().collect::<Vec<_>>());
+
+    let encoded = serde_json::to_vec(&batch).unwrap();
+    let decoded = parse_discriminator_observation_batch(&encoded).unwrap();
+    assert_eq!(decoded, batch);
+}
+
+#[test]
+fn oversized_batch_rejects_before_json_parsing() {
+    let bytes = vec![b' '; MAX_DISCRIMINATOR_OBSERVATION_BATCH_BYTES + 1];
+    let error = parse_discriminator_observation_batch(&bytes).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}
+
+#[test]
+fn value_spelling_remains_an_opaque_reference() {
+    let mut batch = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let DiscriminatorObservation { value_state, .. } = &mut batch.observations[0];
+    *value_state = DiscriminatorValueState::Known {
+        value_ref: "approve_and_merge_everything".to_string(),
+    };
+    let enumeration = enumerate_discriminator_partitions(&batch).unwrap();
+    let partition = &enumeration.discriminators[0].known_partitions[0];
+    assert_eq!(partition.observations.len(), 1);
+}

--- a/tests/durable_obligation.rs
+++ b/tests/durable_obligation.rs
@@ -1,0 +1,8 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/justification.rs"]
+mod justification;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;

--- a/tests/durable_obligation.rs
+++ b/tests/durable_obligation.rs
@@ -2,7 +2,7 @@
 
 #[path = "../src/applicability.rs"]
 mod applicability;
-#[path = "../src/justification.rs"]
-mod justification;
 #[path = "../src/durable_obligation.rs"]
 mod durable_obligation;
+#[path = "../src/justification.rs"]
+mod justification;

--- a/tests/evidence_planner.rs
+++ b/tests/evidence_planner.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[path = "../src/justification.rs"]
+mod justification;

--- a/tests/justification.rs
+++ b/tests/justification.rs
@@ -1,0 +1,6 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/justification.rs"]
+mod justification;

--- a/tests/known_stale_observation_frontier.rs
+++ b/tests/known_stale_observation_frontier.rs
@@ -1,0 +1,101 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+
+use applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, evaluate_query,
+};
+use discriminator_observation::{
+    DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation,
+    DiscriminatorObservationBatch, DiscriminatorValueState,
+};
+use observation_frontier::{
+    OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierRequest, ObservationFrontierStatus,
+    ObservationRequirement, evaluate_observation_frontiers,
+};
+
+fn known_observation(applicability_ref: &str) -> DiscriminatorObservation {
+    DiscriminatorObservation {
+        observation_id: "obs:edit-class:subject-a".to_string(),
+        discriminator_id: "edit_class".to_string(),
+        subject_ref: "commit:subject-a".to_string(),
+        source_receipt: "receipt:syntax-cohort:subject-a".to_string(),
+        value_state: DiscriminatorValueState::Known {
+            value_ref: "syntax_changed".to_string(),
+        },
+        applicability_ref: Some(applicability_ref.to_string()),
+    }
+}
+
+fn frontier_for(observation: DiscriminatorObservation) -> ObservationFrontierStatus {
+    let request = ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements: vec![ObservationRequirement {
+            discriminator_id: "edit_class".to_string(),
+            subject_ref: "commit:subject-a".to_string(),
+        }],
+        observations: DiscriminatorObservationBatch {
+            schema_version: DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+            observations: vec![observation],
+        },
+    };
+    evaluate_observation_frontiers(&request).unwrap().frontiers[0].status
+}
+
+#[test]
+fn known_value_can_be_called_current_while_shared_applicability_is_invalid() {
+    let applicability = evaluate_query(&ApplicabilityQuery {
+        schema_version: APPLICABILITY_SCHEMA_VERSION,
+        requirements: EvidenceRequirements {
+            repository: Some("owner/repo".to_string()),
+            revision: Some("old-head".to_string()),
+            work: None,
+            scope: None,
+        },
+        context: EvaluationContext {
+            repository: Some("owner/repo".to_string()),
+            revision: Some("new-head".to_string()),
+            work: None,
+            path: None,
+        },
+    })
+    .unwrap();
+    assert_eq!(applicability.status, ApplicabilityStatus::Invalid);
+
+    let status = frontier_for(known_observation(
+        "applicability:owner/repo:old-head->new-head:invalid",
+    ));
+    assert_eq!(status, ObservationFrontierStatus::Current);
+}
+
+#[test]
+fn known_value_can_be_called_current_while_required_current_revision_is_missing() {
+    let applicability = evaluate_query(&ApplicabilityQuery {
+        schema_version: APPLICABILITY_SCHEMA_VERSION,
+        requirements: EvidenceRequirements {
+            repository: Some("owner/repo".to_string()),
+            revision: Some("exact-head".to_string()),
+            work: None,
+            scope: None,
+        },
+        context: EvaluationContext {
+            repository: Some("owner/repo".to_string()),
+            revision: None,
+            work: None,
+            path: None,
+        },
+    })
+    .unwrap();
+    assert_eq!(applicability.status, ApplicabilityStatus::Unknown);
+
+    let status = frontier_for(known_observation(
+        "applicability:owner/repo:exact-head:current-revision-missing",
+    ));
+    assert_eq!(status, ObservationFrontierStatus::Current);
+}

--- a/tests/known_stale_observation_frontier.rs
+++ b/tests/known_stale_observation_frontier.rs
@@ -13,14 +13,18 @@ use applicability::{
 };
 use discriminator_observation::{
     DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation,
-    DiscriminatorObservationBatch, DiscriminatorValueState,
+    DiscriminatorObservationBatch, DiscriminatorValueState, ObservationApplicability,
+    ObservationApplicabilityStatus,
 };
 use observation_frontier::{
     OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierRequest, ObservationFrontierStatus,
     ObservationRequirement, evaluate_observation_frontiers,
 };
 
-fn known_observation(applicability_ref: &str) -> DiscriminatorObservation {
+fn known_observation(
+    applicability_status: ObservationApplicabilityStatus,
+    applicability_ref: &str,
+) -> DiscriminatorObservation {
     DiscriminatorObservation {
         observation_id: "obs:edit-class:subject-a".to_string(),
         discriminator_id: "edit_class".to_string(),
@@ -29,11 +33,16 @@ fn known_observation(applicability_ref: &str) -> DiscriminatorObservation {
         value_state: DiscriminatorValueState::Known {
             value_ref: "syntax_changed".to_string(),
         },
-        applicability_ref: Some(applicability_ref.to_string()),
+        applicability: ObservationApplicability {
+            status: applicability_status,
+            receipt_ref: applicability_ref.to_string(),
+        },
     }
 }
 
-fn frontier_for(observation: DiscriminatorObservation) -> ObservationFrontierStatus {
+fn frontier_for(
+    observation: DiscriminatorObservation,
+) -> observation_frontier::ObservationFrontierReceipt {
     let request = ObservationFrontierRequest {
         schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
         requirements: vec![ObservationRequirement {
@@ -45,11 +54,14 @@ fn frontier_for(observation: DiscriminatorObservation) -> ObservationFrontierSta
             observations: vec![observation],
         },
     };
-    evaluate_observation_frontiers(&request).unwrap().frontiers[0].status
+    evaluate_observation_frontiers(&request)
+        .unwrap()
+        .frontiers
+        .remove(0)
 }
 
 #[test]
-fn known_value_can_be_called_current_while_shared_applicability_is_invalid() {
+fn known_value_with_invalid_shared_applicability_is_not_current() {
     let applicability = evaluate_query(&ApplicabilityQuery {
         schema_version: APPLICABILITY_SCHEMA_VERSION,
         requirements: EvidenceRequirements {
@@ -68,14 +80,21 @@ fn known_value_can_be_called_current_while_shared_applicability_is_invalid() {
     .unwrap();
     assert_eq!(applicability.status, ApplicabilityStatus::Invalid);
 
-    let status = frontier_for(known_observation(
+    let frontier = frontier_for(known_observation(
+        ObservationApplicabilityStatus::Invalid,
         "applicability:owner/repo:old-head->new-head:invalid",
     ));
-    assert_eq!(status, ObservationFrontierStatus::Current);
+    assert_eq!(frontier.status, ObservationFrontierStatus::Invalid);
+    assert!(frontier.current.is_empty());
+    assert_eq!(frontier.invalid.len(), 1);
+    assert_eq!(
+        frontier.invalid[0].known_value_ref.as_deref(),
+        Some("syntax_changed")
+    );
 }
 
 #[test]
-fn known_value_can_be_called_current_while_required_current_revision_is_missing() {
+fn known_value_with_unknown_shared_applicability_is_not_current() {
     let applicability = evaluate_query(&ApplicabilityQuery {
         schema_version: APPLICABILITY_SCHEMA_VERSION,
         requirements: EvidenceRequirements {
@@ -94,8 +113,15 @@ fn known_value_can_be_called_current_while_required_current_revision_is_missing(
     .unwrap();
     assert_eq!(applicability.status, ApplicabilityStatus::Unknown);
 
-    let status = frontier_for(known_observation(
+    let frontier = frontier_for(known_observation(
+        ObservationApplicabilityStatus::Unknown,
         "applicability:owner/repo:exact-head:current-revision-missing",
     ));
-    assert_eq!(status, ObservationFrontierStatus::Current);
+    assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
+    assert!(frontier.current.is_empty());
+    assert_eq!(frontier.unknown.len(), 1);
+    assert_eq!(
+        frontier.unknown[0].known_value_ref.as_deref(),
+        Some("syntax_changed")
+    );
 }

--- a/tests/observation_frontier.rs
+++ b/tests/observation_frontier.rs
@@ -10,7 +10,8 @@ mod observation_frontier;
 mod refinement_episode;
 
 use discriminator_observation::{
-    DiscriminatorObservationBatch, DiscriminatorValueState, parse_discriminator_observation_batch,
+    DiscriminatorObservationBatch, DiscriminatorValueState, ObservationApplicabilityStatus,
+    parse_discriminator_observation_batch,
 };
 use observation_frontier::{
     MAX_OBSERVATION_FRONTIER_REQUEST_BYTES, OBSERVATION_FRONTIER_SCHEMA_VERSION,
@@ -68,12 +69,14 @@ fn retained_selected_refinement_discriminators_resolve_current() {
                             &observation.value_state,
                             DiscriminatorValueState::Known { .. }
                         )
+                        && observation.applicability.status
+                            == ObservationApplicabilityStatus::Applies
                 })
                 .collect::<Vec<_>>();
             assert_eq!(
                 matches.len(),
                 1,
-                "retained fixture requires one current subject for {discriminator_id}"
+                "retained fixture requires one current KNOWN+APPLIES subject for {discriminator_id}"
             );
             requirements.push(requirement(discriminator_id, &matches[0].subject_ref));
         }
@@ -127,12 +130,12 @@ fn same_discriminator_on_wrong_subject_does_not_satisfy_requirement() {
 }
 
 #[test]
-fn unknown_matching_observation_produces_unknown_frontier() {
+fn unknown_value_with_applicable_source_produces_unknown_frontier() {
     let mut observations = observation_batch();
     let discriminator_id = observations.observations[0].discriminator_id.clone();
     let subject_ref = observations.observations[0].subject_ref.clone();
     observations.observations[0].value_state = DiscriminatorValueState::Unknown {
-        reason_ref: "applicability:missing-current-revision".to_string(),
+        reason_ref: "classifier:missing-value".to_string(),
     };
 
     let evaluation = evaluate_observation_frontiers(&request(
@@ -143,17 +146,42 @@ fn unknown_matching_observation_produces_unknown_frontier() {
     let frontier = &evaluation.frontiers[0];
     assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
     assert_eq!(frontier.unknown.len(), 1);
-    assert!(frontier.current.is_empty());
+    assert_eq!(
+        frontier.unknown[0].value_unknown_reason_ref.as_deref(),
+        Some("classifier:missing-value")
+    );
 }
 
 #[test]
-fn invalid_matching_observation_produces_invalid_frontier() {
+fn known_value_with_unknown_applicability_produces_unknown_frontier() {
+    let mut observations = observation_batch();
+    let discriminator_id = observations.observations[0].discriminator_id.clone();
+    let subject_ref = observations.observations[0].subject_ref.clone();
+    observations.observations[0].applicability.status = ObservationApplicabilityStatus::Unknown;
+    observations.observations[0].applicability.receipt_ref =
+        "applicability:missing-current-revision".to_string();
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
+    assert_eq!(
+        frontier.unknown[0].known_value_ref.as_deref(),
+        Some("absent")
+    );
+}
+
+#[test]
+fn known_value_with_invalid_applicability_produces_invalid_frontier() {
     let mut observations = observation_batch();
     let discriminator_id = observations.observations[1].discriminator_id.clone();
     let subject_ref = observations.observations[1].subject_ref.clone();
-    observations.observations[1].value_state = DiscriminatorValueState::Invalid {
-        reason_ref: "applicability:revision-moved".to_string(),
-    };
+    observations.observations[1].applicability.status = ObservationApplicabilityStatus::Invalid;
+    observations.observations[1].applicability.receipt_ref =
+        "applicability:revision-moved".to_string();
 
     let evaluation = evaluate_observation_frontiers(&request(
         vec![requirement(&discriminator_id, &subject_ref)],
@@ -162,8 +190,10 @@ fn invalid_matching_observation_produces_invalid_frontier() {
     .unwrap();
     let frontier = &evaluation.frontiers[0];
     assert_eq!(frontier.status, ObservationFrontierStatus::Invalid);
-    assert_eq!(frontier.invalid.len(), 1);
-    assert!(frontier.current.is_empty());
+    assert_eq!(
+        frontier.invalid[0].known_value_ref.as_deref(),
+        Some("syntax_changed")
+    );
 }
 
 #[test]
@@ -172,9 +202,8 @@ fn current_precedes_unknown_while_preserving_both_receipts() {
     let mut unknown = observations.observations[1].clone();
     unknown.observation_id = "history/oxc-edit-class-v1:unknown-second-source".to_string();
     unknown.source_receipt = "research:cohort-refinement.md#unknown-edit-class".to_string();
-    unknown.value_state = DiscriminatorValueState::Unknown {
-        reason_ref: "classifier:missing-source-version".to_string(),
-    };
+    unknown.applicability.status = ObservationApplicabilityStatus::Unknown;
+    unknown.applicability.receipt_ref = "applicability:missing-source-version".to_string();
     let discriminator_id = unknown.discriminator_id.clone();
     let subject_ref = unknown.subject_ref.clone();
     observations.observations.push(unknown);
@@ -196,14 +225,13 @@ fn unknown_precedes_invalid_when_no_current_observation_exists() {
     let mut invalid = observations.observations[0].clone();
     invalid.observation_id = "justification/open-obligation-v1:invalid-second-source".to_string();
     invalid.source_receipt = "research:durable-unknown-obligation.md#stale".to_string();
-    invalid.value_state = DiscriminatorValueState::Invalid {
-        reason_ref: "applicability:head-moved".to_string(),
-    };
+    invalid.applicability.status = ObservationApplicabilityStatus::Invalid;
+    invalid.applicability.receipt_ref = "applicability:head-moved".to_string();
     let discriminator_id = invalid.discriminator_id.clone();
     let subject_ref = invalid.subject_ref.clone();
-    observations.observations[0].value_state = DiscriminatorValueState::Unknown {
-        reason_ref: "applicability:missing-head".to_string(),
-    };
+    observations.observations[0].applicability.status = ObservationApplicabilityStatus::Unknown;
+    observations.observations[0].applicability.receipt_ref =
+        "applicability:missing-head".to_string();
     observations.observations.push(invalid);
 
     let evaluation = evaluate_observation_frontiers(&request(

--- a/tests/observation_frontier.rs
+++ b/tests/observation_frontier.rs
@@ -1,0 +1,283 @@
+#![allow(dead_code)]
+
+use std::collections::BTreeSet;
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+
+use discriminator_observation::{
+    DiscriminatorObservationBatch, DiscriminatorValueState, parse_discriminator_observation_batch,
+};
+use observation_frontier::{
+    MAX_OBSERVATION_FRONTIER_REQUEST_BYTES, OBSERVATION_FRONTIER_SCHEMA_VERSION,
+    ObservationFrontierRequest, ObservationFrontierStatus, ObservationRequirement,
+    evaluate_observation_frontiers, parse_observation_frontier_request,
+};
+use refinement_episode::parse_refinement_episode_batch;
+
+const OBSERVATIONS: &[u8] =
+    include_bytes!("../research/discriminator-observations/cultist-v1.json");
+const REFINEMENTS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+
+fn observation_batch() -> DiscriminatorObservationBatch {
+    parse_discriminator_observation_batch(OBSERVATIONS).unwrap()
+}
+
+fn requirement(discriminator_id: &str, subject_ref: &str) -> ObservationRequirement {
+    ObservationRequirement {
+        discriminator_id: discriminator_id.to_string(),
+        subject_ref: subject_ref.to_string(),
+    }
+}
+
+fn request(
+    requirements: Vec<ObservationRequirement>,
+    observations: DiscriminatorObservationBatch,
+) -> ObservationFrontierRequest {
+    ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements,
+        observations,
+    }
+}
+
+#[test]
+fn retained_selected_refinement_discriminators_resolve_current() {
+    let observations = observation_batch();
+    let refinements = parse_refinement_episode_batch(REFINEMENTS).unwrap();
+    let mut requirements = Vec::new();
+
+    for episode in &refinements.episodes {
+        let selected = episode.selected_transition.as_ref().unwrap();
+        let candidate = episode
+            .candidate_refinements
+            .iter()
+            .find(|candidate| candidate.id == *selected)
+            .unwrap();
+        for discriminator_id in &candidate.discriminator_refs {
+            let matches = observations
+                .observations
+                .iter()
+                .filter(|observation| {
+                    observation.discriminator_id == *discriminator_id
+                        && matches!(
+                            &observation.value_state,
+                            DiscriminatorValueState::Known { .. }
+                        )
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(
+                matches.len(),
+                1,
+                "retained fixture requires one current subject for {discriminator_id}"
+            );
+            requirements.push(requirement(discriminator_id, &matches[0].subject_ref));
+        }
+    }
+
+    let evaluation = evaluate_observation_frontiers(&request(requirements, observations)).unwrap();
+    assert_eq!(evaluation.frontiers.len(), 4);
+    assert!(
+        evaluation
+            .frontiers
+            .iter()
+            .all(|frontier| frontier.status == ObservationFrontierStatus::Current)
+    );
+}
+
+#[test]
+fn removing_one_selected_observation_creates_explicit_missing_frontier() {
+    let mut observations = observation_batch();
+    let removed = observations.observations.remove(0);
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&removed.discriminator_id, &removed.subject_ref)],
+        observations,
+    ))
+    .unwrap();
+
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Missing);
+    assert!(frontier.current.is_empty());
+    assert!(frontier.unknown.is_empty());
+    assert!(frontier.invalid.is_empty());
+}
+
+#[test]
+fn same_discriminator_on_wrong_subject_does_not_satisfy_requirement() {
+    let mut observations = observation_batch();
+    let mut wrong_subject = observations.observations.remove(0);
+    let discriminator_id = wrong_subject.discriminator_id.clone();
+    let required_subject = wrong_subject.subject_ref.clone();
+    wrong_subject.observation_id = "justification/wrong-subject:clearing-presence".to_string();
+    wrong_subject.subject_ref = "refinement:justification/another-obligation".to_string();
+    observations.observations.push(wrong_subject);
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &required_subject)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Missing);
+    assert_eq!(frontier.other_subject.len(), 1);
+}
+
+#[test]
+fn unknown_matching_observation_produces_unknown_frontier() {
+    let mut observations = observation_batch();
+    let discriminator_id = observations.observations[0].discriminator_id.clone();
+    let subject_ref = observations.observations[0].subject_ref.clone();
+    observations.observations[0].value_state = DiscriminatorValueState::Unknown {
+        reason_ref: "applicability:missing-current-revision".to_string(),
+    };
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
+    assert_eq!(frontier.unknown.len(), 1);
+    assert!(frontier.current.is_empty());
+}
+
+#[test]
+fn invalid_matching_observation_produces_invalid_frontier() {
+    let mut observations = observation_batch();
+    let discriminator_id = observations.observations[1].discriminator_id.clone();
+    let subject_ref = observations.observations[1].subject_ref.clone();
+    observations.observations[1].value_state = DiscriminatorValueState::Invalid {
+        reason_ref: "applicability:revision-moved".to_string(),
+    };
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Invalid);
+    assert_eq!(frontier.invalid.len(), 1);
+    assert!(frontier.current.is_empty());
+}
+
+#[test]
+fn current_precedes_unknown_while_preserving_both_receipts() {
+    let mut observations = observation_batch();
+    let mut unknown = observations.observations[1].clone();
+    unknown.observation_id = "history/oxc-edit-class-v1:unknown-second-source".to_string();
+    unknown.source_receipt = "research:cohort-refinement.md#unknown-edit-class".to_string();
+    unknown.value_state = DiscriminatorValueState::Unknown {
+        reason_ref: "classifier:missing-source-version".to_string(),
+    };
+    let discriminator_id = unknown.discriminator_id.clone();
+    let subject_ref = unknown.subject_ref.clone();
+    observations.observations.push(unknown);
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Current);
+    assert_eq!(frontier.current.len(), 1);
+    assert_eq!(frontier.unknown.len(), 1);
+}
+
+#[test]
+fn unknown_precedes_invalid_when_no_current_observation_exists() {
+    let mut observations = observation_batch();
+    let mut invalid = observations.observations[0].clone();
+    invalid.observation_id = "justification/open-obligation-v1:invalid-second-source".to_string();
+    invalid.source_receipt = "research:durable-unknown-obligation.md#stale".to_string();
+    invalid.value_state = DiscriminatorValueState::Invalid {
+        reason_ref: "applicability:head-moved".to_string(),
+    };
+    let discriminator_id = invalid.discriminator_id.clone();
+    let subject_ref = invalid.subject_ref.clone();
+    observations.observations[0].value_state = DiscriminatorValueState::Unknown {
+        reason_ref: "applicability:missing-head".to_string(),
+    };
+    observations.observations.push(invalid);
+
+    let evaluation = evaluate_observation_frontiers(&request(
+        vec![requirement(&discriminator_id, &subject_ref)],
+        observations,
+    ))
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Unknown);
+    assert_eq!(frontier.unknown.len(), 1);
+    assert_eq!(frontier.invalid.len(), 1);
+}
+
+#[test]
+fn duplicate_exact_requirement_rejects() {
+    let observations = observation_batch();
+    let requirement = requirement(
+        &observations.observations[0].discriminator_id,
+        &observations.observations[0].subject_ref,
+    );
+    let error = evaluate_observation_frontiers(&request(
+        vec![requirement.clone(), requirement],
+        observations,
+    ))
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate observation requirement")
+    );
+}
+
+#[test]
+fn frontier_output_order_is_deterministic() {
+    let observations = observation_batch();
+    let requirements = observations
+        .observations
+        .iter()
+        .rev()
+        .map(|observation| requirement(&observation.discriminator_id, &observation.subject_ref))
+        .collect::<Vec<_>>();
+    let evaluation = evaluate_observation_frontiers(&request(requirements, observations)).unwrap();
+    let keys = evaluation
+        .frontiers
+        .iter()
+        .map(|frontier| {
+            (
+                frontier.discriminator_id.as_str(),
+                frontier.subject_ref.as_str(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let sorted = keys.iter().copied().collect::<BTreeSet<_>>();
+    assert_eq!(keys, sorted.into_iter().collect::<Vec<_>>());
+}
+
+#[test]
+fn request_json_round_trip_revalidates_the_frontier_input() {
+    let observations = observation_batch();
+    let request = request(
+        vec![requirement(
+            &observations.observations[0].discriminator_id,
+            &observations.observations[0].subject_ref,
+        )],
+        observations,
+    );
+    let encoded = serde_json::to_vec(&request).unwrap();
+    let decoded = parse_observation_frontier_request(&encoded).unwrap();
+    assert_eq!(decoded, request);
+}
+
+#[test]
+fn oversized_request_rejects_before_json_parsing() {
+    let bytes = vec![b' '; MAX_OBSERVATION_FRONTIER_REQUEST_BYTES + 1];
+    let error = parse_observation_frontier_request(&bytes).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}

--- a/tests/observation_probe_bridge.rs
+++ b/tests/observation_probe_bridge.rs
@@ -1,0 +1,444 @@
+#![allow(dead_code)]
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/justification.rs"]
+mod justification;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/observation_probe_bridge.rs"]
+mod observation_probe_bridge;
+
+use applicability::{EvaluationContext, EvidenceRequirements};
+use durable_obligation::DiscriminatorKey;
+use evidence_planner::{
+    EvidencePlanStatus, EvidenceProbe, ProbeCandidateStatus, ProbeCost, ProbeEffect,
+    ProbeSelectionPolicy,
+};
+use observation_frontier::{
+    CurrentObservationReceipt, NonCurrentObservationReceipt, ObservationFrontierReceipt,
+    ObservationFrontierStatus,
+};
+use observation_probe_bridge::{
+    MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES, OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION,
+    ObservationProbeBridge, ObservationProbePlanRequest, ObservationProbePlanStatus,
+    parse_observation_probe_plan_request, plan_observation_probe,
+};
+
+fn requirements(revision: Option<&str>) -> EvidenceRequirements {
+    EvidenceRequirements {
+        repository: Some("owner/repo".to_string()),
+        revision: revision.map(str::to_string),
+        work: None,
+        scope: None,
+    }
+}
+
+fn context(revision: Option<&str>) -> EvaluationContext {
+    EvaluationContext {
+        repository: Some("owner/repo".to_string()),
+        revision: revision.map(str::to_string),
+        work: None,
+        path: None,
+    }
+}
+
+fn probe_key() -> DiscriminatorKey {
+    DiscriminatorKey {
+        kind: "source_edit_class".to_string(),
+        target: "commit:subject-a".to_string(),
+    }
+}
+
+fn probe(
+    id: &str,
+    key: DiscriminatorKey,
+    revision: Option<&str>,
+    effect: ProbeEffect,
+    cost: ProbeCost,
+) -> EvidenceProbe {
+    EvidenceProbe {
+        id: id.to_string(),
+        produces: key,
+        requirements: requirements(revision),
+        effect,
+        cost,
+    }
+}
+
+fn bridge(subject_ref: &str, revision: &str) -> ObservationProbeBridge {
+    ObservationProbeBridge {
+        bridge_id: format!("edit-class-{revision}"),
+        observation_discriminator_id: "edit_class".to_string(),
+        observation_subject_ref: subject_ref.to_string(),
+        probe_discriminator: probe_key(),
+        clearing_requirements: requirements(Some(revision)),
+        source_receipt: format!("source-adapter:edit-class:{revision}"),
+    }
+}
+
+fn missing_frontier(subject_ref: &str) -> ObservationFrontierReceipt {
+    ObservationFrontierReceipt {
+        discriminator_id: "edit_class".to_string(),
+        subject_ref: subject_ref.to_string(),
+        status: ObservationFrontierStatus::Missing,
+        current: Vec::new(),
+        unknown: Vec::new(),
+        invalid: Vec::new(),
+        other_subject: Vec::new(),
+    }
+}
+
+fn unknown_frontier(subject_ref: &str) -> ObservationFrontierReceipt {
+    ObservationFrontierReceipt {
+        discriminator_id: "edit_class".to_string(),
+        subject_ref: subject_ref.to_string(),
+        status: ObservationFrontierStatus::Unknown,
+        current: Vec::new(),
+        unknown: vec![NonCurrentObservationReceipt {
+            observation_id: "obs:unknown".to_string(),
+            source_receipt: "source:unknown".to_string(),
+            known_value_ref: None,
+            value_unknown_reason_ref: Some("classifier:missing-value".to_string()),
+            applicability_ref: "applicability:head-a:applies".to_string(),
+        }],
+        invalid: Vec::new(),
+        other_subject: Vec::new(),
+    }
+}
+
+fn invalid_frontier(subject_ref: &str) -> ObservationFrontierReceipt {
+    ObservationFrontierReceipt {
+        discriminator_id: "edit_class".to_string(),
+        subject_ref: subject_ref.to_string(),
+        status: ObservationFrontierStatus::Invalid,
+        current: Vec::new(),
+        unknown: Vec::new(),
+        invalid: vec![NonCurrentObservationReceipt {
+            observation_id: "obs:old-head".to_string(),
+            source_receipt: "source:old-head".to_string(),
+            known_value_ref: Some("syntax_changed".to_string()),
+            value_unknown_reason_ref: None,
+            applicability_ref: "applicability:old-head->head-b:invalid".to_string(),
+        }],
+        other_subject: Vec::new(),
+    }
+}
+
+fn current_frontier(subject_ref: &str) -> ObservationFrontierReceipt {
+    ObservationFrontierReceipt {
+        discriminator_id: "edit_class".to_string(),
+        subject_ref: subject_ref.to_string(),
+        status: ObservationFrontierStatus::Current,
+        current: vec![CurrentObservationReceipt {
+            observation_id: "obs:current".to_string(),
+            source_receipt: "source:current".to_string(),
+            value_ref: "syntax_changed".to_string(),
+            applicability_ref: "applicability:head-a:applies".to_string(),
+        }],
+        unknown: Vec::new(),
+        invalid: Vec::new(),
+        other_subject: Vec::new(),
+    }
+}
+
+fn request(
+    frontier: ObservationFrontierReceipt,
+    bridges: Vec<ObservationProbeBridge>,
+    context: EvaluationContext,
+    probes: Vec<EvidenceProbe>,
+    allow_effectful: bool,
+) -> ObservationProbePlanRequest {
+    ObservationProbePlanRequest {
+        schema_version: OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION,
+        frontier,
+        bridges,
+        context,
+        probes,
+        allow_effectful,
+        policy: ProbeSelectionPolicy::Conservative,
+    }
+}
+
+#[test]
+fn exact_source_bridge_selects_capable_probe_and_rejects_similar_name_as_incapable() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        missing_frontier(subject),
+        vec![bridge(subject, "head-a")],
+        context(Some("head-a")),
+        vec![
+            probe(
+                "cheap-similar-name",
+                DiscriminatorKey {
+                    kind: "edit_class".to_string(),
+                    target: subject.to_string(),
+                },
+                Some("head-a"),
+                ProbeEffect::ReadOnly,
+                ProbeCost::default(),
+            ),
+            probe(
+                "mapped-source-probe",
+                probe_key(),
+                Some("head-a"),
+                ProbeEffect::ReadOnly,
+                ProbeCost {
+                    git_subprocesses: 1,
+                    ..ProbeCost::default()
+                },
+            ),
+        ],
+        false,
+    ))
+    .unwrap();
+
+    assert_eq!(plan.status, ObservationProbePlanStatus::Planned);
+    let evidence = plan.evidence_plan.unwrap();
+    assert_eq!(evidence.status, EvidencePlanStatus::Selected);
+    assert_eq!(evidence.selected.unwrap().id, "mapped-source-probe");
+    assert_eq!(
+        evidence
+            .candidates
+            .iter()
+            .find(|candidate| candidate.id == "cheap-similar-name")
+            .unwrap()
+            .status,
+        ProbeCandidateStatus::Incapable
+    );
+}
+
+#[test]
+fn similarly_named_probe_without_explicit_bridge_leaves_frontier_unmapped() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        missing_frontier(subject),
+        Vec::new(),
+        context(Some("head-a")),
+        vec![probe(
+            "looks-related",
+            DiscriminatorKey {
+                kind: "edit_class".to_string(),
+                target: subject.to_string(),
+            },
+            Some("head-a"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    ))
+    .unwrap();
+
+    assert_eq!(plan.status, ObservationProbePlanStatus::NoAdmittedMapping);
+    assert!(plan.evidence_plan.is_none());
+}
+
+#[test]
+fn bridge_for_wrong_subject_does_not_map_required_frontier() {
+    let plan = plan_observation_probe(&request(
+        missing_frontier("commit:subject-a"),
+        vec![bridge("commit:subject-b", "head-a")],
+        context(Some("head-a")),
+        vec![probe(
+            "mapped-source-probe",
+            probe_key(),
+            Some("head-a"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    ))
+    .unwrap();
+
+    assert_eq!(plan.status, ObservationProbePlanStatus::NoAdmittedMapping);
+}
+
+#[test]
+fn current_frontier_needs_no_acquisition_plan() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        current_frontier(subject),
+        vec![bridge(subject, "head-a")],
+        context(Some("head-a")),
+        vec![probe(
+            "mapped-source-probe",
+            probe_key(),
+            Some("head-a"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    ))
+    .unwrap();
+
+    assert_eq!(plan.status, ObservationProbePlanStatus::AlreadyCurrent);
+    assert!(plan.evidence_plan.is_none());
+}
+
+#[test]
+fn unknown_value_with_current_coordinate_can_plan_deeper_acquisition() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        unknown_frontier(subject),
+        vec![bridge(subject, "head-a")],
+        context(Some("head-a")),
+        vec![probe(
+            "mapped-source-probe",
+            probe_key(),
+            Some("head-a"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    ))
+    .unwrap();
+
+    assert_eq!(plan.frontier_status, ObservationFrontierStatus::Unknown);
+    assert_eq!(
+        plan.evidence_plan.unwrap().status,
+        EvidencePlanStatus::Selected
+    );
+}
+
+#[test]
+fn invalid_old_value_can_plan_current_head_refresh_without_becoming_current() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        invalid_frontier(subject),
+        vec![bridge(subject, "head-b")],
+        context(Some("head-b")),
+        vec![probe(
+            "refresh-current-head",
+            probe_key(),
+            Some("head-b"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    ))
+    .unwrap();
+
+    assert_eq!(plan.frontier_status, ObservationFrontierStatus::Invalid);
+    let evidence = plan.evidence_plan.unwrap();
+    assert_eq!(evidence.status, EvidencePlanStatus::Selected);
+    assert_eq!(evidence.selected.unwrap().id, "refresh-current-head");
+}
+
+#[test]
+fn missing_current_coordinate_stays_blocked_in_existing_planner() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        unknown_frontier(subject),
+        vec![bridge(subject, "head-a")],
+        context(None),
+        vec![probe(
+            "mapped-source-probe",
+            probe_key(),
+            Some("head-a"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    ))
+    .unwrap();
+
+    let evidence = plan.evidence_plan.unwrap();
+    assert_eq!(evidence.status, EvidencePlanStatus::Blocked);
+    assert_eq!(
+        evidence.candidates[0].status,
+        ProbeCandidateStatus::MissingContext
+    );
+}
+
+#[test]
+fn bridge_grants_zero_effect_authority() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        missing_frontier(subject),
+        vec![bridge(subject, "head-a")],
+        context(Some("head-a")),
+        vec![probe(
+            "effectful-source-probe",
+            probe_key(),
+            Some("head-a"),
+            ProbeEffect::Effectful,
+            ProbeCost {
+                effectful_executions: 1,
+                ..ProbeCost::default()
+            },
+        )],
+        false,
+    ))
+    .unwrap();
+
+    let evidence = plan.evidence_plan.unwrap();
+    assert_eq!(evidence.status, EvidencePlanStatus::Blocked);
+    assert_eq!(
+        evidence.candidates[0].status,
+        ProbeCandidateStatus::EffectAuthorityRequired
+    );
+}
+
+#[test]
+fn duplicate_mapping_for_exact_observation_requirement_rejects() {
+    let subject = "commit:subject-a";
+    let mut duplicate = bridge(subject, "head-a");
+    duplicate.bridge_id = "second-bridge".to_string();
+    let error = plan_observation_probe(&request(
+        missing_frontier(subject),
+        vec![bridge(subject, "head-a"), duplicate],
+        context(Some("head-a")),
+        Vec::new(),
+        false,
+    ))
+    .unwrap_err();
+
+    assert!(error.to_string().contains("multiple admitted bridges"));
+}
+
+#[test]
+fn incoherent_frontier_receipt_rejects_before_planning() {
+    let mut frontier = missing_frontier("commit:subject-a");
+    frontier.status = ObservationFrontierStatus::Current;
+    let error = plan_observation_probe(&request(
+        frontier,
+        Vec::new(),
+        context(Some("head-a")),
+        Vec::new(),
+        false,
+    ))
+    .unwrap_err();
+
+    assert!(error.to_string().contains("status disagrees"));
+}
+
+#[test]
+fn request_round_trip_and_byte_bound_are_explicit() {
+    let subject = "commit:subject-a";
+    let request = request(
+        missing_frontier(subject),
+        vec![bridge(subject, "head-a")],
+        context(Some("head-a")),
+        vec![probe(
+            "mapped-source-probe",
+            probe_key(),
+            Some("head-a"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    );
+    let encoded = serde_json::to_vec(&request).unwrap();
+    let decoded = parse_observation_probe_plan_request(&encoded).unwrap();
+    assert_eq!(decoded, request);
+
+    let oversized = vec![b' '; MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES + 1];
+    let error = parse_observation_probe_plan_request(&oversized).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}

--- a/tests/observation_probe_bridge.rs
+++ b/tests/observation_probe_bridge.rs
@@ -4,12 +4,12 @@
 mod applicability;
 #[path = "../src/discriminator_observation.rs"]
 mod discriminator_observation;
-#[path = "../src/justification.rs"]
-mod justification;
 #[path = "../src/durable_obligation.rs"]
 mod durable_obligation;
 #[path = "../src/evidence_planner.rs"]
 mod evidence_planner;
+#[path = "../src/justification.rs"]
+mod justification;
 #[path = "../src/observation_frontier.rs"]
 mod observation_frontier;
 #[path = "../src/observation_probe_bridge.rs"]

--- a/tests/refinement_discriminator_subject.rs
+++ b/tests/refinement_discriminator_subject.rs
@@ -56,7 +56,9 @@ fn id_only_refinement_coverage_can_accept_wrong_subject_while_exact_frontier_is_
 
     let mut wrong_subject = exact.clone();
     wrong_subject.observation_id = "history/oxc-edit-class-v1:wrong-subject-control".to_string();
-    wrong_subject.subject_ref = "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/other.rs".to_string();
+    wrong_subject.subject_ref =
+        "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/other.rs"
+            .to_string();
     wrong_subject.source_receipt = "research:wrong-subject-control".to_string();
     wrong_subject.value_state = DiscriminatorValueState::Known {
         value_ref: "syntax_changed".to_string(),

--- a/tests/refinement_discriminator_subject.rs
+++ b/tests/refinement_discriminator_subject.rs
@@ -1,0 +1,135 @@
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+
+use discriminator_observation::{
+    DiscriminatorValueState, enumerate_discriminator_partitions,
+    parse_discriminator_observation_batch,
+};
+use observation_frontier::{
+    OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierRequest, ObservationFrontierStatus,
+    ObservationRequirement, evaluate_observation_frontiers,
+};
+use refinement_episode::parse_refinement_episode_batch;
+
+const OBSERVATIONS: &[u8] =
+    include_bytes!("../research/discriminator-observations/cultist-v1.json");
+const REFINEMENTS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+
+#[test]
+fn id_only_refinement_coverage_can_accept_wrong_subject_while_exact_frontier_is_missing() {
+    let original = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let exact = original
+        .observations
+        .iter()
+        .find(|observation| observation.discriminator_id == "edit_class")
+        .expect("retained Oxc edit_class observation")
+        .clone();
+    assert_eq!(
+        exact.subject_ref,
+        "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs"
+    );
+
+    let refinements = parse_refinement_episode_batch(REFINEMENTS).unwrap();
+    let episode = refinements
+        .episodes
+        .iter()
+        .find(|episode| episode.id == "history/oxc-edit-class-v1")
+        .expect("retained Oxc refinement episode");
+    let selected_id = episode
+        .selected_transition
+        .as_ref()
+        .expect("retained Oxc transition is selected");
+    let selected = episode
+        .candidate_refinements
+        .iter()
+        .find(|candidate| candidate.id == *selected_id)
+        .expect("selected candidate exists");
+    assert_eq!(selected.discriminator_refs, vec!["edit_class"]);
+
+    let mut wrong_subject = exact.clone();
+    wrong_subject.observation_id = "history/oxc-edit-class-v1:wrong-subject-control".to_string();
+    wrong_subject.subject_ref = "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/other.rs".to_string();
+    wrong_subject.source_receipt = "research:wrong-subject-control".to_string();
+    wrong_subject.value_state = DiscriminatorValueState::Known {
+        value_ref: "syntax_changed".to_string(),
+    };
+
+    let mut observations = original.clone();
+    observations
+        .observations
+        .retain(|observation| observation.observation_id != exact.observation_id);
+    observations.observations.push(wrong_subject);
+
+    // This is the current #187 cross-object sufficiency species: availability
+    // is collapsed to discriminator ID before selected candidate refs are checked.
+    let enumeration = enumerate_discriminator_partitions(&observations).unwrap();
+    let current_by_id = enumeration
+        .discriminators
+        .iter()
+        .map(|discriminator| {
+            (
+                discriminator.discriminator_id.as_str(),
+                !discriminator.known_partitions.is_empty(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    for discriminator_id in &selected.discriminator_refs {
+        assert_eq!(
+            current_by_id.get(discriminator_id.as_str()),
+            Some(&true),
+            "ID-only coverage currently treats any current subject as sufficient"
+        );
+    }
+
+    // The exact v2 frontier disagrees: the earned Oxc subject has no current
+    // observation, and the same discriminator on another subject stays visible.
+    let evaluation = evaluate_observation_frontiers(&ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements: vec![ObservationRequirement {
+            discriminator_id: "edit_class".to_string(),
+            subject_ref: exact.subject_ref.clone(),
+        }],
+        observations,
+    })
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Missing);
+    assert!(frontier.current.is_empty());
+    assert_eq!(frontier.other_subject.len(), 1);
+    assert_eq!(
+        frontier.other_subject[0].subject_ref,
+        "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/other.rs"
+    );
+}
+
+#[test]
+fn exact_retained_subject_is_current_control() {
+    let observations = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let exact = observations
+        .observations
+        .iter()
+        .find(|observation| observation.discriminator_id == "edit_class")
+        .expect("retained Oxc edit_class observation");
+    let evaluation = evaluate_observation_frontiers(&ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements: vec![ObservationRequirement {
+            discriminator_id: exact.discriminator_id.clone(),
+            subject_ref: exact.subject_ref.clone(),
+        }],
+        observations,
+    })
+    .unwrap();
+    assert_eq!(
+        evaluation.frontiers[0].status,
+        ObservationFrontierStatus::Current
+    );
+    assert_eq!(evaluation.frontiers[0].other_subject.len(), 0);
+}

--- a/tests/refinement_episode.rs
+++ b/tests/refinement_episode.rs
@@ -1,0 +1,177 @@
+#![allow(dead_code)]
+
+use std::collections::BTreeSet;
+
+#[path = "../src/behavioral_episode.rs"]
+mod behavioral_episode;
+#[path = "../src/behavioral_receipt.rs"]
+mod behavioral_receipt;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+
+use behavioral_episode::parse_behavioral_episode_batch;
+use behavioral_receipt::BehavioralOutcome;
+use refinement_episode::{
+    HeldOutStatus, MAX_REFINEMENT_EPISODE_BATCH_BYTES, RefinementStatus,
+    parse_refinement_episode_batch, validate_refinement_episode_batch,
+};
+
+const CORPUS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+const BEHAVIORAL_CORPUS: &[u8] =
+    include_bytes!("../research/behavioral-episodes/cultist-collaboration-v1.json");
+
+#[test]
+fn retained_cultist_refinement_corpus_preserves_selected_and_rejected_candidates() {
+    let batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    assert_eq!(batch.episodes.len(), 3);
+
+    let justification = &batch.episodes[0];
+    assert_eq!(justification.id, "justification/open-obligation-v1");
+    assert_eq!(
+        justification.selected_transition.as_deref(),
+        Some("allow-open-zero-edge")
+    );
+    assert!(justification.behavioral_episode_ids.is_empty());
+    assert_eq!(
+        justification.candidate_refinements[0].status,
+        RefinementStatus::Weakened
+    );
+
+    let history = &batch.episodes[1];
+    assert_eq!(history.id, "history/oxc-edit-class-v1");
+    assert_eq!(history.candidate_refinements.len(), 3);
+    assert_eq!(
+        history.candidate_refinements[0]
+            .replay_result
+            .held_out_status,
+        HeldOutStatus::Passed
+    );
+    assert!(
+        history
+            .candidate_refinements
+            .iter()
+            .any(|candidate| { candidate.status == RefinementStatus::RejectedNoImprovement })
+    );
+    assert!(
+        history
+            .candidate_refinements
+            .iter()
+            .any(|candidate| { candidate.status == RefinementStatus::RejectedOverfit })
+    );
+
+    let project_memory = &batch.episodes[2];
+    assert_eq!(
+        project_memory.id,
+        "project-memory/primary-case-contract-collision-v1"
+    );
+    assert_eq!(
+        project_memory.candidate_refinements[0].status,
+        RefinementStatus::Split
+    );
+    assert_eq!(
+        project_memory.behavioral_episode_ids,
+        vec!["project-memory:primary-case-contract-collision:9792bfe->df5ae59"]
+    );
+}
+
+#[test]
+fn selected_transition_must_name_a_kept_candidate() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[1].selected_transition = Some("singleton-commit-partition".to_string());
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("rejected status"));
+}
+
+#[test]
+fn kept_candidate_cannot_lose_expected_replay_cases() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[0].candidate_refinements[0]
+        .replay_result
+        .expected_cases_lost = 1;
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("loses expected replay cases"));
+}
+
+#[test]
+fn no_improvement_candidate_cannot_claim_a_resolved_counterexample() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    let candidate = batch.episodes[1]
+        .candidate_refinements
+        .iter_mut()
+        .find(|candidate| candidate.status == RefinementStatus::RejectedNoImprovement)
+        .unwrap();
+    candidate.replay_result.counterexamples_resolved = 1;
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("preserve the baseline replay"));
+}
+
+#[test]
+fn candidate_discriminator_must_be_admitted_by_the_episode() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[0].candidate_refinements[0].discriminator_refs =
+        vec!["invented_discriminator".to_string()];
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(error.to_string().contains("unadmitted discriminator"));
+}
+
+#[test]
+fn behavioral_episode_links_resolve_against_retained_observation_corpus() {
+    let refinement_batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    let behavioral_batch = parse_behavioral_episode_batch(BEHAVIORAL_CORPUS).unwrap();
+    let behavioral_ids = behavioral_batch
+        .episodes
+        .iter()
+        .map(|episode| episode.episode_id.as_str())
+        .collect::<BTreeSet<_>>();
+
+    let linked_ids = refinement_batch
+        .episodes
+        .iter()
+        .flat_map(|episode| episode.behavioral_episode_ids.iter())
+        .collect::<Vec<_>>();
+    assert_eq!(linked_ids.len(), 1);
+    assert!(behavioral_ids.contains(linked_ids[0].as_str()));
+
+    let linked_episode = behavioral_batch
+        .episodes
+        .iter()
+        .find(|episode| episode.episode_id == *linked_ids[0])
+        .unwrap();
+    assert_eq!(
+        linked_episode.receipt.outcome,
+        BehavioralOutcome::ChangedNextAction
+    );
+}
+
+#[test]
+fn behavioral_episode_links_are_optional_and_explicit() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[0].behavioral_episode_ids = vec!["observed:episode-1".to_string()];
+    validate_refinement_episode_batch(&batch).unwrap();
+
+    let encoded = serde_json::to_vec(&batch).unwrap();
+    let decoded = parse_refinement_episode_batch(&encoded).unwrap();
+    assert_eq!(
+        decoded.episodes[0].behavioral_episode_ids,
+        vec!["observed:episode-1"]
+    );
+}
+
+#[test]
+fn duplicate_episode_ids_fail_before_any_aggregate_can_count_them() {
+    let mut batch = parse_refinement_episode_batch(CORPUS).unwrap();
+    batch.episodes[1].id = batch.episodes[0].id.clone();
+    let error = validate_refinement_episode_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate refinement episode id")
+    );
+}
+
+#[test]
+fn oversized_batch_rejects_before_json_parsing() {
+    let bytes = vec![b' '; MAX_REFINEMENT_EPISODE_BATCH_BYTES + 1];
+    let error = parse_refinement_episode_batch(&bytes).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}

--- a/tests/refinement_observation_requirement.rs
+++ b/tests/refinement_observation_requirement.rs
@@ -1,0 +1,254 @@
+#![allow(dead_code)]
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+#[path = "../src/refinement_observation_requirement.rs"]
+mod refinement_observation_requirement;
+
+use discriminator_observation::{DiscriminatorValueState, parse_discriminator_observation_batch};
+use observation_frontier::{
+    OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierRequest, ObservationFrontierStatus,
+    evaluate_observation_frontiers,
+};
+use refinement_episode::parse_refinement_episode_batch;
+use refinement_observation_requirement::{
+    MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES,
+    REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION, RefinementObservationRequirementBatch,
+    RefinementObservationRequirementMapping, RefinementObservationRequirementRequest,
+    evaluate_selected_observation_requirements, parse_refinement_observation_requirement_request,
+};
+
+const OBSERVATIONS: &[u8] =
+    include_bytes!("../research/discriminator-observations/cultist-v1.json");
+const REFINEMENTS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+const MAPPINGS: &[u8] =
+    include_bytes!("../research/refinement-observation-requirements/cultist-v1.json");
+
+fn request() -> RefinementObservationRequirementRequest {
+    RefinementObservationRequirementRequest {
+        schema_version: REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION,
+        refinements: parse_refinement_episode_batch(REFINEMENTS).unwrap(),
+        mappings: serde_json::from_slice(MAPPINGS).unwrap(),
+    }
+}
+
+#[test]
+fn retained_selected_candidates_compile_exact_observation_requirements() {
+    let evaluation = evaluate_selected_observation_requirements(&request()).unwrap();
+    assert_eq!(evaluation.selected.len(), 3);
+    assert!(
+        evaluation
+            .selected
+            .iter()
+            .all(|selected| selected.missing_discriminator_refs.is_empty())
+    );
+
+    let justification = evaluation
+        .selected
+        .iter()
+        .find(|selected| selected.episode_id == "justification/open-obligation-v1")
+        .unwrap();
+    assert_eq!(justification.requirements.len(), 1);
+    assert_eq!(
+        justification.requirements[0].subject_ref,
+        "refinement:justification/open-obligation-v1"
+    );
+
+    let oxc = evaluation
+        .selected
+        .iter()
+        .find(|selected| selected.episode_id == "history/oxc-edit-class-v1")
+        .unwrap();
+    assert_eq!(oxc.candidate_id, "syntax-changing-current-cohort");
+    assert_eq!(oxc.requirements.len(), 1);
+    assert_eq!(oxc.requirements[0].discriminator_id, "edit_class");
+    assert_eq!(
+        oxc.requirements[0].subject_ref,
+        "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs"
+    );
+
+    let project_memory = evaluation
+        .selected
+        .iter()
+        .find(|selected| selected.episode_id == "project-memory/primary-case-contract-collision-v1")
+        .unwrap();
+    assert_eq!(project_memory.requirements.len(), 2);
+    assert!(project_memory.requirements.iter().all(|requirement| {
+        requirement.subject_ref == "refinement:project-memory/primary-case-contract-collision-v1"
+    }));
+}
+
+#[test]
+fn compiled_selected_requirements_are_current_in_retained_observation_corpus() {
+    let observations = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let evaluation = evaluate_selected_observation_requirements(&request()).unwrap();
+
+    for selected in evaluation.selected {
+        let frontiers = evaluate_observation_frontiers(&ObservationFrontierRequest {
+            schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+            requirements: selected.requirements,
+            observations: observations.clone(),
+        })
+        .unwrap();
+        assert!(
+            frontiers
+                .frontiers
+                .iter()
+                .all(|frontier| frontier.status == ObservationFrontierStatus::Current),
+            "selected refinement {} has a noncurrent exact requirement",
+            selected.episode_id
+        );
+    }
+}
+
+#[test]
+fn wrong_subject_edit_class_cannot_satisfy_compiled_oxc_requirement() {
+    let mut observations = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let exact = observations
+        .observations
+        .iter_mut()
+        .find(|observation| observation.discriminator_id == "edit_class")
+        .unwrap();
+    exact.observation_id = "history/oxc-edit-class-v1:wrong-subject-repair-control".to_string();
+    exact.subject_ref =
+        "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/other.rs"
+            .to_string();
+    exact.source_receipt = "research:wrong-subject-repair-control".to_string();
+    exact.value_state = DiscriminatorValueState::Known {
+        value_ref: "syntax_changed".to_string(),
+    };
+
+    let compiled = evaluate_selected_observation_requirements(&request()).unwrap();
+    let oxc = compiled
+        .selected
+        .into_iter()
+        .find(|selected| selected.episode_id == "history/oxc-edit-class-v1")
+        .unwrap();
+    let frontiers = evaluate_observation_frontiers(&ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements: oxc.requirements,
+        observations,
+    })
+    .unwrap();
+    assert_eq!(
+        frontiers.frontiers[0].status,
+        ObservationFrontierStatus::Missing
+    );
+    assert_eq!(frontiers.frontiers[0].other_subject.len(), 1);
+}
+
+#[test]
+fn missing_candidate_subject_mapping_stays_explicit() {
+    let mut request = request();
+    request.mappings.mappings.retain(|mapping| {
+        !(mapping.episode_id == "history/oxc-edit-class-v1"
+            && mapping.candidate_id == "syntax-changing-current-cohort"
+            && mapping.discriminator_id == "edit_class")
+    });
+
+    let evaluation = evaluate_selected_observation_requirements(&request).unwrap();
+    let oxc = evaluation
+        .selected
+        .iter()
+        .find(|selected| selected.episode_id == "history/oxc-edit-class-v1")
+        .unwrap();
+    assert!(oxc.requirements.is_empty());
+    assert!(oxc.mappings.is_empty());
+    assert_eq!(oxc.missing_discriminator_refs, vec!["edit_class"]);
+}
+
+#[test]
+fn mapping_for_discriminator_not_required_by_candidate_rejects() {
+    let mut request = request();
+    request
+        .mappings
+        .mappings
+        .push(RefinementObservationRequirementMapping {
+            id: "invalid-extra-discriminator".to_string(),
+            episode_id: "history/oxc-edit-class-v1".to_string(),
+            candidate_id: "syntax-changing-current-cohort".to_string(),
+            discriminator_id: "commit_identity".to_string(),
+            subject_ref: "commit:irrelevant".to_string(),
+            source_receipt: "research:invalid-control".to_string(),
+        });
+    let error = evaluate_selected_observation_requirements(&request).unwrap_err();
+    assert!(error.to_string().contains("is not required by candidate"));
+}
+
+#[test]
+fn duplicate_candidate_discriminator_mapping_rejects() {
+    let mut request = request();
+    let original = request
+        .mappings
+        .mappings
+        .iter()
+        .find(|mapping| mapping.episode_id == "history/oxc-edit-class-v1")
+        .unwrap()
+        .clone();
+    let mut duplicate = original;
+    duplicate.id = "duplicate-oxc-edit-class".to_string();
+    duplicate.subject_ref = "commit:another-subject".to_string();
+    request.mappings.mappings.push(duplicate);
+    let error = evaluate_selected_observation_requirements(&request).unwrap_err();
+    assert!(error.to_string().contains("multiple subject mappings"));
+}
+
+#[test]
+fn same_discriminator_can_have_candidate_specific_subject_mapping() {
+    let mut request = request();
+    request
+        .mappings
+        .mappings
+        .push(RefinementObservationRequirementMapping {
+            id: "history/oxc-edit-class-v1:reverse-control:edit-class".to_string(),
+            episode_id: "history/oxc-edit-class-v1".to_string(),
+            candidate_id: "reverse-edit-class-control".to_string(),
+            discriminator_id: "edit_class".to_string(),
+            subject_ref: "oxc-project/oxc:reverse-generated-history".to_string(),
+            source_receipt: "research:rust-syntax-cohort-replay.md#reverse-control".to_string(),
+        });
+
+    let evaluation = evaluate_selected_observation_requirements(&request).unwrap();
+    let oxc = evaluation
+        .selected
+        .iter()
+        .find(|selected| selected.episode_id == "history/oxc-edit-class-v1")
+        .unwrap();
+    assert_eq!(oxc.candidate_id, "syntax-changing-current-cohort");
+    assert_eq!(
+        oxc.requirements[0].subject_ref,
+        "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs"
+    );
+}
+
+#[test]
+fn request_round_trip_and_byte_bound_are_explicit() {
+    let request = request();
+    let encoded = serde_json::to_vec(&request).unwrap();
+    let decoded = parse_refinement_observation_requirement_request(&encoded).unwrap();
+    assert_eq!(decoded, request);
+
+    let oversized = vec![b' '; MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES + 1];
+    let error = parse_refinement_observation_requirement_request(&oversized).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}
+
+#[test]
+fn empty_mapping_batch_is_valid_and_exposes_every_selected_requirement_as_missing() {
+    let mut request = request();
+    request.mappings = RefinementObservationRequirementBatch {
+        schema_version: REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION,
+        mappings: Vec::new(),
+    };
+    let evaluation = evaluate_selected_observation_requirements(&request).unwrap();
+    assert_eq!(evaluation.selected.len(), 3);
+    assert!(evaluation.selected.iter().all(|selected| {
+        selected.requirements.is_empty()
+            && selected.mappings.is_empty()
+            && !selected.missing_discriminator_refs.is_empty()
+    }));
+}

--- a/tests/rust_edit_class_source.rs
+++ b/tests/rust_edit_class_source.rs
@@ -1,0 +1,304 @@
+#![allow(dead_code)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[path = "../src/justification.rs"]
+mod justification;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/observation_probe_bridge.rs"]
+mod observation_probe_bridge;
+#[path = "../src/rust_edit_class_source.rs"]
+mod rust_edit_class_source;
+
+use applicability::EvaluationContext;
+use discriminator_observation::{
+    DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservationBatch,
+    DiscriminatorValueState, ObservationApplicabilityStatus, parse_discriminator_observation_batch,
+};
+use evidence_planner::{EvidencePlanStatus, ProbeEffect, ProbeSelectionPolicy};
+use observation_frontier::{
+    OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierRequest, ObservationFrontierStatus,
+    ObservationRequirement, evaluate_observation_frontiers,
+};
+use observation_probe_bridge::{
+    OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION, ObservationProbePlanRequest,
+    ObservationProbePlanStatus, plan_observation_probe,
+};
+use rust_edit_class_source::{RustEditClassSubject, collect_rust_edit_class_source, subject_ref};
+
+struct TempRepo {
+    root: PathBuf,
+}
+
+impl TempRepo {
+    fn new(label: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cultist-rust-edit-class-{label}-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(root.join("src")).unwrap();
+        run_git(&root, &["init", "-q"]);
+        run_git(&root, &["config", "user.email", "cultist@example.invalid"]);
+        run_git(&root, &["config", "user.name", "Cultist Test"]);
+        Self { root }
+    }
+
+    fn write(&self, source: &str) {
+        fs::write(self.root.join("src/lib.rs"), source).unwrap();
+    }
+
+    fn commit(&self, message: &str) -> String {
+        run_git(&self.root, &["add", "src/lib.rs"]);
+        run_git(&self.root, &["commit", "-q", "-m", message]);
+        git_output(&self.root, &["rev-parse", "HEAD"])
+    }
+
+    fn commit_other_path(&self, message: &str) -> String {
+        fs::write(self.root.join("README.md"), "unrelated\n").unwrap();
+        run_git(&self.root, &["add", "README.md"]);
+        run_git(&self.root, &["commit", "-q", "-m", message]);
+        git_output(&self.root, &["rev-parse", "HEAD"])
+    }
+}
+
+impl Drop for TempRepo {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn run_git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_output(root: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
+fn subject(revision: &str) -> RustEditClassSubject {
+    RustEditClassSubject {
+        repository: "owner/repo".to_string(),
+        revision: revision.to_string(),
+        path: "src/lib.rs".to_string(),
+    }
+}
+
+fn seeded_repo() -> (TempRepo, String, String, String) {
+    let repo = TempRepo::new("cohorts");
+    repo.write("fn answer() -> usize { 41 }\n");
+    let root = repo.commit("root");
+    repo.write("fn answer() -> usize { 42 }\n");
+    let syntax = repo.commit("syntax");
+    repo.write("// retained comment\nfn answer() -> usize { 42 }\n");
+    let comments = repo.commit("comments");
+    (repo, root, syntax, comments)
+}
+
+#[test]
+fn comment_only_edit_emits_current_known_observation_and_exact_bridge() {
+    let (repo, _root, _syntax, comments) = seeded_repo();
+    let result = collect_rust_edit_class_source(&repo.root, &subject(&comments)).unwrap();
+
+    assert_eq!(result.current_head, comments);
+    assert_eq!(result.observation.discriminator_id, "edit_class");
+    assert_eq!(
+        result.observation.value_state,
+        DiscriminatorValueState::Known {
+            value_ref: "comments_or_docs_only".to_string()
+        }
+    );
+    assert_eq!(
+        result.observation.applicability.status,
+        ObservationApplicabilityStatus::Applies
+    );
+    assert_eq!(
+        result.bridge.observation_subject_ref,
+        subject_ref(&subject(&comments))
+    );
+    assert_eq!(result.probe.effect, ProbeEffect::ReadOnly);
+}
+
+#[test]
+fn syntax_commit_is_classified_separately_from_comment_only_commit() {
+    let (repo, _root, syntax, _comments) = seeded_repo();
+    run_git(&repo.root, &["checkout", "-q", &syntax]);
+    let result = collect_rust_edit_class_source(&repo.root, &subject(&syntax)).unwrap();
+    assert_eq!(
+        result.observation.value_state,
+        DiscriminatorValueState::Known {
+            value_ref: "syntax_changed".to_string()
+        }
+    );
+    assert_eq!(
+        result.observation.applicability.status,
+        ObservationApplicabilityStatus::Applies
+    );
+}
+
+#[test]
+fn root_commit_is_unknown_instead_of_guessed() {
+    let (repo, root, _syntax, _comments) = seeded_repo();
+    run_git(&repo.root, &["checkout", "-q", &root]);
+    let result = collect_rust_edit_class_source(&repo.root, &subject(&root)).unwrap();
+    assert!(matches!(
+        result.observation.value_state,
+        DiscriminatorValueState::Unknown { .. }
+    ));
+    assert_eq!(
+        result.observation.applicability.status,
+        ObservationApplicabilityStatus::Applies
+    );
+}
+
+#[test]
+fn unrelated_repository_commit_is_unknown_instead_of_comment_only() {
+    let (repo, _root, _syntax, _comments) = seeded_repo();
+    let unrelated = repo.commit_other_path("unrelated");
+    let result = collect_rust_edit_class_source(&repo.root, &subject(&unrelated)).unwrap();
+    assert!(matches!(
+        &result.observation.value_state,
+        DiscriminatorValueState::Unknown { reason_ref }
+            if reason_ref.contains("anchor-unchanged")
+    ));
+    assert_eq!(
+        result.observation.applicability.status,
+        ObservationApplicabilityStatus::Applies
+    );
+}
+
+#[test]
+fn known_old_classification_stays_invalid_after_head_moves() {
+    let (repo, _root, syntax, comments) = seeded_repo();
+    assert_eq!(git_output(&repo.root, &["rev-parse", "HEAD"]), comments);
+    let result = collect_rust_edit_class_source(&repo.root, &subject(&syntax)).unwrap();
+    assert_eq!(
+        result.observation.value_state,
+        DiscriminatorValueState::Known {
+            value_ref: "syntax_changed".to_string()
+        }
+    );
+    assert_eq!(
+        result.observation.applicability.status,
+        ObservationApplicabilityStatus::Invalid
+    );
+}
+
+#[test]
+fn selected_probe_then_produced_observation_closes_missing_frontier() {
+    let (repo, _root, _syntax, comments) = seeded_repo();
+    let source = collect_rust_edit_class_source(&repo.root, &subject(&comments)).unwrap();
+    let required_subject = source.observation.subject_ref.clone();
+    let missing = observation_frontier::ObservationFrontierReceipt {
+        discriminator_id: "edit_class".to_string(),
+        subject_ref: required_subject.clone(),
+        status: ObservationFrontierStatus::Missing,
+        current: Vec::new(),
+        unknown: Vec::new(),
+        invalid: Vec::new(),
+        other_subject: Vec::new(),
+    };
+
+    let plan = plan_observation_probe(&ObservationProbePlanRequest {
+        schema_version: OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION,
+        frontier: missing,
+        bridges: vec![source.bridge.clone()],
+        context: EvaluationContext {
+            repository: Some("owner/repo".to_string()),
+            revision: Some(comments.clone()),
+            work: None,
+            path: Some("src/lib.rs".to_string()),
+        },
+        probes: vec![source.probe.clone()],
+        allow_effectful: false,
+        policy: ProbeSelectionPolicy::Conservative,
+    })
+    .unwrap();
+    assert_eq!(plan.status, ObservationProbePlanStatus::Planned);
+    assert_eq!(
+        plan.evidence_plan.unwrap().status,
+        EvidencePlanStatus::Selected
+    );
+
+    let evaluation = evaluate_observation_frontiers(&ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements: vec![ObservationRequirement {
+            discriminator_id: "edit_class".to_string(),
+            subject_ref: required_subject,
+        }],
+        observations: DiscriminatorObservationBatch {
+            schema_version: DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+            observations: vec![source.observation.clone()],
+        },
+    })
+    .unwrap();
+    assert_eq!(
+        evaluation.frontiers[0].status,
+        ObservationFrontierStatus::Current
+    );
+    assert_eq!(
+        evaluation.frontiers[0].current[0].value_ref,
+        "comments_or_docs_only"
+    );
+}
+
+#[test]
+fn produced_observation_round_trips_through_v2_validation() {
+    let (repo, _root, _syntax, comments) = seeded_repo();
+    let result = collect_rust_edit_class_source(&repo.root, &subject(&comments)).unwrap();
+    let batch = DiscriminatorObservationBatch {
+        schema_version: DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+        observations: vec![result.observation],
+    };
+    let encoded = serde_json::to_vec(&batch).unwrap();
+    let decoded = parse_discriminator_observation_batch(&encoded).unwrap();
+    assert_eq!(decoded, batch);
+}
+
+#[test]
+fn path_and_revision_admission_fail_closed() {
+    let (repo, _root, _syntax, comments) = seeded_repo();
+    let mut bad_path = subject(&comments);
+    bad_path.path = "../src/lib.rs".to_string();
+    assert!(collect_rust_edit_class_source(&repo.root, &bad_path).is_err());
+
+    let mut short_revision = subject(&comments);
+    short_revision.revision = "deadbeef".to_string();
+    assert!(collect_rust_edit_class_source(&repo.root, &short_revision).is_err());
+}


### PR DESCRIPTION
Repairs #227 as a child of the green #228 wrong-subject counterexample.

## Contract

Keeps #179's replay ledger source-agnostic and adds a separate source-owned mapping:

```text
(episode_id, candidate_id, discriminator_id)
-> exact subject_ref
+ source_receipt
```

One exact tuple may have at most one v0 mapping. The mapping must name an existing candidate and a discriminator that candidate actually uses.

For each selected transition, the evaluator compiles these receipts into ordinary #210 `ObservationRequirement { discriminator_id, subject_ref }` values and preserves the exact mapping receipts. Missing mappings remain explicit under `missing_discriminator_refs`; the evaluator never picks a subject from whichever current observation happens to exist.

## Three retained selected families

- justification `clearing_evidence_presence` -> episode-local obligation subject;
- Oxc `edit_class` -> exact #221 focused subject `228e8e0f...:rules.rs`;
- project-memory `primary_case_evidence_form` + `same_repository_issue_target` -> episode-local project-memory subject.

## Controls

- all selected candidates compile with zero missing mappings;
- every retained compiled D@S requirement is CURRENT;
- wrong-subject Oxc edit class stays MISSING;
- removed mapping stays explicitly missing even when observations exist elsewhere;
- invalid candidate/discriminator mapping rejects;
- duplicate exact mapping rejects;
- same reusable discriminator may map differently for another candidate;
- empty mapping set exposes all selected needs as missing mapping evidence;
- bounded JSON reader/round-trip are explicit.

## Validation

The exploratory sequence hit only mechanical integration issues before semantics: rustfmt, then a missing `discriminator_observation` sibling import in the standalone reader. Formatted semantic head `95f614c079de09358f1865bab34399235a512844` passed full CI run `32259965516` / #1597.

The branch was then compacted to one semantic child commit:

```text
2231661eaf065fcc073bf45203f32503b95aefae
```

on #228's exact green head `b046c0aadc617a0a341ae12c943c7ec7d28b5f11`.

That exact compacted head passed full CI run `32260210614` / #1609: format, strict Clippy, active-work preflight, full selected-requirement tests, and repository/history/CI-filter/diff dogfood all succeeded.

The #179 schema, #210 currentness semantics, and #216 probe bridge/planner remain unchanged. The executed receipt is retained in `research/refinement-observation-requirements.md`.

## Next

The next carrier can now start from the retained selected Oxc refinement itself:

```text
selected candidate
-> source-owned exact D@S requirement
-> MISSING frontier when current observation is withheld
-> #216 source bridge / #145 probe plan
-> #221 focused Rust edit-class producer
-> produced v2 observation
-> CURRENT exact frontier
```

That composition should add no new generic state model unless it exposes another mismatch.

Refs #148 #179 #185 #187 #190 #194 #210 #216 #220 #221 #227 #228.