### PR TITLE
research: bind skill-relative references before agent execution

### DIFF
--- a/tests/skill_relative_reference_binding.rs
+++ b/tests/skill_relative_reference_binding.rs
@@ -144,11 +144,13 @@ fn explicit_root_binding_does_not_make_traversal_or_absolute_references_valid() 
 
     for invalid in ["../scripts/fetch_comments.py", "/tmp/fetch_comments.py", ""] {
         let reference = Path::new(invalid);
-        assert!(resolve_reference(
-            &context,
-            reference,
-            ReferenceResolution::ExplicitSkillRoot(&context.skill_root),
-        )
-        .is_none());
+        assert!(
+            resolve_reference(
+                &context,
+                reference,
+                ReferenceResolution::ExplicitSkillRoot(&context.skill_root),
+            )
+            .is_none()
+        );
     }
 }

--- a/tests/skill_relative_reference_binding.rs
+++ b/tests/skill_relative_reference_binding.rs
@@ -1,0 +1,154 @@
+use std::collections::BTreeSet;
+use std::path::{Component, Path, PathBuf};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct SkillReferenceContext {
+    target_repository_root: PathBuf,
+    skill_root: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum ReferenceResolution<'a> {
+    AmbientTarget(&'a Path),
+    ExplicitSkillRoot(&'a Path),
+}
+
+fn validate_relative_reference(reference: &Path) -> bool {
+    !reference.as_os_str().is_empty()
+        && !reference.is_absolute()
+        && reference
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+}
+
+fn resolve_reference(
+    context: &SkillReferenceContext,
+    reference: &Path,
+    mode: ReferenceResolution<'_>,
+) -> Option<PathBuf> {
+    if !validate_relative_reference(reference) {
+        return None;
+    }
+    let root = match mode {
+        ReferenceResolution::AmbientTarget(root) => root,
+        ReferenceResolution::ExplicitSkillRoot(root) => root,
+    };
+    Some(root.join(reference))
+}
+
+fn fixture_context(target_root: &str) -> SkillReferenceContext {
+    SkillReferenceContext {
+        target_repository_root: PathBuf::from(target_root),
+        skill_root: PathBuf::from("/installed-skills/gh-address-comments"),
+    }
+}
+
+fn bundled_skill_paths() -> BTreeSet<PathBuf> {
+    [PathBuf::from(
+        "/installed-skills/gh-address-comments/scripts/fetch_comments.py",
+    )]
+    .into_iter()
+    .collect()
+}
+
+#[test]
+fn same_relative_reference_resolves_to_different_objects_under_two_ambient_roots() {
+    let context = fixture_context("/workspace/repository-a");
+    let reference = Path::new("scripts/fetch_comments.py");
+
+    let target_resolution = resolve_reference(
+        &context,
+        reference,
+        ReferenceResolution::AmbientTarget(&context.target_repository_root),
+    )
+    .unwrap();
+    let skill_resolution = resolve_reference(
+        &context,
+        reference,
+        ReferenceResolution::ExplicitSkillRoot(&context.skill_root),
+    )
+    .unwrap();
+
+    assert_eq!(
+        target_resolution,
+        PathBuf::from("/workspace/repository-a/scripts/fetch_comments.py")
+    );
+    assert_eq!(
+        skill_resolution,
+        PathBuf::from("/installed-skills/gh-address-comments/scripts/fetch_comments.py")
+    );
+    assert_ne!(target_resolution, skill_resolution);
+}
+
+#[test]
+fn known_bundled_helper_is_recoverable_from_explicit_skill_root_but_not_target_cwd() {
+    let context = fixture_context("/workspace/repository-a");
+    let reference = Path::new("scripts/fetch_comments.py");
+    let known = bundled_skill_paths();
+
+    let target_resolution = resolve_reference(
+        &context,
+        reference,
+        ReferenceResolution::AmbientTarget(&context.target_repository_root),
+    )
+    .unwrap();
+    let skill_resolution = resolve_reference(
+        &context,
+        reference,
+        ReferenceResolution::ExplicitSkillRoot(&context.skill_root),
+    )
+    .unwrap();
+
+    assert!(!known.contains(&target_resolution));
+    assert!(known.contains(&skill_resolution));
+}
+
+#[test]
+fn explicit_skill_root_resolution_is_invariant_to_target_repository_movement() {
+    let first = fixture_context("/workspace/repository-a");
+    let second = fixture_context("/tmp/another-checkout");
+    let reference = Path::new("scripts/fetch_comments.py");
+
+    let first_target = resolve_reference(
+        &first,
+        reference,
+        ReferenceResolution::AmbientTarget(&first.target_repository_root),
+    )
+    .unwrap();
+    let second_target = resolve_reference(
+        &second,
+        reference,
+        ReferenceResolution::AmbientTarget(&second.target_repository_root),
+    )
+    .unwrap();
+    let first_bound = resolve_reference(
+        &first,
+        reference,
+        ReferenceResolution::ExplicitSkillRoot(&first.skill_root),
+    )
+    .unwrap();
+    let second_bound = resolve_reference(
+        &second,
+        reference,
+        ReferenceResolution::ExplicitSkillRoot(&second.skill_root),
+    )
+    .unwrap();
+
+    assert_ne!(first_target, second_target);
+    assert_eq!(first_bound, second_bound);
+}
+
+#[test]
+fn explicit_root_binding_does_not_make_traversal_or_absolute_references_valid() {
+    let context = fixture_context("/workspace/repository-a");
+
+    for invalid in ["../scripts/fetch_comments.py", "/tmp/fetch_comments.py", ""] {
+        let reference = Path::new(invalid);
+        assert!(resolve_reference(
+            &context,
+            reference,
+            ReferenceResolution::ExplicitSkillRoot(&context.skill_root),
+        )
+        .is_none());
+    }
+}

--- a/tests/skill_relative_reference_binding.rs
+++ b/tests/skill_relative_reference_binding.rs
@@ -8,9 +8,9 @@ struct SkillReferenceContext {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum ReferenceResolution<'a> {
-    AmbientTarget(&'a Path),
-    ExplicitSkillRoot(&'a Path),
+enum ReferenceResolution {
+    AmbientTarget,
+    ExplicitSkillRoot,
 }
 
 fn validate_relative_reference(reference: &Path) -> bool {
@@ -24,14 +24,14 @@ fn validate_relative_reference(reference: &Path) -> bool {
 fn resolve_reference(
     context: &SkillReferenceContext,
     reference: &Path,
-    mode: ReferenceResolution<'_>,
+    mode: ReferenceResolution,
 ) -> Option<PathBuf> {
     if !validate_relative_reference(reference) {
         return None;
     }
     let root = match mode {
-        ReferenceResolution::AmbientTarget(root) => root,
-        ReferenceResolution::ExplicitSkillRoot(root) => root,
+        ReferenceResolution::AmbientTarget => &context.target_repository_root,
+        ReferenceResolution::ExplicitSkillRoot => &context.skill_root,
     };
     Some(root.join(reference))
 }
@@ -59,13 +59,13 @@ fn same_relative_reference_resolves_to_different_objects_under_two_ambient_roots
     let target_resolution = resolve_reference(
         &context,
         reference,
-        ReferenceResolution::AmbientTarget(&context.target_repository_root),
+        ReferenceResolution::AmbientTarget,
     )
     .unwrap();
     let skill_resolution = resolve_reference(
         &context,
         reference,
-        ReferenceResolution::ExplicitSkillRoot(&context.skill_root),
+        ReferenceResolution::ExplicitSkillRoot,
     )
     .unwrap();
 
@@ -89,13 +89,13 @@ fn known_bundled_helper_is_recoverable_from_explicit_skill_root_but_not_target_c
     let target_resolution = resolve_reference(
         &context,
         reference,
-        ReferenceResolution::AmbientTarget(&context.target_repository_root),
+        ReferenceResolution::AmbientTarget,
     )
     .unwrap();
     let skill_resolution = resolve_reference(
         &context,
         reference,
-        ReferenceResolution::ExplicitSkillRoot(&context.skill_root),
+        ReferenceResolution::ExplicitSkillRoot,
     )
     .unwrap();
 
@@ -109,30 +109,14 @@ fn explicit_skill_root_resolution_is_invariant_to_target_repository_movement() {
     let second = fixture_context("/tmp/another-checkout");
     let reference = Path::new("scripts/fetch_comments.py");
 
-    let first_target = resolve_reference(
-        &first,
-        reference,
-        ReferenceResolution::AmbientTarget(&first.target_repository_root),
-    )
-    .unwrap();
-    let second_target = resolve_reference(
-        &second,
-        reference,
-        ReferenceResolution::AmbientTarget(&second.target_repository_root),
-    )
-    .unwrap();
-    let first_bound = resolve_reference(
-        &first,
-        reference,
-        ReferenceResolution::ExplicitSkillRoot(&first.skill_root),
-    )
-    .unwrap();
-    let second_bound = resolve_reference(
-        &second,
-        reference,
-        ReferenceResolution::ExplicitSkillRoot(&second.skill_root),
-    )
-    .unwrap();
+    let first_target = resolve_reference(&first, reference, ReferenceResolution::AmbientTarget)
+        .unwrap();
+    let second_target = resolve_reference(&second, reference, ReferenceResolution::AmbientTarget)
+        .unwrap();
+    let first_bound = resolve_reference(&first, reference, ReferenceResolution::ExplicitSkillRoot)
+        .unwrap();
+    let second_bound = resolve_reference(&second, reference, ReferenceResolution::ExplicitSkillRoot)
+        .unwrap();
 
     assert_ne!(first_target, second_target);
     assert_eq!(first_bound, second_bound);
@@ -148,7 +132,7 @@ fn explicit_root_binding_does_not_make_traversal_or_absolute_references_valid() 
             resolve_reference(
                 &context,
                 reference,
-                ReferenceResolution::ExplicitSkillRoot(&context.skill_root),
+                ReferenceResolution::ExplicitSkillRoot,
             )
             .is_none()
         );

--- a/tests/skill_relative_reference_binding.rs
+++ b/tests/skill_relative_reference_binding.rs
@@ -56,18 +56,10 @@ fn same_relative_reference_resolves_to_different_objects_under_two_ambient_roots
     let context = fixture_context("/workspace/repository-a");
     let reference = Path::new("scripts/fetch_comments.py");
 
-    let target_resolution = resolve_reference(
-        &context,
-        reference,
-        ReferenceResolution::AmbientTarget,
-    )
-    .unwrap();
-    let skill_resolution = resolve_reference(
-        &context,
-        reference,
-        ReferenceResolution::ExplicitSkillRoot,
-    )
-    .unwrap();
+    let target_resolution =
+        resolve_reference(&context, reference, ReferenceResolution::AmbientTarget).unwrap();
+    let skill_resolution =
+        resolve_reference(&context, reference, ReferenceResolution::ExplicitSkillRoot).unwrap();
 
     assert_eq!(
         target_resolution,
@@ -86,18 +78,10 @@ fn known_bundled_helper_is_recoverable_from_explicit_skill_root_but_not_target_c
     let reference = Path::new("scripts/fetch_comments.py");
     let known = bundled_skill_paths();
 
-    let target_resolution = resolve_reference(
-        &context,
-        reference,
-        ReferenceResolution::AmbientTarget,
-    )
-    .unwrap();
-    let skill_resolution = resolve_reference(
-        &context,
-        reference,
-        ReferenceResolution::ExplicitSkillRoot,
-    )
-    .unwrap();
+    let target_resolution =
+        resolve_reference(&context, reference, ReferenceResolution::AmbientTarget).unwrap();
+    let skill_resolution =
+        resolve_reference(&context, reference, ReferenceResolution::ExplicitSkillRoot).unwrap();
 
     assert!(!known.contains(&target_resolution));
     assert!(known.contains(&skill_resolution));
@@ -109,14 +93,14 @@ fn explicit_skill_root_resolution_is_invariant_to_target_repository_movement() {
     let second = fixture_context("/tmp/another-checkout");
     let reference = Path::new("scripts/fetch_comments.py");
 
-    let first_target = resolve_reference(&first, reference, ReferenceResolution::AmbientTarget)
-        .unwrap();
-    let second_target = resolve_reference(&second, reference, ReferenceResolution::AmbientTarget)
-        .unwrap();
-    let first_bound = resolve_reference(&first, reference, ReferenceResolution::ExplicitSkillRoot)
-        .unwrap();
-    let second_bound = resolve_reference(&second, reference, ReferenceResolution::ExplicitSkillRoot)
-        .unwrap();
+    let first_target =
+        resolve_reference(&first, reference, ReferenceResolution::AmbientTarget).unwrap();
+    let second_target =
+        resolve_reference(&second, reference, ReferenceResolution::AmbientTarget).unwrap();
+    let first_bound =
+        resolve_reference(&first, reference, ReferenceResolution::ExplicitSkillRoot).unwrap();
+    let second_bound =
+        resolve_reference(&second, reference, ReferenceResolution::ExplicitSkillRoot).unwrap();
 
     assert_ne!(first_target, second_target);
     assert_eq!(first_bound, second_bound);
@@ -129,12 +113,8 @@ fn explicit_root_binding_does_not_make_traversal_or_absolute_references_valid() 
     for invalid in ["../scripts/fetch_comments.py", "/tmp/fetch_comments.py", ""] {
         let reference = Path::new(invalid);
         assert!(
-            resolve_reference(
-                &context,
-                reference,
-                ReferenceResolution::ExplicitSkillRoot,
-            )
-            .is_none()
+            resolve_reference(&context, reference, ReferenceResolution::ExplicitSkillRoot,)
+                .is_none()
         );
     }
 }


### PR DESCRIPTION
Progresses #225/#134 with one deterministic context-binding counterexample inspired by source-confirmed `openai/skills#96`.

## Question

Can a skill instruction containing a relative helper reference be independently reconstructible when the execution environment has both a target repository root and an installed skill root?

## Test-only model

The fixture uses:

```text
reference = scripts/fetch_comments.py

target repository root
  /workspace/repository-a

skill root
  /installed-skills/gh-address-comments
```

Two candidate resolution contexts produce:

```text
ambient target cwd
  /workspace/repository-a/scripts/fetch_comments.py

explicit skill root
  /installed-skills/gh-address-comments/scripts/fetch_comments.py
```

The same relative bytes therefore do not identify one object unless the containing protocol/instruction binds the root.

## Controls

- a fixture inventory contains the helper only under the explicit skill root;
- ambient target-root resolution therefore misses the known bundled helper;
- moving the target repository changes the ambient resolution;
- explicit skill-root resolution stays invariant across target checkout movement;
- absolute paths, traversal, and empty references are not made valid merely by supplying a skill root.

## External source relation

#226 retains exact source evidence for `openai/skills#96`:

- current `gh-address-comments/SKILL.md` at the retained exact commit instructs `Run scripts/fetch_comments.py`;
- the helper exists inside that skill's own `scripts/` directory.

This PR does **not** claim a universal Codex cwd rule or independently reproduce the reported runtime fallback. It extracts the generic ambient-context ambiguity only.

## Product / protocol implication

For reusable skill/agent references, prefer:

```text
relative reference
+ explicitly bound owner/root identity
```

over relying on whichever cwd/checkout the receiver currently inhabits.

This is the external Agent Skills analogue of #134's rule:

> omit context after you have proved it once, not because both sides probably resolve the same ambient root.

## Boundary

- test only; no Agent Skills runtime or product CLI change;
- no vendor-specific path policy;
- synthetic path inventory, not filesystem probing;
- explicit root identity does not grant trust/authority;
- one path-resolution hazard does not establish the original issue's full causal story.

Refs #115 #123 #127 #134 #146 #215 #223 #225 #226 #230.