### PR TITLE
research: gate refinement investigation demand

### DIFF
--- a/examples/refinement_investigation_demand.rs
+++ b/examples/refinement_investigation_demand.rs
@@ -1,0 +1,51 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+#[allow(dead_code)]
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[allow(dead_code)]
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[allow(dead_code)]
+#[path = "../src/refinement_candidate_readiness.rs"]
+mod refinement_candidate_readiness;
+#[allow(dead_code)]
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+#[allow(dead_code)]
+#[path = "../src/refinement_investigation_demand.rs"]
+mod refinement_investigation_demand;
+#[allow(dead_code)]
+#[path = "../src/refinement_observation_requirement.rs"]
+mod refinement_observation_requirement;
+
+use refinement_candidate_readiness::{
+    MAX_REFINEMENT_CANDIDATE_READINESS_REQUEST_BYTES, parse_refinement_candidate_readiness_request,
+};
+use refinement_investigation_demand::evaluate_refinement_investigation_demand;
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("refinement-investigation-demand: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_REFINEMENT_CANDIDATE_READINESS_REQUEST_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_REFINEMENT_CANDIDATE_READINESS_REQUEST_BYTES {
+        return Err(format!(
+            "refinement investigation request exceeds the {MAX_REFINEMENT_CANDIDATE_READINESS_REQUEST_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let request = parse_refinement_candidate_readiness_request(&bytes)?;
+    let evaluation = evaluate_refinement_investigation_demand(&request)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}

--- a/research/refinement-investigation-demand.md
+++ b/research/refinement-investigation-demand.md
@@ -1,0 +1,284 @@
+# Refinement investigation demand
+
+Tracking: #248. Builds on #243 candidate readiness and the exact observation/acquisition chain established by #231, #210, #216, and #235.
+
+## Trigger
+
+#243 deliberately reports evidence readiness for every retained refinement candidate, including candidates deterministic replay already rejected.
+
+In the retained Oxc episode, the default readiness view contains:
+
+```text
+syntax-changing-current-cohort
+  replay   weakened
+  selected true
+  evidence current
+
+reverse-edit-class-control
+  replay   rejected_no_improvement
+  selected false
+  evidence blocked
+  missing mapping edit_class
+
+singleton-commit-partition
+  replay   rejected_overfit
+  selected false
+  evidence blocked
+  missing mapping commit_identity
+```
+
+The two rejected alternatives are blocked because their candidate-specific observation requirements were never mapped. That is useful readiness information, yet it creates an important downstream trap:
+
+```text
+blocked => acquire evidence
+```
+
+would request new mapping/evidence work for candidates replay already rejected.
+
+## V0 disposition
+
+`src/refinement_investigation_demand.rs` consumes the existing #243 request/evaluator and emits one research-only disposition per candidate:
+
+```text
+RefinementInvestigationDisposition
+  episode_id
+  candidate_id
+  is_selected_transition
+  replay_status
+  evidence_status
+  disposition
+    satisfied
+    requirement_mapping_needed
+    observation_acquisition_needed
+    replay_rejected
+    unselected
+  missing_requirement_mappings[]
+  acquisition_frontiers[]
+```
+
+The priority is intentional:
+
+```text
+replay rejected
+  -> replay_rejected
+
+surviving but unselected
+  -> unselected
+
+selected + evidence current
+  -> satisfied
+
+selected + missing exact D@S mapping
+  -> requirement_mapping_needed
+
+selected + mapped noncurrent D@S frontier
+  -> observation_acquisition_needed
+```
+
+A blocked selected candidate must expose either a missing mapping or at least one noncurrent frontier. Any other blocked state fails closed in this composition.
+
+## Why mapping need and observation acquisition stay separate
+
+#231 earned the exact source-owned relation:
+
+```text
+(candidate, discriminator)
+-> subject_ref
+```
+
+#216 can plan a probe only after that exact D@S requirement exists.
+
+Therefore:
+
+```text
+missing mapping
+  -> requirement_mapping_needed
+  -> source/admission research first
+
+mapped MISSING | UNKNOWN | INVALID frontier
+  -> observation_acquisition_needed
+  -> exact frontier can later enter #216 planning
+```
+
+The first carrier stops before #216. It decides which evidence gap deserves investigation; it grants zero probe-selection or execution authority.
+
+## Retained Oxc controls
+
+### Default over-acquisition control
+
+The raw `evidence_status=blocked` set contains the two rejected alternatives.
+
+The investigation disposition keeps both quiet:
+
+```text
+reverse-edit-class-control
+  -> replay_rejected
+
+singleton-commit-partition
+  -> replay_rejected
+```
+
+The selected candidate is current and therefore `satisfied`.
+
+### Selected survivor, exact observation withheld
+
+Withhold:
+
+```text
+edit_class @ oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:
+             crates/oxc_linter/src/rules.rs
+```
+
+and insert a same-discriminator current observation for `other.rs`.
+
+The #243 Oxc blocked set now has three candidates. Investigation demand emits exactly one acquisition-capable candidate:
+
+```text
+syntax-changing-current-cohort
+  replay       weakened
+  selected     true
+  evidence     blocked
+  disposition  observation_acquisition_needed
+  frontier     MISSING @ exact rules.rs subject
+  other_subject = 1
+```
+
+Both replay-rejected alternatives remain `replay_rejected` with empty acquisition frontiers.
+
+### Selected survivor, mapping removed
+
+Removing the selected candidate's #231 mapping yields:
+
+```text
+requirement_mapping_needed
+missing_requirement_mappings = [edit_class]
+acquisition_frontiers = []
+```
+
+The observation corpus is never searched for a substitute subject.
+
+### Replay rejected + perfect current evidence
+
+Synthetic controls supply exact candidate-specific mappings/current observations for both rejected Oxc alternatives.
+
+Their readiness becomes `current`; their investigation disposition remains:
+
+```text
+replay_rejected
+```
+
+Current evidence cannot turn a replay rejection into investigation demand.
+
+### Unselected replay survivor
+
+A synthetic `retained` Oxc candidate reuses the admitted `edit_class` dimension while remaining outside `selected_transition`.
+
+With current evidence or blocked evidence, its disposition remains:
+
+```text
+unselected
+```
+
+Selection remains an explicit prerequisite for current investigation work.
+
+### UNKNOWN / INVALID exact evidence
+
+The selected Oxc candidate with an exact mapped UNKNOWN or INVALID observation remains a mapped noncurrent frontier and therefore becomes:
+
+```text
+observation_acquisition_needed
+```
+
+The exact frontier status is preserved in `acquisition_frontiers`.
+
+## Reader
+
+```text
+cargo run --example refinement_investigation_demand < request.json
+```
+
+The reader accepts the same bounded #243 readiness request:
+
+```text
+refinements
+candidate -> exact observation mappings
+current observation batch
+```
+
+It calls #243 for readiness, then applies only the investigation-disposition policy above.
+
+## Boundary
+
+- research only;
+- explicit selected transition required before investigation demand;
+- replay rejection suppresses investigation demand;
+- unselected surviving candidates stay quiet;
+- missing requirement mapping is separate from observation acquisition;
+- only mapped noncurrent frontiers enter `acquisition_frontiers`;
+- no #216 probe selection or execution in this carrier;
+- no automatic candidate ranking, selection, or promotion;
+- no product CLI/report-schema change.
+
+## Execution receipt
+
+The first CI attempt on semantic head `ed2c423b4bfb8ffe8f962bc7d26ab95ff80d534a` stopped only at rustfmt:
+
+```text
+run:        32267215085
+run number: 1786
+```
+
+The formatter delta changed only the example/test carrier layout.
+
+Formatted semantic head:
+
+```text
+35fe45373e129194ffadc3e9b926094b25b75672
+```
+
+passed full ordinary CI:
+
+```text
+run:        32267419110
+run number: 1794
+result:     success
+```
+
+The run passed format, strict Clippy, active-work preflight, all investigation-demand controls, and repository/history/CI-filter/diff dogfood.
+
+The executed controls prove:
+
+```text
+default retained Oxc readiness
+  blocked candidates = 2
+  both replay rejected
+  acquisition frontiers = 0
+
+selected exact observation withheld
+  blocked Oxc candidates = 3
+  selected survivor -> observation_acquisition_needed
+  exact frontier = MISSING
+  rejected alternatives -> replay_rejected
+
+selected exact mapping removed
+  -> requirement_mapping_needed
+  -> no acquisition frontier
+
+rejected alternatives + exact current synthetic evidence
+  -> replay_rejected
+  -> no acquisition frontier
+
+unselected replay survivor, current or blocked
+  -> unselected
+  -> no acquisition frontier
+
+selected exact UNKNOWN / INVALID observation
+  -> observation_acquisition_needed
+  -> exact frontier status preserved
+```
+
+A generic blocked-candidate acquisition rule therefore over-requests work. Explicit replay/selection gating removes that waste before probe planning.
+
+North star:
+
+> Spend investigation effort only on the selected refinement that survived replay, and only after the exact evidence gap is identified.

--- a/research/refinement-investigation-held-out-contract.md
+++ b/research/refinement-investigation-held-out-contract.md
@@ -1,0 +1,69 @@
+# Held-out replay state in refinement investigation demand
+
+Tracking: #248. This note resolves the review edge raised on PR #251 before downstream probe planning treats a selected candidate as investigation-eligible.
+
+## Contract
+
+At the investigation-demand layer, **replay survival is status-level non-rejection**:
+
+```text
+Retained | Weakened | Split
+  -> surviving candidate status
+
+RejectedNoImprovement | RejectedOverfit | RejectedLostExpectedCase
+  -> replay_rejected
+```
+
+Held-out replay completion remains an independent receipt axis. The refinement-episode validator already permits kept candidates with:
+
+```text
+held_out_status = passed | not_run | unknown
+```
+
+and rejects kept candidates with:
+
+```text
+held_out_status = failed
+```
+
+Investigation demand therefore does not promote `not_run` or `unknown` to `passed`, and it does not invent a second rejection rule for them.
+
+## Visibility requirement
+
+`RefinementInvestigationDisposition` carries the complete source `ReplayResult` alongside the existing convenience `replay_status` field.
+
+That preserves:
+
+```text
+expected cases retained/lost
+counterexamples resolved/remaining
+held_out_status
+```
+
+for downstream readers such as #255. A caller can distinguish:
+
+```text
+selected survivor + held_out passed
+selected survivor + held_out not_run
+selected survivor + held_out unknown
+```
+
+while receiving the same current investigation disposition when the evidence state is otherwise identical.
+
+## Controls
+
+`tests/refinement_investigation_held_out_contract.rs` proves two explicit cases:
+
+1. selected Oxc survivor + current evidence + held-out `unknown` -> `satisfied`, with `unknown` preserved in the emitted replay result;
+2. selected Oxc survivor + exact mapped observation missing + held-out `not_run` -> `observation_acquisition_needed`, with `not_run` preserved and the exact missing subject frontier emitted.
+
+This makes the policy explicit without claiming held-out replay completion.
+
+## Boundary
+
+- no held-out `not_run`/`unknown` -> `passed` rewrite;
+- no new candidate selection or promotion authority;
+- no probe execution authority;
+- downstream planning may apply a stricter held-out prerequisite later, but it must do so explicitly from the preserved replay result rather than inferring completion from `replay_status`.
+
+Refs #179 #243 #248 #251 #255.

--- a/src/refinement_investigation_demand.rs
+++ b/src/refinement_investigation_demand.rs
@@ -1,0 +1,139 @@
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::observation_frontier::{ObservationFrontierReceipt, ObservationFrontierStatus};
+use crate::refinement_candidate_readiness::{
+    CandidateEvidenceStatus, RefinementCandidateReadinessRequest,
+    evaluate_refinement_candidate_readiness,
+};
+use crate::refinement_episode::RefinementStatus;
+
+pub const REFINEMENT_INVESTIGATION_DEMAND_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefinementInvestigationDispositionStatus {
+    Satisfied,
+    RequirementMappingNeeded,
+    ObservationAcquisitionNeeded,
+    ReplayRejected,
+    Unselected,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementInvestigationDisposition {
+    pub episode_id: String,
+    pub candidate_id: String,
+    pub is_selected_transition: bool,
+    pub replay_status: RefinementStatus,
+    pub evidence_status: CandidateEvidenceStatus,
+    pub disposition: RefinementInvestigationDispositionStatus,
+    pub missing_requirement_mappings: Vec<String>,
+    pub acquisition_frontiers: Vec<ObservationFrontierReceipt>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementInvestigationDemandEvaluation {
+    pub schema_version: u32,
+    pub candidates: Vec<RefinementInvestigationDisposition>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RefinementInvestigationDemandError {
+    message: String,
+}
+
+impl RefinementInvestigationDemandError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for RefinementInvestigationDemandError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for RefinementInvestigationDemandError {}
+
+pub fn evaluate_refinement_investigation_demand(
+    request: &RefinementCandidateReadinessRequest,
+) -> Result<RefinementInvestigationDemandEvaluation, RefinementInvestigationDemandError> {
+    let readiness = evaluate_refinement_candidate_readiness(request).map_err(|error| {
+        RefinementInvestigationDemandError::new(format!(
+            "candidate readiness evaluation failed: {error}"
+        ))
+    })?;
+
+    let mut candidates = Vec::with_capacity(readiness.candidates.len());
+    for candidate in readiness.candidates {
+        let replay_rejected = matches!(
+            candidate.replay_status,
+            RefinementStatus::RejectedNoImprovement
+                | RefinementStatus::RejectedOverfit
+                | RefinementStatus::RejectedLostExpectedCase
+        );
+
+        let (disposition, acquisition_frontiers) = if replay_rejected {
+            (
+                RefinementInvestigationDispositionStatus::ReplayRejected,
+                Vec::new(),
+            )
+        } else if !candidate.is_selected_transition {
+            (
+                RefinementInvestigationDispositionStatus::Unselected,
+                Vec::new(),
+            )
+        } else if candidate.evidence_status == CandidateEvidenceStatus::Current {
+            (
+                RefinementInvestigationDispositionStatus::Satisfied,
+                Vec::new(),
+            )
+        } else if !candidate.missing_requirement_mappings.is_empty() {
+            (
+                RefinementInvestigationDispositionStatus::RequirementMappingNeeded,
+                Vec::new(),
+            )
+        } else {
+            let acquisition_frontiers = candidate
+                .requirement_frontiers
+                .iter()
+                .filter(|frontier| frontier.status != ObservationFrontierStatus::Current)
+                .cloned()
+                .collect::<Vec<_>>();
+            if acquisition_frontiers.is_empty() {
+                return Err(RefinementInvestigationDemandError::new(format!(
+                    "selected blocked candidate {} / {} has no missing mapping or noncurrent frontier",
+                    candidate.episode_id, candidate.candidate_id
+                )));
+            }
+            (
+                RefinementInvestigationDispositionStatus::ObservationAcquisitionNeeded,
+                acquisition_frontiers,
+            )
+        };
+
+        candidates.push(RefinementInvestigationDisposition {
+            episode_id: candidate.episode_id,
+            candidate_id: candidate.candidate_id,
+            is_selected_transition: candidate.is_selected_transition,
+            replay_status: candidate.replay_status,
+            evidence_status: candidate.evidence_status,
+            disposition,
+            missing_requirement_mappings: candidate.missing_requirement_mappings,
+            acquisition_frontiers,
+        });
+    }
+
+    Ok(RefinementInvestigationDemandEvaluation {
+        schema_version: REFINEMENT_INVESTIGATION_DEMAND_SCHEMA_VERSION,
+        candidates,
+    })
+}

--- a/src/refinement_investigation_demand.rs
+++ b/src/refinement_investigation_demand.rs
@@ -8,7 +8,7 @@ use crate::refinement_candidate_readiness::{
     CandidateEvidenceStatus, RefinementCandidateReadinessRequest,
     evaluate_refinement_candidate_readiness,
 };
-use crate::refinement_episode::RefinementStatus;
+use crate::refinement_episode::{RefinementStatus, ReplayResult};
 
 pub const REFINEMENT_INVESTIGATION_DEMAND_SCHEMA_VERSION: u32 = 1;
 
@@ -29,6 +29,7 @@ pub struct RefinementInvestigationDisposition {
     pub candidate_id: String,
     pub is_selected_transition: bool,
     pub replay_status: RefinementStatus,
+    pub replay_result: ReplayResult,
     pub evidence_status: CandidateEvidenceStatus,
     pub disposition: RefinementInvestigationDispositionStatus,
     pub missing_requirement_mappings: Vec<String>,
@@ -125,6 +126,7 @@ pub fn evaluate_refinement_investigation_demand(
             candidate_id: candidate.candidate_id,
             is_selected_transition: candidate.is_selected_transition,
             replay_status: candidate.replay_status,
+            replay_result: candidate.replay_result,
             evidence_status: candidate.evidence_status,
             disposition,
             missing_requirement_mappings: candidate.missing_requirement_mappings,

--- a/tests/refinement_investigation_demand.rs
+++ b/tests/refinement_investigation_demand.rs
@@ -1,0 +1,449 @@
+#![allow(dead_code)]
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/refinement_candidate_readiness.rs"]
+mod refinement_candidate_readiness;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+#[path = "../src/refinement_investigation_demand.rs"]
+mod refinement_investigation_demand;
+#[path = "../src/refinement_observation_requirement.rs"]
+mod refinement_observation_requirement;
+
+use discriminator_observation::{
+    DiscriminatorObservation, DiscriminatorValueState, ObservationApplicability,
+    ObservationApplicabilityStatus, parse_discriminator_observation_batch,
+};
+use observation_frontier::ObservationFrontierStatus;
+use refinement_candidate_readiness::{
+    CandidateEvidenceStatus, REFINEMENT_CANDIDATE_READINESS_SCHEMA_VERSION,
+    RefinementCandidateReadinessRequest, evaluate_refinement_candidate_readiness,
+};
+use refinement_episode::{RefinementStatus, parse_refinement_episode_batch};
+use refinement_investigation_demand::{
+    RefinementInvestigationDispositionStatus, evaluate_refinement_investigation_demand,
+};
+use refinement_observation_requirement::RefinementObservationRequirementMapping;
+
+const OBSERVATIONS: &[u8] =
+    include_bytes!("../research/discriminator-observations/cultist-v1.json");
+const REFINEMENTS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+const MAPPINGS: &[u8] =
+    include_bytes!("../research/refinement-observation-requirements/cultist-v1.json");
+const OXC_EPISODE: &str = "history/oxc-edit-class-v1";
+const SELECTED_OXC_CANDIDATE: &str = "syntax-changing-current-cohort";
+const SELECTED_OXC_SUBJECT: &str =
+    "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs";
+
+fn request() -> RefinementCandidateReadinessRequest {
+    RefinementCandidateReadinessRequest {
+        schema_version: REFINEMENT_CANDIDATE_READINESS_SCHEMA_VERSION,
+        refinements: parse_refinement_episode_batch(REFINEMENTS).unwrap(),
+        mappings: serde_json::from_slice(MAPPINGS).unwrap(),
+        observations: parse_discriminator_observation_batch(OBSERVATIONS).unwrap(),
+    }
+}
+
+fn current_observation(
+    observation_id: &str,
+    discriminator_id: &str,
+    subject_ref: &str,
+    value_ref: &str,
+) -> DiscriminatorObservation {
+    DiscriminatorObservation {
+        observation_id: observation_id.to_string(),
+        discriminator_id: discriminator_id.to_string(),
+        subject_ref: subject_ref.to_string(),
+        source_receipt: format!("research:refinement-investigation:{observation_id}"),
+        value_state: DiscriminatorValueState::Known {
+            value_ref: value_ref.to_string(),
+        },
+        applicability: ObservationApplicability {
+            status: ObservationApplicabilityStatus::Applies,
+            receipt_ref: format!("research:refinement-investigation:{observation_id}:applies"),
+        },
+    }
+}
+
+fn withhold_selected_oxc_observation(request: &mut RefinementCandidateReadinessRequest) {
+    let exact = request
+        .observations
+        .observations
+        .iter()
+        .find(|observation| {
+            observation.discriminator_id == "edit_class"
+                && observation.subject_ref == SELECTED_OXC_SUBJECT
+        })
+        .unwrap()
+        .clone();
+    request
+        .observations
+        .observations
+        .retain(|observation| observation.observation_id != exact.observation_id);
+    request.observations.observations.push(current_observation(
+        "investigation-demand:wrong-path-edit-class",
+        "edit_class",
+        "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/other.rs",
+        "syntax_changed",
+    ));
+}
+
+fn add_rejected_oxc_candidate_evidence(request: &mut RefinementCandidateReadinessRequest) {
+    let reverse_subject = "refinement:history/oxc-edit-class-v1/reverse-edit-class-control";
+    request
+        .mappings
+        .mappings
+        .push(RefinementObservationRequirementMapping {
+            id: "investigation-demand:reverse-edit-class".to_string(),
+            episode_id: OXC_EPISODE.to_string(),
+            candidate_id: "reverse-edit-class-control".to_string(),
+            discriminator_id: "edit_class".to_string(),
+            subject_ref: reverse_subject.to_string(),
+            source_receipt: "research:refinement-investigation:reverse-mapping".to_string(),
+        });
+    request.observations.observations.push(current_observation(
+        "investigation-demand:reverse-current",
+        "edit_class",
+        reverse_subject,
+        "syntax_changed",
+    ));
+
+    let singleton_subject = "refinement:history/oxc-edit-class-v1/singleton-commit-partition";
+    request
+        .mappings
+        .mappings
+        .push(RefinementObservationRequirementMapping {
+            id: "investigation-demand:singleton-identity".to_string(),
+            episode_id: OXC_EPISODE.to_string(),
+            candidate_id: "singleton-commit-partition".to_string(),
+            discriminator_id: "commit_identity".to_string(),
+            subject_ref: singleton_subject.to_string(),
+            source_receipt: "research:refinement-investigation:singleton-mapping".to_string(),
+        });
+    request.observations.observations.push(current_observation(
+        "investigation-demand:singleton-current",
+        "commit_identity",
+        singleton_subject,
+        "228e8e0f85c0e7aeded02c5e27fd810004d3b41a",
+    ));
+}
+
+fn add_unselected_survivor(request: &mut RefinementCandidateReadinessRequest, with_mapping: bool) {
+    let episode = request
+        .refinements
+        .episodes
+        .iter_mut()
+        .find(|episode| episode.id == OXC_EPISODE)
+        .unwrap();
+    let mut candidate = episode
+        .candidate_refinements
+        .iter()
+        .find(|candidate| candidate.id == SELECTED_OXC_CANDIDATE)
+        .unwrap()
+        .clone();
+    candidate.id = "syntax-changing-unselected-control".to_string();
+    candidate.hypothesis_after.id = "syntax-changing-unselected-control-hypothesis".to_string();
+    candidate.hypothesis_after.statement =
+        "Synthetic surviving candidate used only to prove selection gates investigation demand."
+            .to_string();
+    candidate.status = RefinementStatus::Retained;
+    candidate.source_receipts =
+        vec!["research:refinement-investigation:unselected-control".to_string()];
+    episode.candidate_refinements.push(candidate);
+
+    if with_mapping {
+        let mut mapping = request
+            .mappings
+            .mappings
+            .iter()
+            .find(|mapping| {
+                mapping.episode_id == OXC_EPISODE
+                    && mapping.candidate_id == SELECTED_OXC_CANDIDATE
+                    && mapping.discriminator_id == "edit_class"
+            })
+            .unwrap()
+            .clone();
+        mapping.id = "investigation-demand:unselected-edit-class".to_string();
+        mapping.candidate_id = "syntax-changing-unselected-control".to_string();
+        mapping.source_receipt = "research:refinement-investigation:unselected-mapping".to_string();
+        request.mappings.mappings.push(mapping);
+    }
+}
+
+#[test]
+fn default_blocked_set_would_over_acquire_replay_rejected_oxc_candidates() {
+    let request = request();
+    let readiness = evaluate_refinement_candidate_readiness(&request).unwrap();
+    let mut blocked = readiness
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.episode_id == OXC_EPISODE
+                && candidate.evidence_status == CandidateEvidenceStatus::Blocked
+        })
+        .map(|candidate| candidate.candidate_id.clone())
+        .collect::<Vec<_>>();
+    blocked.sort();
+    assert_eq!(
+        blocked,
+        vec![
+            "reverse-edit-class-control".to_string(),
+            "singleton-commit-partition".to_string(),
+        ]
+    );
+
+    let investigation = evaluate_refinement_investigation_demand(&request).unwrap();
+    let oxc = investigation
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.episode_id == OXC_EPISODE)
+        .collect::<Vec<_>>();
+    let selected = oxc
+        .iter()
+        .copied()
+        .find(|candidate| candidate.candidate_id == SELECTED_OXC_CANDIDATE)
+        .unwrap();
+    assert_eq!(
+        selected.disposition,
+        RefinementInvestigationDispositionStatus::Satisfied
+    );
+    assert!(selected.acquisition_frontiers.is_empty());
+
+    for rejected_id in ["reverse-edit-class-control", "singleton-commit-partition"] {
+        let rejected = oxc
+            .iter()
+            .copied()
+            .find(|candidate| candidate.candidate_id == rejected_id)
+            .unwrap();
+        assert_eq!(
+            rejected.disposition,
+            RefinementInvestigationDispositionStatus::ReplayRejected
+        );
+        assert!(rejected.acquisition_frontiers.is_empty());
+    }
+}
+
+#[test]
+fn only_selected_survivor_emits_observation_acquisition_for_missing_exact_evidence() {
+    let mut request = request();
+    withhold_selected_oxc_observation(&mut request);
+
+    let readiness = evaluate_refinement_candidate_readiness(&request).unwrap();
+    assert_eq!(
+        readiness
+            .candidates
+            .iter()
+            .filter(|candidate| {
+                candidate.episode_id == OXC_EPISODE
+                    && candidate.evidence_status == CandidateEvidenceStatus::Blocked
+            })
+            .count(),
+        3
+    );
+
+    let investigation = evaluate_refinement_investigation_demand(&request).unwrap();
+    let selected = investigation
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.episode_id == OXC_EPISODE && candidate.candidate_id == SELECTED_OXC_CANDIDATE
+        })
+        .unwrap();
+    assert_eq!(selected.replay_status, RefinementStatus::Weakened);
+    assert_eq!(selected.evidence_status, CandidateEvidenceStatus::Blocked);
+    assert_eq!(
+        selected.disposition,
+        RefinementInvestigationDispositionStatus::ObservationAcquisitionNeeded
+    );
+    assert!(selected.missing_requirement_mappings.is_empty());
+    assert_eq!(selected.acquisition_frontiers.len(), 1);
+    assert_eq!(
+        selected.acquisition_frontiers[0].status,
+        ObservationFrontierStatus::Missing
+    );
+    assert_eq!(
+        selected.acquisition_frontiers[0].subject_ref,
+        SELECTED_OXC_SUBJECT
+    );
+    assert_eq!(selected.acquisition_frontiers[0].other_subject.len(), 1);
+
+    for rejected_id in ["reverse-edit-class-control", "singleton-commit-partition"] {
+        let rejected = investigation
+            .candidates
+            .iter()
+            .find(|candidate| {
+                candidate.episode_id == OXC_EPISODE && candidate.candidate_id == rejected_id
+            })
+            .unwrap();
+        assert_eq!(
+            rejected.disposition,
+            RefinementInvestigationDispositionStatus::ReplayRejected
+        );
+        assert!(rejected.acquisition_frontiers.is_empty());
+    }
+}
+
+#[test]
+fn selected_survivor_missing_subject_mapping_requests_mapping_research() {
+    let mut request = request();
+    request.mappings.mappings.retain(|mapping| {
+        !(mapping.episode_id == OXC_EPISODE
+            && mapping.candidate_id == SELECTED_OXC_CANDIDATE
+            && mapping.discriminator_id == "edit_class")
+    });
+
+    let investigation = evaluate_refinement_investigation_demand(&request).unwrap();
+    let selected = investigation
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.episode_id == OXC_EPISODE && candidate.candidate_id == SELECTED_OXC_CANDIDATE
+        })
+        .unwrap();
+    assert_eq!(
+        selected.disposition,
+        RefinementInvestigationDispositionStatus::RequirementMappingNeeded
+    );
+    assert_eq!(selected.missing_requirement_mappings, vec!["edit_class"]);
+    assert!(selected.acquisition_frontiers.is_empty());
+}
+
+#[test]
+fn rejected_candidates_stay_quiet_even_with_perfect_current_evidence() {
+    let mut request = request();
+    add_rejected_oxc_candidate_evidence(&mut request);
+
+    let investigation = evaluate_refinement_investigation_demand(&request).unwrap();
+    for (candidate_id, replay_status) in [
+        (
+            "reverse-edit-class-control",
+            RefinementStatus::RejectedNoImprovement,
+        ),
+        (
+            "singleton-commit-partition",
+            RefinementStatus::RejectedOverfit,
+        ),
+    ] {
+        let candidate = investigation
+            .candidates
+            .iter()
+            .find(|candidate| {
+                candidate.episode_id == OXC_EPISODE && candidate.candidate_id == candidate_id
+            })
+            .unwrap();
+        assert_eq!(candidate.replay_status, replay_status);
+        assert_eq!(candidate.evidence_status, CandidateEvidenceStatus::Current);
+        assert_eq!(
+            candidate.disposition,
+            RefinementInvestigationDispositionStatus::ReplayRejected
+        );
+        assert!(candidate.acquisition_frontiers.is_empty());
+    }
+}
+
+#[test]
+fn unselected_replay_survivor_stays_quiet_with_current_or_blocked_evidence() {
+    let mut current = request();
+    add_unselected_survivor(&mut current, true);
+    let current_result = evaluate_refinement_investigation_demand(&current).unwrap();
+    let current_candidate = current_result
+        .candidates
+        .iter()
+        .find(|candidate| candidate.candidate_id == "syntax-changing-unselected-control")
+        .unwrap();
+    assert_eq!(current_candidate.replay_status, RefinementStatus::Retained);
+    assert_eq!(
+        current_candidate.evidence_status,
+        CandidateEvidenceStatus::Current
+    );
+    assert_eq!(
+        current_candidate.disposition,
+        RefinementInvestigationDispositionStatus::Unselected
+    );
+    assert!(current_candidate.acquisition_frontiers.is_empty());
+
+    let mut blocked = request();
+    add_unselected_survivor(&mut blocked, false);
+    let blocked_result = evaluate_refinement_investigation_demand(&blocked).unwrap();
+    let blocked_candidate = blocked_result
+        .candidates
+        .iter()
+        .find(|candidate| candidate.candidate_id == "syntax-changing-unselected-control")
+        .unwrap();
+    assert_eq!(blocked_candidate.replay_status, RefinementStatus::Retained);
+    assert_eq!(
+        blocked_candidate.evidence_status,
+        CandidateEvidenceStatus::Blocked
+    );
+    assert_eq!(
+        blocked_candidate.disposition,
+        RefinementInvestigationDispositionStatus::Unselected
+    );
+    assert_eq!(
+        blocked_candidate.missing_requirement_mappings,
+        vec!["edit_class"]
+    );
+    assert!(blocked_candidate.acquisition_frontiers.is_empty());
+}
+
+#[test]
+fn mapped_unknown_and_invalid_selected_evidence_are_acquisition_frontiers() {
+    let mut unknown = request();
+    let observation = unknown
+        .observations
+        .observations
+        .iter_mut()
+        .find(|observation| observation.subject_ref == SELECTED_OXC_SUBJECT)
+        .unwrap();
+    observation.value_state = DiscriminatorValueState::Unknown {
+        reason_ref: "research:refinement-investigation:unknown-control".to_string(),
+    };
+    let unknown_result = evaluate_refinement_investigation_demand(&unknown).unwrap();
+    let unknown_candidate = unknown_result
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.episode_id == OXC_EPISODE && candidate.candidate_id == SELECTED_OXC_CANDIDATE
+        })
+        .unwrap();
+    assert_eq!(
+        unknown_candidate.disposition,
+        RefinementInvestigationDispositionStatus::ObservationAcquisitionNeeded
+    );
+    assert_eq!(unknown_candidate.acquisition_frontiers.len(), 1);
+    assert_eq!(
+        unknown_candidate.acquisition_frontiers[0].status,
+        ObservationFrontierStatus::Unknown
+    );
+
+    let mut invalid = request();
+    let observation = invalid
+        .observations
+        .observations
+        .iter_mut()
+        .find(|observation| observation.subject_ref == SELECTED_OXC_SUBJECT)
+        .unwrap();
+    observation.applicability.status = ObservationApplicabilityStatus::Invalid;
+    observation.applicability.receipt_ref =
+        "research:refinement-investigation:invalid-control".to_string();
+    let invalid_result = evaluate_refinement_investigation_demand(&invalid).unwrap();
+    let invalid_candidate = invalid_result
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.episode_id == OXC_EPISODE && candidate.candidate_id == SELECTED_OXC_CANDIDATE
+        })
+        .unwrap();
+    assert_eq!(
+        invalid_candidate.disposition,
+        RefinementInvestigationDispositionStatus::ObservationAcquisitionNeeded
+    );
+    assert_eq!(invalid_candidate.acquisition_frontiers.len(), 1);
+    assert_eq!(
+        invalid_candidate.acquisition_frontiers[0].status,
+        ObservationFrontierStatus::Invalid
+    );
+}

