### PR TITLE
research: plan only admitted refinement acquisition frontiers

### DIFF
--- a/.github/workflows/refinement-demand-probe-planning.yml
+++ b/.github/workflows/refinement-demand-probe-planning.yml
@@ -1,0 +1,322 @@
+name: Refinement demand probe planning
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/refinement-demand-probe-planning.yml"
+      - "research/refinement-episodes/cultist-v1.json"
+      - "research/refinement-observation-requirements/cultist-v1.json"
+      - "research/discriminator-observations/cultist-v1.json"
+      - "src/refinement_candidate_readiness.rs"
+      - "src/refinement_investigation_demand.rs"
+      - "src/observation_frontier.rs"
+      - "src/observation_probe_bridge.rs"
+      - "src/rust_edit_class_source.rs"
+      - "examples/refinement_investigation_demand.rs"
+      - "examples/observation_probe_plan.rs"
+      - "examples/rust_edit_class_observation.rs"
+      - "tests/refinement_demand_probe_planning.rs"
+
+permissions:
+  contents: read
+
+jobs:
+  selected-oxc-demand-plan:
+    if: github.event_name == 'workflow_dispatch' || github.head_ref == 'research/refinement-demand-probe-planning'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Cultist
+        uses: actions/checkout@v4
+        with:
+          path: cultist
+
+      - name: Install stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Build independent readers
+        run: |
+          cargo build --release \
+            --example refinement_investigation_demand \
+            --example observation_probe_plan \
+            --example rust_edit_class_observation \
+            --manifest-path cultist/Cargo.toml
+
+      - name: Build retained selected-candidate demand request
+        id: demand
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          refinements = json.loads(Path("cultist/research/refinement-episodes/cultist-v1.json").read_text())
+          mappings = json.loads(Path("cultist/research/refinement-observation-requirements/cultist-v1.json").read_text())
+          observations = json.loads(Path("cultist/research/discriminator-observations/cultist-v1.json").read_text())
+
+          episode = "history/oxc-edit-class-v1"
+          candidate = "syntax-changing-current-cohort"
+          revision = "228e8e0f85c0e7aeded02c5e27fd810004d3b41a"
+          path = "crates/oxc_linter/src/rules.rs"
+          subject = f"oxc-project/oxc@{revision}:{path}"
+
+          mapping = next(
+              row for row in mappings["mappings"]
+              if row["episode_id"] == episode
+              and row["candidate_id"] == candidate
+              and row["discriminator_id"] == "edit_class"
+          )
+          assert mapping["subject_ref"] == subject, mapping
+
+          exact = next(
+              row for row in observations["observations"]
+              if row["discriminator_id"] == "edit_class"
+              and row["subject_ref"] == subject
+          )
+          observations["observations"] = [
+              row for row in observations["observations"]
+              if row["observation_id"] != exact["observation_id"]
+          ]
+
+          wrong_path = json.loads(json.dumps(exact))
+          wrong_path["observation_id"] = "demand-plan:wrong-path-edit-class"
+          wrong_path["subject_ref"] = subject.replace("/rules.rs", "/other.rs")
+          wrong_path["source_receipt"] = "research:demand-plan:wrong-path"
+          observations["observations"].append(wrong_path)
+
+          pinned = json.loads(json.dumps(exact))
+          pinned["observation_id"] = "demand-plan:pinned-head-control"
+          pinned["subject_ref"] = (
+              "oxc-project/oxc@8783524015b1e6ff1c39ccf426df0bb07cbbc588:"
+              "crates/oxc_linter/src/rules.rs"
+          )
+          pinned["source_receipt"] = "research:demand-plan:pinned-head-control"
+          pinned["value_state"] = {
+              "state": "unknown",
+              "reason_ref": "rust-edit-class:anchor-unchanged:demand-plan-control",
+          }
+          observations["observations"].append(pinned)
+
+          request = {
+              "schema_version": 1,
+              "refinements": refinements,
+              "mappings": mappings,
+              "observations": observations,
+          }
+          Path("demand-request.json").write_text(json.dumps(request), encoding="utf-8")
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as out:
+              out.write(f"revision={revision}\n")
+              out.write(f"path={path}\n")
+              out.write(f"subject_ref={subject}\n")
+          PY
+
+      - name: Admit only selected replay-surviving acquisition demand
+        run: |
+          "$PWD/cultist/target/release/examples/refinement_investigation_demand" \
+            < demand-request.json \
+            > demand-before.json
+          cat demand-before.json
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          result = json.loads(Path("demand-before.json").read_text())
+          oxc = [row for row in result["candidates"] if row["episode_id"] == "history/oxc-edit-class-v1"]
+          selected = next(row for row in oxc if row["candidate_id"] == "syntax-changing-current-cohort")
+          assert selected["replay_status"] == "weakened", selected
+          assert selected["evidence_status"] == "blocked", selected
+          assert selected["disposition"] == "observation_acquisition_needed", selected
+          assert selected["missing_requirement_mappings"] == [], selected
+          assert len(selected["acquisition_frontiers"]) == 1, selected
+          frontier = selected["acquisition_frontiers"][0]
+          assert frontier["status"] == "missing", frontier
+          assert len(frontier["other_subject"]) == 2, frontier
+
+          for candidate_id in ["reverse-edit-class-control", "singleton-commit-partition"]:
+              rejected = next(row for row in oxc if row["candidate_id"] == candidate_id)
+              assert rejected["disposition"] == "replay_rejected", rejected
+              assert rejected["acquisition_frontiers"] == [], rejected
+
+          acquisition_count = sum(len(row["acquisition_frontiers"]) for row in oxc)
+          assert acquisition_count == 1, oxc
+          Path("acquisition-frontier.json").write_text(json.dumps(frontier), encoding="utf-8")
+          PY
+
+      - name: Checkout pinned Oxc history
+        uses: actions/checkout@v4
+        with:
+          repository: oxc-project/oxc
+          ref: 8783524015b1e6ff1c39ccf426df0bb07cbbc588
+          fetch-depth: 200
+          persist-credentials: false
+          path: target
+
+      - name: Verify demanded subject is still latest focused anchor commit
+        env:
+          EXPECTED_REVISION: ${{ steps.demand.outputs.revision }}
+          TARGET_PATH: ${{ steps.demand.outputs.path }}
+        run: |
+          set -euo pipefail
+          test "$(git -C target rev-parse HEAD)" = "8783524015b1e6ff1c39ccf426df0bb07cbbc588"
+          focused="$(git -C target log --no-merges -1 --format='%H' -- "$TARGET_PATH")"
+          test "$focused" = "$EXPECTED_REVISION"
+          test -n "$(git -C target diff-tree --no-commit-id --name-only -r "$focused" -- "$TARGET_PATH")"
+          git -C target show --no-patch --format='%H %s' "$focused"
+
+      - name: Preserve pinned repository-head UNKNOWN source control
+        env:
+          TARGET_PATH: ${{ steps.demand.outputs.path }}
+        run: |
+          set -euo pipefail
+          "$PWD/cultist/target/release/examples/rust_edit_class_observation" \
+            "$PWD/target" \
+            oxc-project/oxc \
+            8783524015b1e6ff1c39ccf426df0bb07cbbc588 \
+            "$TARGET_PATH" \
+            > pinned-head-source.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          observation = json.loads(Path("pinned-head-source.json").read_text())["observation"]
+          assert observation["value_state"]["state"] == "unknown", observation
+          assert "anchor-unchanged" in observation["value_state"]["reason_ref"], observation
+          PY
+
+      - name: Checkout demanded focused commit
+        env:
+          EXPECTED_REVISION: ${{ steps.demand.outputs.revision }}
+        run: |
+          set -euo pipefail
+          git -C target checkout -q "$EXPECTED_REVISION"
+          test "$(git -C target rev-parse HEAD)" = "$EXPECTED_REVISION"
+
+      - name: Execute admitted source producer
+        env:
+          EXPECTED_REVISION: ${{ steps.demand.outputs.revision }}
+          TARGET_PATH: ${{ steps.demand.outputs.path }}
+        run: |
+          set -euo pipefail
+          "$PWD/cultist/target/release/examples/rust_edit_class_observation" \
+            "$PWD/target" \
+            oxc-project/oxc \
+            "$EXPECTED_REVISION" \
+            "$TARGET_PATH" \
+            > source-result.json
+          cat source-result.json
+
+      - name: Require source bridge matches admitted acquisition frontier
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          frontier = json.loads(Path("acquisition-frontier.json").read_text())
+          source = json.loads(Path("source-result.json").read_text())
+          assert source["bridge"]["observation_discriminator_id"] == frontier["discriminator_id"], source
+          assert source["bridge"]["observation_subject_ref"] == frontier["subject_ref"], source
+          assert source["observation"]["discriminator_id"] == frontier["discriminator_id"], source
+          assert source["observation"]["subject_ref"] == frontier["subject_ref"], source
+          assert source["observation"]["value_state"] == {
+              "state": "known",
+              "value_ref": "syntax_changed",
+          }, source
+          assert source["observation"]["applicability"]["status"] == "applies", source
+          PY
+
+      - name: Plan only the admitted acquisition frontier
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          frontier = json.loads(Path("acquisition-frontier.json").read_text())
+          source = json.loads(Path("source-result.json").read_text())
+          subject = source["subject"]
+          request = {
+              "schema_version": 1,
+              "frontier": frontier,
+              "bridges": [source["bridge"]],
+              "context": {
+                  "repository": subject["repository"],
+                  "revision": subject["revision"],
+                  "path": subject["path"],
+              },
+              "probes": [source["probe"]],
+              "allow_effectful": False,
+              "policy": "conservative",
+          }
+          Path("plan-request.json").write_text(json.dumps(request), encoding="utf-8")
+          PY
+
+          "$PWD/cultist/target/release/examples/observation_probe_plan" \
+            < plan-request.json \
+            > plan.json
+          cat plan.json
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          plan = json.loads(Path("plan.json").read_text())
+          assert plan["frontier_status"] == "missing", plan
+          assert plan["status"] == "planned", plan
+          assert plan["evidence_plan"]["status"] == "selected", plan
+          PY
+
+      - name: Insert produced observation and reevaluate investigation demand
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          request = json.loads(Path("demand-request.json").read_text())
+          source = json.loads(Path("source-result.json").read_text())
+          request["observations"]["observations"].append(source["observation"])
+          Path("demand-after-request.json").write_text(json.dumps(request), encoding="utf-8")
+          PY
+
+          "$PWD/cultist/target/release/examples/refinement_investigation_demand" \
+            < demand-after-request.json \
+            > demand-after.json
+          cat demand-after.json
+
+      - name: Assert demand-gated probe-planning loop
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          before = json.loads(Path("demand-before.json").read_text())
+          after = json.loads(Path("demand-after.json").read_text())
+          plan = json.loads(Path("plan.json").read_text())
+
+          before_oxc = [row for row in before["candidates"] if row["episode_id"] == "history/oxc-edit-class-v1"]
+          after_oxc = [row for row in after["candidates"] if row["episode_id"] == "history/oxc-edit-class-v1"]
+          before_selected = next(row for row in before_oxc if row["candidate_id"] == "syntax-changing-current-cohort")
+          after_selected = next(row for row in after_oxc if row["candidate_id"] == "syntax-changing-current-cohort")
+
+          assert before_selected["disposition"] == "observation_acquisition_needed", before_selected
+          assert len(before_selected["acquisition_frontiers"]) == 1, before_selected
+          assert plan["evidence_plan"]["status"] == "selected", plan
+          assert after_selected["disposition"] == "satisfied", after_selected
+          assert after_selected["evidence_status"] == "current", after_selected
+          assert after_selected["acquisition_frontiers"] == [], after_selected
+
+          for rows in [before_oxc, after_oxc]:
+              for candidate_id in ["reverse-edit-class-control", "singleton-commit-partition"]:
+                  rejected = next(row for row in rows if row["candidate_id"] == candidate_id)
+                  assert rejected["disposition"] == "replay_rejected", rejected
+                  assert rejected["acquisition_frontiers"] == [], rejected
+
+          print(json.dumps({
+              "episode_id": "history/oxc-edit-class-v1",
+              "candidate_id": "syntax-changing-current-cohort",
+              "initial_disposition": before_selected["disposition"],
+              "initial_frontier": before_selected["acquisition_frontiers"][0]["status"],
+              "selected_probe": plan["evidence_plan"]["selected"]["id"],
+              "final_disposition": after_selected["disposition"],
+              "rejected_candidates_planned": 0,
+          }, indent=2, sort_keys=True))
+          PY

