### PR TITLE
research: admit fresh-session behavioral trial run receipts

### DIFF
--- a/examples/behavioral_trial_run.rs
+++ b/examples/behavioral_trial_run.rs
@@ -1,0 +1,80 @@
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+#[allow(dead_code)]
+#[path = "../src/behavioral_trial.rs"]
+mod behavioral_trial;
+#[allow(dead_code)]
+#[path = "../src/behavioral_trial_run.rs"]
+mod behavioral_trial_run;
+
+use behavioral_trial::{MAX_BEHAVIORAL_TRIAL_BYTES, parse_behavioral_trial_plan};
+use behavioral_trial_run::{
+    MAX_BEHAVIORAL_TRIAL_RUN_RECEIPT_BYTES, evaluate_behavioral_trial_runs,
+    parse_behavioral_trial_run_receipt,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("behavioral-trial-run: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut args = std::env::args().skip(1);
+    let plan_path = next_path(&mut args)?;
+    let first_run_path = next_path(&mut args)?;
+    let second_run_path = next_path(&mut args)?;
+    if args.next().is_some() {
+        return Err(usage().into());
+    }
+
+    let plan = parse_behavioral_trial_plan(&read_bounded(&plan_path, MAX_BEHAVIORAL_TRIAL_BYTES)?)
+        .map_err(|error| invalid_data(error.to_string()))?;
+    let first = parse_behavioral_trial_run_receipt(&read_bounded(
+        &first_run_path,
+        MAX_BEHAVIORAL_TRIAL_RUN_RECEIPT_BYTES,
+    )?)
+    .map_err(invalid_data)?;
+    let second = parse_behavioral_trial_run_receipt(&read_bounded(
+        &second_run_path,
+        MAX_BEHAVIORAL_TRIAL_RUN_RECEIPT_BYTES,
+    )?)
+    .map_err(invalid_data)?;
+
+    let evaluation =
+        evaluate_behavioral_trial_runs(&plan, &first, &second).map_err(invalid_data)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}
+
+fn next_path(args: &mut impl Iterator<Item = String>) -> Result<String, io::Error> {
+    args.next().ok_or_else(usage)
+}
+
+fn usage() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "usage: behavioral_trial_run PLAN.json RUN_A.json RUN_B.json",
+    )
+}
+
+fn read_bounded(path: impl AsRef<Path>, maximum: usize) -> Result<Vec<u8>, Box<dyn Error>> {
+    let path = path.as_ref();
+    let metadata = fs::metadata(path)?;
+    if metadata.len() > maximum as u64 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{} exceeds {maximum} bytes", path.display()),
+        )
+        .into());
+    }
+    Ok(fs::read(path)?)
+}
+
+fn invalid_data(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}