--- a/tests/refinement_investigation_held_out_contract.rs
+++ b/tests/refinement_investigation_held_out_contract.rs
@@ -1,0 +1,109 @@
+#![allow(dead_code)]
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/refinement_candidate_readiness.rs"]
+mod refinement_candidate_readiness;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+#[path = "../src/refinement_investigation_demand.rs"]
+mod refinement_investigation_demand;
+#[path = "../src/refinement_observation_requirement.rs"]
+mod refinement_observation_requirement;
+
+use discriminator_observation::parse_discriminator_observation_batch;
+use refinement_candidate_readiness::{
+    REFINEMENT_CANDIDATE_READINESS_SCHEMA_VERSION, RefinementCandidateReadinessRequest,
+};
+use refinement_episode::{HeldOutStatus, parse_refinement_episode_batch};
+use refinement_investigation_demand::{
+    RefinementInvestigationDispositionStatus, evaluate_refinement_investigation_demand,
+};
+
+const OBSERVATIONS: &[u8] =
+    include_bytes!("../research/discriminator-observations/cultist-v1.json");
+const REFINEMENTS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+const MAPPINGS: &[u8] =
+    include_bytes!("../research/refinement-observation-requirements/cultist-v1.json");
+const OXC_EPISODE: &str = "history/oxc-edit-class-v1";
+const SELECTED_OXC_CANDIDATE: &str = "syntax-changing-current-cohort";
+const SELECTED_OXC_SUBJECT: &str =
+    "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs";
+
+fn request() -> RefinementCandidateReadinessRequest {
+    RefinementCandidateReadinessRequest {
+        schema_version: REFINEMENT_CANDIDATE_READINESS_SCHEMA_VERSION,
+        refinements: parse_refinement_episode_batch(REFINEMENTS).unwrap(),
+        mappings: serde_json::from_slice(MAPPINGS).unwrap(),
+        observations: parse_discriminator_observation_batch(OBSERVATIONS).unwrap(),
+    }
+}
+
+fn set_selected_held_out(
+    request: &mut RefinementCandidateReadinessRequest,
+    status: HeldOutStatus,
+) {
+    let episode = request
+        .refinements
+        .episodes
+        .iter_mut()
+        .find(|episode| episode.id == OXC_EPISODE)
+        .unwrap();
+    let selected = episode
+        .candidate_refinements
+        .iter_mut()
+        .find(|candidate| candidate.id == SELECTED_OXC_CANDIDATE)
+        .unwrap();
+    selected.replay_result.held_out_status = status;
+}
+
+fn selected<'a>(
+    evaluation: &'a refinement_investigation_demand::RefinementInvestigationDemandEvaluation,
+) -> &'a refinement_investigation_demand::RefinementInvestigationDisposition {
+    evaluation
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.episode_id == OXC_EPISODE && candidate.candidate_id == SELECTED_OXC_CANDIDATE
+        })
+        .unwrap()
+}
+
+#[test]
+fn selected_status_survivor_with_unknown_held_out_stays_satisfied_and_preserves_unknown() {
+    let mut request = request();
+    set_selected_held_out(&mut request, HeldOutStatus::Unknown);
+
+    let evaluation = evaluate_refinement_investigation_demand(&request).unwrap();
+    let candidate = selected(&evaluation);
+    assert_eq!(
+        candidate.disposition,
+        RefinementInvestigationDispositionStatus::Satisfied
+    );
+    assert_eq!(candidate.replay_result.held_out_status, HeldOutStatus::Unknown);
+}
+
+#[test]
+fn selected_status_survivor_with_not_run_held_out_can_request_exact_missing_observation() {
+    let mut request = request();
+    set_selected_held_out(&mut request, HeldOutStatus::NotRun);
+    request.observations.observations.retain(|observation| {
+        !(observation.discriminator_id == "edit_class"
+            && observation.subject_ref == SELECTED_OXC_SUBJECT)
+    });
+
+    let evaluation = evaluate_refinement_investigation_demand(&request).unwrap();
+    let candidate = selected(&evaluation);
+    assert_eq!(
+        candidate.disposition,
+        RefinementInvestigationDispositionStatus::ObservationAcquisitionNeeded
+    );
+    assert_eq!(candidate.replay_result.held_out_status, HeldOutStatus::NotRun);
+    assert_eq!(candidate.acquisition_frontiers.len(), 1);
+    assert_eq!(
+        candidate.acquisition_frontiers[0].subject_ref,
+        SELECTED_OXC_SUBJECT
+    );
+}