--- a/research/refinement-demand-probe-planning.md
+++ b/research/refinement-demand-probe-planning.md
@@ -1,0 +1,186 @@
+# Demand-gated refinement probe planning
+
+Tracking: #190, downstream of #248/#251. Composes #251 refinement investigation demand with #216 observation-probe planning and #221 source-owned Rust edit-class acquisition.
+
+## Question
+
+Can the refinement research loop reach probe planning only through an explicitly admitted selected-candidate acquisition frontier?
+
+#251 earned the precondition:
+
+```text
+replay rejected                  -> replay_rejected
+surviving but unselected         -> unselected
+selected + evidence current      -> satisfied
+selected + missing D@S mapping   -> requirement_mapping_needed
+selected + mapped noncurrent D@S -> observation_acquisition_needed
+```
+
+This carrier asks whether only the last disposition can become a #216 planner request.
+
+## Composition
+
+No new shared module is introduced.
+
+```text
+#179 replay + selected transition
+-> #231 exact candidate D@S mapping
+-> #243 readiness
+-> #251 investigation disposition
+-> observation_acquisition_needed.acquisition_frontier
+-> #221 source-owned bridge + probe
+-> #216 / #145 planner
+-> selected read-only probe
+-> source observation
+-> #251 reevaluation
+-> satisfied
+```
+
+`requirement_mapping_needed` stops before #216 because the exact observation subject is still absent. `replay_rejected`, `unselected`, and `satisfied` carry zero acquisition frontiers, so there is no planner input to manufacture.
+
+## Network-free standard carrier
+
+`tests/refinement_demand_probe_planning.rs` creates a temporary Git repository and uses the real #221 Rust edit-class source adapter.
+
+The selected Oxc candidate is retained as the replay object, while its #231 mapping is rebound by an explicit test receipt to the temporary exact subject:
+
+```text
+owner/repo@<syntax-commit>:src/lib.rs
+```
+
+The source adapter classifies the one-parent lexical Rust change as `syntax_changed` and emits its normal read-only bridge/probe.
+
+### Missing exact observation
+
+With the exact observation absent:
+
+```text
+selected candidate
+  -> observation_acquisition_needed
+  -> exact MISSING frontier
+```
+
+That exact frontier is passed unchanged to #216 with the source-owned bridge/probe. The existing planner returns:
+
+```text
+status         planned
+frontier       missing
+evidence plan  selected
+selected probe rust-edit-class-<sha-prefix>
+```
+
+After inserting the source observation back into the same readiness request, the selected candidate becomes `satisfied` and carries zero acquisition frontiers.
+
+### Quiet dispositions
+
+A current selected candidate is `satisfied`; removing its exact mapping yields `requirement_mapping_needed`. Neither state carries a planner frontier. Replay-rejected Oxc alternatives also carry zero acquisition frontiers.
+
+### UNKNOWN / INVALID
+
+Exact mapped UNKNOWN and INVALID selected observations remain `observation_acquisition_needed`. Their exact #210 frontier status is preserved into #216, and the same admitted read-only source probe remains selectable. Planning itself does not change currentness.
+
+## Public Oxc carrier
+
+`.github/workflows/refinement-demand-probe-planning.yml` replays the same composition against pinned Oxc history.
+
+It:
+
+1. loads retained #179 refinements, #231 mappings, and v2 observations;
+2. withholds exact focused Oxc `edit_class@228e...:rules.rs`;
+3. preserves two other-subject controls: wrong path at the focused commit and UNKNOWN same path at pinned repository head `8783524...`;
+4. runs the #251 investigation-demand reader;
+5. requires the selected Oxc candidate alone to emit one exact MISSING acquisition frontier;
+6. requires both rejected Oxc alternatives to remain `replay_rejected` with zero acquisition frontiers;
+7. verifies `228e8e0f85c0e7aeded02c5e27fd810004d3b41a` is still the latest non-merge `rules.rs` change within the pinned history;
+8. preserves the #221 pinned-head UNKNOWN `anchor-unchanged` source control;
+9. executes the exact focused #221 source producer;
+10. requires its bridge and observation to match the admitted acquisition frontier exactly;
+11. feeds only that frontier into #216 and requires the read-only probe to be selected;
+12. inserts the produced observation into the same demand request;
+13. reruns #251 and requires the selected candidate to become `satisfied` while rejected alternatives remain quiet.
+
+This public carrier is intentionally stricter than a direct frontier→planner replay: the frontier must first survive the candidate replay/selection/demand gate.
+
+## Boundary
+
+- composition only;
+- no new source or planner state model;
+- no implicit candidate-to-probe mapping;
+- no planner request from `requirement_mapping_needed`;
+- no planner request from replay-rejected or unselected candidates;
+- no probe execution authority is granted by demand;
+- #216/#145 effect policy remains authoritative;
+- planning preserves noncurrent frontier status;
+- only produced source observation can make the candidate evidence-current/satisfied;
+- no refinement ranking, selection, or promotion;
+- no product CLI/report-schema change.
+
+## Execution receipt
+
+Initial semantic head `51d33a442a9d5ab537c3ed6816ab7503c41b49e8` produced two useful first-run results:
+
+```text
+ordinary CI
+  run:        32268379996
+  run number: 1835
+  result:     rustfmt-only failure in the local test carrier
+
+public Oxc demand-gated carrier
+  run:        32268380102
+  run number: 1
+  result:     success
+```
+
+The public workflow already proved the complete demand gate before the formatter-only local patch.
+
+After applying the exact rustfmt delta, formatted semantic head:
+
+```text
+5ae06686c72d170869fdd1905da8062561954d94
+```
+
+passed both current-head gates:
+
+```text
+ordinary CI
+  run:        32268549801
+  run number: 1845
+  result:     success
+
+public Oxc demand-gated carrier
+  run:        32268549821
+  run number: 2
+  result:     success
+```
+
+Ordinary CI passed format, strict Clippy, active-work preflight, the temporary-Git demand→source→planner→satisfied controls, UNKNOWN/INVALID planning controls, and repository/history/CI-filter/diff dogfood.
+
+The public carrier proved:
+
+```text
+retained Oxc candidates before acquisition
+  blocked-looking evidence gaps = 3
+  admitted acquisition frontiers = 1
+  replay-rejected planner requests = 0
+
+selected syntax-changing-current-cohort
+  -> observation_acquisition_needed
+  -> exact MISSING edit_class@228e...:rules.rs frontier
+  -> #221 bridge/probe exact match
+  -> #216 planned
+  -> #145 selected read-only probe
+  -> produced KNOWN syntax_changed + APPLIES
+  -> #251 satisfied
+
+reverse-edit-class-control
+singleton-commit-partition
+  -> replay_rejected throughout
+  -> zero acquisition frontiers
+  -> zero planner requests
+```
+
+The decision-changing compression is therefore explicit: a raw blocked-candidate lens would point at three Oxc candidates; replay/selection/subject/currentness gating produces one justified planner request.
+
+North star:
+
+> Reach probe planning only after replay, selection, exact subject binding, and currentness all agree that this evidence gap deserves work.