--- a/research/behavioral-trial-run-receipts.md
+++ b/research/behavioral-trial-run-receipts.md
@@ -1,0 +1,232 @@
+# Paired behavioral trial run receipts
+
+Status: research execution-admission layer for the blind first-action protocol from #245, using the neutral Stensibly plan repaired by #262.
+
+The behavioral-trial core intentionally keeps one semantic observation small:
+
+```text
+worker packet
+-> one first_action_id
+```
+
+That object records the observed action. It does not prove that a two-run experiment used fresh isolated sessions or fixed worker/harness/tool settings.
+
+This layer adds that missing execution receipt **outside** the minimal observation schema.
+
+## Flow
+
+```text
+BehavioralTrialPlan
+-> exact blind BehavioralWorkerPacket bytes
+-> external fresh worker session
+-> preserved raw output
+-> BehavioralTrialRunReceipt
+-> execution-pair admission
+-> existing #245 BehavioralTrialObservation
+-> existing #245 first-action reconciliation
+```
+
+Cultist still does not launch the worker.
+
+## Run receipt v1
+
+Each external run supplies one bounded JSON object:
+
+```text
+schema_version = 1
+
+trial_id
+pair_id
+run_id
+sequence_index = 1 | 2
+
+plan_fingerprint
+worker_packet_fingerprint
+worker_packet_file_sha256
+
+worker_ref
+worker_identity
+harness_identity
+affordance_identity
+sampling_config_sha256
+
+session_id
+fresh_session
+prior_condition_exposure
+
+raw_worker_output_sha256
+first_action_id
+```
+
+`worker_packet_file_sha256` is the SHA-256 of the exact pretty-JSON worker packet file emitted by `behavioral_trial_materialize`, including its terminal newline. This binds the receipt to the concrete bytes given to the worker as well as the typed packet fingerprint.
+
+`raw_worker_output_sha256` binds the normalized first-action receipt back to preserved raw output. Cultist does not infer private reasoning from that output.
+
+## Per-run admission
+
+For each receipt, Cultist recomputes the current plan fingerprint and both materialized worker packets.
+
+The run rejects before pair interpretation if:
+
+- `trial_id` differs from the plan;
+- `plan_fingerprint` differs;
+- the packet fingerprint belongs to neither plan arm;
+- the packet-file SHA differs from the canonical materialized bytes for that packet;
+- `first_action_id` is outside the plan vocabulary;
+- receipt hashes/coordinates are malformed.
+
+These are invalid receipts, not experimental confounds.
+
+## Pair admission
+
+Frozen axes across the pair:
+
+```text
+pair_id
+worker_identity
+harness_identity
+affordance_identity
+sampling_config_sha256
+```
+
+Fresh-session requirements:
+
+```text
+both fresh_session = true
+both prior_condition_exposure = false
+session ids differ
+run ids differ
+sequence indices exactly {1, 2}
+```
+
+The two receipts must also cover both distinct worker-packet fingerprints from the plan.
+
+Pair verdicts:
+
+```text
+admitted
+confounded
+invalid_pair
+```
+
+`confounded` means the frozen axes or fresh-session requirements failed.
+
+`invalid_pair` means individually valid receipts were supplied for the same arm twice, so the pair does not represent the registered intervention.
+
+## Behavioral interpretation
+
+Only an `admitted` execution pair is converted into the existing #245 observations and passed through `evaluate_behavioral_trial_pair()`.
+
+That nested result remains deliberately descriptive:
+
+```text
+control.first_action_id
+treatment.first_action_id
+same_first_action
+```
+
+Execution order does not define arm identity. AB and BA are both admissible because the existing packet fingerprints identify the arms.
+
+The outer result always says:
+
+```text
+automatic_effect_claim = false
+automatic_generalization = false
+```
+
+A changed first action is evidence that the observed action changed in that admitted pair. This layer does not call it improvement, causation, capability retirement, or a promotion criterion.
+
+## Repaired Stensibly exact-byte control
+
+Issue #258 found that the original #254 shared action vocabulary leaked the desired correction. Merged #262 neutralized that vocabulary before any real worker execution and regenerated the executable blind packets.
+
+Current plan fingerprint:
+
+```text
+cultist-behavioral-trial-plan-sha256-v1:1aca6332c77ed72b49cb20593f215c7eb2952121ad9bf3d5ae60bea0df5df024
+```
+
+Current typed worker-packet fingerprints:
+
+```text
+control
+cultist-behavioral-worker-packet-sha256-v1:5fa460fe007276013ed019830daaf9fc8d086cc5d3d5dfdfc5dd33a58052887d
+
+treatment
+cultist-behavioral-worker-packet-sha256-v1:a80303b59b9a46c5f4e6adb446abb01fbaeb5d898911bf6ad1248b3b0cf38549
+```
+
+The retained Stensibly plan must reproduce the exact serialized files from the repaired #262 materializer run:
+
+```text
+control packet file
+sha256 6a568aed1eb660141cd7e7759e47edeb10a5c759fe1402689699dd7b6837149e
+bytes  2252
+
+treatment packet file
+sha256 1063efc8ecdf0313b947923dad8216fb9fa43b2e8b8cafa7ab6b63d53eb65c7d
+bytes  2953
+```
+
+The context bytes remain 1082 / 1775; the serialization changed because the shared action vocabulary is now neutral:
+
+```text
+block_patch
+inspect_accepted_guard_detail
+approve_patch
+inspect_more_repository_context
+```
+
+Artifact receipt from the repaired materializer:
+
+```text
+run       32271062286
+artifact  9372168346
+archive   sha256:d4de6fe63a7088a921cbd6ea1a3c386f22a5620c5c25a71f34edc5bb11fd23cd
+```
+
+The superseded #254/#260 packet identities are intentionally excluded from execution admission.
+
+## Replay command
+
+After an external harness has produced two run receipts:
+
+```text
+cargo run --example behavioral_trial_run -- \
+  research/behavioral-trials/stensibly-index-guard-detail.json \
+  run-a.json \
+  run-b.json
+```
+
+The external harness should preserve the raw worker outputs whose SHA-256 values appear in the receipts.
+
+## What remains outside Cultist
+
+A real execution harness still owns:
+
+- choosing and pinning the worker implementation/version;
+- starting genuinely fresh sessions;
+- fixing sampling configuration;
+- fixing available tools/affordances;
+- keeping organizer arm assignments hidden from the worker;
+- preserving raw outputs;
+- producing the run receipts.
+
+No real worker run exists merely because the synthetic admission tests pass.
+
+## Boundary
+
+- research only;
+- no provider/model SDK;
+- no API key/secret handling;
+- no model-brand taxonomy;
+- no chain-of-thought;
+- no synthetic receipt represented as real behavior;
+- no treatment-effect or causal label;
+- no authority grant;
+- no change to `BehavioralTrialObservation`;
+- no primary product CLI/report change.
+
+North star:
+
+> Admit first-action A/B evidence only when the repository can prove which exact blind input each fresh session received and which experimental axes stayed fixed.

