### PR TITLE
research: admit a non-leaky capability-demand retirement replay

### DIFF
--- a/.github/workflows/capability-demand-retirement-inputs.yml
+++ b/.github/workflows/capability-demand-retirement-inputs.yml
@@ -121,7 +121,7 @@ jobs:
           treatment_scope_subjects = [row["subject"] for row in treatment["scope_recent_history"]]
 
           assert baseline["schema_version"] == 5
-          assert baseline["analysis"] == "agent_context_packet"
+          assert baseline["analysis"] == "agent_context"
           assert baseline["target"]["path"] == "convex/schema.ts"
           assert baseline["budget"]["max_serialized_bytes"] == 32768
           assert baseline["serialized_bytes"] <= 32768

--- a/.github/workflows/capability-demand-retirement-inputs.yml
+++ b/.github/workflows/capability-demand-retirement-inputs.yml
@@ -1,0 +1,214 @@
+name: Capability-demand retirement trial inputs
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/capability-demand-retirement-inputs.yml"
+      - "research/capability-demand-retirement/**"
+      - "tests/capability_demand_retirement.rs"
+      - "examples/agent_context_packet.rs"
+      - "examples/scoped_agent_context_packet.rs"
+      - "examples/support/scoped_agent_context_packet_impl.rs"
+      - "research/external-dogfood-cases.json"
+      - "scripts/external_dogfood_case.py"
+
+permissions:
+  contents: read
+
+jobs:
+  stensibly-convex-index-review-inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Cultist
+        uses: actions/checkout@v4
+        with:
+          path: cultist
+
+      - name: Resolve pinned Stensibly case
+        id: target
+        run: |
+          python cultist/scripts/external_dogfood_case.py \
+            --registry cultist/research/external-dogfood-cases.json \
+            --case stensibly-1575-pre-guard-jei \
+            --github-output "$GITHUB_OUTPUT" \
+            > resolved-target.json
+          cat resolved-target.json
+
+      - name: Install stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Build packet examples
+        run: |
+          cargo build --release --example agent_context_packet --manifest-path cultist/Cargo.toml
+          cargo build --release --example scoped_agent_context_packet --manifest-path cultist/Cargo.toml
+
+      - name: Checkout exact pre-guard Stensibly state
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.target.outputs.repository }}
+          ref: ${{ steps.target.outputs.ref }}
+          fetch-depth: ${{ steps.target.outputs.fetch_depth }}
+          persist-credentials: false
+          path: target
+
+      - name: Verify exact trial coordinate
+        run: |
+          set -euo pipefail
+          test "$(git -C target rev-parse HEAD)" = "85cecf2608ad9e734a67518577fa85b9a08a550c"
+          test "$(git -C target rev-parse HEAD:convex/schema.ts)" = "7fdd51e2f9fba80d1c0a814cea708d601a7b9925"
+
+      - name: Materialize worker task and evaluator oracle
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          spec = json.loads(Path("cultist/research/capability-demand-retirement/stensibly-convex-index-review-v1.json").read_text(encoding="utf-8"))
+          Path("artifacts/worker-task.txt").write_text(spec["worker_task"]["prompt"] + "\n", encoding="utf-8")
+          Path("artifacts/proposed.patch").write_text(spec["worker_task"]["patch"] + "\n", encoding="utf-8")
+          Path("artifacts/evaluator-oracle.json").write_text(
+              json.dumps(spec["oracle"], indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Compile file-local baseline packet at 32 KiB
+        env:
+          CARGO_CULTIST_PACKET_MAX_BYTES: "32768"
+        run: |
+          set -euo pipefail
+          "$PWD/cultist/target/release/examples/agent_context_packet" \
+            "$PWD/target/convex/schema.ts" \
+            > "$PWD/artifacts/file-local-32k.json"
+
+      - name: Compile scoped treatment packet at 32 KiB
+        env:
+          CARGO_CULTIST_PACKET_MAX_BYTES: "32768"
+        run: |
+          set -euo pipefail
+          "$PWD/cultist/target/release/examples/scoped_agent_context_packet" \
+            "$PWD/target/convex/schema.ts" \
+            --scope convex \
+            > "$PWD/artifacts/scoped-convex-32k.json"
+
+      - name: Verify evidence intervention and write manifest
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          artifact_dir = Path("artifacts")
+          spec = json.loads(Path("cultist/research/capability-demand-retirement/stensibly-convex-index-review-v1.json").read_text(encoding="utf-8"))
+          baseline_path = artifact_dir / "file-local-32k.json"
+          treatment_path = artifact_dir / "scoped-convex-32k.json"
+          baseline_raw = baseline_path.read_bytes()
+          treatment_raw = treatment_path.read_bytes()
+          baseline = json.loads(baseline_raw)
+          treatment = json.loads(treatment_raw)
+
+          required = [
+              "Keep Gmail semantic-admission indexes deployable (#1571)",
+              "Keep Gmail mailbox-disposition indexes deployable (#1573)",
+          ]
+          baseline_subjects = [row["subject"] for row in baseline["recent_history"]]
+          treatment_scope_subjects = [row["subject"] for row in treatment["scope_recent_history"]]
+
+          assert baseline["schema_version"] == 5
+          assert baseline["analysis"] == "agent_context_packet"
+          assert baseline["target"]["path"] == "convex/schema.ts"
+          assert baseline["budget"]["max_serialized_bytes"] == 32768
+          assert baseline["serialized_bytes"] <= 32768
+
+          assert treatment["schema_version"] == 1
+          assert treatment["analysis"] == "scoped_agent_context"
+          assert treatment["target"] == "convex/schema.ts"
+          assert treatment["scope"] == "convex"
+          assert treatment["budget"]["max_serialized_bytes"] == 32768
+          assert treatment["serialized_bytes"] <= 32768
+
+          for subject in required:
+              assert not any(subject in observed for observed in baseline_subjects), subject
+              assert any(subject in observed for observed in treatment_scope_subjects), subject
+
+          def digest(path):
+              raw = Path(path).read_bytes()
+              return {"sha256": hashlib.sha256(raw).hexdigest(), "bytes": len(raw)}
+
+          manifest = {
+              "schema_version": 1,
+              "trial_id": spec["trial_id"],
+              "repository": spec["repository"],
+              "revision": spec["revision"],
+              "target_path": spec["target_path"],
+              "target_blob_sha": spec["target_blob_sha"],
+              "worker_visible_common": {
+                  "task": digest(artifact_dir / "worker-task.txt"),
+                  "patch": digest(artifact_dir / "proposed.patch"),
+              },
+              "evaluator_only": {
+                  "oracle": digest(artifact_dir / "evaluator-oracle.json"),
+              },
+              "conditions": {
+                  "file_local_jei": {
+                      "packet": digest(baseline_path),
+                      "decisive_evidence_present": False,
+                  },
+                  "scoped_jei": {
+                      "packet": digest(treatment_path),
+                      "decisive_evidence_present": True,
+                      "decisive_evidence_refs": spec["conditions"][1]["decisive_evidence_refs"],
+                  },
+              },
+          }
+          (artifact_dir / "trial-input-manifest.json").write_text(
+              json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(manifest, indent=2, sort_keys=True))
+          PY
+
+      - name: Write trial input summary
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          manifest_path = Path("artifacts/trial-input-manifest.json")
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as out:
+              out.write("## Capability-demand retirement trial inputs\n\n")
+              if not manifest_path.is_file():
+                  out.write("Input manifest was not produced.\n")
+              else:
+                  manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                  baseline = manifest["conditions"]["file_local_jei"]
+                  treatment = manifest["conditions"]["scoped_jei"]
+                  out.write(f"Trial: `{manifest['trial_id']}`  \n")
+                  out.write(f"Revision: `{manifest['revision']}`  \n")
+                  out.write(f"Target: `{manifest['target_path']}`  \n")
+                  out.write(f"Baseline packet: `{baseline['packet']['bytes']}` bytes · decisive refs: `no`  \n")
+                  out.write(f"Treatment packet: `{treatment['packet']['bytes']}` bytes · decisive refs: `yes`  \n")
+                  out.write("Worker task/patch hashes are shared across both conditions; oracle stays evaluator-only.\n")
+          PY
+
+      - name: Upload frozen trial inputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: capability-demand-retirement-inputs-${{ github.run_id }}
+          path: |
+            artifacts/worker-task.txt
+            artifacts/proposed.patch
+            artifacts/file-local-32k.json
+            artifacts/scoped-convex-32k.json
+            artifacts/evaluator-oracle.json
+            artifacts/trial-input-manifest.json
+          if-no-files-found: error

--- a/research/capability-demand-retirement/stensibly-convex-index-review-v1.json
+++ b/research/capability-demand-retirement/stensibly-convex-index-review-v1.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": 1,
+  "trial_id": "stensibly-convex-index-review-v1",
+  "repository": "teamleaderleo/stensibly",
+  "revision": "85cecf2608ad9e734a67518577fa85b9a08a550c",
+  "target_path": "convex/schema.ts",
+  "target_blob_sha": "7fdd51e2f9fba80d1c0a814cea708d601a7b9925",
+  "worker_task": {
+    "prompt": "Review this proposed patch for merge eligibility against the repository's existing conventions and production constraints. Identify any blocking issue and the smallest corrective action. Do not assume the patch is correct.",
+    "patch": "@@ githubProjectContexts index chain @@\n   .index(\"by_project_issue_accepted\", [\"projectId\", \"issueExternalId\", \"acceptedAt\", \"externalId\"])\n+  .index(\"by_project_issue_revision_instruction_set_sha256_provider_updated_at\", [\"projectId\", \"issueExternalId\", \"sourceRevision\", \"instructionSetSha256\", \"providerUpdatedAt\"]),"
+  },
+  "oracle": {
+    "expected_disposition": "block",
+    "blocking_reason": "convex_index_identifier_limit",
+    "max_identifier_length": 64,
+    "proposed_identifier": "by_project_issue_revision_instruction_set_sha256_provider_updated_at",
+    "proposed_identifier_length": 68,
+    "corrective_action": "shorten_identifier_preserve_field_order"
+  },
+  "conditions": [
+    {
+      "id": "file_local_jei",
+      "packet_kind": "file_local",
+      "budget_bytes": 32768,
+      "scope": null,
+      "decisive_evidence_present": false,
+      "decisive_evidence_refs": []
+    },
+    {
+      "id": "scoped_jei",
+      "packet_kind": "scoped",
+      "budget_bytes": 32768,
+      "scope": "convex",
+      "decisive_evidence_present": true,
+      "decisive_evidence_refs": [
+        "ca5d2c7fdf89666e523972ab6e81610d17b9611b",
+        "85cecf2608ad9e734a67518577fa85b9a08a550c"
+      ]
+    }
+  ],
+  "oracle_leak_control": {
+    "historical_issue": "https://github.com/teamleaderleo/stensibly/issues/1574",
+    "allowed_as_worker_prompt": false,
+    "prohibited_worker_prompt_fragments": [
+      "64",
+      "#1571",
+      "#1573",
+      "overlong",
+      "identifier limit",
+      "by_workspace_id_and_provider_and_mailbox_binding_id_and_provider_message_id",
+      "by_workspace_id_and_provider_and_account_binding_and_mailbox_address_and_provider_thread_id_and_provider_message_id"
+    ]
+  }
+}

--- a/tests/capability_demand_retirement.rs
+++ b/tests/capability_demand_retirement.rs
@@ -1,0 +1,374 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TrialSpec {
+    schema_version: u32,
+    trial_id: String,
+    repository: String,
+    revision: String,
+    target_path: String,
+    target_blob_sha: String,
+    worker_task: WorkerTask,
+    oracle: Oracle,
+    conditions: Vec<Condition>,
+    oracle_leak_control: OracleLeakControl,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WorkerTask {
+    prompt: String,
+    patch: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Oracle {
+    expected_disposition: String,
+    blocking_reason: String,
+    max_identifier_length: usize,
+    proposed_identifier: String,
+    proposed_identifier_length: usize,
+    corrective_action: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum PacketKind {
+    FileLocal,
+    Scoped,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Condition {
+    id: String,
+    packet_kind: PacketKind,
+    budget_bytes: usize,
+    scope: Option<String>,
+    decisive_evidence_present: bool,
+    decisive_evidence_refs: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OracleLeakControl {
+    historical_issue: String,
+    allowed_as_worker_prompt: bool,
+    prohibited_worker_prompt_fragments: Vec<String>,
+}
+
+fn spec() -> TrialSpec {
+    serde_json::from_slice(include_bytes!(
+        "../research/capability-demand-retirement/stensibly-convex-index-review-v1.json"
+    ))
+    .expect("valid capability-demand retirement trial JSON")
+}
+
+fn is_sha(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[test]
+fn held_out_trial_is_exact_non_leaky_and_uses_a_new_failure_instance() {
+    let spec = spec();
+
+    assert_eq!(spec.schema_version, 1);
+    assert_eq!(spec.trial_id, "stensibly-convex-index-review-v1");
+    assert_eq!(spec.repository, "teamleaderleo/stensibly");
+    assert_eq!(
+        spec.revision,
+        "85cecf2608ad9e734a67518577fa85b9a08a550c"
+    );
+    assert_eq!(spec.target_path, "convex/schema.ts");
+    assert_eq!(
+        spec.target_blob_sha,
+        "7fdd51e2f9fba80d1c0a814cea708d601a7b9925"
+    );
+    assert!(is_sha(&spec.revision));
+    assert!(is_sha(&spec.target_blob_sha));
+
+    assert_eq!(spec.oracle.expected_disposition, "block");
+    assert_eq!(
+        spec.oracle.blocking_reason,
+        "convex_index_identifier_limit"
+    );
+    assert_eq!(spec.oracle.max_identifier_length, 64);
+    assert_eq!(
+        spec.oracle.proposed_identifier.chars().count(),
+        spec.oracle.proposed_identifier_length
+    );
+    assert!(spec.oracle.proposed_identifier_length > spec.oracle.max_identifier_length);
+    assert_eq!(
+        spec.oracle.corrective_action,
+        "shorten_identifier_preserve_field_order"
+    );
+    assert!(spec.worker_task.patch.contains(&spec.oracle.proposed_identifier));
+
+    let historical_names = [
+        "by_workspace_id_and_provider_and_mailbox_binding_id_and_provider_message_id",
+        "by_workspace_id_and_provider_and_account_binding_and_mailbox_address_and_provider_thread_id_and_provider_message_id",
+    ];
+    for historical in historical_names {
+        assert_ne!(spec.oracle.proposed_identifier, historical);
+        assert!(!spec.worker_task.patch.contains(historical));
+    }
+
+    let field_positions = [
+        "projectId",
+        "issueExternalId",
+        "sourceRevision",
+        "instructionSetSha256",
+        "providerUpdatedAt",
+    ]
+    .map(|field| spec.worker_task.patch.find(field).expect("field in proposed patch"));
+    assert!(field_positions.windows(2).all(|pair| pair[0] < pair[1]));
+
+    assert!(!spec.oracle_leak_control.allowed_as_worker_prompt);
+    assert_eq!(
+        spec.oracle_leak_control.historical_issue,
+        "https://github.com/teamleaderleo/stensibly/issues/1574"
+    );
+    let prompt_lower = spec.worker_task.prompt.to_ascii_lowercase();
+    for fragment in &spec.oracle_leak_control.prohibited_worker_prompt_fragments {
+        assert!(
+            !prompt_lower.contains(&fragment.to_ascii_lowercase()),
+            "worker prompt leaked oracle fragment {fragment:?}"
+        );
+    }
+}
+
+#[test]
+fn paired_conditions_change_evidence_not_repository_task_or_budget() {
+    let spec = spec();
+    assert_eq!(spec.conditions.len(), 2);
+
+    let conditions = spec
+        .conditions
+        .iter()
+        .map(|condition| (condition.id.as_str(), condition))
+        .collect::<BTreeMap<_, _>>();
+    let baseline = conditions
+        .get("file_local_jei")
+        .expect("file-local baseline condition");
+    let treatment = conditions
+        .get("scoped_jei")
+        .expect("scoped JEI treatment condition");
+
+    assert_eq!(baseline.packet_kind, PacketKind::FileLocal);
+    assert_eq!(baseline.budget_bytes, 32_768);
+    assert!(baseline.scope.is_none());
+    assert!(!baseline.decisive_evidence_present);
+    assert!(baseline.decisive_evidence_refs.is_empty());
+
+    assert_eq!(treatment.packet_kind, PacketKind::Scoped);
+    assert_eq!(treatment.budget_bytes, baseline.budget_bytes);
+    assert_eq!(treatment.scope.as_deref(), Some("convex"));
+    assert!(treatment.decisive_evidence_present);
+
+    let refs = treatment
+        .decisive_evidence_refs
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        refs,
+        BTreeSet::from([
+            "85cecf2608ad9e734a67518577fa85b9a08a550c",
+            "ca5d2c7fdf89666e523972ab6e81610d17b9611b",
+        ])
+    );
+    assert!(refs.iter().all(|reference| is_sha(reference)));
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct ReplayIdentity {
+    repository_revision: &'static str,
+    target_blob: &'static str,
+    task_fingerprint: &'static str,
+    patch_fingerprint: &'static str,
+    worker_identity: &'static str,
+    harness_identity: &'static str,
+    affordance_identity: &'static str,
+    completion_contract_fingerprint: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum RunOutcome {
+    Success,
+    Failed,
+    CorrectEscalation,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct RunReceipt {
+    identity: ReplayIdentity,
+    decisive_evidence_present: bool,
+    outcome: RunOutcome,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum RetirementVerdict {
+    ObservedPairedRetirement,
+    CorrectEscalationThenSuccess,
+    NoDemandObserved,
+    DemandPersists,
+    Confounded,
+    InvalidEvidencePair,
+}
+
+fn evaluate_pair(baseline: &RunReceipt, treatment: &RunReceipt) -> RetirementVerdict {
+    if baseline.identity != treatment.identity {
+        return RetirementVerdict::Confounded;
+    }
+    if baseline.decisive_evidence_present || !treatment.decisive_evidence_present {
+        return RetirementVerdict::InvalidEvidencePair;
+    }
+
+    match (baseline.outcome, treatment.outcome) {
+        (RunOutcome::Failed, RunOutcome::Success) => RetirementVerdict::ObservedPairedRetirement,
+        (RunOutcome::CorrectEscalation, RunOutcome::Success) => {
+            RetirementVerdict::CorrectEscalationThenSuccess
+        }
+        (RunOutcome::Success, _) => RetirementVerdict::NoDemandObserved,
+        _ => RetirementVerdict::DemandPersists,
+    }
+}
+
+fn fixed_identity() -> ReplayIdentity {
+    ReplayIdentity {
+        repository_revision: "repo@85cecf2",
+        target_blob: "schema@7fdd51e",
+        task_fingerprint: "task-v1",
+        patch_fingerprint: "patch-v1",
+        worker_identity: "worker-a@v1",
+        harness_identity: "harness-a@v1",
+        affordance_identity: "read-only-review-tools@v1",
+        completion_contract_fingerprint: "block-index-limit@v1",
+    }
+}
+
+fn run(
+    identity: ReplayIdentity,
+    decisive_evidence_present: bool,
+    outcome: RunOutcome,
+) -> RunReceipt {
+    RunReceipt {
+        identity,
+        decisive_evidence_present,
+        outcome,
+    }
+}
+
+#[test]
+fn fixed_worker_failure_then_treatment_success_is_local_retirement_evidence() {
+    let baseline = run(fixed_identity(), false, RunOutcome::Failed);
+    let treatment = run(fixed_identity(), true, RunOutcome::Success);
+
+    assert_eq!(
+        evaluate_pair(&baseline, &treatment),
+        RetirementVerdict::ObservedPairedRetirement
+    );
+}
+
+#[test]
+fn baseline_success_means_no_success_capability_demand_was_observed() {
+    let baseline = run(fixed_identity(), false, RunOutcome::Success);
+    let treatment = run(fixed_identity(), true, RunOutcome::Success);
+
+    assert_eq!(
+        evaluate_pair(&baseline, &treatment),
+        RetirementVerdict::NoDemandObserved
+    );
+}
+
+#[test]
+fn correct_baseline_escalation_then_treatment_success_is_not_a_model_mistake() {
+    let baseline = run(fixed_identity(), false, RunOutcome::CorrectEscalation);
+    let treatment = run(fixed_identity(), true, RunOutcome::Success);
+
+    assert_eq!(
+        evaluate_pair(&baseline, &treatment),
+        RetirementVerdict::CorrectEscalationThenSuccess
+    );
+}
+
+#[test]
+fn treatment_failure_preserves_residual_capability_demand() {
+    let baseline = run(fixed_identity(), false, RunOutcome::Failed);
+    let treatment = run(fixed_identity(), true, RunOutcome::Failed);
+
+    assert_eq!(
+        evaluate_pair(&baseline, &treatment),
+        RetirementVerdict::DemandPersists
+    );
+}
+
+#[test]
+fn changing_worker_harness_task_or_affordance_confounds_retirement_claim() {
+    for mut changed in [
+        fixed_identity(),
+        fixed_identity(),
+        fixed_identity(),
+        fixed_identity(),
+    ] {
+        let baseline = run(fixed_identity(), false, RunOutcome::Failed);
+        match changed.worker_identity {
+            "worker-a@v1" if changed.harness_identity == "harness-a@v1" => {
+                if changed.task_fingerprint == "task-v1" {
+                    if changed.affordance_identity == "read-only-review-tools@v1" {
+                        changed.worker_identity = "worker-b@v1";
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+        let treatment = run(changed, true, RunOutcome::Success);
+        assert_eq!(
+            evaluate_pair(&baseline, &treatment),
+            RetirementVerdict::Confounded
+        );
+    }
+
+    let mutations = [
+        ("harness-b@v1", "task-v1", "read-only-review-tools@v1"),
+        ("harness-a@v1", "task-v2", "read-only-review-tools@v1"),
+        ("harness-a@v1", "task-v1", "expanded-tools@v2"),
+    ];
+    for (harness, task, affordance) in mutations {
+        let baseline = run(fixed_identity(), false, RunOutcome::Failed);
+        let mut changed = fixed_identity();
+        changed.harness_identity = harness;
+        changed.task_fingerprint = task;
+        changed.affordance_identity = affordance;
+        let treatment = run(changed, true, RunOutcome::Success);
+        assert_eq!(
+            evaluate_pair(&baseline, &treatment),
+            RetirementVerdict::Confounded
+        );
+    }
+}
+
+#[test]
+fn decisive_evidence_presence_must_actually_flip_across_the_pair() {
+    let both_absent = (
+        run(fixed_identity(), false, RunOutcome::Failed),
+        run(fixed_identity(), false, RunOutcome::Success),
+    );
+    let both_present = (
+        run(fixed_identity(), true, RunOutcome::Failed),
+        run(fixed_identity(), true, RunOutcome::Success),
+    );
+
+    assert_eq!(
+        evaluate_pair(&both_absent.0, &both_absent.1),
+        RetirementVerdict::InvalidEvidencePair
+    );
+    assert_eq!(
+        evaluate_pair(&both_present.0, &both_present.1),
+        RetirementVerdict::InvalidEvidencePair
+    );
+}

--- a/tests/capability_demand_retirement.rs
+++ b/tests/capability_demand_retirement.rs
@@ -79,10 +79,7 @@ fn held_out_trial_is_exact_non_leaky_and_uses_a_new_failure_instance() {
     assert_eq!(spec.schema_version, 1);
     assert_eq!(spec.trial_id, "stensibly-convex-index-review-v1");
     assert_eq!(spec.repository, "teamleaderleo/stensibly");
-    assert_eq!(
-        spec.revision,
-        "85cecf2608ad9e734a67518577fa85b9a08a550c"
-    );
+    assert_eq!(spec.revision, "85cecf2608ad9e734a67518577fa85b9a08a550c");
     assert_eq!(spec.target_path, "convex/schema.ts");
     assert_eq!(
         spec.target_blob_sha,
@@ -92,10 +89,7 @@ fn held_out_trial_is_exact_non_leaky_and_uses_a_new_failure_instance() {
     assert!(is_sha(&spec.target_blob_sha));
 
     assert_eq!(spec.oracle.expected_disposition, "block");
-    assert_eq!(
-        spec.oracle.blocking_reason,
-        "convex_index_identifier_limit"
-    );
+    assert_eq!(spec.oracle.blocking_reason, "convex_index_identifier_limit");
     assert_eq!(spec.oracle.max_identifier_length, 64);
     assert_eq!(
         spec.oracle.proposed_identifier.chars().count(),
@@ -106,7 +100,11 @@ fn held_out_trial_is_exact_non_leaky_and_uses_a_new_failure_instance() {
         spec.oracle.corrective_action,
         "shorten_identifier_preserve_field_order"
     );
-    assert!(spec.worker_task.patch.contains(&spec.oracle.proposed_identifier));
+    assert!(
+        spec.worker_task
+            .patch
+            .contains(&spec.oracle.proposed_identifier)
+    );
 
     let historical_names = [
         "by_workspace_id_and_provider_and_mailbox_binding_id_and_provider_message_id",
@@ -124,7 +122,12 @@ fn held_out_trial_is_exact_non_leaky_and_uses_a_new_failure_instance() {
         "instructionSetSha256",
         "providerUpdatedAt",
     ]
-    .map(|field| spec.worker_task.patch.find(field).expect("field in proposed patch"));
+    .map(|field| {
+        spec.worker_task
+            .patch
+            .find(field)
+            .expect("field in proposed patch")
+    });
     assert!(field_positions.windows(2).all(|pair| pair[0] < pair[1]));
 
     assert!(!spec.oracle_leak_control.allowed_as_worker_prompt);
@@ -263,6 +266,15 @@ fn run(
     }
 }
 
+fn assert_confounded(changed: ReplayIdentity) {
+    let baseline = run(fixed_identity(), false, RunOutcome::Failed);
+    let treatment = run(changed, true, RunOutcome::Success);
+    assert_eq!(
+        evaluate_pair(&baseline, &treatment),
+        RetirementVerdict::Confounded
+    );
+}
+
 #[test]
 fn fixed_worker_failure_then_treatment_success_is_local_retirement_evidence() {
     let baseline = run(fixed_identity(), false, RunOutcome::Failed);
@@ -308,48 +320,38 @@ fn treatment_failure_preserves_residual_capability_demand() {
 }
 
 #[test]
-fn changing_worker_harness_task_or_affordance_confounds_retirement_claim() {
-    for mut changed in [
-        fixed_identity(),
-        fixed_identity(),
-        fixed_identity(),
-        fixed_identity(),
-    ] {
-        let baseline = run(fixed_identity(), false, RunOutcome::Failed);
-        match changed.worker_identity {
-            "worker-a@v1" if changed.harness_identity == "harness-a@v1" => {
-                if changed.task_fingerprint == "task-v1" {
-                    if changed.affordance_identity == "read-only-review-tools@v1" {
-                        changed.worker_identity = "worker-b@v1";
-                    }
-                }
-            }
-            _ => unreachable!(),
-        }
-        let treatment = run(changed, true, RunOutcome::Success);
-        assert_eq!(
-            evaluate_pair(&baseline, &treatment),
-            RetirementVerdict::Confounded
-        );
-    }
+fn every_frozen_identity_axis_can_confound_a_retirement_claim() {
+    let mut changed = fixed_identity();
+    changed.repository_revision = "repo@different";
+    assert_confounded(changed);
 
-    let mutations = [
-        ("harness-b@v1", "task-v1", "read-only-review-tools@v1"),
-        ("harness-a@v1", "task-v2", "read-only-review-tools@v1"),
-        ("harness-a@v1", "task-v1", "expanded-tools@v2"),
-    ];
-    for (harness, task, affordance) in mutations {
-        let baseline = run(fixed_identity(), false, RunOutcome::Failed);
-        let mut changed = fixed_identity();
-        changed.harness_identity = harness;
-        changed.task_fingerprint = task;
-        changed.affordance_identity = affordance;
-        let treatment = run(changed, true, RunOutcome::Success);
-        assert_eq!(
-            evaluate_pair(&baseline, &treatment),
-            RetirementVerdict::Confounded
-        );
-    }
+    let mut changed = fixed_identity();
+    changed.target_blob = "schema@different";
+    assert_confounded(changed);
+
+    let mut changed = fixed_identity();
+    changed.task_fingerprint = "task-v2";
+    assert_confounded(changed);
+
+    let mut changed = fixed_identity();
+    changed.patch_fingerprint = "patch-v2";
+    assert_confounded(changed);
+
+    let mut changed = fixed_identity();
+    changed.worker_identity = "worker-b@v1";
+    assert_confounded(changed);
+
+    let mut changed = fixed_identity();
+    changed.harness_identity = "harness-b@v1";
+    assert_confounded(changed);
+
+    let mut changed = fixed_identity();
+    changed.affordance_identity = "expanded-tools@v2";
+    assert_confounded(changed);
+
+    let mut changed = fixed_identity();
+    changed.completion_contract_fingerprint = "different-oracle@v2";
+    assert_confounded(changed);
 }
 
 #[test]

--- a/tests/capability_demand_retirement.rs
+++ b/tests/capability_demand_retirement.rs
@@ -196,6 +196,7 @@ struct ReplayIdentity {
     worker_identity: &'static str,
     harness_identity: &'static str,
     affordance_identity: &'static str,
+    sampling_config_fingerprint: &'static str,
     completion_contract_fingerprint: &'static str,
 }
 
@@ -210,12 +211,14 @@ enum RunOutcome {
 struct RunReceipt {
     identity: ReplayIdentity,
     decisive_evidence_present: bool,
+    fresh_session: bool,
+    prior_condition_exposure: bool,
     outcome: RunOutcome,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum RetirementVerdict {
-    ObservedPairedRetirement,
+    PairedRetirementSignal,
     CorrectEscalationThenSuccess,
     NoDemandObserved,
     DemandPersists,
@@ -224,7 +227,12 @@ enum RetirementVerdict {
 }
 
 fn evaluate_pair(baseline: &RunReceipt, treatment: &RunReceipt) -> RetirementVerdict {
-    if baseline.identity != treatment.identity {
+    if baseline.identity != treatment.identity
+        || !baseline.fresh_session
+        || !treatment.fresh_session
+        || baseline.prior_condition_exposure
+        || treatment.prior_condition_exposure
+    {
         return RetirementVerdict::Confounded;
     }
     if baseline.decisive_evidence_present || !treatment.decisive_evidence_present {
@@ -232,7 +240,7 @@ fn evaluate_pair(baseline: &RunReceipt, treatment: &RunReceipt) -> RetirementVer
     }
 
     match (baseline.outcome, treatment.outcome) {
-        (RunOutcome::Failed, RunOutcome::Success) => RetirementVerdict::ObservedPairedRetirement,
+        (RunOutcome::Failed, RunOutcome::Success) => RetirementVerdict::PairedRetirementSignal,
         (RunOutcome::CorrectEscalation, RunOutcome::Success) => {
             RetirementVerdict::CorrectEscalationThenSuccess
         }
@@ -250,6 +258,7 @@ fn fixed_identity() -> ReplayIdentity {
         worker_identity: "worker-a@v1",
         harness_identity: "harness-a@v1",
         affordance_identity: "read-only-review-tools@v1",
+        sampling_config_fingerprint: "sampling-config@v1",
         completion_contract_fingerprint: "block-index-limit@v1",
     }
 }
@@ -262,6 +271,8 @@ fn run(
     RunReceipt {
         identity,
         decisive_evidence_present,
+        fresh_session: true,
+        prior_condition_exposure: false,
         outcome,
     }
 }
@@ -276,13 +287,13 @@ fn assert_confounded(changed: ReplayIdentity) {
 }
 
 #[test]
-fn fixed_worker_failure_then_treatment_success_is_local_retirement_evidence() {
+fn fixed_worker_failure_then_treatment_success_is_a_signal_not_replication() {
     let baseline = run(fixed_identity(), false, RunOutcome::Failed);
     let treatment = run(fixed_identity(), true, RunOutcome::Success);
 
     assert_eq!(
         evaluate_pair(&baseline, &treatment),
-        RetirementVerdict::ObservedPairedRetirement
+        RetirementVerdict::PairedRetirementSignal
     );
 }
 
@@ -320,7 +331,7 @@ fn treatment_failure_preserves_residual_capability_demand() {
 }
 
 #[test]
-fn every_frozen_identity_axis_can_confound_a_retirement_claim() {
+fn every_frozen_identity_axis_can_confound_a_retirement_signal() {
     let mut changed = fixed_identity();
     changed.repository_revision = "repo@different";
     assert_confounded(changed);
@@ -350,8 +361,31 @@ fn every_frozen_identity_axis_can_confound_a_retirement_claim() {
     assert_confounded(changed);
 
     let mut changed = fixed_identity();
+    changed.sampling_config_fingerprint = "sampling-config@v2";
+    assert_confounded(changed);
+
+    let mut changed = fixed_identity();
     changed.completion_contract_fingerprint = "different-oracle@v2";
     assert_confounded(changed);
+}
+
+#[test]
+fn reused_or_treatment_contaminated_sessions_confound_the_pair() {
+    let mut baseline = run(fixed_identity(), false, RunOutcome::Failed);
+    let treatment = run(fixed_identity(), true, RunOutcome::Success);
+    baseline.fresh_session = false;
+    assert_eq!(
+        evaluate_pair(&baseline, &treatment),
+        RetirementVerdict::Confounded
+    );
+
+    let baseline = run(fixed_identity(), false, RunOutcome::Failed);
+    let mut treatment = run(fixed_identity(), true, RunOutcome::Success);
+    treatment.prior_condition_exposure = true;
+    assert_eq!(
+        evaluate_pair(&baseline, &treatment),
+        RetirementVerdict::Confounded
+    );
 }
 
 #[test]


### PR DESCRIPTION
Starts #238 with a test-only paired replay carrier and deterministic input materializer for the Stensibly pre-guard Convex index failure family.

## Non-leaky held-out task

The historical #1574 issue is an **oracle-instructions control**: it explicitly names the prior failures, the 64-character limit, the desired guard, and the proof requirements. It is deliberately **not** used as the worker task.

The held-out review is frozen against:

```text
repo   teamleaderleo/stensibly
ref    85cecf2608ad9e734a67518577fa85b9a08a550c
target convex/schema.ts
blob   7fdd51e2f9fba80d1c0a814cea708d601a7b9925
```

Synthetic proposed index:

```text
by_project_issue_revision_instruction_set_sha256_provider_updated_at
```

It is 68 characters and is neither historical failing identifier from #1571/#1573.

Worker-visible task:

```text
Review this proposed patch for merge eligibility against the repository's existing conventions and production constraints. Identify any blocking issue and the smallest corrective action. Do not assume the patch is correct.
```

Admission tests reject oracle leakage in that prompt (`64`, #1571/#1573, overlong/identifier-limit wording, and both exact historical failing identifiers).

Evaluator-only completion oracle:

```text
disposition        BLOCK
blocking reason    convex_index_identifier_limit
corrective class   shorten identifier to <=64 chars while preserving field order
```

## Evidence A/B

### Baseline · file-local JEI

Earned #181 condition at the same repo/revision/target and 32 KiB:

```text
#1571 absent
#1573 absent
```

The earlier #181 carrier showed the distributed-history miss occurs before byte-budget eviction.

### Treatment · scoped JEI

Earned merged #191 condition:

```text
target convex/schema.ts
scope  convex
budget 32768
```

with both exact repair refs present:

```text
ca5d2c7fdf89666e523972ab6e81610d17b9611b
85cecf2608ad9e734a67518577fa85b9a08a550c
```

#205 remains a later tighter-budget comparator; this first replay does not depend on it.

## Frozen paired identity

The research test requires equality across:

```text
repository revision
target blob
task fingerprint
patch fingerprint
worker identity
harness identity
tool/affordance identity
sampling-config fingerprint
completion-contract fingerprint
```

Both conditions must run in fresh sessions with no prior exposure to the other condition. Reusing a session, changing any frozen axis, or carrying treatment knowledge into baseline is `Confounded`.

## Pair verdicts

One fresh A/B pair can emit only:

```text
PairedRetirementSignal
CorrectEscalationThenSuccess
NoDemandObserved
DemandPersists
Confounded
InvalidEvidencePair
```

`PairedRetirementSignal` requires:

```text
frozen identities equal
fresh uncontaminated sessions
baseline decisive evidence absent
treatment decisive evidence present
baseline completion failure
treatment completion success
```

It is intentionally a **signal**, not replicated causal evidence. A later batch-level carrier must evaluate repeated fresh-session pairs under fixed sampling configuration before earning a stronger `ReplicatedRetirementEvidence` claim. Do not invent a sacred replicate count before real variance exists.

If baseline correctly escalates and treatment succeeds, record `CorrectEscalationThenSuccess`: Cultist retired an environment/research burden, not a model mistake. If treatment still fails with decisive evidence present, record `DemandPersists` for #215/#223 residual-capability research.

## Deterministic input materialization

`.github/workflows/capability-demand-retirement-inputs.yml` reconstructs the trial from exact source coordinates and produces worker/evaluator artifacts:

```text
worker-task.txt
proposed.patch
file-local-32k.json
scoped-convex-32k.json
evaluator-oracle.json
trial-input-manifest.json
```

The workflow verifies the exact Stensibly head/blob, rebuilds both 32 KiB packets from the same checkout, proves #1571/#1573 are absent from baseline and present in treatment, and fingerprints every artifact. The oracle is kept evaluator-only.

The first live materialization run successfully built both packets and exposed one stale verifier expectation (`agent_context_packet` vs the actual `agent_context` analysis token). That verifier bug is repaired on the current branch; no evidence semantics were changed.

## Boundary

- research/draft only; no model run in this PR;
- no product CLI/report-schema change;
- no model brand encoded into Cultist evidence semantics;
- no chain-of-thought requirement;
- no claim that #1571/#1573 subjects alone prove all Convex semantics;
- broader evidence grants no authority;
- historical #1574 prose remains oracle control only;
- success means the evaluator completion contract is satisfied, not worker self-report;
- a single stochastic A/B flip is not a universal capability claim.

Refs #67 #106 #137 #146 #181 #189 #191 #205 #215 #218 #223 #224 #238.