--- a/tests/refinement_demand_probe_planning.rs
+++ b/tests/refinement_demand_probe_planning.rs
@@ -43,7 +43,7 @@ use observation_probe_bridge::{
 use refinement_candidate_readiness::{
     REFINEMENT_CANDIDATE_READINESS_SCHEMA_VERSION, RefinementCandidateReadinessRequest,
 };
-use refinement_episode::parse_refinement_episode_batch;
+use refinement_episode::{HeldOutStatus, parse_refinement_episode_batch};
 use refinement_investigation_demand::{
     RefinementInvestigationDispositionStatus, evaluate_refinement_investigation_demand,
 };
@@ -182,6 +182,24 @@ fn request_for_subject(subject: &RustEditClassSubject) -> RefinementCandidateRea
     request
 }
 
+fn set_selected_held_out(
+    request: &mut RefinementCandidateReadinessRequest,
+    held_out_status: HeldOutStatus,
+) {
+    let episode = request
+        .refinements
+        .episodes
+        .iter_mut()
+        .find(|episode| episode.id == OXC_EPISODE)
+        .unwrap();
+    let selected = episode
+        .candidate_refinements
+        .iter_mut()
+        .find(|candidate| candidate.id == SELECTED_OXC_CANDIDATE)
+        .unwrap();
+    selected.replay_result.held_out_status = held_out_status;
+}
+
 fn selected_disposition(
     request: &RefinementCandidateReadinessRequest,
 ) -> refinement_investigation_demand::RefinementInvestigationDisposition {
@@ -264,6 +282,32 @@ fn selected_acquisition_demand_routes_to_real_source_probe_and_closes_after_obse
         RefinementInvestigationDispositionStatus::Satisfied
     );
     assert!(after.acquisition_frontiers.is_empty());
