### PR TITLE
ci: reject new direct external GitHub links in human prose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,28 @@ jobs:
         run: |
           python -m py_compile \
             scripts/github_reference_url.py \
-            scripts/github_reference_url_test.py
+            scripts/github_reference_url_test.py \
+            scripts/external_github_reference_guard.py \
+            scripts/external_github_reference_guard_test.py
           python scripts/github_reference_url_test.py
+          python scripts/external_github_reference_guard_test.py
+      - name: External GitHub reference guard for pull request
+        if: github.event_name == 'pull_request'
+        env:
+          CULTIST_BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          python scripts/external_github_reference_guard.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --base "$CULTIST_BASE" \
+            --event "$GITHUB_EVENT_PATH"
+      - name: External GitHub reference guard for push
+        if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
+        env:
+          CULTIST_BASE: ${{ github.event.before }}
+        run: |
+          python scripts/external_github_reference_guard.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --base "$CULTIST_BASE"
       - name: Active work heads-up
         if: github.event_name == 'pull_request'
         continue-on-error: true

--- a/docs/external-reference-policy.md
+++ b/docs/external-reference-policy.md
@@ -46,6 +46,26 @@ Examples include:
 
 Do not rewrite evidence merely to satisfy presentation hygiene. Apply the redirect rule at the human-facing rendering layer.
 