--- a/src/behavioral_trial_run.rs
+++ b/src/behavioral_trial_run.rs
@@ -1,0 +1,329 @@
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::behavioral_trial::BehavioralTrialArmKind;
+use crate::behavioral_trial::{
+    BEHAVIORAL_TRIAL_SCHEMA_VERSION, BehavioralTrialEvaluation, BehavioralTrialObservation,
+    BehavioralTrialPair, BehavioralTrialPlan, BehavioralWorkerPacket,
+    evaluate_behavioral_trial_pair, fingerprint_plan, materialize_worker_packet,
+};
+
+pub const BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION: u32 = 1;
+pub const MAX_BEHAVIORAL_TRIAL_RUN_RECEIPT_BYTES: usize = 128 * 1024;
+
+const MAX_COORDINATE_BYTES: usize = 2048;
+const SHA256_HEX_BYTES: usize = 64;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralTrialRunReceipt {
+    pub schema_version: u32,
+    pub trial_id: String,
+    pub pair_id: String,
+    pub run_id: String,
+    pub sequence_index: u32,
+    pub plan_fingerprint: String,
+    pub worker_packet_fingerprint: String,
+    pub worker_packet_file_sha256: String,
+    pub worker_ref: String,
+    pub worker_identity: String,
+    pub harness_identity: String,
+    pub affordance_identity: String,
+    pub sampling_config_sha256: String,
+    pub session_id: String,
+    pub fresh_session: bool,
+    pub prior_condition_exposure: bool,
+    pub raw_worker_output_sha256: String,
+    pub first_action_id: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BehavioralTrialRunVerdict {
+    Admitted,
+    Confounded,
+    InvalidPair,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralTrialRunEvaluation {
+    pub schema_version: u32,
+    pub trial_id: String,
+    pub plan_fingerprint: String,
+    pub pair_id: String,
+    pub run_ids: Vec<String>,
+    pub execution_order_packet_fingerprints: Vec<String>,
+    pub verdict: BehavioralTrialRunVerdict,
+    pub frozen_identity_match: bool,
+    pub fresh_uncontaminated_sessions: bool,
+    pub distinct_arm_coverage: bool,
+    pub behavioral_evaluation: Option<BehavioralTrialEvaluation>,
+    pub automatic_effect_claim: bool,
+    pub automatic_generalization: bool,
+}
+
+pub fn parse_behavioral_trial_run_receipt(
+    bytes: &[u8],
+) -> Result<BehavioralTrialRunReceipt, String> {
+    if bytes.len() > MAX_BEHAVIORAL_TRIAL_RUN_RECEIPT_BYTES {
+        return Err(format!(
+            "behavioral trial run receipt exceeds the {}-byte limit",
+            MAX_BEHAVIORAL_TRIAL_RUN_RECEIPT_BYTES
+        ));
+    }
+    let receipt: BehavioralTrialRunReceipt =
+        serde_json::from_slice(bytes).map_err(|error| error.to_string())?;
+    validate_receipt_shape(&receipt)?;
+    Ok(receipt)
+}
+
+pub fn canonical_worker_packet_file_sha256(
+    packet: &BehavioralWorkerPacket,
+) -> Result<String, String> {
+    let mut bytes = serde_json::to_string_pretty(packet)
+        .map_err(|error| format!("failed to serialize worker packet: {error}"))?
+        .into_bytes();
+    bytes.push(b'\n');
+    Ok(sha256_hex(&bytes))
+}
+
+pub fn evaluate_behavioral_trial_runs(
+    plan: &BehavioralTrialPlan,
+    first: &BehavioralTrialRunReceipt,
+    second: &BehavioralTrialRunReceipt,
+) -> Result<BehavioralTrialRunEvaluation, String> {
+    let plan_fingerprint = fingerprint_plan(plan).map_err(|error| error.to_string())?;
+    let control_packet = materialize_worker_packet(plan, BehavioralTrialArmKind::Control)
+        .map_err(|error| error.to_string())?;
+    let treatment_packet = materialize_worker_packet(plan, BehavioralTrialArmKind::Treatment)
+        .map_err(|error| error.to_string())?;
+
+    validate_receipt_against_plan(
+        first,
+        plan,
+        &plan_fingerprint,
+        &control_packet,
+        &treatment_packet,
+    )?;
+    validate_receipt_against_plan(
+        second,
+        plan,
+        &plan_fingerprint,
+        &control_packet,
+        &treatment_packet,
+    )?;
+
+    let frozen_identity_match = first.pair_id == second.pair_id
+        && first.worker_identity == second.worker_identity
+        && first.harness_identity == second.harness_identity
+        && first.affordance_identity == second.affordance_identity
+        && first.sampling_config_sha256 == second.sampling_config_sha256;
+
+    let fresh_uncontaminated_sessions = first.fresh_session
+        && second.fresh_session
+        && !first.prior_condition_exposure
+        && !second.prior_condition_exposure
+        && first.session_id != second.session_id
+        && first.run_id != second.run_id
+        && BTreeSet::from([first.sequence_index, second.sequence_index]) == BTreeSet::from([1, 2]);
+
+    let packet_set = BTreeSet::from([
+        first.worker_packet_fingerprint.as_str(),
+        second.worker_packet_fingerprint.as_str(),
+    ]);
+    let expected_packet_set = BTreeSet::from([
+        control_packet.worker_packet_fingerprint.as_str(),
+        treatment_packet.worker_packet_fingerprint.as_str(),
+    ]);
+    let distinct_arm_coverage = packet_set == expected_packet_set;
+
+    let verdict = if !frozen_identity_match || !fresh_uncontaminated_sessions {
+        BehavioralTrialRunVerdict::Confounded
+    } else if !distinct_arm_coverage {
+        BehavioralTrialRunVerdict::InvalidPair
+    } else {
+        BehavioralTrialRunVerdict::Admitted
+    };
+
+    let behavioral_evaluation = if verdict == BehavioralTrialRunVerdict::Admitted {
+        let pair = BehavioralTrialPair {
+            schema_version: BEHAVIORAL_TRIAL_SCHEMA_VERSION,
+            plan: Box::new(plan.clone()),
+            observations: vec![observation(first), observation(second)],
+        };
+        Some(evaluate_behavioral_trial_pair(&pair).map_err(|error| error.to_string())?)
+    } else {
+        None
+    };
+
+    Ok(BehavioralTrialRunEvaluation {
+        schema_version: BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION,
+        trial_id: plan.trial_id.clone(),
+        plan_fingerprint,
+        pair_id: first.pair_id.clone(),
+        run_ids: vec![first.run_id.clone(), second.run_id.clone()],
+        execution_order_packet_fingerprints: vec![
+            first.worker_packet_fingerprint.clone(),
+            second.worker_packet_fingerprint.clone(),
+        ],
+        verdict,
+        frozen_identity_match,
+        fresh_uncontaminated_sessions,
+        distinct_arm_coverage,
+        behavioral_evaluation,
+        automatic_effect_claim: false,
+        automatic_generalization: false,
+    })
+}
+
+fn validate_receipt_shape(receipt: &BehavioralTrialRunReceipt) -> Result<(), String> {
+    if receipt.schema_version != BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported behavioral trial run receipt schema {}; expected {}",
+            receipt.schema_version, BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION
+        ));
+    }
+    for (value, field) in [
+        (&receipt.trial_id, "trial_id"),
+        (&receipt.pair_id, "pair_id"),
+        (&receipt.run_id, "run_id"),
+        (&receipt.plan_fingerprint, "plan_fingerprint"),
+        (
+            &receipt.worker_packet_fingerprint,
+            "worker_packet_fingerprint",
+        ),
+        (&receipt.worker_ref, "worker_ref"),
+        (&receipt.worker_identity, "worker_identity"),
+        (&receipt.harness_identity, "harness_identity"),
+        (&receipt.affordance_identity, "affordance_identity"),
+        (&receipt.session_id, "session_id"),
+        (&receipt.first_action_id, "first_action_id"),
+    ] {
+        validate_coordinate(value, field)?;
+    }
+    if !(1..=2).contains(&receipt.sequence_index) {
+        return Err("sequence_index must be 1 or 2 for a paired behavioral replay".into());
+    }
+    validate_sha256(
+        &receipt.worker_packet_file_sha256,
+        "worker_packet_file_sha256",
+    )?;
+    validate_sha256(&receipt.sampling_config_sha256, "sampling_config_sha256")?;
+    validate_sha256(
+        &receipt.raw_worker_output_sha256,
+        "raw_worker_output_sha256",
+    )?;
+    Ok(())
+}
+
+fn validate_receipt_against_plan(
+    receipt: &BehavioralTrialRunReceipt,
+    plan: &BehavioralTrialPlan,
+    plan_fingerprint: &str,
+    control_packet: &BehavioralWorkerPacket,
+    treatment_packet: &BehavioralWorkerPacket,
+) -> Result<(), String> {
+    validate_receipt_shape(receipt)?;
+    if receipt.trial_id != plan.trial_id {
+        return Err(format!(
+            "run {} trial_id does not match the registered plan",
+            receipt.run_id
+        ));
+    }
+    if receipt.plan_fingerprint != plan_fingerprint {
+        return Err(format!(
+            "run {} plan_fingerprint does not match the registered plan",
+            receipt.run_id
+        ));
+    }
+
+    let packet = if receipt.worker_packet_fingerprint == control_packet.worker_packet_fingerprint {
+        control_packet
+    } else if receipt.worker_packet_fingerprint == treatment_packet.worker_packet_fingerprint {
+        treatment_packet
+    } else {
+        return Err(format!(
+            "run {} names an unknown worker-packet fingerprint",
+            receipt.run_id
+        ));
+    };
+
+    let expected_file_sha256 = canonical_worker_packet_file_sha256(packet)?;
+    if receipt.worker_packet_file_sha256 != expected_file_sha256 {
+        return Err(format!(
+            "run {} worker-packet file SHA256 does not match the canonical packet bytes",
+            receipt.run_id
+        ));
+    }
+
+    if !plan
+        .allowed_first_actions
+        .iter()
+        .any(|action| action.id == receipt.first_action_id)
+    {
+        return Err(format!(
+            "run {} first_action_id `{}` is outside the registered action vocabulary",
+            receipt.run_id, receipt.first_action_id
+        ));
+    }
+    Ok(())
+}
+
+fn observation(receipt: &BehavioralTrialRunReceipt) -> BehavioralTrialObservation {
+    BehavioralTrialObservation {
+        schema_version: BEHAVIORAL_TRIAL_SCHEMA_VERSION,
+        trial_id: receipt.trial_id.clone(),
+        plan_fingerprint: receipt.plan_fingerprint.clone(),
+        worker_packet_fingerprint: receipt.worker_packet_fingerprint.clone(),
+        worker_ref: receipt.worker_ref.clone(),
+        first_action_id: receipt.first_action_id.clone(),
+    }
+}
+
+fn validate_coordinate(value: &str, field: &str) -> Result<(), String> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_COORDINATE_BYTES
+        || value.contains('\0')
+        || value.chars().any(char::is_control)
+    {
+        return Err(format!(
+            "{field} must be a bounded non-empty canonical single-line coordinate"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_sha256(value: &str, field: &str) -> Result<(), String> {
+    if value.len() != SHA256_HEX_BYTES
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(format!(
+            "{field} must contain exactly 64 lowercase SHA-256 hex characters"
+        ));
+    }
+    Ok(())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(SHA256_HEX_BYTES);
+    for byte in digest {
+        output.push(hex_digit(byte >> 4));
+        output.push(hex_digit(byte & 0x0f));
+    }
+    output
+}
+
+fn hex_digit(nibble: u8) -> char {
+    match nibble {
+        0..=9 => char::from(b'0' + nibble),
+        10..=15 => char::from(b'a' + (nibble - 10)),
+        _ => unreachable!("nibble is masked to four bits"),
+    }
+}

--- a/tests/behavioral_trial_run.rs
+++ b/tests/behavioral_trial_run.rs
@@ -80,12 +80,7 @@ fn admitted_ab_pair_reuses_existing_behavioral_reconciliation() {
         1,
         "inspect_accepted_guard_detail",
     );
-    let treatment = receipt(
-        &plan,
-        BehavioralTrialArmKind::Treatment,
-        2,
-        "block_patch",
-    );
+    let treatment = receipt(&plan, BehavioralTrialArmKind::Treatment, 2, "block_patch");
 
     let result = evaluate_behavioral_trial_runs(&plan, &control, &treatment).unwrap();
     assert_eq!(result.verdict, BehavioralTrialRunVerdict::Admitted);
@@ -109,12 +104,7 @@ fn admitted_ab_pair_reuses_existing_behavioral_reconciliation() {
 #[test]
 fn admitted_ba_order_maps_arms_by_packet_fingerprint() {
     let plan = plan();
-    let treatment = receipt(
-        &plan,
-        BehavioralTrialArmKind::Treatment,
-        1,
-        "block_patch",
-    );
+    let treatment = receipt(&plan, BehavioralTrialArmKind::Treatment, 1, "block_patch");
     let control = receipt(
         &plan,
         BehavioralTrialArmKind::Control,
@@ -174,12 +164,7 @@ fn frozen_worker_harness_affordance_or_sampling_drift_confounds_pair() {
     ];
 
     for mutate in mutations.drain(..) {
-        let mut treatment = receipt(
-            &plan,
-            BehavioralTrialArmKind::Treatment,
-            2,
-            "block_patch",
-        );
+        let mut treatment = receipt(&plan, BehavioralTrialArmKind::Treatment, 2, "block_patch");
         mutate(&mut treatment);
         let result = evaluate_behavioral_trial_runs(&plan, &baseline, &treatment).unwrap();
         assert_eq!(result.verdict, BehavioralTrialRunVerdict::Confounded);
@@ -198,33 +183,18 @@ fn reused_nonfresh_or_preexposed_sessions_confound_pair() {
         "inspect_accepted_guard_detail",
     );
 
-    let mut treatment = receipt(
-        &plan,
-        BehavioralTrialArmKind::Treatment,
-        2,
-        "block_patch",
-    );
+    let mut treatment = receipt(&plan, BehavioralTrialArmKind::Treatment, 2, "block_patch");
     treatment.session_id = control.session_id.clone();
     let result = evaluate_behavioral_trial_runs(&plan, &control, &treatment).unwrap();
     assert_eq!(result.verdict, BehavioralTrialRunVerdict::Confounded);
     assert!(!result.fresh_uncontaminated_sessions);
 
-    let mut treatment = receipt(
-        &plan,
-        BehavioralTrialArmKind::Treatment,
-        2,
-        "block_patch",
-    );
+    let mut treatment = receipt(&plan, BehavioralTrialArmKind::Treatment, 2, "block_patch");
     treatment.fresh_session = false;
     let result = evaluate_behavioral_trial_runs(&plan, &control, &treatment).unwrap();
     assert_eq!(result.verdict, BehavioralTrialRunVerdict::Confounded);
 
-    let mut treatment = receipt(
-        &plan,
-        BehavioralTrialArmKind::Treatment,
-        2,
-        "block_patch",
-    );
+    let mut treatment = receipt(&plan, BehavioralTrialArmKind::Treatment, 2, "block_patch");
     treatment.prior_condition_exposure = true;
     let result = evaluate_behavioral_trial_runs(&plan, &control, &treatment).unwrap();
     assert_eq!(result.verdict, BehavioralTrialRunVerdict::Confounded);
@@ -256,12 +226,7 @@ fn packet_file_hash_tampering_rejects_before_pair_interpretation() {
         1,
         "inspect_accepted_guard_detail",
     );
-    let mut treatment = receipt(
-        &plan,
-        BehavioralTrialArmKind::Treatment,
-        2,
-        "block_patch",
-    );
+    let mut treatment = receipt(&plan, BehavioralTrialArmKind::Treatment, 2, "block_patch");
     treatment.worker_packet_file_sha256 = CONTROL_FILE_SHA.into();
 
     let error = evaluate_behavioral_trial_runs(&plan, &control, &treatment).unwrap_err();
@@ -277,12 +242,7 @@ fn unknown_packet_fingerprint_rejects_before_pair_interpretation() {
         1,
         "inspect_accepted_guard_detail",
     );
-    let mut treatment = receipt(
-        &plan,
-        BehavioralTrialArmKind::Treatment,
-        2,
-        "block_patch",
-    );
+    let mut treatment = receipt(&plan, BehavioralTrialArmKind::Treatment, 2, "block_patch");
     treatment.worker_packet_fingerprint =
         "cultist-behavioral-worker-packet-sha256-v1:0000000000000000000000000000000000000000000000000000000000000000"
             .into();
@@ -300,12 +260,7 @@ fn action_outside_registered_vocabulary_rejects_before_pair_interpretation() {
         1,
         "inspect_accepted_guard_detail",
     );
-    let mut treatment = receipt(
-        &plan,
-        BehavioralTrialArmKind::Treatment,
-        2,
-        "block_patch",
-    );
+    let mut treatment = receipt(&plan, BehavioralTrialArmKind::Treatment, 2, "block_patch");
     treatment.first_action_id = "invent_new_action".into();
 
     let error = evaluate_behavioral_trial_runs(&plan, &control, &treatment).unwrap_err();

--- a/tests/behavioral_trial_run.rs
+++ b/tests/behavioral_trial_run.rs
@@ -20,6 +20,10 @@ const CONTROL_FILE_SHA: &str = "6a568aed1eb660141cd7e7759e47edeb10a5c759fe140268
 const TREATMENT_FILE_SHA: &str = "1063efc8ecdf0313b947923dad8216fb9fa43b2e8b8cafa7ab6b63d53eb65c7d";
 const SAMPLING_SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const OUTPUT_SHA: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const OTHER_SAMPLING_SHA: &str =
+    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+type ReceiptMutation = fn(&mut BehavioralTrialRunReceipt);
 
 fn plan() -> BehavioralTrialPlan {
     parse_behavioral_trial_plan(PLAN).expect("retained Stensibly plan should parse")
@@ -53,6 +57,22 @@ fn receipt(
         raw_worker_output_sha256: OUTPUT_SHA.into(),
         first_action_id: first_action_id.into(),
     }
+}
+
+fn drift_worker(receipt: &mut BehavioralTrialRunReceipt) {
+    receipt.worker_identity = "other-worker@v1".into();
+}
+
+fn drift_harness(receipt: &mut BehavioralTrialRunReceipt) {
+    receipt.harness_identity = "other-harness@v1".into();
+}
+
+fn drift_affordance(receipt: &mut BehavioralTrialRunReceipt) {
+    receipt.affordance_identity = "other-affordance@v1".into();
+}
+
+fn drift_sampling(receipt: &mut BehavioralTrialRunReceipt) {
+    receipt.sampling_config_sha256 = OTHER_SAMPLING_SHA.into();
 }
 
 #[test]
@@ -152,18 +172,14 @@ fn frozen_worker_harness_affordance_or_sampling_drift_confounds_pair() {
         1,
         "inspect_accepted_guard_detail",
     );
-
-    let mut mutations: Vec<Box<dyn Fn(&mut BehavioralTrialRunReceipt)>> = vec![
-        Box::new(|receipt| receipt.worker_identity = "other-worker@v1".into()),
-        Box::new(|receipt| receipt.harness_identity = "other-harness@v1".into()),
-        Box::new(|receipt| receipt.affordance_identity = "other-affordance@v1".into()),
-        Box::new(|receipt| {
-            receipt.sampling_config_sha256 =
-                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc".into()
-        }),
+    let mutations: [ReceiptMutation; 4] = [
+        drift_worker,
+        drift_harness,
+        drift_affordance,
+        drift_sampling,
     ];
 
-    for mutate in mutations.drain(..) {
+    for mutate in mutations {
         let mut treatment = receipt(&plan, BehavioralTrialArmKind::Treatment, 2, "block_patch");
         mutate(&mut treatment);
         let result = evaluate_behavioral_trial_runs(&plan, &baseline, &treatment).unwrap();

--- a/tests/behavioral_trial_run.rs
+++ b/tests/behavioral_trial_run.rs
@@ -20,8 +20,7 @@ const CONTROL_FILE_SHA: &str = "6a568aed1eb660141cd7e7759e47edeb10a5c759fe140268
 const TREATMENT_FILE_SHA: &str = "1063efc8ecdf0313b947923dad8216fb9fa43b2e8b8cafa7ab6b63d53eb65c7d";
 const SAMPLING_SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const OUTPUT_SHA: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-const OTHER_SAMPLING_SHA: &str =
-    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+const OTHER_SAMPLING_SHA: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
 
 type ReceiptMutation = fn(&mut BehavioralTrialRunReceipt);
 

--- a/tests/behavioral_trial_run.rs
+++ b/tests/behavioral_trial_run.rs
@@ -1,0 +1,313 @@
+#[allow(dead_code)]
+#[path = "../src/behavioral_trial.rs"]
+mod behavioral_trial;
+#[allow(dead_code)]
+#[path = "../src/behavioral_trial_run.rs"]
+mod behavioral_trial_run;
+
+use behavioral_trial::{
+    BehavioralTrialArmKind, BehavioralTrialPlan, fingerprint_plan, materialize_worker_packet,
+    parse_behavioral_trial_plan,
+};
+use behavioral_trial_run::{
+    BehavioralTrialRunReceipt, BehavioralTrialRunVerdict, canonical_worker_packet_file_sha256,
+    evaluate_behavioral_trial_runs,
+};
+
+const PLAN: &[u8] =
+    include_bytes!("../research/behavioral-trials/stensibly-index-guard-detail.json");
+const CONTROL_FILE_SHA: &str = "6a568aed1eb660141cd7e7759e47edeb10a5c759fe1402689699dd7b6837149e";
+const TREATMENT_FILE_SHA: &str = "1063efc8ecdf0313b947923dad8216fb9fa43b2e8b8cafa7ab6b63d53eb65c7d";
+const SAMPLING_SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OUTPUT_SHA: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+fn plan() -> BehavioralTrialPlan {
+    parse_behavioral_trial_plan(PLAN).expect("retained Stensibly plan should parse")
+}
+
+fn receipt(
+    plan: &BehavioralTrialPlan,
+    arm: BehavioralTrialArmKind,
+    sequence_index: u32,
+    first_action_id: &str,
+) -> BehavioralTrialRunReceipt {
+    let packet = materialize_worker_packet(plan, arm).expect("fixture packet should materialize");
+    BehavioralTrialRunReceipt {
+        schema_version: 1,
+        trial_id: plan.trial_id.clone(),
+        pair_id: "pair-001".into(),
+        run_id: format!("run-{sequence_index}"),
+        sequence_index,
+        plan_fingerprint: fingerprint_plan(plan).expect("fixture plan should fingerprint"),
+        worker_packet_fingerprint: packet.worker_packet_fingerprint.clone(),
+        worker_packet_file_sha256: canonical_worker_packet_file_sha256(&packet)
+            .expect("fixture packet should serialize"),
+        worker_ref: format!("worker-session-{sequence_index}"),
+        worker_identity: "fixed-worker@v1".into(),
+        harness_identity: "first-action-harness@v1".into(),
+        affordance_identity: "packet-only-choice@v1".into(),
+        sampling_config_sha256: SAMPLING_SHA.into(),
+        session_id: format!("session-{sequence_index}"),
+        fresh_session: true,
+        prior_condition_exposure: false,
+        raw_worker_output_sha256: OUTPUT_SHA.into(),
+        first_action_id: first_action_id.into(),
+    }
+}
+
+#[test]
+fn retained_neutral_plan_reproduces_exact_262_packet_file_hashes() {
+    let plan = plan();
+    let control = materialize_worker_packet(&plan, BehavioralTrialArmKind::Control).unwrap();
+    let treatment = materialize_worker_packet(&plan, BehavioralTrialArmKind::Treatment).unwrap();
+
+    assert_eq!(
+        canonical_worker_packet_file_sha256(&control).unwrap(),
+        CONTROL_FILE_SHA
+    );
+    assert_eq!(
+        canonical_worker_packet_file_sha256(&treatment).unwrap(),
+        TREATMENT_FILE_SHA
+    );
+}
+
+#[test]
+fn admitted_ab_pair_reuses_existing_behavioral_reconciliation() {
+    let plan = plan();
+    let control = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        1,
+        "inspect_accepted_guard_detail",
+    );
+    let treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        2,
+        "block_patch",
+    );
+
+    let result = evaluate_behavioral_trial_runs(&plan, &control, &treatment).unwrap();
+    assert_eq!(result.verdict, BehavioralTrialRunVerdict::Admitted);
+    assert!(result.frozen_identity_match);
+    assert!(result.fresh_uncontaminated_sessions);
+    assert!(result.distinct_arm_coverage);
+    assert!(!result.automatic_effect_claim);
+    assert!(!result.automatic_generalization);
+
+    let behavioral = result
+        .behavioral_evaluation
+        .expect("admitted pair should reconcile");
+    assert_eq!(
+        behavioral.control.first_action_id,
+        "inspect_accepted_guard_detail"
+    );
+    assert_eq!(behavioral.treatment.first_action_id, "block_patch");
+    assert!(!behavioral.same_first_action);
+}
+
+#[test]
+fn admitted_ba_order_maps_arms_by_packet_fingerprint() {
+    let plan = plan();
+    let treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        1,
+        "block_patch",
+    );
+    let control = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        2,
+        "inspect_accepted_guard_detail",
+    );
+
+    let result = evaluate_behavioral_trial_runs(&plan, &treatment, &control).unwrap();
+    assert_eq!(result.verdict, BehavioralTrialRunVerdict::Admitted);
+    let behavioral = result.behavioral_evaluation.unwrap();
+    assert_eq!(
+        behavioral.control.first_action_id,
+        "inspect_accepted_guard_detail"
+    );
+    assert_eq!(behavioral.treatment.first_action_id, "block_patch");
+}
+
+#[test]
+fn admitted_pair_can_preserve_the_same_first_action() {
+    let plan = plan();
+    let control = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        1,
+        "inspect_more_repository_context",
+    );
+    let treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        2,
+        "inspect_more_repository_context",
+    );
+
+    let result = evaluate_behavioral_trial_runs(&plan, &control, &treatment).unwrap();
+    assert_eq!(result.verdict, BehavioralTrialRunVerdict::Admitted);
+    assert!(result.behavioral_evaluation.unwrap().same_first_action);
+}
+
+#[test]
+fn frozen_worker_harness_affordance_or_sampling_drift_confounds_pair() {
+    let plan = plan();
+    let baseline = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        1,
+        "inspect_accepted_guard_detail",
+    );
+
+    let mut mutations: Vec<Box<dyn Fn(&mut BehavioralTrialRunReceipt)>> = vec![
+        Box::new(|receipt| receipt.worker_identity = "other-worker@v1".into()),
+        Box::new(|receipt| receipt.harness_identity = "other-harness@v1".into()),
+        Box::new(|receipt| receipt.affordance_identity = "other-affordance@v1".into()),
+        Box::new(|receipt| {
+            receipt.sampling_config_sha256 =
+                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc".into()
+        }),
+    ];
+
+    for mutate in mutations.drain(..) {
+        let mut treatment = receipt(
+            &plan,
+            BehavioralTrialArmKind::Treatment,
+            2,
+            "block_patch",
+        );
+        mutate(&mut treatment);
+        let result = evaluate_behavioral_trial_runs(&plan, &baseline, &treatment).unwrap();
+        assert_eq!(result.verdict, BehavioralTrialRunVerdict::Confounded);
+        assert!(!result.frozen_identity_match);
+        assert!(result.behavioral_evaluation.is_none());
+    }
+}
+
+#[test]
+fn reused_nonfresh_or_preexposed_sessions_confound_pair() {
+    let plan = plan();
+    let control = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        1,
+        "inspect_accepted_guard_detail",
+    );
+
+    let mut treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        2,
+        "block_patch",
+    );
+    treatment.session_id = control.session_id.clone();
+    let result = evaluate_behavioral_trial_runs(&plan, &control, &treatment).unwrap();
+    assert_eq!(result.verdict, BehavioralTrialRunVerdict::Confounded);
+    assert!(!result.fresh_uncontaminated_sessions);
+
+    let mut treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        2,
+        "block_patch",
+    );
+    treatment.fresh_session = false;
+    let result = evaluate_behavioral_trial_runs(&plan, &control, &treatment).unwrap();
+    assert_eq!(result.verdict, BehavioralTrialRunVerdict::Confounded);
+
+    let mut treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        2,
+        "block_patch",
+    );
+    treatment.prior_condition_exposure = true;
+    let result = evaluate_behavioral_trial_runs(&plan, &control, &treatment).unwrap();
+    assert_eq!(result.verdict, BehavioralTrialRunVerdict::Confounded);
+}
+
+#[test]
+fn same_packet_twice_is_an_invalid_pair_without_behavioral_interpretation() {
+    let plan = plan();
+    let first = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        1,
+        "inspect_accepted_guard_detail",
+    );
+    let second = receipt(&plan, BehavioralTrialArmKind::Control, 2, "approve_patch");
+
+    let result = evaluate_behavioral_trial_runs(&plan, &first, &second).unwrap();
+    assert_eq!(result.verdict, BehavioralTrialRunVerdict::InvalidPair);
+    assert!(!result.distinct_arm_coverage);
+    assert!(result.behavioral_evaluation.is_none());
+}
+
+#[test]
+fn packet_file_hash_tampering_rejects_before_pair_interpretation() {
+    let plan = plan();
+    let control = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        1,
+        "inspect_accepted_guard_detail",
+    );
+    let mut treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        2,
+        "block_patch",
+    );
+    treatment.worker_packet_file_sha256 = CONTROL_FILE_SHA.into();
+
+    let error = evaluate_behavioral_trial_runs(&plan, &control, &treatment).unwrap_err();
+    assert!(error.contains("file SHA256"));
+}
+
+#[test]
+fn unknown_packet_fingerprint_rejects_before_pair_interpretation() {
+    let plan = plan();
+    let control = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        1,
+        "inspect_accepted_guard_detail",
+    );
+    let mut treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        2,
+        "block_patch",
+    );
+    treatment.worker_packet_fingerprint =
+        "cultist-behavioral-worker-packet-sha256-v1:0000000000000000000000000000000000000000000000000000000000000000"
+            .into();
+
+    let error = evaluate_behavioral_trial_runs(&plan, &control, &treatment).unwrap_err();
+    assert!(error.contains("unknown worker-packet fingerprint"));
+}
+
+#[test]
+fn action_outside_registered_vocabulary_rejects_before_pair_interpretation() {
+    let plan = plan();
+    let control = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        1,
+        "inspect_accepted_guard_detail",
+    );
+    let mut treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        2,
+        "block_patch",
+    );
+    treatment.first_action_id = "invent_new_action".into();
+
+    let error = evaluate_behavioral_trial_runs(&plan, &control, &treatment).unwrap_err();
+    assert!(error.contains("outside the registered action vocabulary"));
+}