+}
+
+#[test]
+fn held_out_not_run_remains_visible_on_the_disposition_that_authorizes_planning() {
+    let (_repo, _revision, source) = local_source();
+    let mut request = request_for_subject(&source.subject);
+    set_selected_held_out(&mut request, HeldOutStatus::NotRun);
+
+    let disposition = selected_disposition(&request);
+    assert_eq!(
+        disposition.disposition,
+        RefinementInvestigationDispositionStatus::ObservationAcquisitionNeeded
+    );
+    assert_eq!(
+        disposition.replay_result.held_out_status,
+        HeldOutStatus::NotRun
+    );
+    assert_eq!(disposition.acquisition_frontiers.len(), 1);
+
+    let plan = plan_frontier(&source, disposition.acquisition_frontiers[0].clone());
+    assert_eq!(plan.status, ObservationProbePlanStatus::Planned);
+    assert_eq!(plan.frontier_status, ObservationFrontierStatus::Missing);
+    assert_eq!(
+        plan.evidence_plan.as_ref().unwrap().status,
+        EvidencePlanStatus::Selected
+    );
 }
 
 #[test]

--- a/tests/refinement_demand_probe_planning.rs
+++ b/tests/refinement_demand_probe_planning.rs
@@ -1,0 +1,366 @@
+#![allow(dead_code)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[path = "../src/justification.rs"]
+mod justification;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/observation_probe_bridge.rs"]
+mod observation_probe_bridge;
+#[path = "../src/refinement_candidate_readiness.rs"]
+mod refinement_candidate_readiness;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+#[path = "../src/refinement_investigation_demand.rs"]
+mod refinement_investigation_demand;
+#[path = "../src/refinement_observation_requirement.rs"]
+mod refinement_observation_requirement;
+#[path = "../src/rust_edit_class_source.rs"]
+mod rust_edit_class_source;
+
+use applicability::EvaluationContext;
+use discriminator_observation::{
+    DiscriminatorValueState, ObservationApplicabilityStatus, parse_discriminator_observation_batch,
+};
+use evidence_planner::{EvidencePlanStatus, ProbeSelectionPolicy};
+use observation_frontier::ObservationFrontierStatus;
+use observation_probe_bridge::{
+    OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION, ObservationProbePlanRequest,
+    ObservationProbePlanStatus, plan_observation_probe,
+};
+use refinement_candidate_readiness::{
+    REFINEMENT_CANDIDATE_READINESS_SCHEMA_VERSION, RefinementCandidateReadinessRequest,
+};
+use refinement_episode::parse_refinement_episode_batch;
+use refinement_investigation_demand::{
+    RefinementInvestigationDispositionStatus, evaluate_refinement_investigation_demand,
+};
+use rust_edit_class_source::{RustEditClassSubject, collect_rust_edit_class_source, subject_ref};
+
+const OBSERVATIONS: &[u8] =
+    include_bytes!("../research/discriminator-observations/cultist-v1.json");
+const REFINEMENTS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+const MAPPINGS: &[u8] =
+    include_bytes!("../research/refinement-observation-requirements/cultist-v1.json");
+const OXC_EPISODE: &str = "history/oxc-edit-class-v1";
+const SELECTED_OXC_CANDIDATE: &str = "syntax-changing-current-cohort";
+
+struct TempRepo {
+    root: PathBuf,
+}
+
+impl TempRepo {
+    fn new(label: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cultist-refinement-demand-plan-{label}-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(root.join("src")).unwrap();
+        run_git(&root, &["init", "-q"]);
+        run_git(&root, &["config", "user.email", "cultist@example.invalid"]);
+        run_git(&root, &["config", "user.name", "Cultist Test"]);
+        Self { root }
+    }
+
+    fn write(&self, source: &str) {
+        fs::write(self.root.join("src/lib.rs"), source).unwrap();
+    }
+
+    fn commit(&self, message: &str) -> String {
+        run_git(&self.root, &["add", "src/lib.rs"]);
+        run_git(&self.root, &["commit", "-q", "-m", message]);
+        git_output(&self.root, &["rev-parse", "HEAD"])
+    }
+}
+
+impl Drop for TempRepo {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn run_git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_output(root: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
+fn local_source() -> (
+    TempRepo,
+    String,
+    rust_edit_class_source::RustEditClassSourceResult,
+) {
+    let repo = TempRepo::new("source");
+    repo.write("fn answer() -> usize { 41 }\n");
+    repo.commit("root");
+    repo.write("fn answer() -> usize { 42 }\n");
+    let revision = repo.commit("syntax");
+    let subject = RustEditClassSubject {
+        repository: "owner/repo".to_string(),
+        revision: revision.clone(),
+        path: "src/lib.rs".to_string(),
+    };
+    let source = collect_rust_edit_class_source(&repo.root, &subject).unwrap();
+    assert_eq!(source.current_head, revision);
+    assert_eq!(
+        source.observation.value_state,
+        DiscriminatorValueState::Known {
+            value_ref: "syntax_changed".to_string()
+        }
+    );
+    assert_eq!(
+        source.observation.applicability.status,
+        ObservationApplicabilityStatus::Applies
+    );
+    (repo, revision, source)
+}
+
+fn request_for_subject(subject: &RustEditClassSubject) -> RefinementCandidateReadinessRequest {
+    let mut request = RefinementCandidateReadinessRequest {
+        schema_version: REFINEMENT_CANDIDATE_READINESS_SCHEMA_VERSION,
+        refinements: parse_refinement_episode_batch(REFINEMENTS).unwrap(),
+        mappings: serde_json::from_slice(MAPPINGS).unwrap(),
+        observations: parse_discriminator_observation_batch(OBSERVATIONS).unwrap(),
+    };
+    let subject_ref = subject_ref(subject);
+    let mapping = request
+        .mappings
+        .mappings
+        .iter_mut()
+        .find(|mapping| {
+            mapping.episode_id == OXC_EPISODE
+                && mapping.candidate_id == SELECTED_OXC_CANDIDATE
+                && mapping.discriminator_id == "edit_class"
+        })
+        .unwrap();
+    mapping.subject_ref = subject_ref;
+    mapping.source_receipt = "research:refinement-demand-plan:local-subject".to_string();
+
+    request
+        .observations
+        .observations
+        .retain(|observation| observation.discriminator_id != "edit_class");
+    request
+}
+
+fn selected_disposition(
+    request: &RefinementCandidateReadinessRequest,
+) -> refinement_investigation_demand::RefinementInvestigationDisposition {
+    evaluate_refinement_investigation_demand(request)
+        .unwrap()
+        .candidates
+        .into_iter()
+        .find(|candidate| {
+            candidate.episode_id == OXC_EPISODE && candidate.candidate_id == SELECTED_OXC_CANDIDATE
+        })
+        .unwrap()
+}
+
+fn plan_frontier(
+    source: &rust_edit_class_source::RustEditClassSourceResult,
+    frontier: observation_frontier::ObservationFrontierReceipt,
+) -> observation_probe_bridge::ObservationProbePlan {
+    plan_observation_probe(&ObservationProbePlanRequest {
+        schema_version: OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION,
+        frontier,
+        bridges: vec![source.bridge.clone()],
+        context: EvaluationContext {
+            repository: Some(source.subject.repository.clone()),
+            revision: Some(source.subject.revision.clone()),
+            work: None,
+            path: Some(source.subject.path.clone()),
+        },
+        probes: vec![source.probe.clone()],
+        allow_effectful: false,
+        policy: ProbeSelectionPolicy::Conservative,
+    })
+    .unwrap()
+}
+
+#[test]
+fn selected_acquisition_demand_routes_to_real_source_probe_and_closes_after_observation() {
+    let (_repo, _revision, source) = local_source();
+    let mut request = request_for_subject(&source.subject);
+
+    let before = selected_disposition(&request);
+    assert_eq!(
+        before.disposition,
+        RefinementInvestigationDispositionStatus::ObservationAcquisitionNeeded
+    );
+    assert_eq!(before.acquisition_frontiers.len(), 1);
+    assert_eq!(
+        before.acquisition_frontiers[0].status,
+        ObservationFrontierStatus::Missing
+    );
+    assert_eq!(
+        before.acquisition_frontiers[0].subject_ref,
+        source.observation.subject_ref
+    );
+
+    let plan = plan_frontier(&source, before.acquisition_frontiers[0].clone());
+    assert_eq!(plan.status, ObservationProbePlanStatus::Planned);
+    assert_eq!(plan.frontier_status, ObservationFrontierStatus::Missing);
+    assert_eq!(
+        plan.evidence_plan.as_ref().unwrap().status,
+        EvidencePlanStatus::Selected
+    );
+    assert_eq!(
+        plan.evidence_plan
+            .as_ref()
+            .unwrap()
+            .selected
+            .as_ref()
+            .unwrap()
+            .id,
+        source.probe.id
+    );
+
+    request
+        .observations
+        .observations
+        .push(source.observation.clone());
+    let after = selected_disposition(&request);
+    assert_eq!(
+        after.disposition,
+        RefinementInvestigationDispositionStatus::Satisfied
+    );
+    assert!(after.acquisition_frontiers.is_empty());
+}
+
+#[test]
+fn non_acquisition_dispositions_emit_zero_planner_frontiers() {
+    let (_repo, _revision, source) = local_source();
+    let mut current = request_for_subject(&source.subject);
+    current
+        .observations
+        .observations
+        .push(source.observation.clone());
+    let current_result = evaluate_refinement_investigation_demand(&current).unwrap();
+    let selected = current_result
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.episode_id == OXC_EPISODE && candidate.candidate_id == SELECTED_OXC_CANDIDATE
+        })
+        .unwrap();
+    assert_eq!(
+        selected.disposition,
+        RefinementInvestigationDispositionStatus::Satisfied
+    );
+    assert!(selected.acquisition_frontiers.is_empty());
+    assert!(
+        current_result
+            .candidates
+            .iter()
+            .filter(|candidate| candidate.episode_id == OXC_EPISODE)
+            .filter(|candidate| {
+                matches!(
+                    candidate.disposition,
+                    RefinementInvestigationDispositionStatus::ReplayRejected
+                        | RefinementInvestigationDispositionStatus::Unselected
+                )
+            })
+            .all(|candidate| candidate.acquisition_frontiers.is_empty())
+    );
+
+    let mut missing_mapping = request_for_subject(&source.subject);
+    missing_mapping.mappings.mappings.retain(|mapping| {
+        !(mapping.episode_id == OXC_EPISODE
+            && mapping.candidate_id == SELECTED_OXC_CANDIDATE
+            && mapping.discriminator_id == "edit_class")
+    });
+    let selected = selected_disposition(&missing_mapping);
+    assert_eq!(
+        selected.disposition,
+        RefinementInvestigationDispositionStatus::RequirementMappingNeeded
+    );
+    assert!(selected.acquisition_frontiers.is_empty());
+}
+
+#[test]
+fn mapped_unknown_and_invalid_selected_frontiers_both_reach_existing_planner() {
+    let (_repo, _revision, source) = local_source();
+
+    let mut unknown = request_for_subject(&source.subject);
+    let mut unknown_observation = source.observation.clone();
+    unknown_observation.value_state = DiscriminatorValueState::Unknown {
+        reason_ref: "research:refinement-demand-plan:unknown".to_string(),
+    };
+    unknown.observations.observations.push(unknown_observation);
+    let unknown_demand = selected_disposition(&unknown);
+    assert_eq!(
+        unknown_demand.disposition,
+        RefinementInvestigationDispositionStatus::ObservationAcquisitionNeeded
+    );
+    assert_eq!(
+        unknown_demand.acquisition_frontiers[0].status,
+        ObservationFrontierStatus::Unknown
+    );
+    let unknown_plan = plan_frontier(&source, unknown_demand.acquisition_frontiers[0].clone());
+    assert_eq!(unknown_plan.status, ObservationProbePlanStatus::Planned);
+    assert_eq!(
+        unknown_plan.evidence_plan.unwrap().status,
+        EvidencePlanStatus::Selected
+    );
+
+    let mut invalid = request_for_subject(&source.subject);
+    let mut invalid_observation = source.observation.clone();
+    invalid_observation.applicability.status = ObservationApplicabilityStatus::Invalid;
+    invalid_observation.applicability.receipt_ref =
+        "research:refinement-demand-plan:invalid".to_string();
+    invalid.observations.observations.push(invalid_observation);
+    let invalid_demand = selected_disposition(&invalid);
+    assert_eq!(
+        invalid_demand.disposition,
+        RefinementInvestigationDispositionStatus::ObservationAcquisitionNeeded
+    );
+    assert_eq!(
+        invalid_demand.acquisition_frontiers[0].status,
+        ObservationFrontierStatus::Invalid
+    );
+    let invalid_plan = plan_frontier(&source, invalid_demand.acquisition_frontiers[0].clone());
+    assert_eq!(invalid_plan.status, ObservationProbePlanStatus::Planned);
+    assert_eq!(
+        invalid_plan.evidence_plan.unwrap().status,
+        EvidencePlanStatus::Selected
+    );
+}


