### PR TITLE
research: reconstruct a proof-surface mismatch

### DIFF
--- a/examples/proof_surface.rs
+++ b/examples/proof_surface.rs
@@ -1,0 +1,61 @@
+#[path = "../src/project_memory.rs"]
+mod project_memory;
+#[path = "../src/proof_surface.rs"]
+mod proof_surface;
+
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use project_memory::{MAX_PROJECT_MEMORY_BYTES, parse_project_memory_packet};
+use proof_surface::{MAX_PROOF_SURFACE_BYTES, evaluate_proof_surface, parse_proof_surface_claim};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("proof-surface: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut args = std::env::args().skip(1);
+    let memory_path = args.next().ok_or_else(usage_error)?;
+    let claim_path = args.next().ok_or_else(usage_error)?;
+    if args.next().is_some() {
+        return Err(usage_error().into());
+    }
+
+    let memory_bytes = read_bounded(&memory_path, MAX_PROJECT_MEMORY_BYTES)?;
+    let claim_bytes = read_bounded(&claim_path, MAX_PROOF_SURFACE_BYTES)?;
+    let memory = parse_project_memory_packet(&memory_bytes).map_err(invalid_data)?;
+    memory.summary().map_err(invalid_data)?;
+    let claim = parse_proof_surface_claim(&claim_bytes).map_err(invalid_data)?;
+    let evaluation = evaluate_proof_surface(&memory, &claim).map_err(invalid_data)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}
+
+fn read_bounded(path: impl AsRef<Path>, maximum: usize) -> Result<Vec<u8>, Box<dyn Error>> {
+    let path = path.as_ref();
+    let metadata = fs::metadata(path)?;
+    if metadata.len() > maximum as u64 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{} exceeds {maximum} bytes", path.display()),
+        )
+        .into());
+    }
+    Ok(fs::read(path)?)
+}
+
+fn usage_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "usage: proof_surface PROJECT_MEMORY.json PROOF_SURFACE_CLAIM.json",
+    )
+}
+
+fn invalid_data(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}

--- a/research/project-memory/stensibly-1515.json
+++ b/research/project-memory/stensibly-1515.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "repository": "teamleaderleo/stensibly",
+  "anchor": {
+    "kind": "pull_request",
+    "number": 1515
+  },
+  "artifacts": [
+    {
+      "reference": {
+        "kind": "pull_request",
+        "number": 1515
+      },
+      "title": "Dogfood: stale mail head recovery R5Q7",
+      "state": "closed",
+      "created_at": "2026-08-15T06:53:47Z",
+      "closed_at": "2026-08-15T06:54:50Z",
+      "revision": {
+        "head_sha": "1321b1fc8793e3ac301bbba1eeb39ab274bc0f1e",
+        "base_sha": "249a30d84bd60042d2dcae08521166546162efc1",
+        "merged": false
+      },
+      "changed_paths": [
+        "docs/dogfood-stale-mail-r5q7.md"
+      ],
+      "evidence_text": "Draft-only adversarial dogfood target for #1488/#1504.\n\nAborted as a proof target after the verifier accidentally created a PR review COMMENT instead of the required ordinary conversation comment. The A→B stale-head refusal itself was clean, but this PR is intentionally excluded from the final exactly-one-conversation-comment evidence.\n\nHandle: STN-HANDOFF:R5Q7\n\nNever merge.\n\n— Rook · adversarial recovery verifier",
+      "evidence_complete": true
+    }
+  ],
+  "edges": []
+}

--- a/research/proof-surface-mismatch.md
+++ b/research/proof-surface-mismatch.md
@@ -62,7 +62,7 @@ The research evaluator classifies:
 The selected source requirement is bound to the exact phrase:
 
 ```text
-ordinary conversation comment
+required ordinary conversation comment
 ```
 
 ## Retained memory
@@ -71,14 +71,14 @@ ordinary conversation comment
 
 `research/proof-surface/stensibly-1515.json` preserves the source excerpts plus the exact provider event receipt.
 
-Expected evaluation:
+The retained evaluation is:
 
 ```text
-status                  observed_proof_surface_mismatch
-behavior_passed         true
-required artifact       issue_conversation_comment
-produced artifact       pull_request_review
-proof_valid             false
+status                     observed_proof_surface_mismatch
+behavior_passed            true
+required artifact          issue_conversation_comment
+produced artifact          pull_request_review
+proof_valid                false
 automatic behavior failure false
 automatic acceptance       false
 ```
@@ -103,11 +103,11 @@ The ordinary Rust suite requires:
 1. the retained real event classifies as `pull_request_review` even though its body says “conversation comment”;
 2. an exact `issuecomment-<id>` event with no review state satisfies the required surface;
 3. missing behavior-success marker stays `behavior_evidence_missing`;