+## Changed-prose guard
+
+CI checks newly added Markdown lines and pull-request bodies for direct external `https://github.com/...` references outside code examples. Existing historical Markdown is not rescanned on unrelated changes.
+
+The guard accepts:
+
+```text
+https://redirect.github.com/OWNER/REPOSITORY/issues/123
+https://github.com/teamleaderleo/cultist/issues/123
+https://api.github.com/repos/OWNER/REPOSITORY/issues/123
+```
+
+Canonical external GitHub source text may remain in Markdown when exact wording is evidence. Keep the exception local by placing this marker on the same line or immediately before the evidence line:
+
+```html
+<!-- cultist:allow-canonical-github-evidence -->
+```
+
+Do not use the marker as a file- or section-level bypass. It applies to one prose line only. Prefer `redirect.github.com` for ordinary clickable references.
+
 ## Rule of thumb
 
 ```text

--- a/scripts/external_github_reference_guard.py
+++ b/scripts/external_github_reference_guard.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Reject new human-facing direct external github.com links.
+
+The guard applies presentation hygiene only. Canonical provider/evidence URLs may be
+retained with an explicit local escape marker, and code examples are ignored.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit
+
+ALLOW_MARKER = "<!-- cultist:allow-canonical-github-evidence -->"
+DIRECT_GITHUB_URL_RE = re.compile(r"https://github\.com/[^\s<>()\[\]`\"']+")
+INLINE_CODE_RE = re.compile(r"`[^`]*`")
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+
+class GuardError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Violation:
+    source: str
+    line: int
+    url: str
+
+
+def repository_from_url(url: str) -> str | None:
+    parsed = urlsplit(url)
+    if parsed.scheme != "https" or (parsed.hostname or "").lower() != "github.com":
+        return None
+    components = [component for component in parsed.path.split("/") if component]
+    if len(components) < 2:
+        return None
+    return f"{components[0]}/{components[1]}"
+
+
+def strip_inline_code(line: str) -> str:
+    return INLINE_CODE_RE.sub("", line)
+
+
+def scan_text(
+    text: str,
+    *,
+    source: str,
+    current_repository: str,
+    eligible_lines: set[int] | None = None,
+) -> list[Violation]:
+    violations: list[Violation] = []
+    in_fence = False
+    allow_next_line = False
+
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        fence = FENCE_RE.match(line)
+        if fence:
+            in_fence = not in_fence
+            allow_next_line = False
+            continue
+        if in_fence:
+            continue
+
+        marker_on_line = ALLOW_MARKER in line
+        if marker_on_line and line.strip() == ALLOW_MARKER:
+            allow_next_line = True
+            continue
+
+        eligible = eligible_lines is None or line_number in eligible_lines
+        sanitized = strip_inline_code(line)
+        matches = list(DIRECT_GITHUB_URL_RE.finditer(sanitized))
+        allow_this_line = marker_on_line or allow_next_line
+        allow_next_line = False
+
+        if not eligible or allow_this_line:
+            continue
+
+        for match in matches:
+            url = match.group(0).rstrip(".,;:!?")
+            repository = repository_from_url(url)
+            if repository is None or repository == current_repository:
+                continue
+            violations.append(Violation(source=source, line=line_number, url=url))
+
+    return violations
+
+
+def git_diff(base: str, root: Path) -> str:
+    completed = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--unified=0",
+            "--no-color",
+            f"{base}...HEAD",
+            "--",
+            "*.md",
+        ],
+        cwd=root,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or "git diff failed"
+        raise GuardError(f"could not diff changed Markdown from `{base}`: {detail}")
+    return completed.stdout
+
+
+def added_markdown_lines(diff: str) -> dict[str, set[int]]:
+    result: dict[str, set[int]] = {}
+    current_path: str | None = None
+    new_line: int | None = None
+
+    for raw_line in diff.splitlines():
+        if raw_line.startswith("+++ "):
+            value = raw_line[4:]
+            if value == "/dev/null":
+                current_path = None
+            elif value.startswith("b/"):
+                current_path = value[2:]
+                result.setdefault(current_path, set())
+            else:
+                raise GuardError(f"unsupported git diff path line: {raw_line}")
+            new_line = None
+            continue
+
+        if raw_line.startswith("@@ "):
+            match = re.search(r"\+(\d+)(?:,(\d+))?", raw_line)
+            if match is None:
+                raise GuardError(f"could not parse git hunk header: {raw_line}")
+            new_line = int(match.group(1))
+            continue
+
+        if current_path is None or new_line is None:
+            continue
+        if raw_line.startswith("+") and not raw_line.startswith("+++"):
+            result[current_path].add(new_line)
+            new_line += 1
+        elif raw_line.startswith("-") and not raw_line.startswith("---"):
+            continue
+        else:
+            new_line += 1
+
+    return result
+
+
+def scan_changed_markdown(
+    *, base: str, root: Path, current_repository: str
+) -> list[Violation]:
+    diff = git_diff(base, root)
+    changed = added_markdown_lines(diff)
+    violations: list[Violation] = []
+    for relative_path, eligible_lines in sorted(changed.items()):
+        if not eligible_lines:
+            continue
+        path = root / relative_path
+        if not path.is_file():
+            continue
+        violations.extend(
+            scan_text(
+                path.read_text(encoding="utf-8"),
+                source=relative_path,
+                current_repository=current_repository,
+                eligible_lines=eligible_lines,
+            )
+        )
+    return violations
+
+
+def scan_pull_request_body(
+    *, event_path: Path, current_repository: str
+) -> list[Violation]:
+    try:
+        event = json.loads(event_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise GuardError(f"could not read pull-request event JSON: {error}") from error
+    pull_request = event.get("pull_request")
+    if not isinstance(pull_request, dict):
+        raise GuardError("event JSON does not contain a pull_request object")
+    body = pull_request.get("body") or ""
+    if not isinstance(body, str):
+        raise GuardError("pull_request.body must be a string or null")
+    return scan_text(
+        body,
+        source="pull_request.body",
+        current_repository=current_repository,
+    )
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Reject newly introduced human-facing direct external github.com links."
+    )
+    result.add_argument("--repository", required=True, help="Current owner/repository")
+    result.add_argument("--base", help="Git base commit/ref for changed Markdown scanning")
+    result.add_argument("--event", type=Path, help="GitHub pull_request event JSON to scan")
+    result.add_argument("--root", type=Path, default=Path("."))
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    if args.base is None and args.event is None:
+        raise SystemExit("external-github-reference-guard: provide --base and/or --event")
+
+    try:
+        violations: list[Violation] = []
+        if args.base is not None:
+            violations.extend(
+                scan_changed_markdown(
+                    base=args.base,
+                    root=args.root,
+                    current_repository=args.repository,
+                )
+            )
+        if args.event is not None:
+            violations.extend(
+                scan_pull_request_body(
+                    event_path=args.event,
+                    current_repository=args.repository,
+                )
+            )
+    except GuardError as error:
+        raise SystemExit(f"external-github-reference-guard: {error}") from error
+
+    if violations:
+        print("Direct external github.com references are not allowed in new human-facing prose:")
+        for violation in violations:
+            print(f"  {violation.source}:{violation.line}: {violation.url}")
+        print(
+            "Use https://redirect.github.com/... or add the local canonical-evidence marker "
+            "when exact source text must remain canonical."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/external_github_reference_guard_test.py
+++ b/scripts/external_github_reference_guard_test.py
@@ -127,6 +127,8 @@ def test_changed_markdown_uses_full_file_for_fence_context_but_only_added_lines(
             f"Intro\n\n```text\ncanonical example\n{EXTERNAL}\n```\n\nExisting prose.\nNew prose: {EXTERNAL}\n",
             encoding="utf-8",
         )
+        git(root, "add", "doc.md")
+        git(root, "commit", "-qm", "change")
 
         violations = guard.scan_changed_markdown(
             base=base,

--- a/scripts/external_github_reference_guard_test.py
+++ b/scripts/external_github_reference_guard_test.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import external_github_reference_guard as guard
+
+REPOSITORY = "teamleaderleo/cultist"
+EXTERNAL = "https://github.com/example/project/issues/123"
+REDIRECT = "https://redirect.github.com/example/project/issues/123"
+SAME_REPO = "https://github.com/teamleaderleo/cultist/issues/123"
+
+
+def assert_violation(text: str) -> None:
+    violations = guard.scan_text(
+        text,
+        source="fixture.md",
+        current_repository=REPOSITORY,
+    )
+    assert len(violations) == 1, violations
+    assert violations[0].url == EXTERNAL, violations
+
+
+def test_direct_external_url_fails() -> None:
+    assert_violation(f"See [{EXTERNAL}]({EXTERNAL}).")
+
+
+def test_redirect_and_same_repo_pass() -> None:
+    for text in [
+        f"See [external]({REDIRECT}).",
+        f"See [local]({SAME_REPO}).",
+    ]:
+        assert guard.scan_text(
+            text,
+            source="fixture.md",
+            current_repository=REPOSITORY,
+        ) == []
+
+
+def test_code_examples_and_inline_code_pass() -> None:
+    text = f"""Before.
+
+```text
+{EXTERNAL}
+```
+
+Literal `{EXTERNAL}` is evidence syntax here.
+"""
+    assert guard.scan_text(
+        text,
+        source="fixture.md",
+        current_repository=REPOSITORY,
+    ) == []
+
+
+def test_local_evidence_marker_allows_next_or_same_line() -> None:
+    next_line = f"""{guard.ALLOW_MARKER}
+Exact source: {EXTERNAL}
+"""
+    same_line = f"Exact source: {EXTERNAL} {guard.ALLOW_MARKER}"
+    for text in [next_line, same_line]:
+        assert guard.scan_text(
+            text,
+            source="fixture.md",
+            current_repository=REPOSITORY,
+        ) == []
+
+
+def test_marker_does_not_leak_past_one_line() -> None:
+    text = f"""{guard.ALLOW_MARKER}
+Exact source: {EXTERNAL}
+Another source: {EXTERNAL}
+"""
+    violations = guard.scan_text(
+        text,
+        source="fixture.md",
+        current_repository=REPOSITORY,
+    )
+    assert [(item.line, item.url) for item in violations] == [(3, EXTERNAL)]
+
+
+def test_added_markdown_line_parser_ignores_deletions_and_context() -> None:
+    diff = """diff --git a/doc.md b/doc.md
+index 1111111..2222222 100644
+--- a/doc.md
++++ b/doc.md
+@@ -2,2 +2,3 @@
+ context
+-old
++new
++added
+"""
+    assert guard.added_markdown_lines(diff) == {"doc.md": {3, 4}}
+
+
+def git(root: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def test_changed_markdown_uses_full_file_for_fence_context_but_only_added_lines() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        git(root, "init", "-q")
+        git(root, "config", "user.email", "fixture@example.test")
+        git(root, "config", "user.name", "Fixture")
+        path = root / "doc.md"
+        path.write_text(
+            "Intro\n\n```text\ncanonical example\n```\n\nExisting prose.\n",
+            encoding="utf-8",
+        )
+        git(root, "add", "doc.md")
+        git(root, "commit", "-qm", "base")
+        base = git(root, "rev-parse", "HEAD")
+
+        path.write_text(
+            f"Intro\n\n```text\ncanonical example\n{EXTERNAL}\n```\n\nExisting prose.\nNew prose: {EXTERNAL}\n",
+            encoding="utf-8",
+        )
+
+        violations = guard.scan_changed_markdown(
+            base=base,
+            root=root,
+            current_repository=REPOSITORY,
+        )
+        assert [(item.source, item.line, item.url) for item in violations] == [
+            ("doc.md", 9, EXTERNAL)
+        ]
+
+
+def test_pull_request_body_scanner_uses_same_rules() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        event_path = Path(directory) / "event.json"
+        event_path.write_text(
+            json.dumps(
+                {
+                    "pull_request": {
+                        "body": f"Local: {SAME_REPO}\nExternal: {EXTERNAL}"
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        violations = guard.scan_pull_request_body(
+            event_path=event_path,
+            current_repository=REPOSITORY,
+        )
+        assert [(item.line, item.url) for item in violations] == [(2, EXTERNAL)]
+
+
+def test_bad_event_rejects() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        event_path = Path(directory) / "event.json"
+        event_path.write_text("{}", encoding="utf-8")
+        try:
+            guard.scan_pull_request_body(
+                event_path=event_path,
+                current_repository=REPOSITORY,
+            )
+        except guard.GuardError as error:
+            assert "pull_request object" in str(error)
+        else:
+            raise AssertionError("expected GuardError")
+
+
+def main() -> int:
+    tests = [value for name, value in globals().items() if name.startswith("test_")]
+    for test in sorted(tests, key=lambda value: value.__name__):
+        test()
+    print(f"external GitHub reference guard: {len(tests)} controls passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/external_github_reference_guard_test.py
+++ b/scripts/external_github_reference_guard_test.py
@@ -25,7 +25,7 @@ def assert_violation(text: str) -> None:
 
 
 def test_direct_external_url_fails() -> None:
-    assert_violation(f"See [{EXTERNAL}]({EXTERNAL}).")
+    assert_violation(f"See [external]({EXTERNAL}).")
 
 
 def test_redirect_and_same_repo_pass() -> None:


### PR DESCRIPTION
## What

Progress #247 by enforcing the existing external-reference policy on newly introduced human-facing prose.

CI now checks:

```text
added lines in changed Markdown files
pull-request body
```

and rejects direct external `github.com` URLs outside Markdown code examples when the target repository differs from Cultist.

Accepted cases include:

```text
redirect.github.com external references
same-repository github.com references
api.github.com machine/provider coordinates
fenced and inline code examples
```

A rare exact canonical evidence quotation can use one evidence-local marker:

```text
<!-- cultist:allow-canonical-github-evidence -->
```

The marker applies only to the same/next prose line. There is no path-level bypass.

## Changed-lines boundary

Repository Markdown scanning derives the added line numbers from `git diff --unified=0`, then scans the complete current file so code-fence state remains correct even when a hunk starts inside an existing fence.

Deleted/context lines are ignored. Existing historical Markdown does not block unrelated work.

The pull-request body is checked as a whole because it is newly submitted human-facing prose.

## Controls

The Python suite covers direct external rejection, redirect/same-repo acceptance, fenced and inline code, local evidence marker scope, diff added-line accounting, full-file fence context with changed-line filtering, pull-request body scanning, and malformed event rejection.

## Concurrent-main note

Current `main` advanced after this branch started with a cohort-refinement commit touching only new refinement example/research/source/test paths. There is no changed-path overlap. PR merge-view CI is the compatibility authority.

## Boundary

- internal CI only;
- no external calls or writes;
- no automatic source rewriting;
- no historical Markdown sweep;
- exact machine/evidence URLs remain canonical when explicitly admitted;
- no ordinary Cultist CLI/report change.

Closes #247.

Refs #245.