### PR DESCRIPTION
Progresses #264 by adding a research-only execution-admission wrapper around the existing #245 minimal first-action observation, rebased onto the neutral Stensibly plan from merged #262.

## Boundary preserved

`BehavioralTrialObservation` remains unchanged:

```text
trial_id
plan_fingerprint
worker_packet_fingerprint
worker_ref
first_action_id
```

The outer `BehavioralTrialRunReceipt` proves whether two externally produced worker runs are comparable before Cultist creates those observations.

## Run receipt v1

One run binds:

```text
trial_id
pair_id
run_id
sequence_index
plan_fingerprint
worker_packet_fingerprint
worker_packet_file_sha256
worker_ref
worker_identity
harness_identity
affordance_identity
sampling_config_sha256
session_id
fresh_session
prior_condition_exposure
raw_worker_output_sha256
first_action_id
```

The packet-file SHA is recomputed from the exact canonical pretty-JSON `BehavioralWorkerPacket` bytes, including the materializer's terminal newline.

## Invalid receipt vs experimental confound

Malformed/forged run content rejects before pair interpretation:

- wrong trial or plan fingerprint;
- unknown packet fingerprint;
- packet-file SHA mismatch;
- first action outside the registered vocabulary;
- malformed hashes/coordinates.

Pair comparability is typed separately:

