### PR TITLE
research: admit capability-demand worker run receipts

### DIFF
--- a/examples/capability_demand_retirement.rs
+++ b/examples/capability_demand_retirement.rs
@@ -1,0 +1,71 @@
+#[path = "../src/capability_demand_retirement.rs"]
+mod capability_demand_retirement;
+
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use capability_demand_retirement::{
+    MAX_RUN_RECEIPT_BYTES, MAX_TRIAL_MANIFEST_BYTES, MAX_TRIAL_SPEC_BYTES, evaluate_pair,
+    parse_run_receipt, parse_trial_manifest, parse_trial_spec,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("capability-demand-retirement: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut args = std::env::args().skip(1);
+    let trial_path = next_path(&mut args)?;
+    let manifest_path = next_path(&mut args)?;
+    let first_run_path = next_path(&mut args)?;
+    let second_run_path = next_path(&mut args)?;
+    if args.next().is_some() {
+        return Err(usage().into());
+    }
+
+    let trial = parse_trial_spec(&read_bounded(&trial_path, MAX_TRIAL_SPEC_BYTES)?)
+        .map_err(invalid_data)?;
+    let manifest = parse_trial_manifest(&read_bounded(&manifest_path, MAX_TRIAL_MANIFEST_BYTES)?)
+        .map_err(invalid_data)?;
+    let first = parse_run_receipt(&read_bounded(&first_run_path, MAX_RUN_RECEIPT_BYTES)?)
+        .map_err(invalid_data)?;
+    let second = parse_run_receipt(&read_bounded(&second_run_path, MAX_RUN_RECEIPT_BYTES)?)
+        .map_err(invalid_data)?;
+
+    let evaluation = evaluate_pair(&trial, &manifest, &first, &second).map_err(invalid_data)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}
+
+fn next_path(args: &mut impl Iterator<Item = String>) -> Result<String, io::Error> {
+    args.next().ok_or_else(usage)
+}
+
+fn usage() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "usage: capability_demand_retirement TRIAL.json INPUT_MANIFEST.json RUN_A.json RUN_B.json",
+    )
+}
+
+fn read_bounded(path: impl AsRef<Path>, maximum: usize) -> Result<Vec<u8>, Box<dyn Error>> {
+    let path = path.as_ref();
+    let metadata = fs::metadata(path)?;
+    if metadata.len() > maximum as u64 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{} exceeds {maximum} bytes", path.display()),
+        )
+        .into());
+    }
+    Ok(fs::read(path)?)
+}
+
+fn invalid_data(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}

--- a/examples/capability_demand_retirement.rs
+++ b/examples/capability_demand_retirement.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 #[path = "../src/capability_demand_retirement.rs"]
 mod capability_demand_retirement;
 

--- a/research/capability-demand-retirement/run-receipts.md
+++ b/research/capability-demand-retirement/run-receipts.md
@@ -1,0 +1,235 @@
+# Capability-demand retirement run receipts
+
+Status: research execution boundary for #238 / #215 / #223.
+
+The frozen Stensibly trial and deterministic input materializer now exist on `main`. This slice defines the next boundary without embedding a model/provider SDK in Cultist:
+
+```text
+external fresh worker session
+  -> raw worker output + observable harness receipts
+  -> external evaluator/harness normalizes one RunOutcome
+  -> WorkerRunReceipt v1
+  -> Cultist validates frozen identities and packet fingerprints
+  -> paired retirement verdict
+```
+
+Cultist does **not** infer private reasoning, grade prose similarity, call a model, or accept worker self-reported success as the completion oracle.
+
+## Executed input coordinate
+
+The retained historical manifest:
+
+```text
+research/capability-demand-retirement/
+  stensibly-convex-index-review-v1-input-manifest-32264661913.json
+```
+
+comes from GitHub Actions run `32264661913`, artifact `9369686491`.
+
+Artifact archive digest:
+
+```text
+sha256:8dd0df40868b451f5d48aaea771893214e7e3442b08f100e7994a567d4338163
+```
+
+Frozen worker-visible identities from that run:
+
+```text
+task sha256
+  84aaf8f8d3b6880017d25432c763fea5732306117144fc37415992969754f873
+
+patch sha256
+  647281f95818f22784c7468e208bd2b9b5cb2c34ecb38be4b929cf4019c89ba5
+```
+
+Evaluator-only completion contract:
+
+```text
+oracle sha256
+  bce60719e97d861a9223661d349b3171ee3eafb3f87e9042999a32a6bd39771b
+```
+
+Evidence intervention:
+
+```text
+file_local_jei
+  bytes   14,086
+  sha256  e4549a10f86448779a21307d97ea75f2ae1acfd15b43099cbca6f600f0781bdf
+  decisive distributed repair refs present = false
+
+scoped_jei
+  bytes   18,795
+  sha256  2e6acd81e324f3b290b9f93c5bf0ec3d9a66004bd44a855069cc65802f94af46
+  decisive distributed repair refs present = true
+```
+
+The retained manifest is an execution receipt for those exact input bytes. Future materializer runs may legitimately produce different packet hashes if the packet compiler changes. A worker replay must bind to the manifest whose bytes it actually received.
+
+## WorkerRunReceipt v1
+
+Each external run supplies one bounded JSON object with:
+
+```text
+schema_version = 1
+
+trial_id
+pair_id
+run_id
+condition_id
+sequence_index = 1 | 2
+
+repository
+revision
+target_path
+target_blob_sha
+
+task_sha256
+patch_sha256
+evidence_packet_sha256
+completion_contract_sha256
+
+worker_identity
+harness_identity
+affordance_identity
+sampling_config_sha256
+
+session_id
+fresh_session
+prior_condition_exposure
+checkout_reset_receipt_sha256
+worker_output_sha256
+
+evaluated_outcome
+  success
+  failed
+  correct_escalation
+
+evidence_inspection
+  consulted
+  not_consulted
+  unobservable
+
+context_expanded
+```
+
+`evaluated_outcome` is a harness/evaluator classification. It must be produced from the fixed completion contract and observable worker output/actions. It is not a field the worker gets to declare authoritative about itself.
+
+`worker_output_sha256` binds the normalized receipt back to the preserved raw output. `checkout_reset_receipt_sha256` binds the harness assertion that the repository/worktree was reset for that run.
+
+## Pair admission
+
+Cultist verifies each receipt against the supplied materialized input manifest:
+
+- exact trial/repository/revision/target/blob identity;
+- exact task and patch fingerprints;
+- exact evidence-packet fingerprint for the named condition;
+- exact completion-contract fingerprint;
+- known condition ID.
+
+The pair then checks frozen experimental axes:
+
+```text
+pair identity
+worker identity
+harness identity
+affordance identity
+sampling configuration
+```
+
+and session isolation:
+
+```text
+both runs fresh
+no prior-condition exposure
+unique session IDs
+unique run IDs
+sequence indices exactly {1, 2}
+```
+
+Changing a frozen axis or reusing/contaminating a session yields:
+
+```text
+confounded
+```
+
+Supplying two conditions that do not flip the manifest's `decisive_evidence_present` state yields:
+
+```text
+invalid_evidence_pair
+```
+
+The evaluator determines baseline/treatment roles from the manifest evidence state, not execution order. This allows balanced BA/AB runs later without changing semantics.
+
+## Pair verdicts
+
+For one admitted fresh pair:
+
+```text
+baseline failed
++treatment success
+  -> paired_retirement_signal
+
+baseline correct_escalation
++treatment success
+  -> correct_escalation_then_success
+
+baseline success
+  -> no_demand_observed
+
+otherwise with a valid evidence flip
+  -> demand_persists
+```
+
+A single pair remains a local signal. It does not become replicated causal evidence merely because the JSON validator returned a successful verdict.
+
+The pair output always retains:
+
+```text
+automatic_causal_claim = false
+automatic_generalization = false
+```
+
+## Replay command
+
+After an external harness has produced two admitted run receipts:
+
+```text
+cargo run --example capability_demand_retirement -- \
+  research/capability-demand-retirement/stensibly-convex-index-review-v1.json \
+  trial-input-manifest.json \
+  run-a.json \
+  run-b.json
+```
+
+The manifest should be the exact materialized manifest used to supply the worker packets, not a hand-retyped approximation.
+
+## Why Cultist stops here
+
+Model execution belongs to the harness/provider layer because a valid #238 replay needs:
+
+- genuinely fresh sessions;
+- fixed worker/model and sampling configuration;
+- fixed tool affordances;
+- raw output preservation;
+- no cross-condition memory;
+- later replication under balanced/randomized condition order.
+
+Cultist's role is to make that experiment independently auditable from repository evidence and exact receipts.
+
+This also keeps provider credentials, billing, retry policy, and model-routing authority outside the repository-analysis core.
+
+## Boundary
+
+- research only;
+- no primary `cargo-cultist` CLI change;
+- no provider/model SDK;
+- no API key or secret handling;
+- no private chain-of-thought;
+- no prose-similarity completion judge;
+- no automatic capability ranking;
+- no authority grant from successful task completion;
+- synthetic unit-test receipts are never promoted as executed worker evidence.
+
+North star:
+
+> Make a worker A/B replay easy to audit and hard to accidentally confound before spending any interpretation on the result.