-4. retained source excerpt lacking the ordinary-comment requirement stays `requirement_evidence_missing`;
+4. retained source excerpt lacking the required ordinary-comment phrase stays `requirement_evidence_missing`;
 5. missing provider-event body marker stays `provider_event_body_missing`;
 6. URL/ID mismatch stays `produced_artifact_unclassifiable`;
 7. provider event bound to another PR stays unclassifiable;
-8. required artifact kind and canonical source marker must agree;
+8. required artifact kind and canonical `required ...` source marker must agree;
 9. invented source excerpts reject against retained project-memory text;
 10. claim input is bounded before JSON parsing.
 
@@ -118,6 +118,44 @@ cargo run --example proof_surface -- \
   research/project-memory/stensibly-1515.json \
   research/proof-surface/stensibly-1515.json
 ```
+
+## Executed current-main receipt
+
+The formatted semantic code + retained evidence head was:
+
+```text
+head:       f4b2f389dcd498d5a188ef0f7c1f37e9d1199912
+main:       be09462db0f4df2d002bc90d7c5ccc042f737092
+merge view: 8ba904ed75ded2a7a03db003649aa96116bdd6b5
+```
+
+GitHub Actions receipt:
+
+```text
+CI run:                    32261351691  success
+Generated provenance run:  32261351575  success
+```
+
+The merge-view CI passed:
+
+```text
+rustfmt
+all-target Clippy with -D warnings
+project-memory lineage controls
+GitHub review-memory adapter controls
+GitHub issue-closure adapter controls
+external GitHub reference controls
+full Rust tests
+repository scan text + JSON dogfood
+bounded history text + JSON dogfood
+CI test-filter text + JSON dogfood
+positive/control CI-filter fixtures
+pull-request diff text + JSON dogfood
+```
+
+The retained proof-surface tests passed all ten adversarial controls above. The existing live GitHub review-memory carrier skipped on its own path filter, so this replay consumed retained evidence only and performed no provider fetch.
+
+The only change after this semantic receipt is the durable receipt prose in this research note.
 
 ## Product direction
 

--- a/research/proof-surface-mismatch.md
+++ b/research/proof-surface-mismatch.md
@@ -1,0 +1,135 @@
+# Reconstructing a proof-surface mismatch
+
+Stensibly preserves an adversarial dogfood case where the underlying stale-head recovery behavior succeeded while the acceptance proof failed because the verifier produced the wrong GitHub artifact type.
+
+Human-facing external link:
+
+- [Stensibly PR #1515](https://redirect.github.com/teamleaderleo/stensibly/pull/1515)
+
+The retained machine/provider receipt keeps the exact canonical event URL and review state because those fields establish semantic artifact identity.
+
+## Behavior and proof are separate
+
+The #1515 PR body explicitly records both facts:
+
+```text
+The A→B stale-head refusal itself was clean.
+```
+
+and:
+
+```text
+Aborted as a proof target after the verifier accidentally created a PR review COMMENT instead of the required ordinary conversation comment.
+```
+
+So the historical episode already separates:
+
+```text
+behavioral discriminator
+```
+
+from:
+
+```text
+acceptance-proof artifact
+```
+
+The first succeeded. The second used the wrong semantic surface.
+
+## Provider artifact
+
+The retained provider event has:
+
+```text
+id            4943138474
+review state  COMMENTED
+URL identity  pullrequestreview-4943138474
+body          R5Q7 dogfood: mail-originated conversation comment accepted only after current-head refresh.
+```
+
+Its body sounds like the desired artifact, which makes this a useful anti-cheat case. Semantic identity comes from the provider event type, not from prose similarity.
+
+The research evaluator classifies:
+
+```text
+#pullrequestreview-<id> + review=COMMENTED
+  -> pull_request_review
+
+#issuecomment-<id> + no review state
+  -> issue_conversation_comment
+```
+
+The selected source requirement is bound to the exact phrase:
+
+```text
+ordinary conversation comment
+```
+
+## Retained memory
+
+`research/project-memory/stensibly-1515.json` preserves the exact closed/unmerged PR, exact head/base coordinates, complete PR body, and disposable changed path.
+
+`research/proof-surface/stensibly-1515.json` preserves the source excerpts plus the exact provider event receipt.
+
+Expected evaluation:
+
+```text
+status                  observed_proof_surface_mismatch
+behavior_passed         true
+required artifact       issue_conversation_comment
+produced artifact       pull_request_review
+proof_valid             false
+automatic behavior failure false
+automatic acceptance       false
+```
+
+## Evaluation states
+
+The evaluator can return:
+
+```text
+behavior_evidence_missing
+requirement_evidence_missing
+provider_event_body_missing
+produced_artifact_unclassifiable
+proof_surface_matched
+observed_proof_surface_mismatch
+```
+
+## Adversarial controls
+
+The ordinary Rust suite requires:
+
+1. the retained real event classifies as `pull_request_review` even though its body says “conversation comment”;
+2. an exact `issuecomment-<id>` event with no review state satisfies the required surface;
+3. missing behavior-success marker stays `behavior_evidence_missing`;
+4. retained source excerpt lacking the ordinary-comment requirement stays `requirement_evidence_missing`;
+5. missing provider-event body marker stays `provider_event_body_missing`;
+6. URL/ID mismatch stays `produced_artifact_unclassifiable`;
+7. provider event bound to another PR stays unclassifiable;
+8. required artifact kind and canonical source marker must agree;
+9. invented source excerpts reject against retained project-memory text;
+10. claim input is bounded before JSON parsing.
+
+## Replay
+
+```text
+cargo run --example proof_surface -- \
+  research/project-memory/stensibly-1515.json \
+  research/proof-surface/stensibly-1515.json
+```
+
+## Product direction
+
+This adds another temporal/evidence disposition beside the first three historical replays:
+
+```text
+repeated repair class -> common guard
+accepted proxy -> counterexample -> narrower predicate
+authoritative vs lagging observation -> bounded convergence / hard exhaustion
+behavior correct + wrong proof artifact type -> proof surface mismatch
+```
+
+The useful lesson is local and precise: acceptance evidence can require an exact provider semantic type. Semantically adjacent content does not satisfy that contract automatically.
+
+Refs #15 #18 #41 #74 #222 #229 #233.

--- a/research/proof-surface/stensibly-1515.json
+++ b/research/proof-surface/stensibly-1515.json
@@ -9,7 +9,7 @@
   "behavior_evidence": "The A→B stale-head refusal itself was clean, but this PR is intentionally excluded from the final exactly-one-conversation-comment evidence.",
   "requirement_evidence": "Aborted as a proof target after the verifier accidentally created a PR review COMMENT instead of the required ordinary conversation comment.",
   "behavior_marker": "stale-head refusal itself was clean",
-  "requirement_marker": "ordinary conversation comment",
+  "requirement_marker": "required ordinary conversation comment",
   "required_artifact_kind": "issue_conversation_comment",
   "provider_event": {
     "url": "https://github.com/teamleaderleo/stensibly/pull/1515#pullrequestreview-4943138474",

--- a/research/proof-surface/stensibly-1515.json
+++ b/research/proof-surface/stensibly-1515.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "repository": "teamleaderleo/stensibly",
+  "candidate_id": "stensibly-r5q7-proof-surface-mismatch",
+  "subject": {
+    "kind": "pull_request",
+    "number": 1515
+  },
+  "behavior_evidence": "The A→B stale-head refusal itself was clean, but this PR is intentionally excluded from the final exactly-one-conversation-comment evidence.",
+  "requirement_evidence": "Aborted as a proof target after the verifier accidentally created a PR review COMMENT instead of the required ordinary conversation comment.",
+  "behavior_marker": "stale-head refusal itself was clean",
+  "requirement_marker": "ordinary conversation comment",
+  "required_artifact_kind": "issue_conversation_comment",
+  "provider_event": {
+    "url": "https://github.com/teamleaderleo/stensibly/pull/1515#pullrequestreview-4943138474",
+    "id": 4943138474,
+    "body": "R5Q7 dogfood: mail-originated conversation comment accepted only after current-head refresh.",
+    "review_state": "COMMENTED"
+  },
+  "provider_body_marker": "accepted only after current-head refresh"
+}

--- a/src/proof_surface.rs
+++ b/src/proof_surface.rs
@@ -1,0 +1,292 @@
+use serde::{Deserialize, Serialize};
+
+use crate::project_memory::{ArtifactRef, ProjectArtifact, ProjectMemoryPacket};
+
+pub const PROOF_SURFACE_SCHEMA_VERSION: u32 = 1;
+pub const MAX_PROOF_SURFACE_BYTES: usize = 128 * 1024;
+const MAX_ID_BYTES: usize = 256;
+const MAX_EVIDENCE_BYTES: usize = 8 * 1024;
+const MAX_MARKER_BYTES: usize = 1024;
+const MAX_EVENT_BODY_BYTES: usize = 8 * 1024;
+const MAX_EVENT_URL_BYTES: usize = 2048;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProofArtifactKind {
+    IssueConversationComment,
+    PullRequestReview,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderProofArtifact {
+    pub url: String,
+    pub id: u64,
+    pub body: String,
+    pub review_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProofSurfaceClaim {
+    pub schema_version: u32,
+    pub repository: String,
+    pub candidate_id: String,
+    pub subject: ArtifactRef,
+    pub behavior_evidence: String,
+    pub requirement_evidence: String,
+    pub behavior_marker: String,
+    pub requirement_marker: String,
+    pub required_artifact_kind: ProofArtifactKind,
+    pub provider_event: ProviderProofArtifact,
+    pub provider_body_marker: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProofSurfaceStatus {
+    BehaviorEvidenceMissing,
+    RequirementEvidenceMissing,
+    ProviderEventBodyMissing,
+    ProducedArtifactUnclassifiable,
+    ProofSurfaceMatched,
+    ObservedProofSurfaceMismatch,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ProofSurfaceEvaluation {
+    pub schema_version: u32,
+    pub repository: String,
+    pub candidate_id: String,
+    pub subject: ArtifactRef,
+    pub status: ProofSurfaceStatus,
+    pub behavior_passed: bool,
+    pub required_artifact_kind: ProofArtifactKind,
+    pub produced_artifact_kind: Option<ProofArtifactKind>,
+    pub proof_valid: bool,
+    pub automatic_behavior_failure: bool,
+    pub automatic_acceptance: bool,
+}
+
+pub fn parse_proof_surface_claim(bytes: &[u8]) -> Result<ProofSurfaceClaim, String> {
+    if bytes.len() > MAX_PROOF_SURFACE_BYTES {
+        return Err(format!(
+            "proof-surface claim exceeds {} bytes",
+            MAX_PROOF_SURFACE_BYTES
+        ));
+    }
+    let claim: ProofSurfaceClaim = serde_json::from_slice(bytes)
+        .map_err(|error| format!("invalid proof-surface JSON: {error}"))?;
+    claim.validate_shape()?;
+    Ok(claim)
+}
+
+pub fn evaluate_proof_surface(
+    memory: &ProjectMemoryPacket,
+    claim: &ProofSurfaceClaim,
+) -> Result<ProofSurfaceEvaluation, String> {
+    memory.validate()?;
+    claim.validate_shape()?;
+    if memory.repository != claim.repository {
+        return Err(format!(
+            "proof-surface repository `{}` disagrees with project-memory repository `{}`",
+            claim.repository, memory.repository
+        ));
+    }
+
+    let subject = artifact(memory, claim.subject)?;
+    validate_exact_source_excerpt(subject, &claim.behavior_evidence, claim.subject)?;
+    validate_exact_source_excerpt(subject, &claim.requirement_evidence, claim.subject)?;
+
+    let behavior_passed = claim.behavior_evidence.contains(&claim.behavior_marker);
+    let requirement_present = claim.requirement_evidence.contains(&claim.requirement_marker);
+    let provider_body_present = claim.provider_event.body.contains(&claim.provider_body_marker);
+    let produced_artifact_kind = classify_provider_artifact(claim);
+    let proof_valid = produced_artifact_kind == Some(claim.required_artifact_kind);
+
+    let status = if !behavior_passed {
+        ProofSurfaceStatus::BehaviorEvidenceMissing
+    } else if !requirement_present {
+        ProofSurfaceStatus::RequirementEvidenceMissing
+    } else if !provider_body_present {
+        ProofSurfaceStatus::ProviderEventBodyMissing
+    } else if produced_artifact_kind.is_none() {
+        ProofSurfaceStatus::ProducedArtifactUnclassifiable
+    } else if proof_valid {
+        ProofSurfaceStatus::ProofSurfaceMatched
+    } else {
+        ProofSurfaceStatus::ObservedProofSurfaceMismatch
+    };
+
+    Ok(ProofSurfaceEvaluation {
+        schema_version: PROOF_SURFACE_SCHEMA_VERSION,
+        repository: claim.repository.clone(),
+        candidate_id: claim.candidate_id.clone(),
+        subject: claim.subject,
+        status,
+        behavior_passed,
+        required_artifact_kind: claim.required_artifact_kind,
+        produced_artifact_kind,
+        proof_valid,
+        automatic_behavior_failure: false,
+        automatic_acceptance: false,
+    })
+}
+
+impl ProofSurfaceClaim {
+    fn validate_shape(&self) -> Result<(), String> {
+        if self.schema_version != PROOF_SURFACE_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported proof-surface schema version {}",
+                self.schema_version
+            ));
+        }
+        validate_repository(&self.repository)?;
+        validate_single_line(&self.candidate_id, "candidate_id", MAX_ID_BYTES)?;
+        if self.subject.number == 0 {
+            return Err("proof-surface subject number must be positive".to_string());
+        }
+        validate_evidence(&self.behavior_evidence, "behavior_evidence")?;
+        validate_evidence(&self.requirement_evidence, "requirement_evidence")?;
+        validate_marker(&self.behavior_marker, "behavior_marker")?;
+        validate_marker(&self.requirement_marker, "requirement_marker")?;
+        validate_marker(&self.provider_body_marker, "provider_body_marker")?;
+        let canonical_requirement = canonical_requirement_marker(self.required_artifact_kind);
+        if self.requirement_marker != canonical_requirement {
+            return Err(format!(
+                "requirement_marker for {:?} must be `{canonical_requirement}`",
+                self.required_artifact_kind
+            ));
+        }
+        validate_provider_event(&self.provider_event)?;
+        Ok(())
+    }
+}
+
+fn classify_provider_artifact(claim: &ProofSurfaceClaim) -> Option<ProofArtifactKind> {
+    let prefix = format!(
+        "https://github.com/{}/pull/{}",
+        claim.repository, claim.subject.number
+    );
+    if !claim.provider_event.url.starts_with(&prefix) {
+        return None;
+    }
+
+    let review_suffix = format!("#pullrequestreview-{}", claim.provider_event.id);
+    if claim.provider_event.url == format!("{prefix}{review_suffix}")
+        && claim.provider_event.review_state.as_deref() == Some("COMMENTED")
+    {
+        return Some(ProofArtifactKind::PullRequestReview);
+    }
+
+    let issue_comment_suffix = format!("#issuecomment-{}", claim.provider_event.id);
+    if claim.provider_event.url == format!("{prefix}{issue_comment_suffix}")
+        && claim.provider_event.review_state.is_none()
+    {
+        return Some(ProofArtifactKind::IssueConversationComment);
+    }
+
+    None
+}
+
+fn canonical_requirement_marker(kind: ProofArtifactKind) -> &'static str {
+    match kind {
+        ProofArtifactKind::IssueConversationComment => "ordinary conversation comment",
+        ProofArtifactKind::PullRequestReview => "PR review COMMENT",
+    }
+}
+
+fn artifact(
+    memory: &ProjectMemoryPacket,
+    reference: ArtifactRef,
+) -> Result<&ProjectArtifact, String> {
+    memory
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.reference == reference)
+        .ok_or_else(|| {
+            format!(
+                "proof-surface artifact {} is absent from project memory",
+                display_ref(reference)
+            )
+        })
+}
+
+fn validate_exact_source_excerpt(
+    artifact: &ProjectArtifact,
+    evidence: &str,
+    reference: ArtifactRef,
+) -> Result<(), String> {
+    if !artifact.evidence_text.contains(evidence) {
+        return Err(format!(
+            "proof-surface evidence for {} is absent from retained project-memory text",
+            display_ref(reference)
+        ));
+    }
+    Ok(())
+}
+
+fn validate_provider_event(event: &ProviderProofArtifact) -> Result<(), String> {
+    if event.id == 0 {
+        return Err("provider event id must be positive".to_string());
+    }
+    if event.url.is_empty()
+        || event.url.len() > MAX_EVENT_URL_BYTES
+        || event.url.contains('\0')
+        || event.url.bytes().any(|byte| matches!(byte, b'\n' | b'\r'))
+    {
+        return Err("provider event URL is empty, malformed, or too long".to_string());
+    }
+    if event.body.is_empty() || event.body.len() > MAX_EVENT_BODY_BYTES || event.body.contains('\0') {
+        return Err("provider event body is empty, malformed, or too long".to_string());
+    }
+    if let Some(review_state) = &event.review_state {
+        validate_single_line(review_state, "review_state", 64)?;
+    }
+    Ok(())
+}
+
+fn validate_evidence(value: &str, label: &str) -> Result<(), String> {
+    if value.is_empty() || value.len() > MAX_EVIDENCE_BYTES || value.contains('\0') {
+        return Err(format!("{label} is empty, malformed, or too long"));
+    }
+    Ok(())
+}
+
+fn validate_marker(value: &str, label: &str) -> Result<(), String> {
+    validate_single_line(value, label, MAX_MARKER_BYTES)
+}
+
+fn validate_single_line(value: &str, label: &str, maximum: usize) -> Result<(), String> {
+    if value.is_empty()
+        || value.len() > maximum
+        || value.contains('\0')
+        || value.bytes().any(|byte| matches!(byte, b'\n' | b'\r'))
+    {
+        return Err(format!("{label} is empty, malformed, or too long"));
+    }
+    Ok(())
+}
+
+fn validate_repository(value: &str) -> Result<(), String> {
+    let Some((owner, repository)) = value.split_once('/') else {
+        return Err("repository must be canonical owner/name".to_string());
+    };
+    if owner.is_empty()
+        || repository.is_empty()
+        || repository.contains('/')
+        || !owner.bytes().all(valid_repository_char)
+        || !repository.bytes().all(valid_repository_char)
+    {
+        return Err("repository must be canonical owner/name".to_string());
+    }
+    Ok(())
+}
+
+fn valid_repository_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')
+}
+
+fn display_ref(reference: ArtifactRef) -> String {
+    format!("{:?}#{}", reference.kind, reference.number)
+}

--- a/src/proof_surface.rs
+++ b/src/proof_surface.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::project_memory::{ArtifactRef, ProjectArtifact, ProjectMemoryPacket};
+use crate::project_memory::{ArtifactKind, ArtifactRef, ProjectArtifact, ProjectMemoryPacket};
 
 pub const PROOF_SURFACE_SCHEMA_VERSION: u32 = 1;
 pub const MAX_PROOF_SURFACE_BYTES: usize = 128 * 1024;
@@ -143,8 +143,8 @@ impl ProofSurfaceClaim {
         }
         validate_repository(&self.repository)?;
         validate_single_line(&self.candidate_id, "candidate_id", MAX_ID_BYTES)?;
-        if self.subject.number == 0 {
-            return Err("proof-surface subject number must be positive".to_string());
+        if self.subject.kind != ArtifactKind::PullRequest || self.subject.number == 0 {
+            return Err("proof-surface subject must be a positive pull-request reference".to_string());
         }
         validate_evidence(&self.behavior_evidence, "behavior_evidence")?;
         validate_evidence(&self.requirement_evidence, "requirement_evidence")?;
@@ -191,8 +191,8 @@ fn classify_provider_artifact(claim: &ProofSurfaceClaim) -> Option<ProofArtifact
 
 fn canonical_requirement_marker(kind: ProofArtifactKind) -> &'static str {
     match kind {
-        ProofArtifactKind::IssueConversationComment => "ordinary conversation comment",
-        ProofArtifactKind::PullRequestReview => "PR review COMMENT",
+        ProofArtifactKind::IssueConversationComment => "required ordinary conversation comment",
+        ProofArtifactKind::PullRequestReview => "required PR review COMMENT",
     }
 }
 
@@ -237,7 +237,10 @@ fn validate_provider_event(event: &ProviderProofArtifact) -> Result<(), String> 
     {
         return Err("provider event URL is empty, malformed, or too long".to_string());
     }
-    if event.body.is_empty() || event.body.len() > MAX_EVENT_BODY_BYTES || event.body.contains('\0') {
+    if event.body.is_empty()
+        || event.body.len() > MAX_EVENT_BODY_BYTES
+        || event.body.contains('\0')
+    {
         return Err("provider event body is empty, malformed, or too long".to_string());
     }
     if let Some(review_state) = &event.review_state {

--- a/src/proof_surface.rs
+++ b/src/proof_surface.rs
@@ -99,8 +99,13 @@ pub fn evaluate_proof_surface(
     validate_exact_source_excerpt(subject, &claim.requirement_evidence, claim.subject)?;
 
     let behavior_passed = claim.behavior_evidence.contains(&claim.behavior_marker);
-    let requirement_present = claim.requirement_evidence.contains(&claim.requirement_marker);
-    let provider_body_present = claim.provider_event.body.contains(&claim.provider_body_marker);
+    let requirement_present = claim
+        .requirement_evidence
+        .contains(&claim.requirement_marker);
+    let provider_body_present = claim
+        .provider_event
+        .body
+        .contains(&claim.provider_body_marker);
     let produced_artifact_kind = classify_provider_artifact(claim);
     let proof_valid = produced_artifact_kind == Some(claim.required_artifact_kind);
 
@@ -144,7 +149,9 @@ impl ProofSurfaceClaim {
         validate_repository(&self.repository)?;
         validate_single_line(&self.candidate_id, "candidate_id", MAX_ID_BYTES)?;
         if self.subject.kind != ArtifactKind::PullRequest || self.subject.number == 0 {
-            return Err("proof-surface subject must be a positive pull-request reference".to_string());
+            return Err(
+                "proof-surface subject must be a positive pull-request reference".to_string(),
+            );
         }
         validate_evidence(&self.behavior_evidence, "behavior_evidence")?;
         validate_evidence(&self.requirement_evidence, "requirement_evidence")?;
@@ -237,9 +244,7 @@ fn validate_provider_event(event: &ProviderProofArtifact) -> Result<(), String> 
     {
         return Err("provider event URL is empty, malformed, or too long".to_string());
     }
-    if event.body.is_empty()
-        || event.body.len() > MAX_EVENT_BODY_BYTES
-        || event.body.contains('\0')
+    if event.body.is_empty() || event.body.len() > MAX_EVENT_BODY_BYTES || event.body.contains('\0')
     {
         return Err("provider event body is empty, malformed, or too long".to_string());
     }

--- a/tests/proof_surface.rs
+++ b/tests/proof_surface.rs
@@ -1,0 +1,181 @@
+#[path = "../src/project_memory.rs"]
+mod project_memory;
+#[path = "../src/proof_surface.rs"]
+mod proof_surface;
+
+use project_memory::{ArtifactKind, ArtifactRef, parse_project_memory_packet};
+use proof_surface::{
+    MAX_PROOF_SURFACE_BYTES, ProofArtifactKind, ProofSurfaceStatus, evaluate_proof_surface,
+    parse_proof_surface_claim,
+};
+
+const MEMORY: &[u8] = include_bytes!("../research/project-memory/stensibly-1515.json");
+const CLAIM: &[u8] = include_bytes!("../research/proof-surface/stensibly-1515.json");
+
+fn inputs() -> (
+    project_memory::ProjectMemoryPacket,
+    proof_surface::ProofSurfaceClaim,
+) {
+    let memory = parse_project_memory_packet(MEMORY).unwrap();
+    memory.summary().unwrap();
+    let claim = parse_proof_surface_claim(CLAIM).unwrap();
+    (memory, claim)
+}
+
+fn pr(number: u64) -> ArtifactRef {
+    ArtifactRef {
+        kind: ArtifactKind::PullRequest,
+        number,
+    }
+}
+
+#[test]
+fn retained_stensibly_episode_is_an_observed_surface_mismatch() {
+    let (memory, claim) = inputs();
+    let evaluation = evaluate_proof_surface(&memory, &claim).unwrap();
+
+    assert_eq!(
+        evaluation.status,
+        ProofSurfaceStatus::ObservedProofSurfaceMismatch
+    );
+    assert_eq!(evaluation.subject, pr(1515));
+    assert!(evaluation.behavior_passed);
+    assert_eq!(
+        evaluation.required_artifact_kind,
+        ProofArtifactKind::IssueConversationComment
+    );
+    assert_eq!(
+        evaluation.produced_artifact_kind,
+        Some(ProofArtifactKind::PullRequestReview)
+    );
+    assert!(!evaluation.proof_valid);
+    assert!(!evaluation.automatic_behavior_failure);
+    assert!(!evaluation.automatic_acceptance);
+}
+
+#[test]
+fn semantic_event_type_wins_over_conversation_like_body_text() {
+    let (memory, claim) = inputs();
+    assert!(claim.provider_event.body.contains("conversation comment"));
+
+    let evaluation = evaluate_proof_surface(&memory, &claim).unwrap();
+    assert_eq!(
+        evaluation.produced_artifact_kind,
+        Some(ProofArtifactKind::PullRequestReview)
+    );
+    assert_eq!(
+        evaluation.status,
+        ProofSurfaceStatus::ObservedProofSurfaceMismatch
+    );
+}
+
+#[test]
+fn matching_issue_conversation_comment_is_a_valid_surface() {
+    let (memory, mut claim) = inputs();
+    claim.provider_event.url = format!(
+        "https://github.com/teamleaderleo/stensibly/pull/1515#issuecomment-{}",
+        claim.provider_event.id
+    );
+    claim.provider_event.review_state = None;
+
+    let evaluation = evaluate_proof_surface(&memory, &claim).unwrap();
+    assert_eq!(evaluation.status, ProofSurfaceStatus::ProofSurfaceMatched);
+    assert_eq!(
+        evaluation.produced_artifact_kind,
+        Some(ProofArtifactKind::IssueConversationComment)
+    );
+    assert!(evaluation.proof_valid);
+    assert!(evaluation.behavior_passed);
+}
+
+#[test]
+fn behavior_success_must_be_explicit_in_retained_source() {
+    let (memory, mut claim) = inputs();
+    claim.behavior_marker = "behavior success marker absent".to_string();
+
+    let evaluation = evaluate_proof_surface(&memory, &claim).unwrap();
+    assert_eq!(
+        evaluation.status,
+        ProofSurfaceStatus::BehaviorEvidenceMissing
+    );
+    assert!(!evaluation.behavior_passed);
+}
+
+#[test]
+fn proof_requirement_must_be_explicit_in_retained_source() {
+    let (memory, mut claim) = inputs();
+    claim.requirement_evidence = claim.behavior_evidence.clone();
+
+    let evaluation = evaluate_proof_surface(&memory, &claim).unwrap();
+    assert_eq!(
+        evaluation.status,
+        ProofSurfaceStatus::RequirementEvidenceMissing
+    );
+}
+
+#[test]
+fn provider_event_body_must_match_the_retained_event() {
+    let (memory, mut claim) = inputs();
+    claim.provider_body_marker = "provider event marker absent".to_string();
+
+    let evaluation = evaluate_proof_surface(&memory, &claim).unwrap();
+    assert_eq!(
+        evaluation.status,
+        ProofSurfaceStatus::ProviderEventBodyMissing
+    );
+}
+
+#[test]
+fn provider_event_url_and_id_must_classify_together() {
+    let (memory, mut claim) = inputs();
+    claim.provider_event.url =
+        "https://github.com/teamleaderleo/stensibly/pull/1515#pullrequestreview-1".to_string();
+
+    let evaluation = evaluate_proof_surface(&memory, &claim).unwrap();
+    assert_eq!(
+        evaluation.status,
+        ProofSurfaceStatus::ProducedArtifactUnclassifiable
+    );
+    assert_eq!(evaluation.produced_artifact_kind, None);
+    assert!(!evaluation.proof_valid);
+}
+
+#[test]
+fn provider_event_must_belong_to_the_subject_pull_request() {
+    let (memory, mut claim) = inputs();
+    claim.provider_event.url = format!(
+        "https://github.com/teamleaderleo/stensibly/pull/1514#pullrequestreview-{}",
+        claim.provider_event.id
+    );
+
+    let evaluation = evaluate_proof_surface(&memory, &claim).unwrap();
+    assert_eq!(
+        evaluation.status,
+        ProofSurfaceStatus::ProducedArtifactUnclassifiable
+    );
+}
+
+#[test]
+fn required_kind_and_source_marker_are_bound_together() {
+    let (memory, mut claim) = inputs();
+    claim.required_artifact_kind = ProofArtifactKind::PullRequestReview;
+
+    let error = evaluate_proof_surface(&memory, &claim).unwrap_err();
+    assert!(error.contains("requirement_marker"));
+}
+
+#[test]
+fn invented_behavior_excerpt_is_rejected() {
+    let (memory, mut claim) = inputs();
+    claim.behavior_evidence = "The behavior definitely worked in every possible sense.".to_string();
+
+    let error = evaluate_proof_surface(&memory, &claim).unwrap_err();
+    assert!(error.contains("absent from retained project-memory text"));
+}
+
+#[test]
+fn claim_input_is_bounded_before_json_parse() {
+    let bytes = vec![b' '; MAX_PROOF_SURFACE_BYTES + 1];
+    let error = parse_proof_surface_claim(&bytes).unwrap_err();
+    assert!(error.contains("exceeds"));
+}


### PR DESCRIPTION
## Goal

Progress #41/#15 with a fourth temporal/evidence species beside merged #222/#229/#233: behavior succeeds, yet acceptance proof remains invalid because the verifier produced the wrong provider artifact type.

Human-facing source ref:

- [Stensibly #1515](https://redirect.github.com/teamleaderleo/stensibly/pull/1515)

## Historical episode

The retained #1515 body explicitly says:

```text
The A→B stale-head refusal itself was clean.
```

and:

```text
Aborted as a proof target after the verifier accidentally created a PR review COMMENT instead of the required ordinary conversation comment.
```

The returned provider event has:

```text
id            4943138474
review state  COMMENTED
URL identity  pullrequestreview-4943138474
body          R5Q7 dogfood: mail-originated conversation comment accepted only after current-head refresh.
```

The event body sounds like the desired proof artifact. Its provider semantic identity is still a pull-request review.

## Semantic classification

`src/proof_surface.rs` derives the produced type from the retained provider receipt:

```text
#pullrequestreview-<id> + review=COMMENTED
  -> pull_request_review