```text
admitted
confounded
invalid_pair
```

Frozen axes:

```text
pair id
worker identity
harness identity
affordance identity
sampling config
```

Fresh-session controls:

```text
both fresh
no prior-condition exposure
unique session ids
unique run ids
sequence indices exactly {1,2}
```

Supplying the same valid arm twice yields `invalid_pair`.

## Reuse existing #245 semantics

Only an `admitted` pair constructs the existing `BehavioralTrialPair` and calls `evaluate_behavioral_trial_pair()` unchanged.

The nested output remains descriptive:

```text
control first_action_id
treatment first_action_id
same_first_action
```

AB and BA execution orders are both accepted because packet fingerprints identify the arms.

Every outer result retains:

```text
automatic_effect_claim = false
automatic_generalization = false
```

## Neutral-plan exact-byte compatibility

Merged #262 repaired the shared action vocabulary before any real worker execution. This lane now binds only the repaired executable packets:

```text
plan
cultist-behavioral-trial-plan-sha256-v1:1aca6332c77ed72b49cb20593f215c7eb2952121ad9bf3d5ae60bea0df5df024

control typed packet
cultist-behavioral-worker-packet-sha256-v1:5fa460fe007276013ed019830daaf9fc8d086cc5d3d5dfdfc5dd33a58052887d
file sha256
6a568aed1eb660141cd7e7759e47edeb10a5c759fe1402689699dd7b6837149e

treatment typed packet
cultist-behavioral-worker-packet-sha256-v1:a80303b59b9a46c5f4e6adb446abb01fbaeb5d898911bf6ad1248b3b0cf38549
file sha256
1063efc8ecdf0313b947923dad8216fb9fa43b2e8b8cafa7ab6b63d53eb65c7d
```