--- a/research/capability-demand-retirement/stensibly-convex-index-review-v1-input-manifest-32264661913.json
+++ b/research/capability-demand-retirement/stensibly-convex-index-review-v1-input-manifest-32264661913.json
@@ -1,0 +1,44 @@
+{
+  "conditions": {
+    "file_local_jei": {
+      "decisive_evidence_present": false,
+      "packet": {
+        "bytes": 14086,
+        "sha256": "e4549a10f86448779a21307d97ea75f2ae1acfd15b43099cbca6f600f0781bdf"
+      }
+    },
+    "scoped_jei": {
+      "decisive_evidence_present": true,
+      "decisive_evidence_refs": [
+        "ca5d2c7fdf89666e523972ab6e81610d17b9611b",
+        "85cecf2608ad9e734a67518577fa85b9a08a550c"
+      ],
+      "packet": {
+        "bytes": 18795,
+        "sha256": "2e6acd81e324f3b290b9f93c5bf0ec3d9a66004bd44a855069cc65802f94af46"
+      }
+    }
+  },
+  "evaluator_only": {
+    "oracle": {
+      "bytes": 322,
+      "sha256": "bce60719e97d861a9223661d349b3171ee3eafb3f87e9042999a32a6bd39771b"
+    }
+  },
+  "repository": "teamleaderleo/stensibly",
+  "revision": "85cecf2608ad9e734a67518577fa85b9a08a550c",
+  "schema_version": 1,
+  "target_blob_sha": "7fdd51e2f9fba80d1c0a814cea708d601a7b9925",
+  "target_path": "convex/schema.ts",
+  "trial_id": "stensibly-convex-index-review-v1",
+  "worker_visible_common": {
+    "patch": {
+      "bytes": 321,
+      "sha256": "647281f95818f22784c7468e208bd2b9b5cb2c34ecb38be4b929cf4019c89ba5"
+    },
+    "task": {
+      "bytes": 223,
+      "sha256": "84aaf8f8d3b6880017d25432c763fea5732306117144fc37415992969754f873"
+    }
+  }
+}