### PR DESCRIPTION
Progresses #190 as a pure composition child of green #251.

## Gate before planning

#251 separates candidate dispositions:

```text
replay_rejected
unselected
satisfied
requirement_mapping_needed
observation_acquisition_needed
```

This carrier feeds only `observation_acquisition_needed.acquisition_frontiers[]` into #216. Every other disposition carries zero planner frontiers.

## Held-out replay visibility

Strengthened #251 defines survival as status-level non-rejection while preserving the complete `ReplayResult`, including held-out `passed | not_run | unknown`.

This child now proves the planner consumes that contract without silently strengthening it:

```text
selected survivor
held_out_status = not_run
exact mapped observation missing
-> observation_acquisition_needed
-> held_out not_run remains visible on the authorizing disposition
-> exact #221 source probe plans successfully
```

So current policy permits evidence acquisition for a selected status survivor even while held-out replay is incomplete. Any future stricter held-out prerequisite must become an explicit gate from the preserved replay result.

## Standard CI

A temporary local Git history runs through the real #221 Rust edit-class source adapter. The retained selected Oxc replay candidate is explicitly rebound to the test subject through #231 mapping evidence.

Missing exact observation:

```text
selected survivor
-> observation_acquisition_needed
-> exact MISSING frontier
-> #221 bridge/probe
-> #216 planned
-> #145 evidence plan selected
```