Repaired materializer receipt:

```text
run       32271062286
artifact  9372168346
archive   sha256:d4de6fe63a7088a921cbd6ea1a3c386f22a5620c5c25a71f34edc5bb11fd23cd
```

The superseded #254/#260 packet-file hashes are intentionally rejected by the exact-byte compatibility tests.

## Adversarial controls

The suite covers:

- admitted AB order;
- admitted BA order;
- admitted same first action;
- worker identity drift;
- harness drift;
- affordance drift;
- sampling-config drift;
- session reuse;
- non-fresh session;
- prior-condition exposure;
- same packet twice;
- packet-file SHA tampering;
- unknown packet fingerprint;
- action outside vocabulary.

The synthetic treatment action is now the neutral `block_patch`, matching the repaired registered plan.

## CLI research surface

```text
cargo run --example behavioral_trial_run -- PLAN.json RUN_A.json RUN_B.json
```

This only validates/imports receipts. It never launches a worker.

## Clean rebase

The stale pre-#262 branch history was discarded. The four additive files were replayed on merged #262 `main`, with compatibility controls rebound to the repaired packet bytes.

## Boundary

- research only;
- no worker/model/provider invocation;
- no API key/secret handling;
- no model-brand taxonomy;
- no chain-of-thought;
- no synthetic receipt represented as real behavior;
- no treatment-effect/causal label;
- no authority grant;
- no primary product CLI/report change.

Refs #137 #223 #245 #246 #252 #254 #258 #260 #262 #264.