--- a/src/capability_demand_retirement.rs
+++ b/src/capability_demand_retirement.rs
@@ -1,0 +1,574 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+pub const MAX_TRIAL_SPEC_BYTES: usize = 128 * 1024;
+pub const MAX_TRIAL_MANIFEST_BYTES: usize = 128 * 1024;
+pub const MAX_RUN_RECEIPT_BYTES: usize = 128 * 1024;
+
+const MAX_ID_BYTES: usize = 256;
+const MAX_PATH_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrialSpec {
+    pub schema_version: u32,
+    pub trial_id: String,
+    pub repository: String,
+    pub revision: String,
+    pub target_path: String,
+    pub target_blob_sha: String,
+    pub worker_task: WorkerTask,
+    pub oracle: Oracle,
+    pub conditions: Vec<TrialCondition>,
+    pub oracle_leak_control: OracleLeakControl,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkerTask {
+    pub prompt: String,
+    pub patch: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Oracle {
+    pub expected_disposition: String,
+    pub blocking_reason: String,
+    pub max_identifier_length: usize,
+    pub proposed_identifier: String,
+    pub proposed_identifier_length: usize,
+    pub corrective_action: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PacketKind {
+    FileLocal,
+    Scoped,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrialCondition {
+    pub id: String,
+    pub packet_kind: PacketKind,
+    pub budget_bytes: usize,
+    pub scope: Option<String>,
+    pub decisive_evidence_present: bool,
+    pub decisive_evidence_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OracleLeakControl {
+    pub historical_issue: String,
+    pub allowed_as_worker_prompt: bool,
+    pub prohibited_worker_prompt_fragments: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactDigest {
+    pub sha256: String,
+    pub bytes: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrialInputManifest {
+    pub schema_version: u32,
+    pub trial_id: String,
+    pub repository: String,
+    pub revision: String,
+    pub target_path: String,
+    pub target_blob_sha: String,
+    pub worker_visible_common: WorkerVisibleCommon,
+    pub evaluator_only: EvaluatorOnly,
+    pub conditions: BTreeMap<String, ManifestCondition>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkerVisibleCommon {
+    pub task: ArtifactDigest,
+    pub patch: ArtifactDigest,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvaluatorOnly {
+    pub oracle: ArtifactDigest,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ManifestCondition {
+    pub packet: ArtifactDigest,
+    pub decisive_evidence_present: bool,
+    #[serde(default)]
+    pub decisive_evidence_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunOutcome {
+    Success,
+    Failed,
+    CorrectEscalation,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceInspection {
+    Consulted,
+    NotConsulted,
+    Unobservable,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkerRunReceipt {
+    pub schema_version: u32,
+    pub trial_id: String,
+    pub pair_id: String,
+    pub run_id: String,
+    pub condition_id: String,
+    pub sequence_index: u32,
+    pub repository: String,
+    pub revision: String,
+    pub target_path: String,
+    pub target_blob_sha: String,
+    pub task_sha256: String,
+    pub patch_sha256: String,
+    pub evidence_packet_sha256: String,
+    pub completion_contract_sha256: String,
+    pub worker_identity: String,
+    pub harness_identity: String,
+    pub affordance_identity: String,
+    pub sampling_config_sha256: String,
+    pub session_id: String,
+    pub fresh_session: bool,
+    pub prior_condition_exposure: bool,
+    pub checkout_reset_receipt_sha256: String,
+    pub worker_output_sha256: String,
+    pub evaluated_outcome: RunOutcome,
+    pub evidence_inspection: EvidenceInspection,
+    pub context_expanded: bool,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetirementVerdict {
+    PairedRetirementSignal,
+    CorrectEscalationThenSuccess,
+    NoDemandObserved,
+    DemandPersists,
+    Confounded,
+    InvalidEvidencePair,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PairEvaluation {
+    pub schema_version: u32,
+    pub trial_id: String,
+    pub pair_id: String,
+    pub condition_ids: Vec<String>,
+    pub verdict: RetirementVerdict,
+    pub frozen_identity_match: bool,
+    pub fresh_uncontaminated_sessions: bool,
+    pub decisive_evidence_flip: bool,
+    pub baseline_condition_id: Option<String>,
+    pub treatment_condition_id: Option<String>,
+    pub baseline_outcome: Option<RunOutcome>,
+    pub treatment_outcome: Option<RunOutcome>,
+    pub baseline_evidence_inspection: Option<EvidenceInspection>,
+    pub treatment_evidence_inspection: Option<EvidenceInspection>,
+    pub baseline_context_expanded: Option<bool>,
+    pub treatment_context_expanded: Option<bool>,
+    pub automatic_causal_claim: bool,
+    pub automatic_generalization: bool,
+}
+
+pub fn parse_trial_spec(input: &[u8]) -> Result<TrialSpec, String> {
+    ensure_bounded(input, MAX_TRIAL_SPEC_BYTES, "trial spec")?;
+    let spec: TrialSpec = serde_json::from_slice(input).map_err(|error| error.to_string())?;
+    validate_trial_spec(&spec)?;
+    Ok(spec)
+}
+
+pub fn parse_trial_manifest(input: &[u8]) -> Result<TrialInputManifest, String> {
+    ensure_bounded(input, MAX_TRIAL_MANIFEST_BYTES, "trial input manifest")?;
+    let manifest: TrialInputManifest =
+        serde_json::from_slice(input).map_err(|error| error.to_string())?;
+    validate_manifest(&manifest)?;
+    Ok(manifest)
+}
+
+pub fn parse_run_receipt(input: &[u8]) -> Result<WorkerRunReceipt, String> {
+    ensure_bounded(input, MAX_RUN_RECEIPT_BYTES, "worker run receipt")?;
+    let receipt: WorkerRunReceipt =
+        serde_json::from_slice(input).map_err(|error| error.to_string())?;
+    validate_run_receipt(&receipt)?;
+    Ok(receipt)
+}
+
+pub fn evaluate_pair(
+    spec: &TrialSpec,
+    manifest: &TrialInputManifest,
+    first: &WorkerRunReceipt,
+    second: &WorkerRunReceipt,
+) -> Result<PairEvaluation, String> {
+    validate_manifest_against_spec(spec, manifest)?;
+    validate_receipt_against_manifest(first, manifest)?;
+    validate_receipt_against_manifest(second, manifest)?;
+
+    let first_condition = manifest
+        .conditions
+        .get(&first.condition_id)
+        .ok_or_else(|| format!("unknown first condition {}", first.condition_id))?;
+    let second_condition = manifest
+        .conditions
+        .get(&second.condition_id)
+        .ok_or_else(|| format!("unknown second condition {}", second.condition_id))?;
+
+    let decisive_evidence_flip = first.condition_id != second.condition_id
+        && first_condition.decisive_evidence_present != second_condition.decisive_evidence_present;
+
+    let (baseline, treatment) = if decisive_evidence_flip {
+        if first_condition.decisive_evidence_present {
+            (second, first)
+        } else {
+            (first, second)
+        }
+    } else {
+        (first, second)
+    };
+
+    let frozen_identity_match = same_frozen_identity(first, second);
+    let fresh_uncontaminated_sessions = first.fresh_session
+        && second.fresh_session
+        && !first.prior_condition_exposure
+        && !second.prior_condition_exposure
+        && first.session_id != second.session_id
+        && first.run_id != second.run_id
+        && first.sequence_index != second.sequence_index
+        && BTreeSet::from([first.sequence_index, second.sequence_index]) == BTreeSet::from([1, 2]);
+
+    let verdict = if !frozen_identity_match || !fresh_uncontaminated_sessions {
+        RetirementVerdict::Confounded
+    } else if !decisive_evidence_flip {
+        RetirementVerdict::InvalidEvidencePair
+    } else {
+        match (baseline.evaluated_outcome, treatment.evaluated_outcome) {
+            (RunOutcome::Failed, RunOutcome::Success) => {
+                RetirementVerdict::PairedRetirementSignal
+            }
+            (RunOutcome::CorrectEscalation, RunOutcome::Success) => {
+                RetirementVerdict::CorrectEscalationThenSuccess
+            }
+            (RunOutcome::Success, _) => RetirementVerdict::NoDemandObserved,
+            _ => RetirementVerdict::DemandPersists,
+        }
+    };
+
+    let has_roles = decisive_evidence_flip;
+    Ok(PairEvaluation {
+        schema_version: 1,
+        trial_id: manifest.trial_id.clone(),
+        pair_id: first.pair_id.clone(),
+        condition_ids: vec![first.condition_id.clone(), second.condition_id.clone()],
+        verdict,
+        frozen_identity_match,
+        fresh_uncontaminated_sessions,
+        decisive_evidence_flip,
+        baseline_condition_id: has_roles.then(|| baseline.condition_id.clone()),
+        treatment_condition_id: has_roles.then(|| treatment.condition_id.clone()),
+        baseline_outcome: has_roles.then_some(baseline.evaluated_outcome),
+        treatment_outcome: has_roles.then_some(treatment.evaluated_outcome),
+        baseline_evidence_inspection: has_roles.then_some(baseline.evidence_inspection),
+        treatment_evidence_inspection: has_roles.then_some(treatment.evidence_inspection),
+        baseline_context_expanded: has_roles.then_some(baseline.context_expanded),
+        treatment_context_expanded: has_roles.then_some(treatment.context_expanded),
+        automatic_causal_claim: false,
+        automatic_generalization: false,
+    })
+}
+
+fn validate_trial_spec(spec: &TrialSpec) -> Result<(), String> {
+    if spec.schema_version != 1 {
+        return Err(format!("unsupported trial schema version {}", spec.schema_version));
+    }
+    validate_id(&spec.trial_id, "trial_id")?;
+    validate_id(&spec.repository, "repository")?;
+    validate_git_sha(&spec.revision, "revision")?;
+    validate_path(&spec.target_path, "target_path")?;
+    validate_git_sha(&spec.target_blob_sha, "target_blob_sha")?;
+    if spec.worker_task.prompt.is_empty() || spec.worker_task.patch.is_empty() {
+        return Err("worker task prompt and patch must be non-empty".into());
+    }
+    if spec.conditions.len() < 2 || spec.conditions.len() > 32 {
+        return Err("trial must contain 2..32 conditions".into());
+    }
+    let mut ids = BTreeSet::new();
+    for condition in &spec.conditions {
+        validate_id(&condition.id, "condition id")?;
+        if !ids.insert(condition.id.as_str()) {
+            return Err(format!("duplicate trial condition {}", condition.id));
+        }
+        if condition.budget_bytes == 0 || condition.budget_bytes > 16 * 1024 * 1024 {
+            return Err(format!("condition {} has invalid budget", condition.id));
+        }
+        if condition.decisive_evidence_present && condition.decisive_evidence_refs.is_empty() {
+            return Err(format!(
+                "condition {} marks decisive evidence present without refs",
+                condition.id
+            ));
+        }
+        if !condition.decisive_evidence_present && !condition.decisive_evidence_refs.is_empty() {
+            return Err(format!(
+                "condition {} marks decisive evidence absent but retains refs",
+                condition.id
+            ));
+        }
+        for reference in &condition.decisive_evidence_refs {
+            validate_git_sha(reference, "decisive evidence ref")?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_manifest(manifest: &TrialInputManifest) -> Result<(), String> {
+    if manifest.schema_version != 1 {
+        return Err(format!(
+            "unsupported trial input manifest schema version {}",
+            manifest.schema_version
+        ));
+    }
+    validate_id(&manifest.trial_id, "trial_id")?;
+    validate_id(&manifest.repository, "repository")?;
+    validate_git_sha(&manifest.revision, "revision")?;
+    validate_path(&manifest.target_path, "target_path")?;
+    validate_git_sha(&manifest.target_blob_sha, "target_blob_sha")?;
+    validate_artifact_digest(&manifest.worker_visible_common.task, "task")?;
+    validate_artifact_digest(&manifest.worker_visible_common.patch, "patch")?;
+    validate_artifact_digest(&manifest.evaluator_only.oracle, "oracle")?;
+    if manifest.conditions.len() < 2 || manifest.conditions.len() > 32 {
+        return Err("trial input manifest must contain 2..32 conditions".into());
+    }
+    for (id, condition) in &manifest.conditions {
+        validate_id(id, "condition id")?;
+        validate_artifact_digest(&condition.packet, "condition packet")?;
+        if condition.decisive_evidence_present && condition.decisive_evidence_refs.is_empty() {
+            return Err(format!(
+                "manifest condition {id} marks decisive evidence present without refs"
+            ));
+        }
+        if !condition.decisive_evidence_present && !condition.decisive_evidence_refs.is_empty() {
+            return Err(format!(
+                "manifest condition {id} marks decisive evidence absent but retains refs"
+            ));
+        }
+        for reference in &condition.decisive_evidence_refs {
+            validate_git_sha(reference, "decisive evidence ref")?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_manifest_against_spec(
+    spec: &TrialSpec,
+    manifest: &TrialInputManifest,
+) -> Result<(), String> {
+    if spec.trial_id != manifest.trial_id
+        || spec.repository != manifest.repository
+        || spec.revision != manifest.revision
+        || spec.target_path != manifest.target_path
+        || spec.target_blob_sha != manifest.target_blob_sha
+    {
+        return Err("trial input manifest does not match frozen trial identity".into());
+    }
+
+    let spec_conditions = spec
+        .conditions
+        .iter()
+        .map(|condition| (condition.id.as_str(), condition))
+        .collect::<BTreeMap<_, _>>();
+    if spec_conditions.len() != manifest.conditions.len() {
+        return Err("trial condition set differs between spec and manifest".into());
+    }
+    for (id, condition) in &manifest.conditions {
+        let expected = spec_conditions
+            .get(id.as_str())
+            .ok_or_else(|| format!("manifest contains undeclared condition {id}"))?;
+        if expected.decisive_evidence_present != condition.decisive_evidence_present {
+            return Err(format!("condition {id} decisive-evidence state drifted"));
+        }
+        let expected_refs = expected
+            .decisive_evidence_refs
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        let manifest_refs = condition
+            .decisive_evidence_refs
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        if expected_refs != manifest_refs {
+            return Err(format!("condition {id} decisive-evidence refs drifted"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_run_receipt(receipt: &WorkerRunReceipt) -> Result<(), String> {
+    if receipt.schema_version != 1 {
+        return Err(format!(
+            "unsupported worker run receipt schema version {}",
+            receipt.schema_version
+        ));
+    }
+    for (value, field) in [
+        (&receipt.trial_id, "trial_id"),
+        (&receipt.pair_id, "pair_id"),
+        (&receipt.run_id, "run_id"),
+        (&receipt.condition_id, "condition_id"),
+        (&receipt.repository, "repository"),
+        (&receipt.worker_identity, "worker_identity"),
+        (&receipt.harness_identity, "harness_identity"),
+        (&receipt.affordance_identity, "affordance_identity"),
+        (&receipt.session_id, "session_id"),
+    ] {
+        validate_id(value, field)?;
+    }
+    if !(1..=2).contains(&receipt.sequence_index) {
+        return Err("sequence_index must be 1 or 2 for a paired replay".into());
+    }
+    validate_git_sha(&receipt.revision, "revision")?;
+    validate_path(&receipt.target_path, "target_path")?;
+    validate_git_sha(&receipt.target_blob_sha, "target_blob_sha")?;
+    for (value, field) in [
+        (&receipt.task_sha256, "task_sha256"),
+        (&receipt.patch_sha256, "patch_sha256"),
+        (&receipt.evidence_packet_sha256, "evidence_packet_sha256"),
+        (
+            &receipt.completion_contract_sha256,
+            "completion_contract_sha256",
+        ),
+        (&receipt.sampling_config_sha256, "sampling_config_sha256"),
+        (
+            &receipt.checkout_reset_receipt_sha256,
+            "checkout_reset_receipt_sha256",
+        ),
+        (&receipt.worker_output_sha256, "worker_output_sha256"),
+    ] {
+        validate_sha256(value, field)?;
+    }
+    Ok(())
+}
+
+fn validate_receipt_against_manifest(
+    receipt: &WorkerRunReceipt,
+    manifest: &TrialInputManifest,
+) -> Result<(), String> {
+    if receipt.trial_id != manifest.trial_id
+        || receipt.repository != manifest.repository
+        || receipt.revision != manifest.revision
+        || receipt.target_path != manifest.target_path
+        || receipt.target_blob_sha != manifest.target_blob_sha
+    {
+        return Err(format!(
+            "run {} does not match the frozen trial coordinate",
+            receipt.run_id
+        ));
+    }
+    if receipt.task_sha256 != manifest.worker_visible_common.task.sha256
+        || receipt.patch_sha256 != manifest.worker_visible_common.patch.sha256
+        || receipt.completion_contract_sha256 != manifest.evaluator_only.oracle.sha256
+    {
+        return Err(format!(
+            "run {} does not match frozen task/patch/completion fingerprints",
+            receipt.run_id
+        ));
+    }
+    let condition = manifest
+        .conditions
+        .get(&receipt.condition_id)
+        .ok_or_else(|| format!("run {} names unknown condition", receipt.run_id))?;
+    if receipt.evidence_packet_sha256 != condition.packet.sha256 {
+        return Err(format!(
+            "run {} evidence packet fingerprint does not match condition {}",
+            receipt.run_id, receipt.condition_id
+        ));
+    }
+    Ok(())
+}
+
+fn same_frozen_identity(first: &WorkerRunReceipt, second: &WorkerRunReceipt) -> bool {
+    first.pair_id == second.pair_id
+        && first.trial_id == second.trial_id
+        && first.repository == second.repository
+        && first.revision == second.revision
+        && first.target_path == second.target_path
+        && first.target_blob_sha == second.target_blob_sha
+        && first.task_sha256 == second.task_sha256
+        && first.patch_sha256 == second.patch_sha256
+        && first.completion_contract_sha256 == second.completion_contract_sha256
+        && first.worker_identity == second.worker_identity
+        && first.harness_identity == second.harness_identity
+        && first.affordance_identity == second.affordance_identity
+        && first.sampling_config_sha256 == second.sampling_config_sha256
+}
+
+fn validate_artifact_digest(digest: &ArtifactDigest, field: &str) -> Result<(), String> {
+    validate_sha256(&digest.sha256, &format!("{field}.sha256"))?;
+    if digest.bytes == 0 || digest.bytes > 16 * 1024 * 1024 {
+        return Err(format!("{field}.bytes is outside admitted boundary"));
+    }
+    Ok(())
+}
+
+fn ensure_bounded(input: &[u8], maximum: usize, field: &str) -> Result<(), String> {
+    if input.len() > maximum {
+        return Err(format!("{field} exceeds {maximum} bytes"));
+    }
+    Ok(())
+}
+
+fn validate_id(value: &str, field: &str) -> Result<(), String> {
+    if value.is_empty() || value.len() > MAX_ID_BYTES {
+        return Err(format!("{field} must contain 1..{MAX_ID_BYTES} bytes"));
+    }
+    Ok(())
+}
+
+fn validate_path(value: &str, field: &str) -> Result<(), String> {
+    if value.is_empty()
+        || value.len() > MAX_PATH_BYTES
+        || value.starts_with('/')
+        || value.starts_with("./")
+        || value.ends_with('/')
+        || value.contains('\\')
+        || value.split('/').any(|part| part.is_empty() || part == "." || part == "..")
+    {
+        return Err(format!("{field} must be a canonical repository-relative path"));
+    }
+    Ok(())
+}
+
+fn validate_git_sha(value: &str, field: &str) -> Result<(), String> {
+    validate_hex(value, 40, field)
+}
+
+fn validate_sha256(value: &str, field: &str) -> Result<(), String> {
+    validate_hex(value, 64, field)
+}
+
+fn validate_hex(value: &str, length: usize, field: &str) -> Result<(), String> {
+    if value.len() != length || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(format!("{field} must be exactly {length} hexadecimal characters"));
+    }
+    Ok(())
+}

--- a/src/capability_demand_retirement.rs
+++ b/src/capability_demand_retirement.rs
@@ -263,9 +263,7 @@ pub fn evaluate_pair(
         RetirementVerdict::InvalidEvidencePair
     } else {
         match (baseline.evaluated_outcome, treatment.evaluated_outcome) {
-            (RunOutcome::Failed, RunOutcome::Success) => {
-                RetirementVerdict::PairedRetirementSignal
-            }
+            (RunOutcome::Failed, RunOutcome::Success) => RetirementVerdict::PairedRetirementSignal,
             (RunOutcome::CorrectEscalation, RunOutcome::Success) => {
                 RetirementVerdict::CorrectEscalationThenSuccess
             }
@@ -299,7 +297,10 @@ pub fn evaluate_pair(
 
 fn validate_trial_spec(spec: &TrialSpec) -> Result<(), String> {
     if spec.schema_version != 1 {
-        return Err(format!("unsupported trial schema version {}", spec.schema_version));
+        return Err(format!(
+            "unsupported trial schema version {}",
+            spec.schema_version
+        ));
     }
     validate_id(&spec.trial_id, "trial_id")?;
     validate_id(&spec.repository, "repository")?;
@@ -551,9 +552,13 @@ fn validate_path(value: &str, field: &str) -> Result<(), String> {
         || value.starts_with("./")
         || value.ends_with('/')
         || value.contains('\\')
-        || value.split('/').any(|part| part.is_empty() || part == "." || part == "..")
+        || value
+            .split('/')
+            .any(|part| part.is_empty() || part == "." || part == "..")
     {
-        return Err(format!("{field} must be a canonical repository-relative path"));
+        return Err(format!(
+            "{field} must be a canonical repository-relative path"
+        ));
     }
     Ok(())
 }
@@ -568,7 +573,9 @@ fn validate_sha256(value: &str, field: &str) -> Result<(), String> {
 
 fn validate_hex(value: &str, length: usize, field: &str) -> Result<(), String> {
     if value.len() != length || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        return Err(format!("{field} must be exactly {length} hexadecimal characters"));
+        return Err(format!(
+            "{field} must be exactly {length} hexadecimal characters"
+        ));
     }
     Ok(())
 }

--- a/tests/capability_demand_retirement_receipts.rs
+++ b/tests/capability_demand_retirement_receipts.rs
@@ -1,0 +1,210 @@
+#[path = "../src/capability_demand_retirement.rs"]
+mod capability_demand_retirement;
+
+use capability_demand_retirement::{
+    EvidenceInspection, RetirementVerdict, RunOutcome, WorkerRunReceipt, evaluate_pair,
+    parse_trial_manifest, parse_trial_spec,
+};
+
+const TRIAL: &[u8] = include_bytes!(
+    "../research/capability-demand-retirement/stensibly-convex-index-review-v1.json"
+);
+const MANIFEST: &[u8] = include_bytes!(
+    "../research/capability-demand-retirement/stensibly-convex-index-review-v1-input-manifest-32264661913.json"
+);
+
+const TASK_SHA: &str = "84aaf8f8d3b6880017d25432c763fea5732306117144fc37415992969754f873";
+const PATCH_SHA: &str = "647281f95818f22784c7468e208bd2b9b5cb2c34ecb38be4b929cf4019c89ba5";
+const ORACLE_SHA: &str = "bce60719e97d861a9223661d349b3171ee3eafb3f87e9042999a32a6bd39771b";
+const BASELINE_PACKET_SHA: &str =
+    "e4549a10f86448779a21307d97ea75f2ae1acfd15b43099cbca6f600f0781bdf";
+const TREATMENT_PACKET_SHA: &str =
+    "2e6acd81e324f3b290b9f93c5bf0ec3d9a66004bd44a855069cc65802f94af46";
+const SAMPLING_SHA: &str =
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const RESET_SHA: &str =
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const OUTPUT_SHA: &str =
+    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+fn trial_and_manifest() -> (
+    capability_demand_retirement::TrialSpec,
+    capability_demand_retirement::TrialInputManifest,
+) {
+    (
+        parse_trial_spec(TRIAL).expect("valid retained trial"),
+        parse_trial_manifest(MANIFEST).expect("valid retained manifest"),
+    )
+}
+
+fn receipt(condition: &str, sequence_index: u32, outcome: RunOutcome) -> WorkerRunReceipt {
+    let packet = match condition {
+        "file_local_jei" => BASELINE_PACKET_SHA,
+        "scoped_jei" => TREATMENT_PACKET_SHA,
+        _ => panic!("unknown fixture condition"),
+    };
+    WorkerRunReceipt {
+        schema_version: 1,
+        trial_id: "stensibly-convex-index-review-v1".into(),
+        pair_id: "pair-001".into(),
+        run_id: format!("run-{sequence_index}"),
+        condition_id: condition.into(),
+        sequence_index,
+        repository: "teamleaderleo/stensibly".into(),
+        revision: "85cecf2608ad9e734a67518577fa85b9a08a550c".into(),
+        target_path: "convex/schema.ts".into(),
+        target_blob_sha: "7fdd51e2f9fba80d1c0a814cea708d601a7b9925".into(),
+        task_sha256: TASK_SHA.into(),
+        patch_sha256: PATCH_SHA.into(),
+        evidence_packet_sha256: packet.into(),
+        completion_contract_sha256: ORACLE_SHA.into(),
+        worker_identity: "fixed-worker@v1".into(),
+        harness_identity: "review-harness@v1".into(),
+        affordance_identity: "read-only-repository-review@v1".into(),
+        sampling_config_sha256: SAMPLING_SHA.into(),
+        session_id: format!("session-{sequence_index}"),
+        fresh_session: true,
+        prior_condition_exposure: false,
+        checkout_reset_receipt_sha256: RESET_SHA.into(),
+        worker_output_sha256: OUTPUT_SHA.into(),
+        evaluated_outcome: outcome,
+        evidence_inspection: EvidenceInspection::Unobservable,
+        context_expanded: false,
+    }
+}
+
+#[test]
+fn retained_manifest_binds_the_executed_input_artifacts() {
+    let (trial, manifest) = trial_and_manifest();
+    assert_eq!(manifest.trial_id, trial.trial_id);
+    assert_eq!(manifest.worker_visible_common.task.sha256, TASK_SHA);
+    assert_eq!(manifest.worker_visible_common.task.bytes, 223);
+    assert_eq!(manifest.worker_visible_common.patch.sha256, PATCH_SHA);
+    assert_eq!(manifest.worker_visible_common.patch.bytes, 321);
+    assert_eq!(manifest.evaluator_only.oracle.sha256, ORACLE_SHA);
+    assert_eq!(manifest.evaluator_only.oracle.bytes, 322);
+    assert_eq!(
+        manifest.conditions["file_local_jei"].packet.sha256,
+        BASELINE_PACKET_SHA
+    );
+    assert_eq!(manifest.conditions["file_local_jei"].packet.bytes, 14_086);
+    assert!(!manifest.conditions["file_local_jei"].decisive_evidence_present);
+    assert_eq!(
+        manifest.conditions["scoped_jei"].packet.sha256,
+        TREATMENT_PACKET_SHA
+    );
+    assert_eq!(manifest.conditions["scoped_jei"].packet.bytes, 18_795);
+    assert!(manifest.conditions["scoped_jei"].decisive_evidence_present);
+}
+
+#[test]
+fn failed_baseline_then_successful_treatment_is_a_paired_signal() {
+    let (trial, manifest) = trial_and_manifest();
+    let baseline = receipt("file_local_jei", 1, RunOutcome::Failed);
+    let treatment = receipt("scoped_jei", 2, RunOutcome::Success);
+    let result = evaluate_pair(&trial, &manifest, &baseline, &treatment).unwrap();
+
+    assert_eq!(result.verdict, RetirementVerdict::PairedRetirementSignal);
+    assert_eq!(result.baseline_condition_id.as_deref(), Some("file_local_jei"));
+    assert_eq!(result.treatment_condition_id.as_deref(), Some("scoped_jei"));
+    assert!(result.frozen_identity_match);
+    assert!(result.fresh_uncontaminated_sessions);
+    assert!(result.decisive_evidence_flip);
+    assert!(!result.automatic_causal_claim);
+    assert!(!result.automatic_generalization);
+}
+
+#[test]
+fn pair_order_does_not_define_baseline_and_treatment_roles() {
+    let (trial, manifest) = trial_and_manifest();
+    let treatment = receipt("scoped_jei", 1, RunOutcome::Success);
+    let baseline = receipt("file_local_jei", 2, RunOutcome::Failed);
+    let result = evaluate_pair(&trial, &manifest, &treatment, &baseline).unwrap();
+
+    assert_eq!(result.verdict, RetirementVerdict::PairedRetirementSignal);
+    assert_eq!(result.baseline_condition_id.as_deref(), Some("file_local_jei"));
+    assert_eq!(result.treatment_condition_id.as_deref(), Some("scoped_jei"));
+}
+
+#[test]
+fn baseline_success_means_no_success_demand_was_observed() {
+    let (trial, manifest) = trial_and_manifest();
+    let baseline = receipt("file_local_jei", 1, RunOutcome::Success);
+    let treatment = receipt("scoped_jei", 2, RunOutcome::Success);
+    let result = evaluate_pair(&trial, &manifest, &baseline, &treatment).unwrap();
+    assert_eq!(result.verdict, RetirementVerdict::NoDemandObserved);
+}
+
+#[test]
+fn correct_escalation_then_success_is_preserved_separately() {
+    let (trial, manifest) = trial_and_manifest();
+    let baseline = receipt("file_local_jei", 1, RunOutcome::CorrectEscalation);
+    let treatment = receipt("scoped_jei", 2, RunOutcome::Success);
+    let result = evaluate_pair(&trial, &manifest, &baseline, &treatment).unwrap();
+    assert_eq!(
+        result.verdict,
+        RetirementVerdict::CorrectEscalationThenSuccess
+    );
+}
+
+#[test]
+fn treatment_failure_preserves_demand() {
+    let (trial, manifest) = trial_and_manifest();
+    let baseline = receipt("file_local_jei", 1, RunOutcome::Failed);
+    let treatment = receipt("scoped_jei", 2, RunOutcome::Failed);
+    let result = evaluate_pair(&trial, &manifest, &baseline, &treatment).unwrap();
+    assert_eq!(result.verdict, RetirementVerdict::DemandPersists);
+}
+
+#[test]
+fn worker_or_harness_identity_drift_confounds_the_pair() {
+    let (trial, manifest) = trial_and_manifest();
+    let baseline = receipt("file_local_jei", 1, RunOutcome::Failed);
+    let mut treatment = receipt("scoped_jei", 2, RunOutcome::Success);
+    treatment.worker_identity = "different-worker@v1".into();
+    let result = evaluate_pair(&trial, &manifest, &baseline, &treatment).unwrap();
+    assert_eq!(result.verdict, RetirementVerdict::Confounded);
+
+    let mut treatment = receipt("scoped_jei", 2, RunOutcome::Success);
+    treatment.harness_identity = "different-harness@v1".into();
+    let result = evaluate_pair(&trial, &manifest, &baseline, &treatment).unwrap();
+    assert_eq!(result.verdict, RetirementVerdict::Confounded);
+}
+
+#[test]
+fn reused_or_treatment_contaminated_sessions_confound_the_pair() {
+    let (trial, manifest) = trial_and_manifest();
+    let baseline = receipt("file_local_jei", 1, RunOutcome::Failed);
+    let mut treatment = receipt("scoped_jei", 2, RunOutcome::Success);
+    treatment.session_id = baseline.session_id.clone();
+    let result = evaluate_pair(&trial, &manifest, &baseline, &treatment).unwrap();
+    assert_eq!(result.verdict, RetirementVerdict::Confounded);
+
+    let mut treatment = receipt("scoped_jei", 2, RunOutcome::Success);
+    treatment.prior_condition_exposure = true;
+    let result = evaluate_pair(&trial, &manifest, &baseline, &treatment).unwrap();
+    assert_eq!(result.verdict, RetirementVerdict::Confounded);
+}
+
+#[test]
+fn same_condition_twice_is_invalid_evidence_pair() {
+    let (trial, manifest) = trial_and_manifest();
+    let first = receipt("file_local_jei", 1, RunOutcome::Failed);
+    let second = receipt("file_local_jei", 2, RunOutcome::Success);
+    let result = evaluate_pair(&trial, &manifest, &first, &second).unwrap();
+    assert_eq!(result.verdict, RetirementVerdict::InvalidEvidencePair);
+    assert!(!result.decisive_evidence_flip);
+    assert!(result.baseline_condition_id.is_none());
+    assert!(result.treatment_condition_id.is_none());
+}
+
+#[test]
+fn packet_fingerprint_tampering_rejects_before_pair_interpretation() {
+    let (trial, manifest) = trial_and_manifest();
+    let baseline = receipt("file_local_jei", 1, RunOutcome::Failed);
+    let mut treatment = receipt("scoped_jei", 2, RunOutcome::Success);
+    treatment.evidence_packet_sha256 = BASELINE_PACKET_SHA.into();
+
+    let error = evaluate_pair(&trial, &manifest, &baseline, &treatment).unwrap_err();
+    assert!(error.contains("evidence packet fingerprint"));
+}

--- a/tests/capability_demand_retirement_receipts.rs
+++ b/tests/capability_demand_retirement_receipts.rs
@@ -20,12 +20,9 @@ const BASELINE_PACKET_SHA: &str =
     "e4549a10f86448779a21307d97ea75f2ae1acfd15b43099cbca6f600f0781bdf";
 const TREATMENT_PACKET_SHA: &str =
     "2e6acd81e324f3b290b9f93c5bf0ec3d9a66004bd44a855069cc65802f94af46";
-const SAMPLING_SHA: &str =
-    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-const RESET_SHA: &str =
-    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-const OUTPUT_SHA: &str =
-    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+const SAMPLING_SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const RESET_SHA: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const OUTPUT_SHA: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
 
 fn trial_and_manifest() -> (
     capability_demand_retirement::TrialSpec,
@@ -105,7 +102,10 @@ fn failed_baseline_then_successful_treatment_is_a_paired_signal() {
     let result = evaluate_pair(&trial, &manifest, &baseline, &treatment).unwrap();
 
     assert_eq!(result.verdict, RetirementVerdict::PairedRetirementSignal);
-    assert_eq!(result.baseline_condition_id.as_deref(), Some("file_local_jei"));
+    assert_eq!(
+        result.baseline_condition_id.as_deref(),
+        Some("file_local_jei")
+    );
     assert_eq!(result.treatment_condition_id.as_deref(), Some("scoped_jei"));
     assert!(result.frozen_identity_match);
     assert!(result.fresh_uncontaminated_sessions);
@@ -122,7 +122,10 @@ fn pair_order_does_not_define_baseline_and_treatment_roles() {
     let result = evaluate_pair(&trial, &manifest, &treatment, &baseline).unwrap();
 
     assert_eq!(result.verdict, RetirementVerdict::PairedRetirementSignal);
-    assert_eq!(result.baseline_condition_id.as_deref(), Some("file_local_jei"));
+    assert_eq!(
+        result.baseline_condition_id.as_deref(),
+        Some("file_local_jei")
+    );
     assert_eq!(result.treatment_condition_id.as_deref(), Some("scoped_jei"));
 }
 

--- a/tests/capability_demand_retirement_receipts.rs
+++ b/tests/capability_demand_retirement_receipts.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 #[path = "../src/capability_demand_retirement.rs"]
 mod capability_demand_retirement;
 


### PR DESCRIPTION
Progresses #238 by turning the landed non-leaky Stensibly trial into an externally executable research boundary without embedding any model/provider SDK in Cultist.

## What this adds

A reusable research evaluator accepts:

```text
TRIAL.json
materialized INPUT_MANIFEST.json
RUN_A.json
RUN_B.json
```

and emits one typed pair verdict.

The worker calls remain outside Cultist. The repository owns admission and interpretation of exact receipts.

## Run receipt v1

Each run binds:

- exact trial/repository/revision/target/blob;
- exact shared task + patch hashes;
- exact condition packet hash;
- exact completion-contract/oracle hash;
- worker, harness, affordance, and sampling identities;
- pair/run/session identities and sequence position;
- fresh-session + prior-condition-exposure state;
- checkout-reset receipt hash;
- raw worker-output hash;
- evaluator-normalized outcome (`success | failed | correct_escalation`);
- evidence inspection observability;
- context expansion.

`evaluated_outcome` is a harness/evaluator classification from the fixed completion contract and observable output/actions. It is not worker self-report.

## Pair semantics

The evaluator derives baseline/treatment from the materialized manifest's `decisive_evidence_present` state, not execution order.

It preserves the #239 verdict vocabulary:

```text
paired_retirement_signal
correct_escalation_then_success
no_demand_observed
demand_persists
confounded
invalid_evidence_pair
```

Frozen worker/harness/affordance/sampling drift or session reuse/contamination yields `confounded`. Two conditions without the decisive-evidence flip yield `invalid_evidence_pair`.

Every output keeps:

```text
automatic_causal_claim = false
automatic_generalization = false
```

## Retained executed input manifest

This PR preserves the exact successful materialization receipt from run `32264661913`, artifact `9369686491`:

```text
baseline
  14,086 bytes
  e4549a10f86448779a21307d97ea75f2ae1acfd15b43099cbca6f600f0781bdf

treatment
  18,795 bytes
  2e6acd81e324f3b290b9f93c5bf0ec3d9a66004bd44a855069cc65802f94af46
```

Artifact archive digest:

```text
sha256:8dd0df40868b451f5d48aaea771893214e7e3442b08f100e7994a567d4338163
```

This is an input receipt only. No synthetic unit-test run is represented as real worker evidence.

## Adversarial controls

The ordinary Rust suite covers:

- failed baseline -> successful treatment signal;
- reversed BA execution order;
- baseline success -> no demand observed;
- correct escalation -> separate environment/research-burden verdict;
- treatment failure -> demand persists;
- worker/harness identity drift -> confounded;
- reused/contaminated sessions -> confounded;
- same condition twice -> invalid evidence pair;
- evidence packet fingerprint tampering -> reject before interpretation.

## CLI research surface

```text
cargo run --example capability_demand_retirement -- \
  TRIAL.json INPUT_MANIFEST.json RUN_A.json RUN_B.json
```

## Boundary

- research only;
- no primary cargo-cultist CLI change;
- no model/provider SDK or API key handling;
- no prose-similarity judge;
- no chain-of-thought requirement;
- no automatic capability rank;
- no authority grant from success;
- real worker execution still requires genuinely fresh external sessions.

Refs #137 #146 #181 #191 #215 #223 #238 #239.