### PR TITLE
research: freeze blindable paired behavioral trials

### DIFF
--- a/examples/behavioral_trial_materialize.rs
+++ b/examples/behavioral_trial_materialize.rs
@@ -1,0 +1,45 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+use serde::Deserialize;
+
+#[allow(dead_code)]
+#[path = "../src/behavioral_trial.rs"]
+mod behavioral_trial;
+
+use behavioral_trial::{
+    BehavioralTrialArmKind, BehavioralTrialPlan, MAX_BEHAVIORAL_TRIAL_BYTES,
+    materialize_worker_packet,
+};
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MaterializeRequest {
+    arm: BehavioralTrialArmKind,
+    plan: Box<BehavioralTrialPlan>,
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("behavioral-trial-materialize: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_BEHAVIORAL_TRIAL_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_BEHAVIORAL_TRIAL_BYTES {
+        return Err(format!(
+            "behavioral-trial materialize request exceeds the {MAX_BEHAVIORAL_TRIAL_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let request: MaterializeRequest = serde_json::from_slice(&bytes)?;
+    let packet = materialize_worker_packet(request.plan.as_ref(), request.arm)?;
+    println!("{}", serde_json::to_string_pretty(&packet)?);
+    Ok(())
+}

--- a/examples/behavioral_trial_reconcile.rs
+++ b/examples/behavioral_trial_reconcile.rs
@@ -1,0 +1,35 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+#[allow(dead_code)]
+#[path = "../src/behavioral_trial.rs"]
+mod behavioral_trial;
+
+use behavioral_trial::{
+    MAX_BEHAVIORAL_TRIAL_BYTES, evaluate_behavioral_trial_pair, parse_behavioral_trial_pair,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("behavioral-trial-reconcile: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_BEHAVIORAL_TRIAL_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_BEHAVIORAL_TRIAL_BYTES {
+        return Err(format!(
+            "behavioral-trial pair exceeds the {MAX_BEHAVIORAL_TRIAL_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let pair = parse_behavioral_trial_pair(&bytes)?;
+    let evaluation = evaluate_behavioral_trial_pair(&pair)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}

--- a/research/behavioral-trials.md
+++ b/research/behavioral-trials.md
@@ -1,0 +1,277 @@
+# Blindable paired behavioral trials
+
+Issue #241 fills the A/B seam left open by #137's behavioral receipts.
+
+Behavioral receipts answer:
+
+```text
+what happened after one evidence candidate surfaced or stayed quiet?
+```
+
+Paired trials answer a narrower comparison question:
+
+```text
+with the same task and raw historical facts,
+did the registered control and treatment packets produce the same first-action ID?
+```
+
+The protocol deliberately stops there. `different first action` is not serialized as improvement, treatment effect, success, prevention, or product promotion.
+
+## Internal-only boundary
+
+The first trial protocol performs no provider or model calls.
+
+It uses retained same-repository corpus files and produces local JSON packets. External source identities in the registered contexts are literal provenance, not new external interactions.
+
+The experiment adds no ordinary `cargo-cultist` command or `AnalysisReport` field.
+
+## Plan v1
+
+`src/behavioral_trial.rs` defines a bounded plan:
+
+```text
+BehavioralTrialPlan
+  trial_id
+  task_instruction
+  allowed_first_actions[]
+  control
+    context_ref
+    exact context text
+    context_digest
+  treatment
+    context_ref
+    exact context text
+    context_digest
+```
+
+Each context digest uses:
+
+```text
+cultist-behavioral-context-sha256-v1
+```
+
+The supplied digest is validated against the exact context bytes. Control and treatment must have different exact digests.
+
+The fully validated typed plan receives:
+
+```text
+cultist-behavioral-trial-plan-sha256-v1:<sha256>
+```
+
+Fingerprint framing is field-order independent after JSON deserialization. One-byte semantic/context changes produce a different fingerprint.
+
+## Blindable worker packet
+
+The organizer selects an arm when materializing:
+
+```bash
+cargo run --quiet --example behavioral_trial_materialize < materialize-request.json
+```
+
+The returned `BehavioralWorkerPacket` contains:
+
+```text
+trial_id
+plan_fingerprint
+worker_packet_fingerprint
+task_instruction
+context
+context_digest
+allowed_first_actions
+```
+
+It omits:
+
+```text
+control / treatment label
+context_ref
+expected action
+behavioral outcome
+```
+
+The worker-packet fingerprint uses:
+
+```text
+cultist-behavioral-worker-packet-sha256-v1
+```
+
+The organizer retains the arm-to-packet mapping. A worker only needs the materialized packet.
+
+## Worker observation
+
+The worker chooses exactly one registered first-action ID and returns:
+
+```text
+BehavioralTrialObservation
+  trial_id
+  plan_fingerprint
+  worker_packet_fingerprint
+  worker_ref
+  first_action_id
+```
+
+The worker does not classify the result as useful, correct, changed, successful, or causal.
+
+## Pair reconciliation
+
+After one control and one treatment observation exist:
+
+```bash
+cargo run --quiet --example behavioral_trial_reconcile < pair.json
+```
+
+The evaluator maps packet fingerprints back to arms and emits:
+
+```text
+control
+  worker_ref
+  first_action_id
+
+treatment
+  worker_ref
+  first_action_id
+
+same_first_action
+```
+
+It rejects observations for unknown packets, two observations for one arm, changed plan fingerprints, and action IDs outside the pre-registered vocabulary.
+
+A later #137 `BehavioralReceipt` may interpret an observed episode only after the concrete worker consequence is available.
+
+## Registered trial A: stale review front
+
+Plan:
+
+```text
+research/behavioral-trials/prior-review-stale.json
+```
+
+Source carrier already retained by #206/#219:
+
+```text
+The-PR-Agent/pr-agent#2424
+prior review comment 3355870564
+prior reviewed head  8fb9e4e86b4794d39afba2d62413571cbc04a744
+current head         f6070fb1a45516565bbb8deeb02a1f66cec13d91
+prior outcome        patch_changed
+```
+
+Both arms receive those raw coordinates.
+
+Treatment appends only:
+
+```text
+Cultist prior-episode front:
+source disposition: refresh_existing_thread
+old outcome applicability: INVALID
+next: recompute_and_refresh_review_thread
+```
+
+Registered fingerprints:
+
+```text
+plan
+  cultist-behavioral-trial-plan-sha256-v1:b394eefd406bac16e2ba7690bd45f6373d3b029208fdd55d70c3b9a943f15d65
+
+control packet
+  cultist-behavioral-worker-packet-sha256-v1:4a59e3aac7200f97bf059d3df4fa3ba81c322d2ecaaac18ade25724ca6799272
+
+treatment packet
+  cultist-behavioral-worker-packet-sha256-v1:3f9a24e968a1b2cfd2284e6668054537e46eaeca0ba5fdb69c116d4a7b3f8e9d
+```
+
+Action vocabulary includes new-thread, reuse, recompute/refresh, acquire-coordinate, and inspect-more-history choices.
+
+**Status: registered, not executed.**
+
+## Registered trial B: closed issue / re-report front
+
+Plan:
+
+```text
+research/behavioral-trials/closed-rereport.json
+```
+
+Source carrier already retained by #212/#219:
+
+```text
+anthropics/claude-code#31294
+anthropics/claude-code#57507
+prior state       closed
+prior reason      not_planned
+closure actor     github-actions[bot]
+later relation    explicit re-report
+later state       closed
+```
+
+Both arms receive the same raw lifecycle/re-report facts.
+
+Treatment appends only:
+
+```text
+Cultist prior-episode front:
+closure kind: administrative_inactive
+re-report observed: true
+clearance: UNKNOWN
+next: inspect_prior_failure_and_rereport
+```
+
+Registered fingerprints:
+
+```text
+plan
+  cultist-behavioral-trial-plan-sha256-v1:8d42a49630eace01d6c14055a79d41a91dcb22f84f32db2a92e483ec60840ba4
+
+control packet
+  cultist-behavioral-worker-packet-sha256-v1:73ce3562f8fc382db9ab3505236fdf965c5d6b4f6a5c6cd745ddc2b121c8f7e6
+
+treatment packet
+  cultist-behavioral-worker-packet-sha256-v1:6c63c84bcf52831cb0d4bc3490bf3a279bf77cacd67ede8d300fb6c09ca7d4e8
+```
+
+The action vocabulary includes exhausted/prior-only/later-only/combined-inspection/acquire-more-evidence choices.
+
+**Status: registered, not executed.**
+
+## Controls
+
+The standard Rust controls require:
+
+- exact known context, plan, and packet fingerprints;
+- typed plan fingerprint stability across JSON field order/formatting;
+- context mutation changes the arm and plan fingerprints;
+- worker packets omit arm labels and context refs;
+- same first action remains descriptive;
+- different first action remains descriptive;
+- observation order does not determine arm identity;
+- unknown actions reject;
+- duplicate same-arm observations reject;
+- unknown packet fingerprints reject;
+- plan mutation after packet materialization rejects;
+- identical control/treatment contexts reject;
+- supplied context digest must match exact bytes;
+- duplicate action IDs reject;
+- unknown machine fields fail closed.
+
+The two registered plans are parsed and fingerprinted by `tests/behavioral_trial_real.rs` so future edits cannot silently mutate an already-prepared experiment.
+
+## What this earns
+
+Cultist can now do the honest part of a behavioral A/B experiment before any worker is recruited:
+
+```text
+freeze task
+freeze action vocabulary
+freeze raw control context
+freeze treatment projection
+freeze packet identities
+hide arm labels from the worker packet
+accept one exact first-action ID
+compare the pair descriptively
+```
+
+What remains unearned is the result.
+
+Once a fresh-worker pair is actually run, #137 can decide whether to retain the observation as `changed_next_action`, `prevented_or_reversed_wrong_turn`, `useful_same_action`, `irrelevant`, or another existing behavioral outcome.
+
+Refs #137 #213 #217 #219 #237 #241.

--- a/research/behavioral-trials/closed-rereport.json
+++ b/research/behavioral-trials/closed-rereport.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "trial_id": "prior-episode-front:closed-rereport",
+  "task_instruction": "Choose exactly one first justified action before deciding whether the closed historical failure is exhausted.",
+  "allowed_first_actions": [
+    {
+      "id": "treat_closed_as_exhausted",
+      "label": "Treat the closed prior issue as exhausted"
+    },
+    {
+      "id": "inspect_prior_issue",
+      "label": "Inspect the prior issue only"
+    },
+    {
+      "id": "inspect_later_rereport",
+      "label": "Inspect the later re-report only"
+    },
+    {
+      "id": "inspect_prior_failure_and_rereport",
+      "label": "Inspect the prior failure and the later re-report together"
+    },
+    {
+      "id": "acquire_more_evidence",
+      "label": "Acquire more evidence before deciding"
+    }
+  ],
+  "control": {
+    "context_ref": "research/prior-episode-front/claude-code-57507.json#raw",
+    "context": "Source identities: anthropics/claude-code#31294 and anthropics/claude-code#57507\nPrior issue #31294 state: closed\nPrior state_reason: not_planned\nPrior closed_by: github-actions[bot]\nClosure receipt: Closing for now — inactive for too long. Please open a new issue if this is still relevant.\nLater issue #57507 explicitly says: Re-reporting the bug from #31294; the earlier issue was closed for inactivity, not because it was fixed.\nLater issue #57507 state: closed\nTask: decide the first justified action before treating the historical failure as exhausted.",
+    "context_digest": "cultist-behavioral-context-sha256-v1:68b6eac7092d3df4d00bff5b59031ac7c719d49203b691836bb65a3b45fac015"
+  },
+  "treatment": {
+    "context_ref": "research/prior-episode-front/claude-code-57507.json#front",
+    "context": "Source identities: anthropics/claude-code#31294 and anthropics/claude-code#57507\nPrior issue #31294 state: closed\nPrior state_reason: not_planned\nPrior closed_by: github-actions[bot]\nClosure receipt: Closing for now — inactive for too long. Please open a new issue if this is still relevant.\nLater issue #57507 explicitly says: Re-reporting the bug from #31294; the earlier issue was closed for inactivity, not because it was fixed.\nLater issue #57507 state: closed\nTask: decide the first justified action before treating the historical failure as exhausted.\n\nCultist prior-episode front:\nclosure kind: administrative_inactive\nre-report observed: true\nclearance: UNKNOWN\nnext: inspect_prior_failure_and_rereport",
+    "context_digest": "cultist-behavioral-context-sha256-v1:eeffd05e46d5275e32f63ff6cf49ff0307882b4d603bc2a83328d86374153127"
+  }
+}

--- a/research/behavioral-trials/prior-review-stale.json
+++ b/research/behavioral-trials/prior-review-stale.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "trial_id": "prior-episode-front:stale-review",
+  "task_instruction": "Choose exactly one first justified action for the retained review concern before writing any review feedback.",
+  "allowed_first_actions": [
+    {
+      "id": "post_new_review_thread",
+      "label": "Post a new review thread for the concern"
+    },
+    {
+      "id": "reuse_existing_review_thread",
+      "label": "Reuse the existing review thread as current"
+    },
+    {
+      "id": "recompute_and_refresh_review_thread",
+      "label": "Recompute the concern on the current head and refresh the existing thread"
+    },
+    {
+      "id": "acquire_missing_review_coordinate",
+      "label": "Acquire a missing review coordinate before deciding"
+    },
+    {
+      "id": "inspect_more_history",
+      "label": "Inspect more review history before deciding"
+    }
+  ],
+  "control": {
+    "context_ref": "research/prior-episode-front/pr-agent-2424.json#raw",
+    "context": "Source identity: The-PR-Agent/pr-agent#2424\nCurrent PR head: f6070fb1a45516565bbb8deeb02a1f66cec13d91\nPrior review root: github:pull/2424/review-comment/3355870564\nPrior reviewed head: 8fb9e4e86b4794d39afba2d62413571cbc04a744\nPrior review outcome: patch_changed\nResolution reply: github:pull/2424/review-comment/3355925719\nPath: pr_agent/git_providers/github_provider.py\nTask: decide the first justified action for this concern on the current patch.",
+    "context_digest": "cultist-behavioral-context-sha256-v1:df7f52fa7bd85e71daccdf1d8432f7beefbf30df37bcdd56ece8505d72557023"
+  },
+  "treatment": {
+    "context_ref": "research/prior-episode-front/pr-agent-2424.json#front",
+    "context": "Source identity: The-PR-Agent/pr-agent#2424\nCurrent PR head: f6070fb1a45516565bbb8deeb02a1f66cec13d91\nPrior review root: github:pull/2424/review-comment/3355870564\nPrior reviewed head: 8fb9e4e86b4794d39afba2d62413571cbc04a744\nPrior review outcome: patch_changed\nResolution reply: github:pull/2424/review-comment/3355925719\nPath: pr_agent/git_providers/github_provider.py\nTask: decide the first justified action for this concern on the current patch.\n\nCultist prior-episode front:\nsource disposition: refresh_existing_thread\nold outcome applicability: INVALID\nnext: recompute_and_refresh_review_thread",
+    "context_digest": "cultist-behavioral-context-sha256-v1:a2be1b8687408f87c8a12c2c99188edfe18f22957bfaafb4a87e85c4d1345498"
+  }
+}

--- a/src/behavioral_trial.rs
+++ b/src/behavioral_trial.rs
@@ -153,15 +153,14 @@ pub fn context_digest(context: &str) -> String {
 
 pub fn fingerprint_plan(plan: &BehavioralTrialPlan) -> Result<String, BehavioralTrialError> {
     validate_plan(plan)?;
-    let mut components = Vec::<Vec<u8>>::new();
-    components.push(plan.schema_version.to_be_bytes().to_vec());
-    components.push(plan.trial_id.as_bytes().to_vec());
-    components.push(plan.task_instruction.as_bytes().to_vec());
-    components.push(
+    let mut components = vec![
+        plan.schema_version.to_be_bytes().to_vec(),
+        plan.trial_id.as_bytes().to_vec(),
+        plan.task_instruction.as_bytes().to_vec(),
         (plan.allowed_first_actions.len() as u64)
             .to_be_bytes()
             .to_vec(),
-    );
+    ];
     for action in &plan.allowed_first_actions {
         components.push(action.id.as_bytes().to_vec());
         components.push(action.label.as_bytes().to_vec());

--- a/src/behavioral_trial.rs
+++ b/src/behavioral_trial.rs
@@ -1,0 +1,489 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const BEHAVIORAL_TRIAL_SCHEMA_VERSION: u32 = 1;
+pub const MAX_BEHAVIORAL_TRIAL_BYTES: usize = 512 * 1024;
+pub const CONTEXT_DIGEST_SCHEME: &str = "cultist-behavioral-context-sha256-v1";
+pub const PLAN_FINGERPRINT_SCHEME: &str = "cultist-behavioral-trial-plan-sha256-v1";
+pub const WORKER_PACKET_FINGERPRINT_SCHEME: &str =
+    "cultist-behavioral-worker-packet-sha256-v1";
+const MAX_TRIAL_ID_BYTES: usize = 1024;
+const MAX_TASK_BYTES: usize = 16 * 1024;
+const MAX_CONTEXT_BYTES: usize = 128 * 1024;
+const MAX_CONTEXT_REF_BYTES: usize = 2048;
+const MAX_ACTIONS: usize = 32;
+const MAX_ACTION_ID_BYTES: usize = 256;
+const MAX_ACTION_LABEL_BYTES: usize = 1024;
+const MAX_WORKER_REF_BYTES: usize = 1024;
+const SHA256_HEX_BYTES: usize = 64;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralTrialPlan {
+    pub schema_version: u32,
+    pub trial_id: String,
+    pub task_instruction: String,
+    pub allowed_first_actions: Vec<BehavioralTrialAction>,
+    pub control: BehavioralTrialArm,
+    pub treatment: BehavioralTrialArm,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralTrialAction {
+    pub id: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralTrialArm {
+    pub context_ref: String,
+    pub context: String,
+    pub context_digest: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BehavioralTrialArmKind {
+    Control,
+    Treatment,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralWorkerPacket {
+    pub schema_version: u32,
+    pub trial_id: String,
+    pub plan_fingerprint: String,
+    pub worker_packet_fingerprint: String,
+    pub task_instruction: String,
+    pub context: String,
+    pub context_digest: String,
+    pub allowed_first_actions: Vec<BehavioralTrialAction>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralTrialObservation {
+    pub schema_version: u32,
+    pub trial_id: String,
+    pub plan_fingerprint: String,
+    pub worker_packet_fingerprint: String,
+    pub worker_ref: String,
+    pub first_action_id: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralTrialPair {
+    pub schema_version: u32,
+    pub plan: Box<BehavioralTrialPlan>,
+    pub observations: Vec<BehavioralTrialObservation>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralTrialEvaluation {
+    pub schema_version: u32,
+    pub trial_id: String,
+    pub plan_fingerprint: String,
+    pub control: BehavioralTrialArmObservation,
+    pub treatment: BehavioralTrialArmObservation,
+    pub same_first_action: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralTrialArmObservation {
+    pub worker_packet_fingerprint: String,
+    pub worker_ref: String,
+    pub first_action_id: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct BehavioralTrialError {
+    message: String,
+}
+
+impl BehavioralTrialError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for BehavioralTrialError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for BehavioralTrialError {}
+
+pub fn parse_behavioral_trial_plan(bytes: &[u8]) -> Result<BehavioralTrialPlan, BehavioralTrialError> {
+    enforce_input_bound(bytes)?;
+    let plan: BehavioralTrialPlan = serde_json::from_slice(bytes).map_err(|error| {
+        BehavioralTrialError::new(format!("invalid behavioral-trial plan JSON: {error}"))
+    })?;
+    validate_plan(&plan)?;
+    Ok(plan)
+}
+
+pub fn parse_behavioral_trial_pair(bytes: &[u8]) -> Result<BehavioralTrialPair, BehavioralTrialError> {
+    enforce_input_bound(bytes)?;
+    let pair: BehavioralTrialPair = serde_json::from_slice(bytes).map_err(|error| {
+        BehavioralTrialError::new(format!("invalid behavioral-trial pair JSON: {error}"))
+    })?;
+    validate_pair_shape(&pair)?;
+    Ok(pair)
+}
+
+pub fn context_digest(context: &str) -> String {
+    hash_single(CONTEXT_DIGEST_SCHEME, context.as_bytes())
+}
+
+pub fn fingerprint_plan(plan: &BehavioralTrialPlan) -> Result<String, BehavioralTrialError> {
+    validate_plan(plan)?;
+    let mut components = Vec::<Vec<u8>>::new();
+    components.push(plan.schema_version.to_be_bytes().to_vec());
+    components.push(plan.trial_id.as_bytes().to_vec());
+    components.push(plan.task_instruction.as_bytes().to_vec());
+    components.push((plan.allowed_first_actions.len() as u64).to_be_bytes().to_vec());
+    for action in &plan.allowed_first_actions {
+        components.push(action.id.as_bytes().to_vec());
+        components.push(action.label.as_bytes().to_vec());
+    }
+    push_arm_components(&mut components, &plan.control);
+    push_arm_components(&mut components, &plan.treatment);
+    Ok(hash_components(PLAN_FINGERPRINT_SCHEME, &components))
+}
+
+pub fn materialize_worker_packet(
+    plan: &BehavioralTrialPlan,
+    arm: BehavioralTrialArmKind,
+) -> Result<BehavioralWorkerPacket, BehavioralTrialError> {
+    validate_plan(plan)?;
+    let plan_fingerprint = fingerprint_plan(plan)?;
+    let selected = match arm {
+        BehavioralTrialArmKind::Control => &plan.control,
+        BehavioralTrialArmKind::Treatment => &plan.treatment,
+    };
+    let packet_fingerprint = fingerprint_worker_packet_material(
+        plan,
+        &plan_fingerprint,
+        &selected.context,
+        &selected.context_digest,
+    );
+
+    Ok(BehavioralWorkerPacket {
+        schema_version: BEHAVIORAL_TRIAL_SCHEMA_VERSION,
+        trial_id: plan.trial_id.clone(),
+        plan_fingerprint,
+        worker_packet_fingerprint: packet_fingerprint,
+        task_instruction: plan.task_instruction.clone(),
+        context: selected.context.clone(),
+        context_digest: selected.context_digest.clone(),
+        allowed_first_actions: plan.allowed_first_actions.clone(),
+    })
+}
+
+pub fn evaluate_behavioral_trial_pair(
+    pair: &BehavioralTrialPair,
+) -> Result<BehavioralTrialEvaluation, BehavioralTrialError> {
+    validate_pair_shape(pair)?;
+    let plan = pair.plan.as_ref();
+    let plan_fingerprint = fingerprint_plan(plan)?;
+    let control_packet = materialize_worker_packet(plan, BehavioralTrialArmKind::Control)?;
+    let treatment_packet = materialize_worker_packet(plan, BehavioralTrialArmKind::Treatment)?;
+
+    let mut mapped = BTreeMap::<BehavioralTrialArmKindKey, &BehavioralTrialObservation>::new();
+    for observation in &pair.observations {
+        validate_observation(observation, plan, &plan_fingerprint)?;
+        let key = if observation.worker_packet_fingerprint == control_packet.worker_packet_fingerprint {
+            BehavioralTrialArmKindKey::Control
+        } else if observation.worker_packet_fingerprint == treatment_packet.worker_packet_fingerprint {
+            BehavioralTrialArmKindKey::Treatment
+        } else {
+            return Err(BehavioralTrialError::new(format!(
+                "observation from worker `{}` names an unknown worker-packet fingerprint",
+                observation.worker_ref
+            )));
+        };
+        if mapped.insert(key, observation).is_some() {
+            return Err(BehavioralTrialError::new(
+                "paired behavioral trial contains two observations for the same arm",
+            ));
+        }
+    }
+
+    let control = mapped
+        .get(&BehavioralTrialArmKindKey::Control)
+        .ok_or_else(|| BehavioralTrialError::new("paired behavioral trial is missing the control observation"))?;
+    let treatment = mapped
+        .get(&BehavioralTrialArmKindKey::Treatment)
+        .ok_or_else(|| BehavioralTrialError::new("paired behavioral trial is missing the treatment observation"))?;
+
+    Ok(BehavioralTrialEvaluation {
+        schema_version: BEHAVIORAL_TRIAL_SCHEMA_VERSION,
+        trial_id: plan.trial_id.clone(),
+        plan_fingerprint,
+        control: arm_observation(control),
+        treatment: arm_observation(treatment),
+        same_first_action: control.first_action_id == treatment.first_action_id,
+    })
+}
+
+fn validate_plan(plan: &BehavioralTrialPlan) -> Result<(), BehavioralTrialError> {
+    if plan.schema_version != BEHAVIORAL_TRIAL_SCHEMA_VERSION {
+        return Err(BehavioralTrialError::new(format!(
+            "unsupported behavioral-trial schema {}; expected {BEHAVIORAL_TRIAL_SCHEMA_VERSION}",
+            plan.schema_version
+        )));
+    }
+    validate_coordinate(&plan.trial_id, "trial_id", MAX_TRIAL_ID_BYTES)?;
+    validate_text(&plan.task_instruction, "task_instruction", MAX_TASK_BYTES)?;
+    if !(2..=MAX_ACTIONS).contains(&plan.allowed_first_actions.len()) {
+        return Err(BehavioralTrialError::new(format!(
+            "allowed_first_actions must contain 2..={MAX_ACTIONS} actions"
+        )));
+    }
+    let mut action_ids = BTreeSet::<&str>::new();
+    for action in &plan.allowed_first_actions {
+        validate_token(&action.id, "action.id", MAX_ACTION_ID_BYTES)?;
+        validate_text(&action.label, "action.label", MAX_ACTION_LABEL_BYTES)?;
+        if !action_ids.insert(&action.id) {
+            return Err(BehavioralTrialError::new(format!(
+                "duplicate behavioral-trial action id `{}`",
+                action.id
+            )));
+        }
+    }
+    validate_arm(&plan.control, "control")?;
+    validate_arm(&plan.treatment, "treatment")?;
+    if plan.control.context_digest == plan.treatment.context_digest {
+        return Err(BehavioralTrialError::new(
+            "control and treatment contexts must have different exact digests",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_arm(arm: &BehavioralTrialArm, label: &str) -> Result<(), BehavioralTrialError> {
+    validate_coordinate(&arm.context_ref, &format!("{label}.context_ref"), MAX_CONTEXT_REF_BYTES)?;
+    validate_text(&arm.context, &format!("{label}.context"), MAX_CONTEXT_BYTES)?;
+    validate_digest(&arm.context_digest, CONTEXT_DIGEST_SCHEME, &format!("{label}.context_digest"))?;
+    let expected = context_digest(&arm.context);
+    if arm.context_digest != expected {
+        return Err(BehavioralTrialError::new(format!(
+            "{label}.context_digest does not match the exact context bytes"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_pair_shape(pair: &BehavioralTrialPair) -> Result<(), BehavioralTrialError> {
+    if pair.schema_version != BEHAVIORAL_TRIAL_SCHEMA_VERSION {
+        return Err(BehavioralTrialError::new(format!(
+            "unsupported behavioral-trial pair schema {}; expected {BEHAVIORAL_TRIAL_SCHEMA_VERSION}",
+            pair.schema_version
+        )));
+    }
+    validate_plan(pair.plan.as_ref())?;
+    if pair.observations.len() != 2 {
+        return Err(BehavioralTrialError::new(
+            "paired behavioral trial requires exactly two observations",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_observation(
+    observation: &BehavioralTrialObservation,
+    plan: &BehavioralTrialPlan,
+    plan_fingerprint: &str,
+) -> Result<(), BehavioralTrialError> {
+    if observation.schema_version != BEHAVIORAL_TRIAL_SCHEMA_VERSION {
+        return Err(BehavioralTrialError::new(format!(
+            "unsupported behavioral-trial observation schema {}; expected {BEHAVIORAL_TRIAL_SCHEMA_VERSION}",
+            observation.schema_version
+        )));
+    }
+    if observation.trial_id != plan.trial_id {
+        return Err(BehavioralTrialError::new(
+            "observation trial_id does not match the registered plan",
+        ));
+    }
+    validate_digest(
+        &observation.plan_fingerprint,
+        PLAN_FINGERPRINT_SCHEME,
+        "observation.plan_fingerprint",
+    )?;
+    if observation.plan_fingerprint != plan_fingerprint {
+        return Err(BehavioralTrialError::new(
+            "observation plan_fingerprint does not match the current registered plan",
+        ));
+    }
+    validate_digest(
+        &observation.worker_packet_fingerprint,
+        WORKER_PACKET_FINGERPRINT_SCHEME,
+        "observation.worker_packet_fingerprint",
+    )?;
+    validate_coordinate(&observation.worker_ref, "observation.worker_ref", MAX_WORKER_REF_BYTES)?;
+    validate_token(
+        &observation.first_action_id,
+        "observation.first_action_id",
+        MAX_ACTION_ID_BYTES,
+    )?;
+    if !plan
+        .allowed_first_actions
+        .iter()
+        .any(|action| action.id == observation.first_action_id)
+    {
+        return Err(BehavioralTrialError::new(format!(
+            "observation first_action_id `{}` is not in the registered action vocabulary",
+            observation.first_action_id
+        )));
+    }
+    Ok(())
+}
+
+fn arm_observation(observation: &BehavioralTrialObservation) -> BehavioralTrialArmObservation {
+    BehavioralTrialArmObservation {
+        worker_packet_fingerprint: observation.worker_packet_fingerprint.clone(),
+        worker_ref: observation.worker_ref.clone(),
+        first_action_id: observation.first_action_id.clone(),
+    }
+}
+
+fn fingerprint_worker_packet_material(
+    plan: &BehavioralTrialPlan,
+    plan_fingerprint: &str,
+    context: &str,
+    context_digest: &str,
+) -> String {
+    let mut components = vec![
+        plan.schema_version.to_be_bytes().to_vec(),
+        plan.trial_id.as_bytes().to_vec(),
+        plan_fingerprint.as_bytes().to_vec(),
+        plan.task_instruction.as_bytes().to_vec(),
+        context.as_bytes().to_vec(),
+        context_digest.as_bytes().to_vec(),
+        (plan.allowed_first_actions.len() as u64).to_be_bytes().to_vec(),
+    ];
+    for action in &plan.allowed_first_actions {
+        components.push(action.id.as_bytes().to_vec());
+        components.push(action.label.as_bytes().to_vec());
+    }
+    hash_components(WORKER_PACKET_FINGERPRINT_SCHEME, &components)
+}
+
+fn push_arm_components(components: &mut Vec<Vec<u8>>, arm: &BehavioralTrialArm) {
+    components.push(arm.context_ref.as_bytes().to_vec());
+    components.push(arm.context.as_bytes().to_vec());
+    components.push(arm.context_digest.as_bytes().to_vec());
+}
+
+fn hash_single(scheme: &str, bytes: &[u8]) -> String {
+    hash_components(scheme, &[bytes.to_vec()])
+}
+
+fn hash_components(scheme: &str, components: &[Vec<u8>]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(scheme.as_bytes());
+    hasher.update([0]);
+    for component in components {
+        hasher.update((component.len() as u64).to_be_bytes());
+        hasher.update(component);
+    }
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(SHA256_HEX_BYTES);
+    for byte in digest {
+        hex.push(hex_digit(byte >> 4));
+        hex.push(hex_digit(byte & 0x0f));
+    }
+    format!("{scheme}:{hex}")
+}
+
+fn validate_digest(value: &str, scheme: &str, field: &str) -> Result<(), BehavioralTrialError> {
+    let prefix = format!("{scheme}:");
+    let Some(digest) = value.strip_prefix(&prefix) else {
+        return Err(BehavioralTrialError::new(format!(
+            "{field} uses an unsupported digest scheme"
+        )));
+    };
+    if digest.len() != SHA256_HEX_BYTES
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(BehavioralTrialError::new(format!(
+            "{field} must contain exactly 64 lowercase SHA-256 hex characters"
+        )));
+    }
+    Ok(())
+}
+
+fn enforce_input_bound(bytes: &[u8]) -> Result<(), BehavioralTrialError> {
+    if bytes.len() > MAX_BEHAVIORAL_TRIAL_BYTES {
+        return Err(BehavioralTrialError::new(format!(
+            "behavioral-trial input exceeds the {MAX_BEHAVIORAL_TRIAL_BYTES}-byte limit"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_coordinate(value: &str, field: &str, maximum: usize) -> Result<(), BehavioralTrialError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > maximum
+        || value.contains('\0')
+        || value.chars().any(char::is_control)
+    {
+        return Err(BehavioralTrialError::new(format!(
+            "{field} must be a bounded non-empty canonical single-line coordinate"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_token(value: &str, field: &str, maximum: usize) -> Result<(), BehavioralTrialError> {
+    validate_coordinate(value, field, maximum)?;
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'_' | b'-' | b'.' | b':' | b'/'))
+    {
+        return Err(BehavioralTrialError::new(format!(
+            "{field} must use lowercase ASCII token characters"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, field: &str, maximum: usize) -> Result<(), BehavioralTrialError> {
+    if value.is_empty() || value.len() > maximum || value.contains('\0') {
+        return Err(BehavioralTrialError::new(format!(
+            "{field} must be bounded non-empty text"
+        )));
+    }
+    Ok(())
+}
+
+fn hex_digit(nibble: u8) -> char {
+    match nibble {
+        0..=9 => char::from(b'0' + nibble),
+        10..=15 => char::from(b'a' + (nibble - 10)),
+        _ => unreachable!("nibble is masked to four bits"),
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+enum BehavioralTrialArmKindKey {
+    Control,
+    Treatment,
+}

--- a/src/behavioral_trial.rs
+++ b/src/behavioral_trial.rs
@@ -9,8 +9,7 @@ pub const BEHAVIORAL_TRIAL_SCHEMA_VERSION: u32 = 1;
 pub const MAX_BEHAVIORAL_TRIAL_BYTES: usize = 512 * 1024;
 pub const CONTEXT_DIGEST_SCHEME: &str = "cultist-behavioral-context-sha256-v1";
 pub const PLAN_FINGERPRINT_SCHEME: &str = "cultist-behavioral-trial-plan-sha256-v1";
-pub const WORKER_PACKET_FINGERPRINT_SCHEME: &str =
-    "cultist-behavioral-worker-packet-sha256-v1";
+pub const WORKER_PACKET_FINGERPRINT_SCHEME: &str = "cultist-behavioral-worker-packet-sha256-v1";
 const MAX_TRIAL_ID_BYTES: usize = 1024;
 const MAX_TASK_BYTES: usize = 16 * 1024;
 const MAX_CONTEXT_BYTES: usize = 128 * 1024;
@@ -126,7 +125,9 @@ impl fmt::Display for BehavioralTrialError {
 
 impl Error for BehavioralTrialError {}
 
-pub fn parse_behavioral_trial_plan(bytes: &[u8]) -> Result<BehavioralTrialPlan, BehavioralTrialError> {
+pub fn parse_behavioral_trial_plan(
+    bytes: &[u8],
+) -> Result<BehavioralTrialPlan, BehavioralTrialError> {
     enforce_input_bound(bytes)?;
     let plan: BehavioralTrialPlan = serde_json::from_slice(bytes).map_err(|error| {
         BehavioralTrialError::new(format!("invalid behavioral-trial plan JSON: {error}"))
@@ -135,7 +136,9 @@ pub fn parse_behavioral_trial_plan(bytes: &[u8]) -> Result<BehavioralTrialPlan, 
     Ok(plan)
 }
 
-pub fn parse_behavioral_trial_pair(bytes: &[u8]) -> Result<BehavioralTrialPair, BehavioralTrialError> {
+pub fn parse_behavioral_trial_pair(
+    bytes: &[u8],
+) -> Result<BehavioralTrialPair, BehavioralTrialError> {
     enforce_input_bound(bytes)?;
     let pair: BehavioralTrialPair = serde_json::from_slice(bytes).map_err(|error| {
         BehavioralTrialError::new(format!("invalid behavioral-trial pair JSON: {error}"))
@@ -154,7 +157,11 @@ pub fn fingerprint_plan(plan: &BehavioralTrialPlan) -> Result<String, Behavioral
     components.push(plan.schema_version.to_be_bytes().to_vec());
     components.push(plan.trial_id.as_bytes().to_vec());
     components.push(plan.task_instruction.as_bytes().to_vec());
-    components.push((plan.allowed_first_actions.len() as u64).to_be_bytes().to_vec());
+    components.push(
+        (plan.allowed_first_actions.len() as u64)
+            .to_be_bytes()
+            .to_vec(),
+    );
     for action in &plan.allowed_first_actions {
         components.push(action.id.as_bytes().to_vec());
         components.push(action.label.as_bytes().to_vec());
@@ -205,16 +212,19 @@ pub fn evaluate_behavioral_trial_pair(
     let mut mapped = BTreeMap::<BehavioralTrialArmKindKey, &BehavioralTrialObservation>::new();
     for observation in &pair.observations {
         validate_observation(observation, plan, &plan_fingerprint)?;
-        let key = if observation.worker_packet_fingerprint == control_packet.worker_packet_fingerprint {
-            BehavioralTrialArmKindKey::Control
-        } else if observation.worker_packet_fingerprint == treatment_packet.worker_packet_fingerprint {
-            BehavioralTrialArmKindKey::Treatment
-        } else {
-            return Err(BehavioralTrialError::new(format!(
-                "observation from worker `{}` names an unknown worker-packet fingerprint",
-                observation.worker_ref
-            )));
-        };
+        let key =
+            if observation.worker_packet_fingerprint == control_packet.worker_packet_fingerprint {
+                BehavioralTrialArmKindKey::Control
+            } else if observation.worker_packet_fingerprint
+                == treatment_packet.worker_packet_fingerprint
+            {
+                BehavioralTrialArmKindKey::Treatment
+            } else {
+                return Err(BehavioralTrialError::new(format!(
+                    "observation from worker `{}` names an unknown worker-packet fingerprint",
+                    observation.worker_ref
+                )));
+            };
         if mapped.insert(key, observation).is_some() {
             return Err(BehavioralTrialError::new(
                 "paired behavioral trial contains two observations for the same arm",
@@ -224,10 +234,16 @@ pub fn evaluate_behavioral_trial_pair(
 
     let control = mapped
         .get(&BehavioralTrialArmKindKey::Control)
-        .ok_or_else(|| BehavioralTrialError::new("paired behavioral trial is missing the control observation"))?;
+        .ok_or_else(|| {
+            BehavioralTrialError::new("paired behavioral trial is missing the control observation")
+        })?;
     let treatment = mapped
         .get(&BehavioralTrialArmKindKey::Treatment)
-        .ok_or_else(|| BehavioralTrialError::new("paired behavioral trial is missing the treatment observation"))?;
+        .ok_or_else(|| {
+            BehavioralTrialError::new(
+                "paired behavioral trial is missing the treatment observation",
+            )
+        })?;
 
     Ok(BehavioralTrialEvaluation {
         schema_version: BEHAVIORAL_TRIAL_SCHEMA_VERSION,
@@ -275,9 +291,17 @@ fn validate_plan(plan: &BehavioralTrialPlan) -> Result<(), BehavioralTrialError>
 }
 
 fn validate_arm(arm: &BehavioralTrialArm, label: &str) -> Result<(), BehavioralTrialError> {
-    validate_coordinate(&arm.context_ref, &format!("{label}.context_ref"), MAX_CONTEXT_REF_BYTES)?;
+    validate_coordinate(
+        &arm.context_ref,
+        &format!("{label}.context_ref"),
+        MAX_CONTEXT_REF_BYTES,
+    )?;
     validate_text(&arm.context, &format!("{label}.context"), MAX_CONTEXT_BYTES)?;
-    validate_digest(&arm.context_digest, CONTEXT_DIGEST_SCHEME, &format!("{label}.context_digest"))?;
+    validate_digest(
+        &arm.context_digest,
+        CONTEXT_DIGEST_SCHEME,
+        &format!("{label}.context_digest"),
+    )?;
     let expected = context_digest(&arm.context);
     if arm.context_digest != expected {
         return Err(BehavioralTrialError::new(format!(
@@ -334,7 +358,11 @@ fn validate_observation(
         WORKER_PACKET_FINGERPRINT_SCHEME,
         "observation.worker_packet_fingerprint",
     )?;
-    validate_coordinate(&observation.worker_ref, "observation.worker_ref", MAX_WORKER_REF_BYTES)?;
+    validate_coordinate(
+        &observation.worker_ref,
+        "observation.worker_ref",
+        MAX_WORKER_REF_BYTES,
+    )?;
     validate_token(
         &observation.first_action_id,
         "observation.first_action_id",
@@ -374,7 +402,9 @@ fn fingerprint_worker_packet_material(
         plan.task_instruction.as_bytes().to_vec(),
         context.as_bytes().to_vec(),
         context_digest.as_bytes().to_vec(),
-        (plan.allowed_first_actions.len() as u64).to_be_bytes().to_vec(),
+        (plan.allowed_first_actions.len() as u64)
+            .to_be_bytes()
+            .to_vec(),
     ];
     for action in &plan.allowed_first_actions {
         components.push(action.id.as_bytes().to_vec());
@@ -438,7 +468,11 @@ fn enforce_input_bound(bytes: &[u8]) -> Result<(), BehavioralTrialError> {
     Ok(())
 }
 
-fn validate_coordinate(value: &str, field: &str, maximum: usize) -> Result<(), BehavioralTrialError> {
+fn validate_coordinate(
+    value: &str,
+    field: &str,
+    maximum: usize,
+) -> Result<(), BehavioralTrialError> {
     if value.is_empty()
         || value.trim() != value
         || value.len() > maximum
@@ -454,10 +488,11 @@ fn validate_coordinate(value: &str, field: &str, maximum: usize) -> Result<(), B
 
 fn validate_token(value: &str, field: &str, maximum: usize) -> Result<(), BehavioralTrialError> {
     validate_coordinate(value, field, maximum)?;
-    if !value
-        .bytes()
-        .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'_' | b'-' | b'.' | b':' | b'/'))
-    {
+    if !value.bytes().all(|byte| {
+        byte.is_ascii_lowercase()
+            || byte.is_ascii_digit()
+            || matches!(byte, b'_' | b'-' | b'.' | b':' | b'/')
+    }) {
         return Err(BehavioralTrialError::new(format!(
             "{field} must use lowercase ASCII token characters"
         )));

--- a/tests/behavioral_trial.rs
+++ b/tests/behavioral_trial.rs
@@ -1,0 +1,257 @@
+#![allow(dead_code)]
+
+#[path = "../src/behavioral_trial.rs"]
+mod behavioral_trial;
+
+use behavioral_trial::{
+    BEHAVIORAL_TRIAL_SCHEMA_VERSION, BehavioralTrialAction, BehavioralTrialArm,
+    BehavioralTrialArmKind, BehavioralTrialObservation, BehavioralTrialPair, BehavioralTrialPlan,
+    CONTEXT_DIGEST_SCHEME, PLAN_FINGERPRINT_SCHEME, WORKER_PACKET_FINGERPRINT_SCHEME,
+    context_digest, evaluate_behavioral_trial_pair, fingerprint_plan, materialize_worker_packet,
+    parse_behavioral_trial_plan,
+};
+
+const EXPECTED_CONTROL_DIGEST: &str = "cultist-behavioral-context-sha256-v1:10944d9f4e3e8d41e3e2aa0d751214c0b413f7090a5a5e459bcaf1ce9be0fe5c";
+const EXPECTED_TREATMENT_DIGEST: &str = "cultist-behavioral-context-sha256-v1:49b365442076db3f9d1fddefabf0feadc6c7e1e66b07f14dbe74dc310f275584";
+const EXPECTED_PLAN_FINGERPRINT: &str = "cultist-behavioral-trial-plan-sha256-v1:ef917cedce917584a050a410c92c7102a53ea62ee4a976337e22d8723bded300";
+const EXPECTED_CONTROL_PACKET: &str = "cultist-behavioral-worker-packet-sha256-v1:de7d024d8d6798059a99cf21d563a7a32948a1c0eca5c396dae1899adb559400";
+const EXPECTED_TREATMENT_PACKET: &str = "cultist-behavioral-worker-packet-sha256-v1:587d983db0d0af54a4fee378bba967c1723a295ce2fc101cb7c7181023cec923";
+
+fn plan() -> BehavioralTrialPlan {
+    BehavioralTrialPlan {
+        schema_version: BEHAVIORAL_TRIAL_SCHEMA_VERSION,
+        trial_id: "trial:fixture".to_string(),
+        task_instruction: "Choose the first justified action.".to_string(),
+        allowed_first_actions: vec![
+            BehavioralTrialAction {
+                id: "inspect_history".to_string(),
+                label: "Inspect prior history".to_string(),
+            },
+            BehavioralTrialAction {
+                id: "continue_current".to_string(),
+                label: "Continue current work".to_string(),
+            },
+        ],
+        control: BehavioralTrialArm {
+            context_ref: "fixture:control".to_string(),
+            context: "No prior episode is surfaced.".to_string(),
+            context_digest: EXPECTED_CONTROL_DIGEST.to_string(),
+        },
+        treatment: BehavioralTrialArm {
+            context_ref: "fixture:treatment".to_string(),
+            context: "Prior episode: stale review; recompute before reuse.".to_string(),
+            context_digest: EXPECTED_TREATMENT_DIGEST.to_string(),
+        },
+    }
+}
+
+fn observation(
+    packet_fingerprint: &str,
+    worker_ref: &str,
+    action: &str,
+) -> BehavioralTrialObservation {
+    BehavioralTrialObservation {
+        schema_version: BEHAVIORAL_TRIAL_SCHEMA_VERSION,
+        trial_id: "trial:fixture".to_string(),
+        plan_fingerprint: EXPECTED_PLAN_FINGERPRINT.to_string(),
+        worker_packet_fingerprint: packet_fingerprint.to_string(),
+        worker_ref: worker_ref.to_string(),
+        first_action_id: action.to_string(),
+    }
+}
+
+fn pair(control_action: &str, treatment_action: &str) -> BehavioralTrialPair {
+    BehavioralTrialPair {
+        schema_version: BEHAVIORAL_TRIAL_SCHEMA_VERSION,
+        plan: Box::new(plan()),
+        observations: vec![
+            observation(EXPECTED_CONTROL_PACKET, "worker:control", control_action),
+            observation(
+                EXPECTED_TREATMENT_PACKET,
+                "worker:treatment",
+                treatment_action,
+            ),
+        ],
+    }
+}
+
+#[test]
+fn exact_small_plan_has_stable_known_digests_and_fingerprints() {
+    assert_eq!(
+        context_digest("No prior episode is surfaced."),
+        EXPECTED_CONTROL_DIGEST
+    );
+    assert_eq!(
+        context_digest("Prior episode: stale review; recompute before reuse."),
+        EXPECTED_TREATMENT_DIGEST
+    );
+    assert_eq!(fingerprint_plan(&plan()).unwrap(), EXPECTED_PLAN_FINGERPRINT);
+
+    let control = materialize_worker_packet(&plan(), BehavioralTrialArmKind::Control).unwrap();
+    let treatment =
+        materialize_worker_packet(&plan(), BehavioralTrialArmKind::Treatment).unwrap();
+    assert_eq!(control.worker_packet_fingerprint, EXPECTED_CONTROL_PACKET);
+    assert_eq!(
+        treatment.worker_packet_fingerprint,
+        EXPECTED_TREATMENT_PACKET
+    );
+}
+
+#[test]
+fn typed_plan_fingerprint_ignores_json_field_order_and_formatting() {
+    let compact = serde_json::to_string(&plan()).unwrap();
+    let reordered = format!(
+        r#"{{
+          "treatment": {},
+          "allowed_first_actions": {},
+          "trial_id": "trial:fixture",
+          "schema_version": 1,
+          "control": {},
+          "task_instruction": "Choose the first justified action."
+        }}"#,
+        serde_json::to_string(&plan().treatment).unwrap(),
+        serde_json::to_string(&plan().allowed_first_actions).unwrap(),
+        serde_json::to_string(&plan().control).unwrap(),
+    );
+
+    let compact_plan = parse_behavioral_trial_plan(compact.as_bytes()).unwrap();
+    let reordered_plan = parse_behavioral_trial_plan(reordered.as_bytes()).unwrap();
+    assert_eq!(compact_plan, reordered_plan);
+    assert_eq!(
+        fingerprint_plan(&compact_plan).unwrap(),
+        fingerprint_plan(&reordered_plan).unwrap()
+    );
+}
+
+#[test]
+fn one_byte_context_mutation_changes_arm_and_plan_fingerprints() {
+    let original = plan();
+    let mut changed = original.clone();
+    changed.treatment.context.push('!');
+    changed.treatment.context_digest = context_digest(&changed.treatment.context);
+
+    assert_ne!(
+        fingerprint_plan(&original).unwrap(),
+        fingerprint_plan(&changed).unwrap()
+    );
+    assert_ne!(
+        materialize_worker_packet(&original, BehavioralTrialArmKind::Treatment)
+            .unwrap()
+            .worker_packet_fingerprint,
+        materialize_worker_packet(&changed, BehavioralTrialArmKind::Treatment)
+            .unwrap()
+            .worker_packet_fingerprint
+    );
+}
+
+#[test]
+fn worker_packets_hide_arm_labels_and_context_refs() {
+    for arm in [BehavioralTrialArmKind::Control, BehavioralTrialArmKind::Treatment] {
+        let packet = materialize_worker_packet(&plan(), arm).unwrap();
+        let json = serde_json::to_string(&packet).unwrap();
+        assert!(!json.contains("context_ref"));
+        assert!(!json.contains("\"control\""));
+        assert!(!json.contains("\"treatment\""));
+        assert!(json.contains(CONTEXT_DIGEST_SCHEME));
+        assert!(json.contains(PLAN_FINGERPRINT_SCHEME));
+        assert!(json.contains(WORKER_PACKET_FINGERPRINT_SCHEME));
+    }
+}
+
+#[test]
+fn same_first_action_is_descriptive_only() {
+    let evaluation = evaluate_behavioral_trial_pair(&pair("inspect_history", "inspect_history"))
+        .unwrap();
+    assert!(evaluation.same_first_action);
+    assert_eq!(evaluation.control.first_action_id, "inspect_history");
+    assert_eq!(evaluation.treatment.first_action_id, "inspect_history");
+}
+
+#[test]
+fn different_first_action_is_descriptive_only() {
+    let evaluation =
+        evaluate_behavioral_trial_pair(&pair("continue_current", "inspect_history")).unwrap();
+    assert!(!evaluation.same_first_action);
+    assert_eq!(evaluation.control.first_action_id, "continue_current");
+    assert_eq!(evaluation.treatment.first_action_id, "inspect_history");
+}
+
+#[test]
+fn observations_can_arrive_in_either_order() {
+    let mut input = pair("continue_current", "inspect_history");
+    input.observations.reverse();
+    let evaluation = evaluate_behavioral_trial_pair(&input).unwrap();
+    assert_eq!(evaluation.control.worker_ref, "worker:control");
+    assert_eq!(evaluation.treatment.worker_ref, "worker:treatment");
+}
+
+#[test]
+fn observation_action_must_be_registered() {
+    let error = evaluate_behavioral_trial_pair(&pair("continue_current", "invented_action"))
+        .unwrap_err();
+    assert!(error.to_string().contains("registered action vocabulary"));
+}
+
+#[test]
+fn two_observations_for_same_arm_reject() {
+    let mut input = pair("continue_current", "inspect_history");
+    input.observations[1].worker_packet_fingerprint = EXPECTED_CONTROL_PACKET.to_string();
+    let error = evaluate_behavioral_trial_pair(&input).unwrap_err();
+    assert!(error.to_string().contains("same arm"));
+}
+
+#[test]
+fn unknown_worker_packet_fingerprint_rejects() {
+    let mut input = pair("continue_current", "inspect_history");
+    input.observations[1].worker_packet_fingerprint = format!(
+        "{WORKER_PACKET_FINGERPRINT_SCHEME}:{}",
+        "0".repeat(64)
+    );
+    let error = evaluate_behavioral_trial_pair(&input).unwrap_err();
+    assert!(error.to_string().contains("unknown worker-packet fingerprint"));
+}
+
+#[test]
+fn plan_mutation_after_observation_rejects() {
+    let mut input = pair("continue_current", "inspect_history");
+    input.plan.task_instruction.push_str(" Changed after registration.");
+    let error = evaluate_behavioral_trial_pair(&input).unwrap_err();
+    assert!(error.to_string().contains("plan_fingerprint"));
+}
+
+#[test]
+fn identical_control_and_treatment_contexts_reject() {
+    let mut input = plan();
+    input.treatment.context = input.control.context.clone();
+    input.treatment.context_digest = input.control.context_digest.clone();
+    let error = fingerprint_plan(&input).unwrap_err();
+    assert!(error.to_string().contains("different exact digests"));
+}
+
+#[test]
+fn supplied_context_digest_must_match_exact_context() {
+    let mut input = plan();
+    input.control.context.push('!');
+    let error = fingerprint_plan(&input).unwrap_err();
+    assert!(error.to_string().contains("does not match the exact context bytes"));
+}
+
+#[test]
+fn duplicate_action_ids_reject() {
+    let mut input = plan();
+    input.allowed_first_actions[1].id = "inspect_history".to_string();
+    let error = fingerprint_plan(&input).unwrap_err();
+    assert!(error.to_string().contains("duplicate behavioral-trial action id"));
+}
+
+#[test]
+fn plan_parser_rejects_unknown_fields() {
+    let mut value = serde_json::to_value(plan()).unwrap();
+    value
+        .as_object_mut()
+        .unwrap()
+        .insert("score".to_string(), serde_json::json!(0.99));
+    let bytes = serde_json::to_vec(&value).unwrap();
+    let error = parse_behavioral_trial_plan(&bytes).unwrap_err();
+    assert!(error.to_string().contains("unknown field"));
+}

--- a/tests/behavioral_trial.rs
+++ b/tests/behavioral_trial.rs
@@ -85,11 +85,13 @@ fn exact_small_plan_has_stable_known_digests_and_fingerprints() {
         context_digest("Prior episode: stale review; recompute before reuse."),
         EXPECTED_TREATMENT_DIGEST
     );
-    assert_eq!(fingerprint_plan(&plan()).unwrap(), EXPECTED_PLAN_FINGERPRINT);
+    assert_eq!(
+        fingerprint_plan(&plan()).unwrap(),
+        EXPECTED_PLAN_FINGERPRINT
+    );
 
     let control = materialize_worker_packet(&plan(), BehavioralTrialArmKind::Control).unwrap();
-    let treatment =
-        materialize_worker_packet(&plan(), BehavioralTrialArmKind::Treatment).unwrap();
+    let treatment = materialize_worker_packet(&plan(), BehavioralTrialArmKind::Treatment).unwrap();
     assert_eq!(control.worker_packet_fingerprint, EXPECTED_CONTROL_PACKET);
     assert_eq!(
         treatment.worker_packet_fingerprint,
@@ -146,7 +148,10 @@ fn one_byte_context_mutation_changes_arm_and_plan_fingerprints() {
 
 #[test]
 fn worker_packets_hide_arm_labels_and_context_refs() {
-    for arm in [BehavioralTrialArmKind::Control, BehavioralTrialArmKind::Treatment] {
+    for arm in [
+        BehavioralTrialArmKind::Control,
+        BehavioralTrialArmKind::Treatment,
+    ] {
         let packet = materialize_worker_packet(&plan(), arm).unwrap();
         let json = serde_json::to_string(&packet).unwrap();
         assert!(!json.contains("context_ref"));
@@ -160,8 +165,8 @@ fn worker_packets_hide_arm_labels_and_context_refs() {
 
 #[test]
 fn same_first_action_is_descriptive_only() {
-    let evaluation = evaluate_behavioral_trial_pair(&pair("inspect_history", "inspect_history"))
-        .unwrap();
+    let evaluation =
+        evaluate_behavioral_trial_pair(&pair("inspect_history", "inspect_history")).unwrap();
     assert!(evaluation.same_first_action);
     assert_eq!(evaluation.control.first_action_id, "inspect_history");
     assert_eq!(evaluation.treatment.first_action_id, "inspect_history");
@@ -187,8 +192,8 @@ fn observations_can_arrive_in_either_order() {
 
 #[test]
 fn observation_action_must_be_registered() {
-    let error = evaluate_behavioral_trial_pair(&pair("continue_current", "invented_action"))
-        .unwrap_err();
+    let error =
+        evaluate_behavioral_trial_pair(&pair("continue_current", "invented_action")).unwrap_err();
     assert!(error.to_string().contains("registered action vocabulary"));
 }
 
@@ -203,18 +208,23 @@ fn two_observations_for_same_arm_reject() {
 #[test]
 fn unknown_worker_packet_fingerprint_rejects() {
     let mut input = pair("continue_current", "inspect_history");
-    input.observations[1].worker_packet_fingerprint = format!(
-        "{WORKER_PACKET_FINGERPRINT_SCHEME}:{}",
-        "0".repeat(64)
-    );
+    input.observations[1].worker_packet_fingerprint =
+        format!("{WORKER_PACKET_FINGERPRINT_SCHEME}:{}", "0".repeat(64));
     let error = evaluate_behavioral_trial_pair(&input).unwrap_err();
-    assert!(error.to_string().contains("unknown worker-packet fingerprint"));
+    assert!(
+        error
+            .to_string()
+            .contains("unknown worker-packet fingerprint")
+    );
 }
 
 #[test]
 fn plan_mutation_after_observation_rejects() {
     let mut input = pair("continue_current", "inspect_history");
-    input.plan.task_instruction.push_str(" Changed after registration.");
+    input
+        .plan
+        .task_instruction
+        .push_str(" Changed after registration.");
     let error = evaluate_behavioral_trial_pair(&input).unwrap_err();
     assert!(error.to_string().contains("plan_fingerprint"));
 }
@@ -233,7 +243,11 @@ fn supplied_context_digest_must_match_exact_context() {
     let mut input = plan();
     input.control.context.push('!');
     let error = fingerprint_plan(&input).unwrap_err();
-    assert!(error.to_string().contains("does not match the exact context bytes"));
+    assert!(
+        error
+            .to_string()
+            .contains("does not match the exact context bytes")
+    );
 }
 
 #[test]
@@ -241,7 +255,11 @@ fn duplicate_action_ids_reject() {
     let mut input = plan();
     input.allowed_first_actions[1].id = "inspect_history".to_string();
     let error = fingerprint_plan(&input).unwrap_err();
-    assert!(error.to_string().contains("duplicate behavioral-trial action id"));
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate behavioral-trial action id")
+    );
 }
 
 #[test]

--- a/tests/behavioral_trial_real.rs
+++ b/tests/behavioral_trial_real.rs
@@ -4,7 +4,8 @@
 mod behavioral_trial;
 
 use behavioral_trial::{
-    BehavioralTrialArmKind, fingerprint_plan, materialize_worker_packet, parse_behavioral_trial_plan,
+    BehavioralTrialArmKind, fingerprint_plan, materialize_worker_packet,
+    parse_behavioral_trial_plan,
 };
 
 #[test]
@@ -32,7 +33,11 @@ fn stale_review_trial_has_stable_registered_packets() {
     );
     assert!(treatment.context.starts_with(&control.context));
     assert!(!control.context.contains("Cultist prior-episode front:"));
-    assert!(treatment.context.contains("old outcome applicability: INVALID"));
+    assert!(
+        treatment
+            .context
+            .contains("old outcome applicability: INVALID")
+    );
     assert!(
         treatment
             .context

--- a/tests/behavioral_trial_real.rs
+++ b/tests/behavioral_trial_real.rs
@@ -1,0 +1,74 @@
+#![allow(dead_code)]
+
+#[path = "../src/behavioral_trial.rs"]
+mod behavioral_trial;
+
+use behavioral_trial::{
+    BehavioralTrialArmKind, fingerprint_plan, materialize_worker_packet, parse_behavioral_trial_plan,
+};
+
+#[test]
+fn stale_review_trial_has_stable_registered_packets() {
+    let plan = parse_behavioral_trial_plan(include_bytes!(
+        "../research/behavioral-trials/prior-review-stale.json"
+    ))
+    .unwrap();
+
+    assert_eq!(
+        fingerprint_plan(&plan).unwrap(),
+        "cultist-behavioral-trial-plan-sha256-v1:b394eefd406bac16e2ba7690bd45f6373d3b029208fdd55d70c3b9a943f15d65"
+    );
+
+    let control = materialize_worker_packet(&plan, BehavioralTrialArmKind::Control).unwrap();
+    let treatment = materialize_worker_packet(&plan, BehavioralTrialArmKind::Treatment).unwrap();
+
+    assert_eq!(
+        control.worker_packet_fingerprint,
+        "cultist-behavioral-worker-packet-sha256-v1:4a59e3aac7200f97bf059d3df4fa3ba81c322d2ecaaac18ade25724ca6799272"
+    );
+    assert_eq!(
+        treatment.worker_packet_fingerprint,
+        "cultist-behavioral-worker-packet-sha256-v1:3f9a24e968a1b2cfd2284e6668054537e46eaeca0ba5fdb69c116d4a7b3f8e9d"
+    );
+    assert!(treatment.context.starts_with(&control.context));
+    assert!(!control.context.contains("Cultist prior-episode front:"));
+    assert!(treatment.context.contains("old outcome applicability: INVALID"));
+    assert!(
+        treatment
+            .context
+            .contains("next: recompute_and_refresh_review_thread")
+    );
+}
+
+#[test]
+fn closed_rereport_trial_has_stable_registered_packets() {
+    let plan = parse_behavioral_trial_plan(include_bytes!(
+        "../research/behavioral-trials/closed-rereport.json"
+    ))
+    .unwrap();
+
+    assert_eq!(
+        fingerprint_plan(&plan).unwrap(),
+        "cultist-behavioral-trial-plan-sha256-v1:8d42a49630eace01d6c14055a79d41a91dcb22f84f32db2a92e483ec60840ba4"
+    );
+
+    let control = materialize_worker_packet(&plan, BehavioralTrialArmKind::Control).unwrap();
+    let treatment = materialize_worker_packet(&plan, BehavioralTrialArmKind::Treatment).unwrap();
+
+    assert_eq!(
+        control.worker_packet_fingerprint,
+        "cultist-behavioral-worker-packet-sha256-v1:73ce3562f8fc382db9ab3505236fdf965c5d6b4f6a5c6cd745ddc2b121c8f7e6"
+    );
+    assert_eq!(
+        treatment.worker_packet_fingerprint,
+        "cultist-behavioral-worker-packet-sha256-v1:6c63c84bcf52831cb0d4bc3490bf3a279bf77cacd67ede8d300fb6c09ca7d4e8"
+    );
+    assert!(treatment.context.starts_with(&control.context));
+    assert!(!control.context.contains("Cultist prior-episode front:"));
+    assert!(treatment.context.contains("clearance: UNKNOWN"));
+    assert!(
+        treatment
+            .context
+            .contains("next: inspect_prior_failure_and_rereport")
+    );
+}


### PR DESCRIPTION
## What

Progress #241 / #137 with a research-only paired-trial protocol for measuring the first justified action under exact control/treatment context packets.

This does **not** run a model or claim a treatment effect. It freezes the experiment and later reconciles two observations descriptively.

## Protocol

`BehavioralTrialPlan` registers:

```text
trial_id
exact task instruction
fixed allowed first-action vocabulary
control context + exact SHA-256 digest
treatment context + exact SHA-256 digest
```

The validated typed plan receives a stable plan fingerprint. One-byte context changes invalidate the arm and plan fingerprints.

Materializing an arm produces a `BehavioralWorkerPacket` containing the task, context, action vocabulary, plan fingerprint, context digest, and worker-packet fingerprint. It deliberately omits the control/treatment label and the internal context ref.

A worker observation carries only:

```text
trial_id
plan fingerprint
worker-packet fingerprint
worker_ref
first_action_id
```

No behavioral outcome or success label is supplied by the worker.

Pair reconciliation maps packet fingerprints back to the registered arms and emits only the two first-action IDs plus:

```text
same_first_action = true/false
```

A different action is not serialized as improvement, causal effect, prevention, or promotion.

## Registered plans

Two #219 prior-episode-front trials are frozen in ordinary test fixtures:

```text
research/behavioral-trials/prior-review-stale.json
research/behavioral-trials/closed-rereport.json
```

Both arms receive the same raw historical facts. Treatment appends only the Cultist prior-episode front.

### Stale review

Literal source identity retained from the existing corpus: `The-PR-Agent/pr-agent#2424`.

Treatment adds:

```text
source disposition: refresh_existing_thread
old outcome applicability: INVALID
next: recompute_and_refresh_review_thread
```

### Closed/re-reported issue

Literal source identities retained from the existing corpus: `anthropics/claude-code#31294` and `anthropics/claude-code#57507`.

Treatment adds:

```text
closure kind: administrative_inactive
re-report observed: true
clearance: UNKNOWN
next: inspect_prior_failure_and_rereport
```

No fresh external fetch or external mutation is part of this PR.

## Organizer examples

```text
behavioral_trial_materialize
  selected arm + registered plan -> blindable worker packet

behavioral_trial_reconcile
  registered plan + exactly two observations -> descriptive pair comparison
```

## Verification

Controls cover stable known context/plan/packet fingerprints, JSON field-order independence after typed parsing, one-byte mutation, hidden arm labels, action-vocabulary enforcement, unknown packet rejection, same-arm duplicate rejection, plan mutation after registration, identical arm rejection, bad supplied digests, duplicate action IDs, and fail-closed unknown fields.

The two real registered plans have exact known plan and worker-packet fingerprints in `tests/behavioral_trial_real.rs`.

## Concurrent-main note

This branch is one commit behind current `main` because `d18f3c1` landed after the lane started. That commit adds only capability-demand-retirement workflow/fixture/test paths. There is no changed-path overlap with this PR. The PR merge-view CI is the authority for current-main compatibility.

## Boundary

- internal Cultist research only;
- no provider/network calls;
- no external writes;
- no model invocation;
- no free-form prose scoring;
- no causal claim from one pair;
- no automatic analyzer promotion/demotion;
- no ordinary CLI/report-schema change.

Closes #241.

Refs #137 #213 #217 #219 #237.