### PR TITLE
policy: make external reference safety pre-write

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,12 @@ jobs:
             scripts/github_reference_url.py \
             scripts/github_reference_url_test.py \
             scripts/external_github_reference_guard.py \
-            scripts/external_github_reference_guard_test.py
+            scripts/external_github_reference_guard_test.py \
+            scripts/external_github_reference_preflight_test.py
           python scripts/github_reference_url_test.py
           python scripts/external_github_reference_guard_test.py
-      - name: External GitHub reference guard for pull request
+          python scripts/external_github_reference_preflight_test.py
+      - name: External GitHub reference post-write detector for pull request
         if: github.event_name == 'pull_request'
         env:
           CULTIST_BASE: ${{ github.event.pull_request.base.sha }}
@@ -63,7 +65,7 @@ jobs:
             --repository "$GITHUB_REPOSITORY" \
             --base "$CULTIST_BASE" \
             --event "$GITHUB_EVENT_PATH"
-      - name: External GitHub reference guard for push
+      - name: External GitHub reference detector for push
         if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
         env:
           CULTIST_BASE: ${{ github.event.before }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,19 +44,50 @@ When proposing a Cultist improvement from dogfood:
 
 A successful task can still expose a product problem. A failed task can still produce useful evidence. Neither automatically proves a general rule.
 
-## Keep external GitHub references precise without incidental backlinks
+## Prevent third-party GitHub backlinks before writing
 
-Cultist frequently cites public GitHub issues, pull requests, reviews, and commits as research evidence. Separate the machine/source coordinate from the human-facing link form.
+Cultist frequently studies public GitHub issues, pull requests, reviews, discussions, commits, and source. Internal research can churn aggressively. Human-facing third-party references require a stricter rule because an accidental GitHub cross-reference cannot be undone after the write has been processed.
 
-In issue bodies, pull-request bodies, and comments:
+For an automated worker, the rule is simple:
 
-- use `https://redirect.github.com/OWNER/REPOSITORY/...` for external GitHub links when a backlink is unnecessary;
-- avoid cross-repository shorthand such as `OWNER/REPOSITORY#123` in conversations when it would create an incidental backlink;
-- keep same-repository references such as `#109` or `#137` short when the cross-reference is intentional.
+**Every third-party GitHub reference the worker creates in human-facing interaction text must already be backlink-safe before the GitHub write happens.**
 
-In repository files, a literal source identity such as `` `The-PR-Agent/pr-agent#2424` `` is often enough. Use a `redirect.github.com` link when human click-through is useful.
+Default to non-linking wording when click-through is unnecessary:
 
-Do not rewrite canonical provider evidence merely for presentation hygiene. Keep `github.com` / `api.github.com` URLs unchanged when they are API inputs, exact source receipts, parser fixtures, workflow inputs, or copied source evidence. Apply backlink avoidance at the human-facing rendering layer.
+```text
+OWNER/REPOSITORY issue 123
+OWNER/REPOSITORY PR 456
+OWNER/REPOSITORY discussion 789
+```
+
+When a link is useful, use the literal redirect host:
+
+```text
+https://redirect.github.com/OWNER/REPOSITORY/issues/123
+https://redirect.github.com/OWNER/REPOSITORY/pull/456
+https://redirect.github.com/OWNER/REPOSITORY/discussions/789
+https://redirect.github.com/OWNER/REPOSITORY/commit/SHA
+```
+
+Automated human-facing text must not emit direct third-party `github.com` URLs or third-party `OWNER/REPOSITORY#123` shorthand. Do not rely on a post-write workflow to prevent a backlink; at that point the interaction already exists.
+
+Repositories under `teamleaderleo/*` are first-party coordination surfaces for this rule. Normal same-repository references such as `#109` and ordinary owned-repository links are allowed.
+
+Before creating or editing an issue, pull request, comment, review, inline review comment, or discussion that mentions third-party GitHub work, preflight the **exact text that will be written**:
+
+```sh
+python scripts/external_github_reference_guard.py \
+  --repository teamleaderleo/cultist \
+  --stdin < proposed-body.md
+```
+
+The write happens only after that preflight succeeds. Interaction preflight has no automated evidence-marker exception.
+
+Do not put clickable third-party issue/PR/discussion references, direct URLs, or cross-repository shorthand in commit messages. Prefer a plain project name and item number without GitHub shorthand, or omit the external coordinate from the commit message entirely.
+
+Canonical `github.com` / `api.github.com` provider coordinates may remain exact on machine/evidence surfaces where identity requires them: API inputs, retained JSON receipts, parser fixtures, workflow inputs, copied source payloads, and other non-interaction evidence. In tracked prose written by an agent, prefer non-linking wording or `redirect.github.com` unless exact canonical source text is itself the retained evidence.
+
+The CI reference guard is a detector and cleanup aid. It is not the prevention boundary.
 
 See `docs/external-reference-policy.md` for the durable policy and examples.
 

--- a/docs/external-reference-policy.md
+++ b/docs/external-reference-policy.md
@@ -1,35 +1,69 @@
 # External GitHub reference policy
 
-Cultist often preserves evidence from public GitHub issues, pull requests, reviews, and commits. Keep source identity exact without creating unnecessary cross-repository backlinks from human-facing GitHub conversations.
+Cultist studies public GitHub history heavily. Internal research can churn. Third-party interaction text must stay quiet unless a human deliberately chooses otherwise.
 
-## Human-facing GitHub conversations
+The prevention boundary is **before the GitHub write**. A CI job that inspects a pull-request body runs after GitHub has already processed that body, so CI is only a detector and cleanup aid.
 
-In issue bodies, pull-request bodies, and comments, use GitHub's backlink-avoiding host for external GitHub references:
+## Automated-worker invariant
+
+Every third-party GitHub reference an automated worker creates in human-facing interaction text must already be backlink-safe before the write occurs.
+
+Default to non-linking wording:
+
+```text
+OWNER/REPOSITORY issue 123
+OWNER/REPOSITORY PR 456
+OWNER/REPOSITORY discussion 789
+```
+
+If click-through is useful, use the literal redirect host:
 
 ```text
 https://redirect.github.com/OWNER/REPOSITORY/issues/123
 https://redirect.github.com/OWNER/REPOSITORY/pull/456
+https://redirect.github.com/OWNER/REPOSITORY/discussions/789
 https://redirect.github.com/OWNER/REPOSITORY/commit/SHA
 ```
 
-Do not use the cross-repository shorthand `OWNER/REPOSITORY#123` when a backlink is unnecessary; GitHub autolinks that form in conversations.
+Automated interaction text must not contain:
 
-Same-repository references such as `#109`, `#137`, or `#198` may stay short when the cross-reference is intentional.
+- direct third-party `github.com` URLs;
+- third-party `OWNER/REPOSITORY#123` shorthand;
+- an intentional-evidence marker used to bypass the interaction rule.
 
-## Repository files
+Repositories under `teamleaderleo/*` are first-party coordination surfaces for this policy. Ordinary links and shorthand among those repositories are allowed.
 
-Research notes may prefer a non-linking source identity when click-through adds little value:
+## Interaction preflight
 
-```text
-`The-PR-Agent/pr-agent#2424`
-`anthropics/claude-code#57507`
+Before an automated worker creates or edits an issue, pull request, comment, review, inline review comment, or discussion that mentions third-party GitHub work, run the scanner against the **exact text that will be written**:
+
+```sh
+python scripts/external_github_reference_guard.py \
+  --repository teamleaderleo/cultist \
+  --stdin < proposed-body.md
 ```
 
-When a clickable external GitHub reference is useful in Markdown, use `redirect.github.com`.
+The GitHub write happens only after this command succeeds.
 
-## Machine and evidence boundaries
+Interaction preflight is intentionally stricter than repository-file detection:
 
-Keep canonical provider coordinates unchanged when they are part of the evidence or required by tooling:
+- it scans direct third-party URLs even inside code blocks;
+- it rejects third-party cross-repository shorthand;
+- it has no automated evidence-marker exception.
+
+A post-write workflow cannot undo a backlink that GitHub has already emitted.
+
+## Commit messages
+
+Do not put clickable third-party issue/PR/discussion references, direct URLs, or `OWNER/REPOSITORY#123` shorthand in automated commit messages.
+
+Use plain non-linking wording such as `ProjectName PR 123`, or omit the external coordinate from the commit message and preserve it in the research receipt instead.
+
+## Repository files and machine evidence
+
+Ordinary tracked files do not create issue/PR conversation backlinks the same way GitHub interaction text does, but automated workers should still use one consistent presentation rule: non-linking wording by default, redirect links when click-through helps.
+
+Canonical provider coordinates may remain exact where identity requires them:
 
 ```text
 https://github.com/...
@@ -44,39 +78,37 @@ Examples include:
 - workflow inputs consumed by GitHub tooling;
 - source payloads copied verbatim as evidence.
 
-Do not rewrite evidence merely to satisfy presentation hygiene. Apply the redirect rule at the human-facing rendering layer.
-
-## Changed-prose guard
-
-CI checks newly added Markdown lines and pull-request bodies for direct external `https://github.com/...` references outside code examples. Existing historical Markdown is not rescanned on unrelated changes.
-
-The guard accepts:
-
-```text
-https://redirect.github.com/OWNER/REPOSITORY/issues/123
-https://github.com/teamleaderleo/cultist/issues/123
-https://api.github.com/repos/OWNER/REPOSITORY/issues/123
-```
-
-Canonical external GitHub source text may remain in Markdown when exact wording is evidence. Keep the exception local by placing this marker on the same line or immediately before the evidence line:
+For a rare exact canonical evidence line in changed Markdown, the changed-file detector still accepts one local marker:
 
 ```html
 <!-- cultist:allow-canonical-github-evidence -->
 ```
 
-Do not use the marker as a file- or section-level bypass. It applies to one prose line only. Prefer `redirect.github.com` for ordinary clickable references.
+That marker applies only to repository-file detection. It never exempts automated interaction preflight.
+
+## CI detector
+
+CI scans newly added Markdown lines and pull-request bodies after the write. Existing historical Markdown is not rescanned on unrelated changes.
+
+The CI detector is useful for catching drift and cleaning up presentation. It is not the mechanism that prevents a third-party backlink.
 
 ## Rule of thumb
 
 ```text
-provider identity / machine input
-  canonical URL
+third-party human-facing mention
+  OWNER/REPOSITORY issue|PR|discussion NUMBER
 
-human-facing external GitHub link
+third-party human-facing link
   redirect.github.com
 
-human-facing source mention with no click-through need
-  literal owner/repo#number
+owned teamleaderleo/* reference
+  ordinary GitHub reference allowed
+
+provider identity / machine input
+  canonical URL when exact identity requires it
+
+GitHub interaction write
+  exact text passes --stdin preflight first
 ```
 
-The goal is precise provenance with fewer incidental backlinks, while keeping machine behavior and retained source evidence exact.
+The goal is high-volume internal research without high-volume third-party GitHub cross-reference noise.

--- a/scripts/external_github_reference_guard.py
+++ b/scripts/external_github_reference_guard.py
@@ -1,24 +1,27 @@
 #!/usr/bin/env python3
-"""Reject new human-facing direct external github.com links.
-
-The guard applies presentation hygiene only. Canonical provider/evidence URLs may be
-retained with an explicit local escape marker, and code examples are ignored.
-"""
+"""Preflight and detect unsafe third-party GitHub references."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlsplit
 
 ALLOW_MARKER = "<!-- cultist:allow-canonical-github-evidence -->"
-DIRECT_GITHUB_URL_RE = re.compile(r"https://github\.com/[^\s<>()\[\]`\"']+")
+DIRECT_GITHUB_URL_RE = re.compile(r"https?://github\.com/[^\s<>()\[\]`\"']+")
+SHORTHAND_RE = re.compile(
+    r"(?<![A-Za-z0-9_.-])([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)#([0-9]+)\b"
+)
 INLINE_CODE_RE = re.compile(r"`[^`]*`")
 FENCE_RE = re.compile(r"^\s*(```|~~~)")
+DEFAULT_OWNED_OWNERS = {"teamleaderleo"}
+MAX_INTERACTION_BYTES = 256 * 1024
 
 
 class GuardError(RuntimeError):
@@ -32,14 +35,36 @@ class Violation:
     url: str
 
 
+def configured_owned_owners() -> set[str]:
+    owners = set(DEFAULT_OWNED_OWNERS)
+    configured = os.environ.get("CULTIST_OWNED_GITHUB_OWNERS", "")
+    owners.update(
+        owner.strip().lower()
+        for owner in configured.split(",")
+        if owner.strip()
+    )
+    return owners
+
+
 def repository_from_url(url: str) -> str | None:
     parsed = urlsplit(url)
-    if parsed.scheme != "https" or (parsed.hostname or "").lower() != "github.com":
+    if parsed.scheme not in {"http", "https"} or (parsed.hostname or "").lower() != "github.com":
         return None
     components = [component for component in parsed.path.split("/") if component]
     if len(components) < 2:
         return None
-    return f"{components[0]}/{components[1]}"
+    return f"{components[0]}/{components[1]}".lower()
+
+
+def is_owned_repository(
+    repository: str,
+    *,
+    current_repository: str,
+    owned_owners: set[str],
+) -> bool:
+    normalized = repository.lower()
+    owner = normalized.split("/", 1)[0]
+    return normalized == current_repository.lower() or owner in owned_owners
 
 
 def strip_inline_code(line: str) -> str:
@@ -52,8 +77,12 @@ def scan_text(
     source: str,
     current_repository: str,
     eligible_lines: set[int] | None = None,
+    owned_owners: set[str] | None = None,
 ) -> list[Violation]:
+    """Scan repository prose; code and one exact-evidence marker stay exempt."""
+
     violations: list[Violation] = []
+    owners = configured_owned_owners() if owned_owners is None else owned_owners
     in_fence = False
     allow_next_line = False
 
@@ -73,20 +102,91 @@ def scan_text(
 
         eligible = eligible_lines is None or line_number in eligible_lines
         sanitized = strip_inline_code(line)
-        matches = list(DIRECT_GITHUB_URL_RE.finditer(sanitized))
         allow_this_line = marker_on_line or allow_next_line
         allow_next_line = False
 
         if not eligible or allow_this_line:
             continue
 
-        for match in matches:
+        for match in DIRECT_GITHUB_URL_RE.finditer(sanitized):
             url = match.group(0).rstrip(".,;:!?")
             repository = repository_from_url(url)
-            if repository is None or repository == current_repository:
+            if repository is None or is_owned_repository(
+                repository,
+                current_repository=current_repository,
+                owned_owners=owners,
+            ):
                 continue
             violations.append(Violation(source=source, line=line_number, url=url))
 
+        for match in SHORTHAND_RE.finditer(sanitized):
+            repository = f"{match.group(1)}/{match.group(2)}".lower()
+            if is_owned_repository(
+                repository,
+                current_repository=current_repository,
+                owned_owners=owners,
+            ):
+                continue
+            violations.append(
+                Violation(
+                    source=source,
+                    line=line_number,
+                    url=f"{match.group(1)}/{match.group(2)}#{match.group(3)}",
+                )
+            )
+
+    return violations
+
+
+def scan_interaction_text(
+    text: str,
+    *,
+    source: str,
+    current_repository: str,
+    owned_owners: set[str] | None = None,
+) -> list[Violation]:
+    """Scan exact outbound GitHub interaction text before the write.
+
+    Interaction preflight has no marker or Markdown-code exception. Automated text
+    either uses redirect.github.com, uses non-linking wording, or stays within an
+    owned repository.
+    """
+
+    encoded = text.encode("utf-8")
+    if len(encoded) > MAX_INTERACTION_BYTES:
+        raise GuardError(
+            f"{source} exceeds the {MAX_INTERACTION_BYTES}-byte interaction preflight limit"
+        )
+
+    owners = configured_owned_owners() if owned_owners is None else owned_owners
+    violations: list[Violation] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        for match in DIRECT_GITHUB_URL_RE.finditer(line):
+            url = match.group(0).rstrip(".,;:!?")
+            repository = repository_from_url(url)
+            if repository is None or is_owned_repository(
+                repository,
+                current_repository=current_repository,
+                owned_owners=owners,
+            ):
+                continue
+            violations.append(Violation(source=source, line=line_number, url=url))
+
+        for match in SHORTHAND_RE.finditer(line):
+            repository = f"{match.group(1)}/{match.group(2)}".lower()
+            if is_owned_repository(
+                repository,
+                current_repository=current_repository,
+                owned_owners=owners,
+            ):
+                continue
+            violations.append(
+                Violation(
+                    source=source,
+                    line=line_number,
+                    url=f"{match.group(1)}/{match.group(2)}#{match.group(3)}",
+                )
+            )
     return violations
 
 
@@ -152,7 +252,11 @@ def added_markdown_lines(diff: str) -> dict[str, set[int]]:
 
 
 def scan_changed_markdown(
-    *, base: str, root: Path, current_repository: str
+    *,
+    base: str,
+    root: Path,
+    current_repository: str,
+    owned_owners: set[str] | None = None,
 ) -> list[Violation]:
     diff = git_diff(base, root)
     changed = added_markdown_lines(diff)
@@ -169,13 +273,17 @@ def scan_changed_markdown(
                 source=relative_path,
                 current_repository=current_repository,
                 eligible_lines=eligible_lines,
+                owned_owners=owned_owners,
             )
         )
     return violations
 
 
 def scan_pull_request_body(
-    *, event_path: Path, current_repository: str
+    *,
+    event_path: Path,
+    current_repository: str,
+    owned_owners: set[str] | None = None,
 ) -> list[Violation]:
     try:
         event = json.loads(event_path.read_text(encoding="utf-8"))
@@ -187,29 +295,38 @@ def scan_pull_request_body(
     body = pull_request.get("body") or ""
     if not isinstance(body, str):
         raise GuardError("pull_request.body must be a string or null")
-    return scan_text(
+    return scan_interaction_text(
         body,
         source="pull_request.body",
         current_repository=current_repository,
+        owned_owners=owned_owners,
     )
 
 
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(
-        description="Reject newly introduced human-facing direct external github.com links."
+        description="Preflight or detect unsafe third-party GitHub references."
     )
     result.add_argument("--repository", required=True, help="Current owner/repository")
     result.add_argument("--base", help="Git base commit/ref for changed Markdown scanning")
     result.add_argument("--event", type=Path, help="GitHub pull_request event JSON to scan")
+    result.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Preflight the exact proposed interaction text from stdin before a GitHub write",
+    )
     result.add_argument("--root", type=Path, default=Path("."))
     return result
 
 
 def main() -> int:
     args = parser().parse_args()
-    if args.base is None and args.event is None:
-        raise SystemExit("external-github-reference-guard: provide --base and/or --event")
+    if args.base is None and args.event is None and not args.stdin:
+        raise SystemExit(
+            "external-github-reference-guard: provide --base, --event, and/or --stdin"
+        )
 
+    owners = configured_owned_owners()
     try:
         violations: list[Violation] = []
         if args.base is not None:
@@ -218,6 +335,7 @@ def main() -> int:
                     base=args.base,
                     root=args.root,
                     current_repository=args.repository,
+                    owned_owners=owners,
                 )
             )
         if args.event is not None:
@@ -225,18 +343,29 @@ def main() -> int:
                 scan_pull_request_body(
                     event_path=args.event,
                     current_repository=args.repository,
+                    owned_owners=owners,
+                )
+            )
+        if args.stdin:
+            violations.extend(
+                scan_interaction_text(
+                    sys.stdin.read(),
+                    source="stdin",
+                    current_repository=args.repository,
+                    owned_owners=owners,
                 )
             )
     except GuardError as error:
         raise SystemExit(f"external-github-reference-guard: {error}") from error
 
     if violations:
-        print("Direct external github.com references are not allowed in new human-facing prose:")
+        print("Unsafe third-party GitHub references detected in human-facing text:")
         for violation in violations:
             print(f"  {violation.source}:{violation.line}: {violation.url}")
         print(
-            "Use https://redirect.github.com/... or add the local canonical-evidence marker "
-            "when exact source text must remain canonical."
+            "Before writing to GitHub, use a literal https://redirect.github.com/... URL "
+            "or non-linking OWNER/REPOSITORY issue/PR/discussion NUMBER wording. "
+            "Do not rely on post-write CI to prevent backlinks."
         )
         return 1
     return 0

--- a/scripts/external_github_reference_preflight_test.py
+++ b/scripts/external_github_reference_preflight_test.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import external_github_reference_guard as guard
+
+REPOSITORY = "teamleaderleo/cultist"
+EXTERNAL_URL = "https://github.com/example/project/issues/123"
+EXTERNAL_REDIRECT = "https://redirect.github.com/example/project/issues/123"
+EXTERNAL_SHORTHAND = "example/project#123"
+OWNED_URL = "https://github.com/teamleaderleo/stensibly/issues/123"
+OWNED_SHORTHAND = "teamleaderleo/stensibly#123"
+
+
+def refs(text: str) -> list[str]:
+    return [
+        violation.url
+        for violation in guard.scan_interaction_text(
+            text,
+            source="fixture",
+            current_repository=REPOSITORY,
+        )
+    ]
+
+
+def test_direct_third_party_url_rejects() -> None:
+    assert refs(f"See {EXTERNAL_URL}.") == [EXTERNAL_URL]
+
+
+def test_redirect_third_party_url_passes() -> None:
+    assert refs(f"See {EXTERNAL_REDIRECT}.") == []
+
+
+def test_non_linking_third_party_wording_passes() -> None:
+    assert refs("See example/project issue 123.") == []
+
+
+def test_third_party_shorthand_rejects() -> None:
+    assert refs(f"See {EXTERNAL_SHORTHAND}.") == [EXTERNAL_SHORTHAND]
+
+
+def test_owned_references_pass() -> None:
+    assert refs(f"See {OWNED_URL} and {OWNED_SHORTHAND}.") == []
+
+
+def test_interaction_code_block_is_not_an_escape() -> None:
+    text = f"```text\n{EXTERNAL_URL}\n```"
+    assert refs(text) == [EXTERNAL_URL]
+
+
+def test_interaction_marker_is_not_an_escape() -> None:
+    text = f"{guard.ALLOW_MARKER}\n{EXTERNAL_URL}"
+    assert refs(text) == [EXTERNAL_URL]
+
+
+def test_configured_owned_owner_extends_first_party_set() -> None:
+    original = os.environ.get("CULTIST_OWNED_GITHUB_OWNERS")
+    os.environ["CULTIST_OWNED_GITHUB_OWNERS"] = "example"
+    try:
+        assert refs(EXTERNAL_URL) == []
+    finally:
+        if original is None:
+            os.environ.pop("CULTIST_OWNED_GITHUB_OWNERS", None)
+        else:
+            os.environ["CULTIST_OWNED_GITHUB_OWNERS"] = original
+
+
+def test_cli_stdin_preflight_rejects_before_write() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/external_github_reference_guard.py",
+            "--repository",
+            REPOSITORY,
+            "--stdin",
+        ],
+        input=f"Proposed body: {EXTERNAL_URL}\n",
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert completed.returncode == 1, completed
+    assert EXTERNAL_URL in completed.stdout, completed.stdout
+    assert "Do not rely on post-write CI" in completed.stdout, completed.stdout
+
+
+def test_cli_stdin_preflight_accepts_redirect() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/external_github_reference_guard.py",
+            "--repository",
+            REPOSITORY,
+            "--stdin",
+        ],
+        input=f"Proposed body: {EXTERNAL_REDIRECT}\n",
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert completed.returncode == 0, completed
+
+
+def main() -> int:
+    tests = [value for name, value in globals().items() if name.startswith("test_")]
+    for test in sorted(tests, key=lambda value: value.__name__):
+        test()
+    print(f"external GitHub interaction preflight: {len(tests)} controls passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Closes #263 by moving third-party GitHub backlink prevention to the automated-worker write boundary.

The central invariant is now:

```text
exact proposed GitHub interaction text
-> preflight
-> GitHub write only after success
```

A post-write CI check remains useful as a detector, but it is explicitly documented as too late to be the prevention boundary.

## Automated interaction rule

For third-party GitHub work, workers now default to non-linking wording:

```text
OWNER/REPOSITORY issue 123
OWNER/REPOSITORY PR 456
OWNER/REPOSITORY discussion 789
```

When click-through is useful, workers use the literal `redirect.github.com` host before the write.

Direct third-party `github.com` URLs and third-party cross-repository shorthand are rejected by interaction preflight. Repositories under `teamleaderleo/*` are treated as first-party coordination surfaces.

## Exact-text preflight

```text
python scripts/external_github_reference_guard.py \
  --repository teamleaderleo/cultist \
  --stdin < proposed-body.md
```

Interaction preflight has no automated evidence-marker escape and does not treat code blocks as an escape. Canonical provider coordinates remain available on machine/evidence surfaces where exact identity is required.

## Agent rule

`AGENTS.md` now requires the preflight before creating or editing issues, pull requests, comments, reviews, inline review comments, or discussions that mention third-party GitHub work. It also forbids clickable third-party item references and shorthand in automated commit messages.

## CI

The existing PR-body check is renamed as a post-write detector. Regression controls cover direct URLs, redirect URLs, non-linking wording, shorthand, owned repositories, code blocks, marker behavior, environment-configured owned owners, and the stdin CLI itself.

## Concurrent main

Current main advanced after the branch started only in observation-frontier and trial-research paths. There is no changed-path overlap; merge-view CI is the compatibility authority.

## Boundary

Internal Cultist policy/tooling only. No third-party writes or fresh external interaction.

Refs #137 #247 #250.