--- a/tests/refinement_investigation_held_out_contract.rs
+++ b/tests/refinement_investigation_held_out_contract.rs
@@ -41,10 +41,7 @@ fn request() -> RefinementCandidateReadinessRequest {
     }
 }
 
-fn set_selected_held_out(
-    request: &mut RefinementCandidateReadinessRequest,
-    status: HeldOutStatus,
-) {
+fn set_selected_held_out(request: &mut RefinementCandidateReadinessRequest, status: HeldOutStatus) {
     let episode = request
         .refinements
         .episodes
@@ -82,7 +79,10 @@ fn selected_status_survivor_with_unknown_held_out_stays_satisfied_and_preserves_
         candidate.disposition,
         RefinementInvestigationDispositionStatus::Satisfied
     );
-    assert_eq!(candidate.replay_result.held_out_status, HeldOutStatus::Unknown);
+    assert_eq!(
+        candidate.replay_result.held_out_status,
+        HeldOutStatus::Unknown
+    );
 }
 
 #[test]
@@ -100,7 +100,10 @@ fn selected_status_survivor_with_not_run_held_out_can_request_exact_missing_obse
         candidate.disposition,
         RefinementInvestigationDispositionStatus::ObservationAcquisitionNeeded
     );
-    assert_eq!(candidate.replay_result.held_out_status, HeldOutStatus::NotRun);
+    assert_eq!(
+        candidate.replay_result.held_out_status,
+        HeldOutStatus::NotRun
+    );
     assert_eq!(candidate.acquisition_frontiers.len(), 1);
     assert_eq!(
         candidate.acquisition_frontiers[0].subject_ref,

--- a/tests/refinement_investigation_held_out_contract.rs
+++ b/tests/refinement_investigation_held_out_contract.rs
@@ -56,9 +56,9 @@ fn set_selected_held_out(request: &mut RefinementCandidateReadinessRequest, stat
     selected.replay_result.held_out_status = status;
 }
 
-fn selected<'a>(
-    evaluation: &'a refinement_investigation_demand::RefinementInvestigationDemandEvaluation,
-) -> &'a refinement_investigation_demand::RefinementInvestigationDisposition {
+fn selected(
+    evaluation: &refinement_investigation_demand::RefinementInvestigationDemandEvaluation,
+) -> &refinement_investigation_demand::RefinementInvestigationDisposition {
     evaluation
         .candidates
         .iter()


### PR DESCRIPTION
Progresses #248 as the replay/selection/currentness gate before expensive refinement investigation.

## Core disposition

For each retained replay candidate:

```text
replay rejected
  -> replay_rejected

survives but is not the selected transition
  -> unselected

selected survivor + all mapped exact observations current
  -> satisfied

selected survivor + missing requirement mapping
  -> requirement_mapping_needed

selected survivor + mapped MISSING | UNKNOWN | INVALID observation frontier
  -> observation_acquisition_needed
```

Rejected and unselected candidates emit zero acquisition frontiers.

## Held-out replay contract

The parent refinement episode permits kept candidates with held-out status:

```text
passed | not_run | unknown
```

and rejects kept candidates whose held-out replay is `failed`.

This lane therefore defines **survival as status-level non-rejection**. Held-out completeness remains an independent receipt axis and is never rewritten to `passed`.

`RefinementInvestigationDisposition` now carries the complete source `ReplayResult` in addition to the convenience `replay_status`, preserving expected/lost cases, counterexample counts, and `held_out_status` for downstream readers.

New executable controls prove:

```text
selected survivor + held_out unknown + current evidence
  -> satisfied
  -> held_out unknown preserved

selected survivor + held_out not_run + exact mapped observation missing
  -> observation_acquisition_needed
  -> held_out not_run preserved
```

A downstream planner may choose a stricter held-out prerequisite later, but it must do so explicitly from this preserved replay result rather than inferring completion from candidate status.

## Current validation

Latest semantic head includes the held-out visibility change and its dedicated contract test. Ordinary CI run `32273560605` passed rustfmt, strict Clippy, the complete test suite, active-work heads-up, all repository/history/CI-test dogfood, and diff text + JSON.

The focused note is retained in:

```text
research/refinement-investigation-held-out-contract.md
```

No acquisition executes here; this layer only says where investigation is justified.

Refs #179 #190 #231 #243 #248 #255.