#issuecomment-<id> + no review state
  -> issue_conversation_comment
```

The required kind is separately bound to the exact source phrase:

```text
required ordinary conversation comment
```

The retained canonical provider event URL stays in the machine fixture because its fragment is evidence identity. Human-facing documentation uses redirect GitHub links.

## Executed retained result

```text
observed_proof_surface_mismatch
behavior_passed            true
required artifact          issue_conversation_comment
produced artifact          pull_request_review
proof_valid                false
automatic behavior failure false
automatic acceptance       false
```

## Adversarial controls

The ordinary Rust suite requires:

- provider semantic type wins over conversation-like event body prose;
- an exact issue-comment event with no review state yields `proof_surface_matched`;
- behavior success must be explicit in retained source;
- proof requirement must be explicit in retained source;
- provider body marker must match the retained event;
- event URL and ID must classify together;
- event must belong to the subject PR;
- required artifact kind must agree with its canonical `required ...` source marker;
- invented source excerpts reject;
- claim input is bounded before JSON parsing.

## Executed current-main receipts

Formatted semantic head:

```text
head:       f4b2f389dcd498d5a188ef0f7c1f37e9d1199912
main:       be09462db0f4df2d002bc90d7c5ccc042f737092
merge view: 8ba904ed75ded2a7a03db003649aa96116bdd6b5
CI:         32261351691 success
provenance: 32261351575 success
```

Final head adds only durable receipt prose in `research/proof-surface-mismatch.md`:

```text
head:       96a951c666e5a6474d80e2897d18b9e46fd75044
merge view: 08ad5ea40e6db7c09e51ea2db1d9d261eebaa2cf
CI:         32261573874 success
provenance: 32261573901 success
```

Both merge-view CI runs passed formatter, all-target Clippy with warnings denied, full tests, project-memory adapter controls, external GitHub reference controls, and normal Cultist repository/history/CI/diff dogfood. Live provider carriers skipped on their path filters; this replay consumed retained evidence only.

## Replay

```text
cargo run --example proof_surface -- \
  research/project-memory/stensibly-1515.json \
  research/proof-surface/stensibly-1515.json
```

## Boundary

Research-only:

- `src/proof_surface.rs`
- `tests/proof_surface.rs`
- `examples/proof_surface.rs`
- `research/project-memory/stensibly-1515.json`
- `research/proof-surface/stensibly-1515.json`
- `research/proof-surface-mismatch.md`

No product CLI/report-schema change; no provider/network call; no automatic behavior failure; no automatic acceptance. Provider artifact identity and behavioral success remain separate axes.

The final merge view is current `main@be09462db0f4df2d002bc90d7c5ccc042f737092` plus this six-file research lane.

Progresses #15
Progresses #41
Refs #18 #74 #222 #229 #233.