### PR TITLE
fix: separate behavioral receipt authenticity from pair freshness

### DIFF
--- a/src/behavioral_trial_run.rs
+++ b/src/behavioral_trial_run.rs
@@ -219,6 +219,8 @@ pub fn evaluate_behavioral_trial_run_pair(
     let plan = pair.plan.as_ref();
     let first_arm = validate_receipt(plan, &pair.runs[0])?;
     let second_arm = validate_receipt(plan, &pair.runs[1])?;
+    require_fresh_uncontaminated_run(&pair.runs[0].metadata)?;
+    require_fresh_uncontaminated_run(&pair.runs[1].metadata)?;
     if first_arm == second_arm {
         return Err(BehavioralTrialRunError::new(
             "behavioral-trial run pair contains two receipts for the same arm",
@@ -435,14 +437,20 @@ fn validate_metadata(metadata: &BehavioralTrialRunMetadata) -> Result<(), Behavi
         "freshness_receipt",
         MAX_RECEIPT_REF_BYTES,
     )?;
+    Ok(())
+}
+
+fn require_fresh_uncontaminated_run(
+    metadata: &BehavioralTrialRunMetadata,
+) -> Result<(), BehavioralTrialRunError> {
     if !metadata.fresh_session {
         return Err(BehavioralTrialRunError::new(
-            "behavioral-trial run requires fresh_session=true",
+            "behavioral-trial admitted pair requires fresh_session=true",
         ));
     }
     if metadata.prior_condition_exposure {
         return Err(BehavioralTrialRunError::new(
-            "behavioral-trial run requires prior_condition_exposure=false",
+            "behavioral-trial admitted pair requires prior_condition_exposure=false",
         ));
     }
     Ok(())

--- a/tests/behavioral_trial_run.rs
+++ b/tests/behavioral_trial_run.rs
@@ -140,28 +140,66 @@ fn real_guard_detail_plan_admits_fresh_ba_pair_and_preserves_exact_run_metadata(
 }
 
 #[test]
-fn receipt_builder_rejects_nonfresh_or_preexposed_run_metadata() {
+fn receipt_builder_preserves_freshness_facts_while_strict_pair_admission_rejects_confounds() {
     let plan = plan();
-    let packet = materialize_worker_packet(&plan, BehavioralTrialArmKind::Control).unwrap();
-    let raw_packet = canonical_worker_packet_bytes(&packet);
-    let raw_output = raw_observation(
+
+    let mut nonfresh_metadata = metadata(1, "session:nonfresh", "provider:session/nonfresh");
+    nonfresh_metadata.fresh_session = false;
+    let nonfresh = run_receipt(
         &plan,
         BehavioralTrialArmKind::Control,
-        "worker-run:control",
+        nonfresh_metadata,
+        "worker-run:nonfresh",
         "inspect_accepted_guard_detail",
     );
+    assert!(!nonfresh.metadata.fresh_session);
+    let treatment = run_receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        metadata(2, "session:treatment-a", "provider:session/treatment-a"),
+        "worker-run:treatment-a",
+        "block_patch",
+    );
+    let error = evaluate_behavioral_trial_run_pair(&BehavioralTrialRunPair {
+        schema_version: BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION,
+        plan: Box::new(plan.clone()),
+        runs: vec![nonfresh, treatment],
+    })
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("admitted pair requires fresh_session=true")
+    );
 
-    let mut nonfresh = metadata(1, "session:one", "provider:session/one");
-    nonfresh.fresh_session = false;
-    let error =
-        build_behavioral_trial_run_receipt(&plan, nonfresh, &raw_packet, &raw_output).unwrap_err();
-    assert!(error.to_string().contains("fresh_session=true"));
-
-    let mut exposed = metadata(1, "session:two", "provider:session/two");
-    exposed.prior_condition_exposure = true;
-    let error =
-        build_behavioral_trial_run_receipt(&plan, exposed, &raw_packet, &raw_output).unwrap_err();
-    assert!(error.to_string().contains("prior_condition_exposure=false"));
+    let mut exposed_metadata = metadata(1, "session:exposed", "provider:session/exposed");
+    exposed_metadata.prior_condition_exposure = true;
+    let exposed = run_receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        exposed_metadata,
+        "worker-run:exposed",
+        "inspect_accepted_guard_detail",
+    );
+    assert!(exposed.metadata.prior_condition_exposure);
+    let treatment = run_receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        metadata(2, "session:treatment-b", "provider:session/treatment-b"),
+        "worker-run:treatment-b",
+        "block_patch",
+    );
+    let error = evaluate_behavioral_trial_run_pair(&BehavioralTrialRunPair {
+        schema_version: BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION,
+        plan: Box::new(plan),
+        runs: vec![exposed, treatment],
+    })
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("admitted pair requires prior_condition_exposure=false")
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #271 and unblocks #264/#265 composition on the merged #269 receipt type.

## Problem

#269 currently rejects `fresh_session=false` and `prior_condition_exposure=true` while building an **individual** byte-authentic receipt. That erases truthful evidence of a confounded run before #264 can classify a valid receipt pair as `confounded`.

## Repair

Keep individual receipt admission about authenticity:

- exact canonical worker-packet bytes;
- exact raw output bytes;
- typed observation binding;
- bounded/canonical metadata coordinates;
- recorded freshness/exposure facts.

Move the strict fresh/no-prior-exposure requirement into `evaluate_behavioral_trial_run_pair()`, which remains the admitted-pair evaluator.

## Controls

The focused test will prove:

- an authentic non-fresh receipt builds and preserves `fresh_session=false`;
- the strict admitted-pair evaluator rejects that pair;
- an authentic prior-exposed receipt builds and preserves `prior_condition_exposure=true`;
- the strict admitted-pair evaluator rejects that pair;
- existing canonical packet-byte and raw-output tamper controls remain green.

This is a two-file semantic repair. A temporary PR-only carrier patches, formats, runs strict Clippy, the focused receipt suite, the full test suite, and `git diff --check`, then pushes only the core/test changes.

Refs #245 #262 #264 #265 #267 #269 #271.