After the source observation is inserted, the same selected candidate becomes `satisfied` with zero acquisition frontiers. Exact mapped UNKNOWN and INVALID frontiers also reach the existing planner while preserving their frontier status.

Current, missing-mapping, replay-rejected, and unselected dispositions create zero planner inputs.

## Public Oxc carrier

The dedicated workflow begins from retained #179/#231/#185 data, withholds exact `edit_class@228e8e0f...:rules.rs`, and preserves wrong-path + pinned-head UNKNOWN controls. #251 admits exactly one Oxc acquisition frontier and keeps both replay-rejected alternatives quiet.

Only that admitted frontier is passed to the #221 source bridge/probe and #216 planner. The workflow inserts the produced `syntax_changed` observation and #251 changes the selected candidate from `observation_acquisition_needed` to `satisfied` while rejected alternatives remain `replay_rejected`.

## Latest validation

Current head:

```text
1065086c45ad167037d290b83d77d52975d1f1a9
```

Ordinary CI:

```text
32274596102 success
```

Public Oxc demand-gated carrier:

```text
32274596165 success
```

The public carrier still passes demand admission, rejected-candidate suppression, exact source-coordinate verification, pinned-head UNKNOWN control, source bridge/frontier identity, #216 planning, source observation insertion, and final `satisfied` reevaluation.

## Behavioral consequence

For the retained Oxc episode, withholding the selected exact observation produces three superficially blocked candidates under the readiness lens. Replay/selection/subject/currentness gating compresses that into:

```text
justified planner requests = 1
replay-rejected planner requests = 0
```

No new shared module is added; this PR is test/workflow composition only.

Refs #137 #145 #148 #179 #190 #210 #216 #221 #231 #235 #240 #243 #248 #251.