### PR TITLE
research: package blind capability-demand worker pairs

### DIFF
--- a/examples/capability_demand_pair_prepare.rs
+++ b/examples/capability_demand_pair_prepare.rs
@@ -1,0 +1,106 @@
+#[allow(dead_code, clippy::too_many_arguments)]
+#[path = "support/capability_demand_pair_trial_binding.rs"]
+mod capability_demand_pair_trial_binding;
+
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use capability_demand_pair_trial_binding::{
+    MAX_WORKER_ARTIFACT_BYTES, parse_order_selection, prepare_bound_pair,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("capability-demand-pair-prepare: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut args = std::env::args().skip(1);
+    let trial_path = next_path(&mut args)?;
+    let manifest_path = next_path(&mut args)?;
+    let task_path = next_path(&mut args)?;
+    let patch_path = next_path(&mut args)?;
+    let packet_one_path = next_path(&mut args)?;
+    let packet_two_path = next_path(&mut args)?;
+    let output_dir = next_path(&mut args)?;
+    let pair_id = args.next().ok_or_else(usage)?;
+    let order = args.next().ok_or_else(usage)?;
+    if args.next().is_some() {
+        return Err(usage().into());
+    }
+
+    let trial = read_bounded(&trial_path, MAX_WORKER_ARTIFACT_BYTES)?;
+    let manifest = read_bounded(&manifest_path, MAX_WORKER_ARTIFACT_BYTES)?;
+    let task = read_bounded(&task_path, MAX_WORKER_ARTIFACT_BYTES)?;
+    let patch = read_bounded(&patch_path, MAX_WORKER_ARTIFACT_BYTES)?;
+    let packet_one = read_bounded(&packet_one_path, MAX_WORKER_ARTIFACT_BYTES)?;
+    let packet_two = read_bounded(&packet_two_path, MAX_WORKER_ARTIFACT_BYTES)?;
+    let order = parse_order_selection(&order).map_err(invalid_data)?;
+
+    let prepared = prepare_bound_pair(
+        &trial,
+        &manifest,
+        &task,
+        &patch,
+        &packet_one,
+        &packet_two,
+        &pair_id,
+        order,
+    )
+    .map_err(invalid_data)?;
+
+    let output_dir = PathBuf::from(output_dir);
+    fs::create_dir(&output_dir)?;
+    write_json(output_dir.join("organizer-plan.json"), &prepared.plan)?;
+
+    for slot in prepared.slots {
+        let slot_dir = output_dir.join(&slot.metadata.slot_id);
+        fs::create_dir(&slot_dir)?;
+        write_json(slot_dir.join("worker-input.json"), &slot.metadata)?;
+        fs::write(slot_dir.join("task.txt"), slot.task)?;
+        fs::write(slot_dir.join("proposed.patch"), slot.patch)?;
+        fs::write(slot_dir.join("evidence.json"), slot.evidence)?;
+    }
+
+    println!("{}", serde_json::to_string_pretty(&prepared.plan)?);
+    Ok(())
+}
+
+fn next_path(args: &mut impl Iterator<Item = String>) -> Result<String, io::Error> {
+    args.next().ok_or_else(usage)
+}
+
+fn usage() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "usage: capability_demand_pair_prepare TRIAL.json MANIFEST.json TASK.txt PATCH.diff PACKET_ONE.json PACKET_TWO.json OUTPUT_DIR PAIR_ID AB|BA|seed:<seed>",
+    )
+}
+
+fn read_bounded(path: impl AsRef<Path>, maximum: usize) -> Result<Vec<u8>, Box<dyn Error>> {
+    let path = path.as_ref();
+    let metadata = fs::metadata(path)?;
+    if metadata.len() > maximum as u64 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{} exceeds {maximum} bytes", path.display()),
+        )
+        .into());
+    }
+    Ok(fs::read(path)?)
+}
+
+fn write_json(path: impl AsRef<Path>, value: &impl serde::Serialize) -> Result<(), Box<dyn Error>> {
+    let mut bytes = serde_json::to_vec_pretty(value)?;
+    bytes.push(b'\n');
+    fs::write(path, bytes)?;
+    Ok(())
+}
+
+fn invalid_data(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}

--- a/examples/capability_demand_run_receipt.rs
+++ b/examples/capability_demand_run_receipt.rs
@@ -1,0 +1,82 @@
+#[allow(dead_code, clippy::too_many_arguments)]
+#[path = "support/capability_demand_pair_execution_impl.rs"]
+mod capability_demand_pair_execution;
+
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use capability_demand_pair_execution::{
+    MAX_EXTERNAL_RUN_METADATA_BYTES, MAX_PAIR_PLAN_BYTES, MAX_WORKER_ARTIFACT_BYTES,
+    build_external_run_receipt, parse_external_run_metadata, parse_organizer_plan,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("capability-demand-run-receipt: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut args = std::env::args().skip(1);
+    let plan_path = next_path(&mut args)?;
+    let metadata_path = next_path(&mut args)?;
+    let sampling_config_path = next_path(&mut args)?;
+    let checkout_reset_path = next_path(&mut args)?;
+    let worker_output_path = next_path(&mut args)?;
+    if args.next().is_some() {
+        return Err(usage().into());
+    }
+
+    let plan = parse_organizer_plan(&read_bounded(&plan_path, MAX_PAIR_PLAN_BYTES)?)
+        .map_err(invalid_data)?;
+    let metadata = parse_external_run_metadata(&read_bounded(
+        &metadata_path,
+        MAX_EXTERNAL_RUN_METADATA_BYTES,
+    )?)
+    .map_err(invalid_data)?;
+    let sampling_config = read_bounded(&sampling_config_path, MAX_WORKER_ARTIFACT_BYTES)?;
+    let checkout_reset = read_bounded(&checkout_reset_path, MAX_WORKER_ARTIFACT_BYTES)?;
+    let worker_output = read_bounded(&worker_output_path, MAX_WORKER_ARTIFACT_BYTES)?;
+
+    let receipt = build_external_run_receipt(
+        &plan,
+        &metadata,
+        &sampling_config,
+        &checkout_reset,
+        &worker_output,
+    )
+    .map_err(invalid_data)?;
+    println!("{}", serde_json::to_string_pretty(&receipt)?);
+    Ok(())
+}
+
+fn next_path(args: &mut impl Iterator<Item = String>) -> Result<String, io::Error> {
+    args.next().ok_or_else(usage)
+}
+
+fn usage() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "usage: capability_demand_run_receipt ORGANIZER_PLAN.json RUN_METADATA.json SAMPLING_CONFIG RESET_RECEIPT RAW_WORKER_OUTPUT",
+    )
+}
+
+fn read_bounded(path: impl AsRef<Path>, maximum: usize) -> Result<Vec<u8>, Box<dyn Error>> {
+    let path = path.as_ref();
+    let metadata = fs::metadata(path)?;
+    if metadata.len() > maximum as u64 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{} exceeds {maximum} bytes", path.display()),
+        )
+        .into());
+    }
+    Ok(fs::read(path)?)
+}
+
+fn invalid_data(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}

--- a/examples/support/capability_demand_pair_execution_impl.rs
+++ b/examples/support/capability_demand_pair_execution_impl.rs
@@ -1,0 +1,721 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+#[path = "../../src/capability_demand_retirement.rs"]
+pub mod capability_demand_retirement;
+
+use capability_demand_retirement::{
+    ArtifactDigest, EvidenceInspection, Oracle, RunOutcome, TrialInputManifest, TrialSpec,
+    parse_run_receipt, parse_trial_manifest, parse_trial_spec,
+};
+
+pub const MAX_WORKER_ARTIFACT_BYTES: usize = 16 * 1024 * 1024;
+pub const MAX_PAIR_PLAN_BYTES: usize = 512 * 1024;
+pub const MAX_EXTERNAL_RUN_METADATA_BYTES: usize = 128 * 1024;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PairOrder {
+    Ab,
+    Ba,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum OrderSelection {
+    Explicit(PairOrder),
+    Seeded(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum OrderSource {
+    Explicit,
+    Seeded { seed_sha256: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PairArtifactDigest {
+    pub sha256: String,
+    pub bytes: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OrganizerSlot {
+    pub slot_id: String,
+    pub run_id: String,
+    pub sequence_index: u32,
+    pub condition_id: String,
+    pub evidence_packet: PairArtifactDigest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OrganizerPlan {
+    pub schema_version: u32,
+    pub trial_id: String,
+    pub pair_id: String,
+    pub repository: String,
+    pub revision: String,
+    pub target_path: String,
+    pub target_blob_sha: String,
+    pub trial_spec_sha256: String,
+    pub input_manifest_sha256: String,
+    pub task: PairArtifactDigest,
+    pub patch: PairArtifactDigest,
+    pub completion_contract_sha256: String,
+    pub order: PairOrder,
+    pub order_source: OrderSource,
+    pub slots: Vec<OrganizerSlot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkerBundleFiles {
+    pub task: PairArtifactDigest,
+    pub patch: PairArtifactDigest,
+    pub evidence: PairArtifactDigest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkerBundleMetadata {
+    pub schema_version: u32,
+    pub trial_id: String,
+    pub pair_id: String,
+    pub slot_id: String,
+    pub run_id: String,
+    pub sequence_index: u32,
+    pub repository: String,
+    pub revision: String,
+    pub target_path: String,
+    pub target_blob_sha: String,
+    pub files: WorkerBundleFiles,
+}
+
+#[derive(Debug, Clone)]
+pub struct PreparedSlot {
+    pub metadata: WorkerBundleMetadata,
+    pub task: Vec<u8>,
+    pub patch: Vec<u8>,
+    pub evidence: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PreparedPair {
+    pub plan: OrganizerPlan,
+    pub slots: Vec<PreparedSlot>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionOrigin {
+    ExternalHarness,
+    SyntheticTest,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalRunMetadata {
+    pub schema_version: u32,
+    pub slot_id: String,
+    pub execution_origin: ExecutionOrigin,
+    pub worker_identity: String,
+    pub harness_identity: String,
+    pub affordance_identity: String,
+    pub session_id: String,
+    pub fresh_session: bool,
+    pub prior_condition_exposure: bool,
+    pub evaluated_outcome: RunOutcome,
+    pub evidence_inspection: EvidenceInspection,
+    pub context_expanded: bool,
+}
+
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+pub fn artifact_digest(bytes: &[u8]) -> PairArtifactDigest {
+    PairArtifactDigest {
+        sha256: sha256_hex(bytes),
+        bytes: bytes.len(),
+    }
+}
+
+pub fn parse_order_selection(value: &str) -> Result<OrderSelection, String> {
+    match value {
+        "AB" | "ab" => Ok(OrderSelection::Explicit(PairOrder::Ab)),
+        "BA" | "ba" => Ok(OrderSelection::Explicit(PairOrder::Ba)),
+        _ => {
+            let seed = value
+                .strip_prefix("seed:")
+                .ok_or_else(|| "order must be AB, BA, or seed:<organizer-seed>".to_string())?;
+            if seed.is_empty() || seed.len() > 1024 {
+                return Err("organizer seed must contain 1..1024 bytes".into());
+            }
+            Ok(OrderSelection::Seeded(seed.to_string()))
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+// V1 keeps the exact frozen artifact set explicit at this research boundary.
+pub fn prepare_pair(
+    trial_bytes: &[u8],
+    manifest_bytes: &[u8],
+    task_bytes: &[u8],
+    patch_bytes: &[u8],
+    packet_one: &[u8],
+    packet_two: &[u8],
+    pair_id: &str,
+    order_selection: OrderSelection,
+) -> Result<PreparedPair, String> {
+    validate_pair_id(pair_id)?;
+    ensure_artifact_bound(task_bytes, "task")?;
+    ensure_artifact_bound(patch_bytes, "patch")?;
+    ensure_artifact_bound(packet_one, "packet one")?;
+    ensure_artifact_bound(packet_two, "packet two")?;
+
+    let spec = parse_trial_spec(trial_bytes)?;
+    let manifest = parse_trial_manifest(manifest_bytes)?;
+    validate_spec_manifest_pair(&spec, &manifest)?;
+
+    let expected_task = line_terminated(&spec.worker_task.prompt);
+    if task_bytes != expected_task {
+        return Err("task bytes do not match the frozen trial worker prompt".into());
+    }
+    let expected_patch = line_terminated(&spec.worker_task.patch);
+    if patch_bytes != expected_patch {
+        return Err("patch bytes do not match the frozen trial proposed patch".into());
+    }
+    verify_digest(
+        task_bytes,
+        &manifest.worker_visible_common.task.sha256,
+        manifest.worker_visible_common.task.bytes,
+        "task",
+    )?;
+    verify_digest(
+        patch_bytes,
+        &manifest.worker_visible_common.patch.sha256,
+        manifest.worker_visible_common.patch.bytes,
+        "patch",
+    )?;
+    if manifest.evaluator_only.oracle != oracle_artifact_digest(&spec.oracle)? {
+        return Err("oracle artifact does not match frozen trial spec".into());
+    }
+
+    if manifest.conditions.len() != 2 {
+        return Err("execution packager v1 requires exactly two manifest conditions".into());
+    }
+
+    let mut packet_by_condition = BTreeMap::new();
+    for packet in [packet_one, packet_two] {
+        let condition_id = identify_packet_condition(packet, &manifest)?;
+        if packet_by_condition.insert(condition_id, packet).is_some() {
+            return Err("two supplied packets resolve to the same condition".into());
+        }
+    }
+    if packet_by_condition.len() != manifest.conditions.len() {
+        return Err("supplied packet set does not cover the complete condition pair".into());
+    }
+
+    let mut baseline_id = None;
+    let mut treatment_id = None;
+    for (condition_id, condition) in &manifest.conditions {
+        if condition.decisive_evidence_present {
+            if treatment_id.replace(condition_id.as_str()).is_some() {
+                return Err(
+                    "execution packager v1 requires exactly one treatment condition".into(),
+                );
+            }
+        } else if baseline_id.replace(condition_id.as_str()).is_some() {
+            return Err("execution packager v1 requires exactly one baseline condition".into());
+        }
+    }
+    let baseline_id = baseline_id.ok_or_else(|| "baseline condition is missing".to_string())?;
+    let treatment_id = treatment_id.ok_or_else(|| "treatment condition is missing".to_string())?;
+
+    let (order, order_source) = resolve_order(pair_id, order_selection);
+    let ordered_condition_ids = match order {
+        PairOrder::Ab => [baseline_id, treatment_id],
+        PairOrder::Ba => [treatment_id, baseline_id],
+    };
+
+    let task_digest = artifact_digest(task_bytes);
+    let patch_digest = artifact_digest(patch_bytes);
+    let mut organizer_slots = Vec::with_capacity(2);
+    let mut prepared_slots = Vec::with_capacity(2);
+    for (offset, condition_id) in ordered_condition_ids.into_iter().enumerate() {
+        let sequence_index = (offset + 1) as u32;
+        let slot_id = format!("slot-{sequence_index}");
+        let run_id = format!("{pair_id}-run-{sequence_index}");
+        let evidence = packet_by_condition
+            .get(condition_id)
+            .ok_or_else(|| format!("missing bytes for condition {condition_id}"))?;
+        let evidence_digest = artifact_digest(evidence);
+
+        organizer_slots.push(OrganizerSlot {
+            slot_id: slot_id.clone(),
+            run_id: run_id.clone(),
+            sequence_index,
+            condition_id: condition_id.to_string(),
+            evidence_packet: evidence_digest.clone(),
+        });
+        prepared_slots.push(PreparedSlot {
+            metadata: WorkerBundleMetadata {
+                schema_version: 1,
+                trial_id: manifest.trial_id.clone(),
+                pair_id: pair_id.to_string(),
+                slot_id,
+                run_id,
+                sequence_index,
+                repository: manifest.repository.clone(),
+                revision: manifest.revision.clone(),
+                target_path: manifest.target_path.clone(),
+                target_blob_sha: manifest.target_blob_sha.clone(),
+                files: WorkerBundleFiles {
+                    task: task_digest.clone(),
+                    patch: patch_digest.clone(),
+                    evidence: evidence_digest,
+                },
+            },
+            task: task_bytes.to_vec(),
+            patch: patch_bytes.to_vec(),
+            evidence: evidence.to_vec(),
+        });
+    }
+
+    Ok(PreparedPair {
+        plan: OrganizerPlan {
+            schema_version: 1,
+            trial_id: manifest.trial_id.clone(),
+            pair_id: pair_id.to_string(),
+            repository: manifest.repository.clone(),
+            revision: manifest.revision.clone(),
+            target_path: manifest.target_path.clone(),
+            target_blob_sha: manifest.target_blob_sha.clone(),
+            trial_spec_sha256: spec.source_sha256.clone(),
+            input_manifest_sha256: sha256_hex(manifest_bytes),
+            task: task_digest,
+            patch: patch_digest,
+            completion_contract_sha256: manifest.evaluator_only.oracle.sha256.clone(),
+            order,
+            order_source,
+            slots: organizer_slots,
+        },
+        slots: prepared_slots,
+    })
+}
+
+pub fn parse_organizer_plan(input: &[u8]) -> Result<OrganizerPlan, String> {
+    if input.len() > MAX_PAIR_PLAN_BYTES {
+        return Err(format!(
+            "organizer plan is {} bytes; maximum is {} bytes",
+            input.len(),
+            MAX_PAIR_PLAN_BYTES
+        ));
+    }
+    let plan: OrganizerPlan = serde_json::from_slice(input).map_err(|error| error.to_string())?;
+    validate_organizer_plan(&plan)?;
+    Ok(plan)
+}
+
+pub fn parse_external_run_metadata(input: &[u8]) -> Result<ExternalRunMetadata, String> {
+    if input.len() > MAX_EXTERNAL_RUN_METADATA_BYTES {
+        return Err(format!(
+            "external run metadata is {} bytes; maximum is {} bytes",
+            input.len(),
+            MAX_EXTERNAL_RUN_METADATA_BYTES
+        ));
+    }
+    let metadata: ExternalRunMetadata =
+        serde_json::from_slice(input).map_err(|error| error.to_string())?;
+    validate_external_run_metadata(&metadata)?;
+    Ok(metadata)
+}
+
+pub fn build_external_run_receipt(
+    plan: &OrganizerPlan,
+    metadata: &ExternalRunMetadata,
+    sampling_config: &[u8],
+    checkout_reset_receipt: &[u8],
+    worker_output: &[u8],
+) -> Result<Value, String> {
+    build_run_receipt(
+        plan,
+        metadata,
+        sampling_config,
+        checkout_reset_receipt,
+        worker_output,
+        false,
+    )
+}
+
+#[cfg(test)]
+pub fn build_synthetic_test_run_receipt(
+    plan: &OrganizerPlan,
+    metadata: &ExternalRunMetadata,
+    sampling_config: &[u8],
+    checkout_reset_receipt: &[u8],
+    worker_output: &[u8],
+) -> Result<Value, String> {
+    build_run_receipt(
+        plan,
+        metadata,
+        sampling_config,
+        checkout_reset_receipt,
+        worker_output,
+        true,
+    )
+}
+
+fn build_run_receipt(
+    plan: &OrganizerPlan,
+    metadata: &ExternalRunMetadata,
+    sampling_config: &[u8],
+    checkout_reset_receipt: &[u8],
+    worker_output: &[u8],
+    allow_synthetic_test: bool,
+) -> Result<Value, String> {
+    ensure_artifact_bound(sampling_config, "sampling config")?;
+    ensure_artifact_bound(checkout_reset_receipt, "checkout reset receipt")?;
+    ensure_artifact_bound(worker_output, "worker output")?;
+    match metadata.execution_origin {
+        ExecutionOrigin::ExternalHarness => {}
+        ExecutionOrigin::SyntheticTest if allow_synthetic_test => {}
+        ExecutionOrigin::SyntheticTest => {
+            return Err("synthetic test metadata cannot produce an external worker receipt".into());
+        }
+    }
+
+    let slot = plan
+        .slots
+        .iter()
+        .find(|slot| slot.slot_id == metadata.slot_id)
+        .ok_or_else(|| format!("unknown organizer slot {}", metadata.slot_id))?;
+
+    let value = serde_json::json!({
+        "schema_version": 1,
+        "trial_id": plan.trial_id,
+        "trial_spec_sha256": plan.trial_spec_sha256,
+        "pair_id": plan.pair_id,
+        "run_id": slot.run_id,
+        "condition_id": slot.condition_id,
+        "sequence_index": slot.sequence_index,
+        "repository": plan.repository,
+        "revision": plan.revision,
+        "target_path": plan.target_path,
+        "target_blob_sha": plan.target_blob_sha,
+        "task_sha256": plan.task.sha256,
+        "patch_sha256": plan.patch.sha256,
+        "evidence_packet_sha256": slot.evidence_packet.sha256,
+        "completion_contract_sha256": plan.completion_contract_sha256,
+        "worker_identity": metadata.worker_identity,
+        "harness_identity": metadata.harness_identity,
+        "affordance_identity": metadata.affordance_identity,
+        "sampling_config_sha256": sha256_hex(sampling_config),
+        "session_id": metadata.session_id,
+        "fresh_session": metadata.fresh_session,
+        "prior_condition_exposure": metadata.prior_condition_exposure,
+        "checkout_reset_receipt_sha256": sha256_hex(checkout_reset_receipt),
+        "worker_output_sha256": sha256_hex(worker_output),
+        "evaluated_outcome": metadata.evaluated_outcome,
+        "evidence_inspection": metadata.evidence_inspection,
+        "context_expanded": metadata.context_expanded,
+    });
+    let encoded = serde_json::to_vec(&value).map_err(|error| error.to_string())?;
+    parse_run_receipt(&encoded)?;
+    Ok(value)
+}
+
+fn resolve_order(pair_id: &str, selection: OrderSelection) -> (PairOrder, OrderSource) {
+    match selection {
+        OrderSelection::Explicit(order) => (order, OrderSource::Explicit),
+        OrderSelection::Seeded(seed) => {
+            let seed_sha256 = sha256_hex(seed.as_bytes());
+            let mut hasher = Sha256::new();
+            hasher.update(seed.as_bytes());
+            hasher.update([0]);
+            hasher.update(pair_id.as_bytes());
+            let digest = hasher.finalize();
+            let order = if digest[0] & 1 == 0 {
+                PairOrder::Ab
+            } else {
+                PairOrder::Ba
+            };
+            (order, OrderSource::Seeded { seed_sha256 })
+        }
+    }
+}
+
+fn identify_packet_condition<'a>(
+    packet: &[u8],
+    manifest: &'a TrialInputManifest,
+) -> Result<&'a str, String> {
+    let digest = artifact_digest(packet);
+    let matches = manifest
+        .conditions
+        .iter()
+        .filter(|(_, condition)| {
+            condition.packet.sha256 == digest.sha256 && condition.packet.bytes == digest.bytes
+        })
+        .map(|(condition_id, _)| condition_id.as_str())
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [condition_id] => Ok(condition_id),
+        [] => Err(format!(
+            "supplied evidence packet {} ({} bytes) is not admitted by the manifest",
+            digest.sha256, digest.bytes
+        )),
+        _ => Err("multiple conditions share the same exact packet identity".into()),
+    }
+}
+
+fn validate_spec_manifest_pair(
+    spec: &TrialSpec,
+    manifest: &TrialInputManifest,
+) -> Result<(), String> {
+    if spec.trial_id != manifest.trial_id
+        || spec.repository != manifest.repository
+        || spec.revision != manifest.revision
+        || spec.target_path != manifest.target_path
+        || spec.target_blob_sha != manifest.target_blob_sha
+    {
+        return Err("trial spec and input manifest name different frozen coordinates".into());
+    }
+    if manifest.trial_spec_sha256 != spec.source_sha256 {
+        return Err("trial input manifest does not match exact frozen trial-spec bytes".into());
+    }
+
+    let spec_conditions = spec
+        .conditions
+        .iter()
+        .map(|condition| (condition.id.as_str(), condition))
+        .collect::<BTreeMap<_, _>>();
+    if spec_conditions.len() != manifest.conditions.len() {
+        return Err("trial spec and input manifest condition sets differ".into());
+    }
+    for (condition_id, manifest_condition) in &manifest.conditions {
+        let spec_condition = spec_conditions
+            .get(condition_id.as_str())
+            .ok_or_else(|| format!("manifest contains undeclared condition {condition_id}"))?;
+        if spec_condition.packet_kind != manifest_condition.packet_kind
+            || spec_condition.budget_bytes != manifest_condition.budget_bytes
+            || spec_condition.scope != manifest_condition.scope
+        {
+            return Err(format!(
+                "condition {condition_id} materialization recipe drifted"
+            ));
+        }
+        let spec_refs = spec_condition
+            .decisive_evidence_refs
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        let manifest_refs = manifest_condition
+            .decisive_evidence_refs
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        if spec_condition.decisive_evidence_present != manifest_condition.decisive_evidence_present
+            || spec_refs != manifest_refs
+        {
+            return Err(format!(
+                "condition {condition_id} differs between trial spec and input manifest"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn oracle_artifact_digest(oracle: &Oracle) -> Result<ArtifactDigest, String> {
+    let values = BTreeMap::from([
+        (
+            "blocking_reason",
+            serde_json::Value::String(oracle.blocking_reason.clone()),
+        ),
+        (
+            "corrective_action",
+            serde_json::Value::String(oracle.corrective_action.clone()),
+        ),
+        (
+            "expected_disposition",
+            serde_json::Value::String(oracle.expected_disposition.clone()),
+        ),
+        (
+            "max_identifier_length",
+            serde_json::Value::from(oracle.max_identifier_length),
+        ),
+        (
+            "proposed_identifier",
+            serde_json::Value::String(oracle.proposed_identifier.clone()),
+        ),
+        (
+            "proposed_identifier_length",
+            serde_json::Value::from(oracle.proposed_identifier_length),
+        ),
+    ]);
+    let mut bytes = serde_json::to_vec_pretty(&values).map_err(|error| error.to_string())?;
+    bytes.push(b'\n');
+    Ok(ArtifactDigest {
+        sha256: sha256_hex(&bytes),
+        bytes: bytes.len(),
+    })
+}
+
+fn line_terminated(value: &str) -> Vec<u8> {
+    let mut bytes = value.as_bytes().to_vec();
+    bytes.push(b'\n');
+    bytes
+}
+
+fn verify_digest(
+    bytes: &[u8],
+    expected_sha256: &str,
+    expected_bytes: usize,
+    label: &str,
+) -> Result<(), String> {
+    let actual = artifact_digest(bytes);
+    if actual.sha256 != expected_sha256 || actual.bytes != expected_bytes {
+        return Err(format!(
+            "{label} does not match the frozen manifest: got {} / {} bytes",
+            actual.sha256, actual.bytes
+        ));
+    }
+    Ok(())
+}
+
+fn validate_pair_id(pair_id: &str) -> Result<(), String> {
+    if pair_id.is_empty() || pair_id.len() > 120 {
+        return Err("pair_id must contain 1..120 bytes".into());
+    }
+    if !pair_id
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'))
+    {
+        return Err("pair_id may contain only ASCII letters, digits, '-', '_', '.', ':'".into());
+    }
+    Ok(())
+}
+
+fn validate_organizer_plan(plan: &OrganizerPlan) -> Result<(), String> {
+    if plan.schema_version != 1 {
+        return Err(format!(
+            "unsupported organizer plan schema version {}",
+            plan.schema_version
+        ));
+    }
+    validate_pair_id(&plan.pair_id)?;
+    if plan.trial_id.is_empty()
+        || plan.repository.is_empty()
+        || !is_git_sha(&plan.revision)
+        || plan.target_path.is_empty()
+        || !is_git_sha(&plan.target_blob_sha)
+    {
+        return Err("organizer plan has incomplete frozen identity".into());
+    }
+    for digest in [
+        &plan.trial_spec_sha256,
+        &plan.input_manifest_sha256,
+        &plan.task.sha256,
+        &plan.patch.sha256,
+        &plan.completion_contract_sha256,
+    ] {
+        validate_sha256(digest, "organizer digest")?;
+    }
+    if plan.task.bytes == 0 || plan.patch.bytes == 0 {
+        return Err("organizer task/patch digests must be non-empty".into());
+    }
+    if plan.slots.len() != 2 {
+        return Err("organizer plan must contain exactly two slots".into());
+    }
+    let slot_ids = plan
+        .slots
+        .iter()
+        .map(|slot| slot.slot_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let run_ids = plan
+        .slots
+        .iter()
+        .map(|slot| slot.run_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let sequences = plan
+        .slots
+        .iter()
+        .map(|slot| slot.sequence_index)
+        .collect::<BTreeSet<_>>();
+    if slot_ids.len() != 2 || run_ids.len() != 2 || sequences != BTreeSet::from([1, 2]) {
+        return Err(
+            "organizer slots must have unique slot/run IDs and sequence indices {1,2}".into(),
+        );
+    }
+    for slot in &plan.slots {
+        if slot.slot_id.is_empty() || slot.run_id.is_empty() || slot.condition_id.is_empty() {
+            return Err("organizer slot identity must be non-empty".into());
+        }
+        validate_sha256(&slot.evidence_packet.sha256, "evidence packet sha256")?;
+        if slot.evidence_packet.bytes == 0 {
+            return Err("organizer evidence packet must be non-empty".into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_external_run_metadata(metadata: &ExternalRunMetadata) -> Result<(), String> {
+    if metadata.schema_version != 1 {
+        return Err(format!(
+            "unsupported external run metadata schema version {}",
+            metadata.schema_version
+        ));
+    }
+    for (value, field) in [
+        (&metadata.slot_id, "slot_id"),
+        (&metadata.worker_identity, "worker_identity"),
+        (&metadata.harness_identity, "harness_identity"),
+        (&metadata.affordance_identity, "affordance_identity"),
+        (&metadata.session_id, "session_id"),
+    ] {
+        if value.is_empty() || value.len() > 256 {
+            return Err(format!("{field} must contain 1..256 bytes"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_sha256(value: &str, field: &str) -> Result<(), String> {
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(format!("{field} must be a 64-hex SHA-256"));
+    }
+    Ok(())
+}
+
+fn is_git_sha(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn ensure_artifact_bound(bytes: &[u8], label: &str) -> Result<(), String> {
+    if bytes.is_empty() {
+        return Err(format!("{label} must be non-empty"));
+    }
+    if bytes.len() > MAX_WORKER_ARTIFACT_BYTES {
+        return Err(format!(
+            "{label} is {} bytes; maximum is {} bytes",
+            bytes.len(),
+            MAX_WORKER_ARTIFACT_BYTES
+        ));
+    }
+    Ok(())
+}

--- a/examples/support/capability_demand_pair_trial_binding.rs
+++ b/examples/support/capability_demand_pair_trial_binding.rs
@@ -1,0 +1,43 @@
+#[path = "capability_demand_pair_execution_impl.rs"]
+pub mod core;
+
+pub use core::{MAX_WORKER_ARTIFACT_BYTES, OrderSelection, PreparedPair, parse_order_selection};
+
+pub fn prepare_bound_pair(
+    trial_bytes: &[u8],
+    manifest_bytes: &[u8],
+    task_bytes: &[u8],
+    patch_bytes: &[u8],
+    packet_one: &[u8],
+    packet_two: &[u8],
+    pair_id: &str,
+    order_selection: OrderSelection,
+) -> Result<PreparedPair, String> {
+    let spec = core::capability_demand_retirement::parse_trial_spec(trial_bytes)?;
+    let expected_task = line_terminated(&spec.worker_task.prompt);
+    let expected_patch = line_terminated(&spec.worker_task.patch);
+
+    if task_bytes != expected_task {
+        return Err("task bytes do not match the frozen trial worker prompt".into());
+    }
+    if patch_bytes != expected_patch {
+        return Err("patch bytes do not match the frozen trial proposed patch".into());
+    }
+
+    core::prepare_pair(
+        trial_bytes,
+        manifest_bytes,
+        task_bytes,
+        patch_bytes,
+        packet_one,
+        packet_two,
+        pair_id,
+        order_selection,
+    )
+}
+
+fn line_terminated(value: &str) -> Vec<u8> {
+    let mut bytes = value.as_bytes().to_vec();
+    bytes.push(b'\n');
+    bytes
+}

--- a/research/capability-demand-retirement/execution-packaging.md
+++ b/research/capability-demand-retirement/execution-packaging.md
@@ -1,0 +1,157 @@
+# Capability-demand retirement execution packaging
+
+Status: research execution tooling for #253 / #238.
+
+The frozen Stensibly trial (#239) and strict worker-run receipt evaluator (#246) already separate repository evidence from model/harness behavior. This slice closes the organizer-side gap before any real model call:
+
+```text
+exact frozen trial inputs
+  -> blind slot 1 / slot 2 bundles
+  -> external fresh worker sessions
+  -> preserved raw outputs + external run metadata
+  -> computed WorkerRunReceipt v1
+  -> existing #246 pair evaluator
+```
+
+## Why a separate organizer plan exists
+
+The worker-facing bundle must not reveal which evidence condition is the baseline or treatment.
+
+Each slot receives only:
+
+```text
+worker-input.json
+  trial / pair / slot / run identity
+  sequence index
+  exact repository / revision / target identity
+  task / patch / evidence fingerprints
+
+task.txt
+proposed.patch
+evidence.json
+```
+
+`worker-input.json` does not contain the condition ID, baseline/treatment label, decisive-evidence flag, or evaluator oracle.
+
+The organizer-only `organizer-plan.json` keeps the slot-to-condition mapping needed to build a valid #246 receipt later.
+
+## Exact-input admission
+
+The packager accepts only task, patch, and evidence bytes whose SHA-256 + byte counts match the supplied materialized input manifest.
+
+For the worker task and proposed patch it also independently reconstructs the line-terminated bytes from the frozen trial spec and requires exact equality. A forged or mismatched manifest therefore cannot silently replace the worker task while preserving the same trial coordinate.
+
+V1 requires exactly two conditions with one `decisive_evidence_present=false` condition and one `true` condition.
+
+## Order control
+
+The organizer may request:
+
+```text
+AB
+BA
+seed:<organizer-seed>
+```
+
+`AB` executes the no-decisive-evidence arm first. `BA` executes the decisive-evidence arm first. Seeded ordering hashes the organizer seed together with the pair ID; only the seed hash is retained in the organizer plan.
+
+Condition semantics do not depend on execution order. #246 derives baseline/treatment roles from the admitted input manifest.
+
+## Preparing a pair
+
+```text
+cargo run --example capability_demand_pair_prepare -- \
+  TRIAL.json \
+  INPUT_MANIFEST.json \
+  worker-task.txt \
+  proposed.patch \
+  packet-one.json \
+  packet-two.json \
+  prepared-pair \
+  pair-001 \
+  seed:batch-001
+```
+
+The output directory must not already exist.
+
+The two packet arguments may be supplied in either order; exact manifest fingerprints identify their conditions.
+
+## External run metadata
+
+After a genuinely external worker session completes one slot, the harness records a bounded metadata object:
+
+```json
+{
+  "schema_version": 1,
+  "slot_id": "slot-1",
+  "execution_origin": "external_harness",
+  "worker_identity": "worker-family@version",
+  "harness_identity": "harness@version",
+  "affordance_identity": "tool-set@version",
+  "session_id": "provider-or-harness-session-id",
+  "fresh_session": true,
+  "prior_condition_exposure": false,
+  "evaluated_outcome": "failed",
+  "evidence_inspection": "unobservable",
+  "context_expanded": false
+}
+```
+
+Starting a new operating-system process is not sufficient evidence for `fresh_session=true`. The external harness owns that assertion and must preserve whatever provider/session receipt justifies it.
+
+`evaluated_outcome` remains an external evaluator classification under the fixed #239 completion contract. This lane adds no prose-similarity or model judge.
+
+## Building an admitted run receipt
+
+```text
+cargo run --example capability_demand_run_receipt -- \
+  prepared-pair/organizer-plan.json \
+  slot-1-run-metadata.json \
+  sampling-config.json \
+  checkout-reset-receipt.txt \
+  raw-worker-output.txt \
+  > run-1.json
+```
+
+The receipt builder computes these fingerprints from the supplied bytes:
+
+```text
+sampling_config_sha256
+checkout_reset_receipt_sha256
+worker_output_sha256
+```
+
+The organizer cannot hand-type those hashes independently. The generated object is reparsed through the existing #246 `WorkerRunReceipt v1` validator before it is emitted.
+
+## Synthetic test boundary
+
+The test suite has a separate `synthetic_test` execution origin that exists only under Rust `cfg(test)`.
+
+The production receipt builder rejects it. Synthetic fake-worker controls can therefore prove AB/BA reconciliation, session-contamination rejection, fingerprint admission, and the `paired_retirement_signal` path without creating JSON that looks like executed external worker evidence.
+
+## What still requires an external harness
+
+This repository tooling deliberately does not perform the two worker calls. A valid real pair still needs:
+
+1. one fixed worker/harness/tool/sampling configuration;
+2. two genuinely fresh sessions;
+3. no condition exposure across sessions;
+4. exact frozen worker bundles;
+5. raw output preservation;
+6. checkout/worktree reset evidence;
+7. an evaluator-owned completion classification;
+8. #246 pair admission and interpretation.
+
+A single successful A/B pair remains a local signal. Replicated retirement evidence requires repeated fresh pairs under controlled order and sampling, as recorded on #238.
+
+## Boundary
+
+- research tooling only;
+- no primary `cargo-cultist` CLI change;
+- no provider/model SDK;
+- no API key or secret handling;
+- no model invocation;
+- no private chain-of-thought;
+- no oracle in worker bundles;
+- no automatic causal/generalization claim;
+- no authority grant from task success.

--- a/tests/capability_demand_pair_execution.rs
+++ b/tests/capability_demand_pair_execution.rs
@@ -1,0 +1,501 @@
+#[allow(dead_code)]
+#[path = "../examples/support/capability_demand_pair_execution_impl.rs"]
+mod capability_demand_pair_execution;
+
+use std::collections::BTreeMap;
+
+use capability_demand_pair_execution::capability_demand_retirement::{
+    EvidenceInspection, RetirementVerdict, RunOutcome, evaluate_pair, parse_run_receipt,
+    parse_trial_manifest, parse_trial_spec,
+};
+use capability_demand_pair_execution::{
+    ExecutionOrigin, ExternalRunMetadata, OrderSelection, PairOrder, artifact_digest,
+    build_external_run_receipt, build_synthetic_test_run_receipt, parse_order_selection,
+    prepare_pair, sha256_hex,
+};
+use serde_json::{Value, json};
+
+const REVISION: &str = "1111111111111111111111111111111111111111";
+const TARGET_BLOB: &str = "2222222222222222222222222222222222222222";
+const DECISIVE_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const DECISIVE_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+struct Fixture {
+    trial: Vec<u8>,
+    manifest: Vec<u8>,
+    task: Vec<u8>,
+    patch: Vec<u8>,
+    baseline: Vec<u8>,
+    treatment: Vec<u8>,
+}
+
+fn fixture() -> Fixture {
+    let task = b"Review the proposed patch for a blocking repository constraint.\n".to_vec();
+    let patch = b"@@ synthetic patch @@\n+new_repository_behavior()\n".to_vec();
+    let baseline = b"{\"analysis\":\"fixture\",\"history\":[\"local-only\"]}\n".to_vec();
+    let treatment =
+        b"{\"analysis\":\"fixture\",\"history\":[\"decisive-a\",\"decisive-b\"]}\n".to_vec();
+
+    let trial = serde_json::to_vec_pretty(&json!({
+        "schema_version": 1,
+        "trial_id": "fixture-capability-demand",
+        "repository": "owner/repo",
+        "revision": REVISION,
+        "target_path": "src/lib.rs",
+        "target_blob_sha": TARGET_BLOB,
+        "worker_task": {
+            "prompt": "Review the proposed patch for a blocking repository constraint.",
+            "patch": "@@ synthetic patch @@\n+new_repository_behavior()"
+        },
+        "oracle": {
+            "expected_disposition": "block",
+            "blocking_reason": "fixture_constraint",
+            "max_identifier_length": 64,
+            "proposed_identifier": "fixture_identifier",
+            "proposed_identifier_length": 18,
+            "corrective_action": "repair_fixture"
+        },
+        "conditions": [
+            {
+                "id": "local_packet",
+                "packet_kind": "file_local",
+                "budget_bytes": 32768,
+                "scope": null,
+                "decisive_evidence_present": false,
+                "decisive_evidence_refs": []
+            },
+            {
+                "id": "expanded_packet",
+                "packet_kind": "scoped",
+                "budget_bytes": 32768,
+                "scope": "src",
+                "decisive_evidence_present": true,
+                "decisive_evidence_refs": [DECISIVE_A, DECISIVE_B]
+            }
+        ],
+        "oracle_leak_control": {
+            "historical_issue": "fixture:oracle-control",
+            "allowed_as_worker_prompt": false,
+            "prohibited_worker_prompt_fragments": ["fixture_constraint"]
+        }
+    }))
+    .unwrap();
+
+    let oracle = fixture_oracle_bytes();
+    let manifest = serde_json::to_vec_pretty(&json!({
+        "schema_version": 1,
+        "trial_spec_sha256": sha256_hex(&trial),
+        "trial_id": "fixture-capability-demand",
+        "repository": "owner/repo",
+        "revision": REVISION,
+        "target_path": "src/lib.rs",
+        "target_blob_sha": TARGET_BLOB,
+        "worker_visible_common": {
+            "task": digest_value(&task),
+            "patch": digest_value(&patch)
+        },
+        "evaluator_only": {
+            "oracle": digest_value(&oracle)
+        },
+        "conditions": {
+            "local_packet": {
+                "packet": digest_value(&baseline),
+                "packet_kind": "file_local",
+                "budget_bytes": 32768,
+                "scope": null,
+                "decisive_evidence_present": false
+            },
+            "expanded_packet": {
+                "packet": digest_value(&treatment),
+                "packet_kind": "scoped",
+                "budget_bytes": 32768,
+                "scope": "src",
+                "decisive_evidence_present": true,
+                "decisive_evidence_refs": [DECISIVE_A, DECISIVE_B]
+            }
+        }
+    }))
+    .unwrap();
+
+    Fixture {
+        trial,
+        manifest,
+        task,
+        patch,
+        baseline,
+        treatment,
+    }
+}
+
+fn fixture_oracle_bytes() -> Vec<u8> {
+    let values = BTreeMap::from([
+        (
+            "blocking_reason",
+            Value::String("fixture_constraint".to_string()),
+        ),
+        (
+            "corrective_action",
+            Value::String("repair_fixture".to_string()),
+        ),
+        ("expected_disposition", Value::String("block".to_string())),
+        ("max_identifier_length", Value::from(64)),
+        (
+            "proposed_identifier",
+            Value::String("fixture_identifier".to_string()),
+        ),
+        ("proposed_identifier_length", Value::from(18)),
+    ]);
+    let mut bytes = serde_json::to_vec_pretty(&values).unwrap();
+    bytes.push(b'\n');
+    bytes
+}
+
+fn digest_value(bytes: &[u8]) -> Value {
+    let digest = artifact_digest(bytes);
+    json!({"sha256": digest.sha256, "bytes": digest.bytes})
+}
+
+fn metadata(
+    slot_id: &str,
+    session_id: &str,
+    outcome: RunOutcome,
+    origin: ExecutionOrigin,
+) -> ExternalRunMetadata {
+    ExternalRunMetadata {
+        schema_version: 1,
+        slot_id: slot_id.to_string(),
+        execution_origin: origin,
+        worker_identity: "worker-family@v1".into(),
+        harness_identity: "harness@v1".into(),
+        affordance_identity: "read-only-tools@v1".into(),
+        session_id: session_id.into(),
+        fresh_session: true,
+        prior_condition_exposure: false,
+        evaluated_outcome: outcome,
+        evidence_inspection: EvidenceInspection::Consulted,
+        context_expanded: false,
+    }
+}
+
+fn receipts_for_signal(
+    order: OrderSelection,
+) -> (
+    Fixture,
+    capability_demand_pair_execution::PreparedPair,
+    Value,
+    Value,
+) {
+    let fixture = fixture();
+    let prepared = prepare_pair(
+        &fixture.trial,
+        &fixture.manifest,
+        &fixture.task,
+        &fixture.patch,
+        &fixture.baseline,
+        &fixture.treatment,
+        "pair-fixture-1",
+        order,
+    )
+    .unwrap();
+
+    let sampling = b"temperature=0;seed=fixture";
+    let reset_one = b"clean checkout before slot one";
+    let reset_two = b"clean checkout before slot two";
+
+    let mut receipts = Vec::new();
+    for slot in &prepared.plan.slots {
+        let condition = slot.condition_id.as_str();
+        let outcome = if condition == "local_packet" {
+            RunOutcome::Failed
+        } else {
+            RunOutcome::Success
+        };
+        let session = if slot.sequence_index == 1 {
+            "session-one"
+        } else {
+            "session-two"
+        };
+        let reset = if slot.sequence_index == 1 {
+            reset_one.as_slice()
+        } else {
+            reset_two.as_slice()
+        };
+        let output = if condition == "local_packet" {
+            b"No blocking issue identified.".as_slice()
+        } else {
+            b"Blocking repository constraint identified.".as_slice()
+        };
+        let receipt = build_synthetic_test_run_receipt(
+            &prepared.plan,
+            &metadata(
+                &slot.slot_id,
+                session,
+                outcome,
+                ExecutionOrigin::SyntheticTest,
+            ),
+            sampling,
+            reset,
+            output,
+        )
+        .unwrap();
+        receipts.push(receipt);
+    }
+
+    (fixture, prepared, receipts.remove(0), receipts.remove(0))
+}
+
+#[test]
+fn worker_bundle_metadata_is_blind_while_organizer_plan_keeps_condition_mapping() {
+    let fixture = fixture();
+    let prepared = prepare_pair(
+        &fixture.trial,
+        &fixture.manifest,
+        &fixture.task,
+        &fixture.patch,
+        &fixture.baseline,
+        &fixture.treatment,
+        "pair-blind",
+        OrderSelection::Explicit(PairOrder::Ab),
+    )
+    .unwrap();
+
+    assert_eq!(prepared.plan.slots[0].condition_id, "local_packet");
+    assert_eq!(prepared.plan.slots[1].condition_id, "expanded_packet");
+
+    for slot in &prepared.slots {
+        let rendered = serde_json::to_string(&slot.metadata).unwrap();
+        for forbidden in [
+            "local_packet",
+            "expanded_packet",
+            "baseline",
+            "treatment",
+            "decisive",
+            "oracle",
+        ] {
+            assert!(
+                !rendered.contains(forbidden),
+                "leaked {forbidden}: {rendered}"
+            );
+        }
+        assert_eq!(slot.task, fixture.task);
+        assert_eq!(slot.patch, fixture.patch);
+    }
+}
+
+#[test]
+fn explicit_and_seeded_order_are_stable_and_do_not_change_condition_semantics() {
+    let fixture = fixture();
+    let ab = prepare_pair(
+        &fixture.trial,
+        &fixture.manifest,
+        &fixture.task,
+        &fixture.patch,
+        &fixture.baseline,
+        &fixture.treatment,
+        "pair-order",
+        parse_order_selection("AB").unwrap(),
+    )
+    .unwrap();
+    let ba = prepare_pair(
+        &fixture.trial,
+        &fixture.manifest,
+        &fixture.task,
+        &fixture.patch,
+        &fixture.baseline,
+        &fixture.treatment,
+        "pair-order",
+        parse_order_selection("BA").unwrap(),
+    )
+    .unwrap();
+    assert_eq!(ab.plan.order, PairOrder::Ab);
+    assert_eq!(ba.plan.order, PairOrder::Ba);
+    assert_eq!(ab.plan.slots[0].condition_id, ba.plan.slots[1].condition_id);
+    assert_eq!(ab.plan.slots[1].condition_id, ba.plan.slots[0].condition_id);
+
+    let seeded_one = prepare_pair(
+        &fixture.trial,
+        &fixture.manifest,
+        &fixture.task,
+        &fixture.patch,
+        &fixture.baseline,
+        &fixture.treatment,
+        "pair-seeded",
+        parse_order_selection("seed:organizer-secret-1").unwrap(),
+    )
+    .unwrap();
+    let seeded_two = prepare_pair(
+        &fixture.trial,
+        &fixture.manifest,
+        &fixture.task,
+        &fixture.patch,
+        &fixture.baseline,
+        &fixture.treatment,
+        "pair-seeded",
+        parse_order_selection("seed:organizer-secret-1").unwrap(),
+    )
+    .unwrap();
+    assert_eq!(seeded_one.plan.order, seeded_two.plan.order);
+    assert_eq!(
+        serde_json::to_value(&seeded_one.plan.order_source).unwrap(),
+        serde_json::to_value(&seeded_two.plan.order_source).unwrap()
+    );
+}
+
+#[test]
+fn exact_artifact_fingerprints_are_required_before_blind_packaging() {
+    let fixture = fixture();
+    let mut wrong_task = fixture.task.clone();
+    wrong_task.push(b'!');
+    assert!(
+        prepare_pair(
+            &fixture.trial,
+            &fixture.manifest,
+            &wrong_task,
+            &fixture.patch,
+            &fixture.baseline,
+            &fixture.treatment,
+            "pair-wrong-task",
+            OrderSelection::Explicit(PairOrder::Ab),
+        )
+        .unwrap_err()
+        .contains("task bytes do not match")
+    );
+
+    let mut wrong_packet = fixture.baseline.clone();
+    wrong_packet.push(b' ');
+    assert!(
+        prepare_pair(
+            &fixture.trial,
+            &fixture.manifest,
+            &fixture.task,
+            &fixture.patch,
+            &wrong_packet,
+            &fixture.treatment,
+            "pair-wrong-packet",
+            OrderSelection::Explicit(PairOrder::Ab),
+        )
+        .unwrap_err()
+        .contains("not admitted by the manifest")
+    );
+}
+
+#[test]
+fn production_receipt_builder_rejects_synthetic_execution_origin() {
+    let fixture = fixture();
+    let prepared = prepare_pair(
+        &fixture.trial,
+        &fixture.manifest,
+        &fixture.task,
+        &fixture.patch,
+        &fixture.baseline,
+        &fixture.treatment,
+        "pair-origin",
+        OrderSelection::Explicit(PairOrder::Ab),
+    )
+    .unwrap();
+    let slot = &prepared.plan.slots[0];
+    let error = build_external_run_receipt(
+        &prepared.plan,
+        &metadata(
+            &slot.slot_id,
+            "synthetic-session",
+            RunOutcome::Failed,
+            ExecutionOrigin::SyntheticTest,
+        ),
+        b"sampling",
+        b"reset",
+        b"raw output",
+    )
+    .unwrap_err();
+    assert!(error.contains("synthetic test metadata"));
+}
+
+#[test]
+fn raw_output_sampling_and_reset_hashes_are_derived_from_supplied_bytes() {
+    let fixture = fixture();
+    let prepared = prepare_pair(
+        &fixture.trial,
+        &fixture.manifest,
+        &fixture.task,
+        &fixture.patch,
+        &fixture.baseline,
+        &fixture.treatment,
+        "pair-hashes",
+        OrderSelection::Explicit(PairOrder::Ab),
+    )
+    .unwrap();
+    let slot = &prepared.plan.slots[0];
+    let sampling = b"temperature=0.2;seed=7";
+    let reset = b"git reset --hard exact-head; git clean -ffd";
+    let output = b"raw worker bytes including punctuation.\n";
+    let value = build_external_run_receipt(
+        &prepared.plan,
+        &metadata(
+            &slot.slot_id,
+            "external-session-1",
+            RunOutcome::Failed,
+            ExecutionOrigin::ExternalHarness,
+        ),
+        sampling,
+        reset,
+        output,
+    )
+    .unwrap();
+
+    assert_eq!(value["sampling_config_sha256"], sha256_hex(sampling));
+    assert_eq!(value["checkout_reset_receipt_sha256"], sha256_hex(reset));
+    assert_eq!(value["worker_output_sha256"], sha256_hex(output));
+    parse_run_receipt(&serde_json::to_vec(&value).unwrap()).unwrap();
+}
+
+#[test]
+fn fake_pair_reaches_real_246_retirement_signal_in_ab_and_ba_order() {
+    for order in [
+        OrderSelection::Explicit(PairOrder::Ab),
+        OrderSelection::Explicit(PairOrder::Ba),
+    ] {
+        let (fixture, _prepared, left, right) = receipts_for_signal(order);
+        let spec = parse_trial_spec(&fixture.trial).unwrap();
+        let manifest = parse_trial_manifest(&fixture.manifest).unwrap();
+        let left = parse_run_receipt(&serde_json::to_vec(&left).unwrap()).unwrap();
+        let right = parse_run_receipt(&serde_json::to_vec(&right).unwrap()).unwrap();
+        let evaluation = evaluate_pair(&spec, &manifest, &left, &right).unwrap();
+        assert_eq!(
+            evaluation.verdict,
+            RetirementVerdict::PairedRetirementSignal
+        );
+        assert!(!evaluation.automatic_causal_claim);
+        assert!(!evaluation.automatic_generalization);
+    }
+}
+
+#[test]
+fn same_session_contamination_is_rejected_by_real_246_evaluator() {
+    let (fixture, prepared, left, right) =
+        receipts_for_signal(OrderSelection::Explicit(PairOrder::Ab));
+    let left: Value = left;
+    let mut right: Value = right;
+    right["session_id"] = left["session_id"].clone();
+
+    let spec = parse_trial_spec(&fixture.trial).unwrap();
+    let manifest = parse_trial_manifest(&fixture.manifest).unwrap();
+    let left = parse_run_receipt(&serde_json::to_vec(&left).unwrap()).unwrap();
+    let right = parse_run_receipt(&serde_json::to_vec(&right).unwrap()).unwrap();
+    let evaluation = evaluate_pair(&spec, &manifest, &left, &right).unwrap();
+    assert_eq!(evaluation.verdict, RetirementVerdict::Confounded);
+    assert_eq!(prepared.plan.slots.len(), 2);
+}
+
+#[test]
+fn tampered_receipt_packet_hash_rejects_before_pair_interpretation() {
+    let (fixture, _prepared, left, right) =
+        receipts_for_signal(OrderSelection::Explicit(PairOrder::Ab));
+    let left = parse_run_receipt(&serde_json::to_vec(&left).unwrap()).unwrap();
+    let mut right_value: Value = right;
+    right_value["evidence_packet_sha256"] = Value::String("f".repeat(64));
+    let right = parse_run_receipt(&serde_json::to_vec(&right_value).unwrap()).unwrap();
+    let spec = parse_trial_spec(&fixture.trial).unwrap();
+    let manifest = parse_trial_manifest(&fixture.manifest).unwrap();
+    let error = evaluate_pair(&spec, &manifest, &left, &right).unwrap_err();
+    assert!(error.contains("evidence packet fingerprint does not match"));
+}


### PR DESCRIPTION
Progresses #253 by closing the organizer-side gap between merged #239/#245/#246 and genuinely external fresh worker sessions.

## What

Adds provider-neutral research tooling:

```text
capability_demand_pair_prepare
  exact frozen trial inputs
  -> organizer-only plan
  -> two blind worker slot directories

capability_demand_run_receipt
  organizer plan + external run metadata + raw artifacts
  -> admitted #246 WorkerRunReceipt v1
```

No model/provider SDK is added and no worker is invoked by this PR.

## Blind pair packaging

Each worker slot receives only:

```text
worker-input.json
task.txt
proposed.patch
evidence.json
```

The metadata carries exact trial/pair/run/repository coordinates plus task/patch/evidence fingerprints, but does not serialize:

```text
condition_id
baseline / treatment
decisive_evidence state
evaluator oracle
```

The organizer-only `organizer-plan.json` retains the slot-to-condition mapping.

The packager verifies exact task/patch/evidence SHA-256 + byte counts against the supplied #246 materialized manifest. Task and patch bytes are independently rebound to the frozen trial spec so a mismatched manifest cannot silently substitute a different worker task.

## Order

Supports:

```text
AB
BA
seed:<organizer-seed>
```

Seeded order is deterministic for one `(seed, pair_id)` and stores only the seed SHA-256. #246 still derives baseline/treatment semantics from `decisive_evidence_present`, not execution order.

## External receipt builder

External metadata supplies observable execution coordinates such as worker/harness/tool identities, session ID, fresh-session assertion, prior-condition exposure, evaluated outcome, evidence-inspection observability, and context expansion.

The builder computes these directly from preserved bytes:

```text
sampling_config_sha256
checkout_reset_receipt_sha256
worker_output_sha256
```

and reparses the emitted JSON through the merged #246 receipt validator.

A `synthetic_test` execution origin exists only under `cfg(test)`; the production builder rejects it so fake-worker controls cannot be emitted as apparently real external evidence.

## Adversarial controls

The test carrier covers:

- worker metadata omits arm labels / oracle semantics;
- organizer plan retains exact condition mapping;
- AB and BA both preserve condition meaning;
- seeded ordering is deterministic;
- wrong task or evidence bytes reject before packaging;
- production receipt builder rejects synthetic execution origin;
- sampling/reset/raw-output hashes come from supplied bytes;
- deterministic fake baseline-fail / treatment-success reaches the real #246 `paired_retirement_signal` evaluator in AB and BA order;
- same-session contamination becomes `confounded`;
- tampered evidence packet fingerprint rejects before pair interpretation.

Synthetic receipts remain in-memory test values only.

## Boundary

- research/execution tooling only;
- no primary CLI/report-schema change;
- no model/provider SDK or API key handling;
- no model invocation;
- no claim that process isolation proves a fresh model session;
- no prose-similarity grader;
- no private chain-of-thought;
- no oracle in worker bundles;
- no automatic causal/generalization claim or authority grant.

The remaining real-world step after this is an external harness executing the two blind slots in genuinely fresh sessions and returning admitted run metadata/raw outputs for #246 scoring.

Refs #137 #215 #223 #238 #239 #245 #246 #253.