### PR TITLE
research: classify behavioral trial pair comparability

### DIFF
--- a/examples/behavioral_trial_pair_classify.rs
+++ b/examples/behavioral_trial_pair_classify.rs
@@ -1,0 +1,41 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+#[allow(dead_code)]
+#[path = "../src/behavioral_trial.rs"]
+mod behavioral_trial;
+#[allow(dead_code)]
+#[path = "../src/behavioral_trial_run.rs"]
+mod behavioral_trial_run;
+#[allow(dead_code)]
+#[path = "../src/behavioral_trial_pair_classification.rs"]
+mod behavioral_trial_pair_classification;
+
+use behavioral_trial_pair_classification::classify_behavioral_trial_run_pair;
+use behavioral_trial_run::{MAX_BEHAVIORAL_TRIAL_RUN_PAIR_BYTES, parse_behavioral_trial_run_pair};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("behavioral-trial-pair-classify: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut input = Vec::new();
+    io::stdin()
+        .take((MAX_BEHAVIORAL_TRIAL_RUN_PAIR_BYTES + 1) as u64)
+        .read_to_end(&mut input)?;
+    if input.len() > MAX_BEHAVIORAL_TRIAL_RUN_PAIR_BYTES {
+        return Err(format!(
+            "behavioral-trial run-pair input exceeds the {}-byte limit",
+            MAX_BEHAVIORAL_TRIAL_RUN_PAIR_BYTES
+        )
+        .into());
+    }
+
+    let pair = parse_behavioral_trial_run_pair(&input)?;
+    let classification = classify_behavioral_trial_run_pair(&pair)?;
+    println!("{}", serde_json::to_string_pretty(&classification)?);
+    Ok(())
+}

--- a/research/behavioral-trial-pair-classification.md
+++ b/research/behavioral-trial-pair-classification.md
@@ -1,0 +1,182 @@
+# Behavioral-trial pair comparability classification
+
+Status: research projection for #264 over the byte-authentic external run receipts merged in #269.
+
+#269 owns individual run authenticity:
+
+```text
+frozen plan
++ exact canonical worker-packet file bytes
++ exact raw typed worker output bytes
++ external run metadata
+-> BehavioralTrialRunReceipt
+```
+
+It hard-rejects malformed, tampered, nonfresh, or prior-exposed individual runs. It also retains enough organizer metadata to inspect whether two individually valid runs are actually comparable.
+
+This layer classifies that **pair-level** question without introducing another run-receipt schema.
+
+## Flow
+
+```text
+BehavioralTrialRunPair
+-> rebuild each receipt from its retained exact bytes
+-> hard reject invalid individual receipt
+-> inspect pair geometry
+-> admitted | confounded | invalid_pair
+-> existing #245 descriptive reconciliation only when admitted
+```
+
+## Verdicts
+
+```text
+admitted
+confounded
+invalid_pair
+```
+
+`admitted` means both exact arms are present once and the frozen execution axes/session coordinates are compatible.
+
+`confounded` means both individual receipts are valid, but the pair changes or reuses an execution axis that prevents clean comparison.
+
+`invalid_pair` means both individual receipts are valid but do not cover the registered two-arm intervention. V1 uses this for same-arm pairs.
+
+Malformed/tampered individual evidence remains an error from the #269 intake boundary. It is never downgraded into one of these experimental verdicts.
+
+## Pair-level reason vocabulary
+
+Typed reasons are:
+
+```text
+same_arm
+worker_identity_drift
+harness_identity_drift
+affordance_identity_drift
+sampling_config_drift
+reused_session_id
+reused_freshness_receipt
+reused_worker_ref
+invalid_sequence_coverage
+```
+
+The classifier preserves all observed pair-level reasons instead of stopping at the first confound.
+
+Verdict precedence is deterministic:
+
+```text
+same_arm present
+-> invalid_pair
+
+otherwise any reason present
+-> confounded
+
+otherwise
+-> admitted
+```
+
+## Individual receipt revalidation
+
+Before pair classification, every retained #269 receipt is rebuilt through `build_behavioral_trial_run_receipt()` using:
+
+```text
+same frozen plan
+receipt.metadata
+receipt.raw_worker_packet exact bytes
+receipt.raw_output exact bytes
+```
+
+The rebuilt receipt must equal the retained receipt exactly.
+
+That rechecks:
+
+- external execution origin;
+- fresh-session / no-prior-exposure assertions;
+- exact neutral #262 materialized packet bytes;
+- exact raw output bytes;
+- derived packet/output hashes;
+- typed observation binding;
+- registered first-action vocabulary.
+
+A receipt whose retained raw output, hash, observation, or packet bytes drift after construction rejects before pair geometry is considered.
+
+## Admitted pair
+
+Only `admitted` calls the existing #269 `evaluate_behavioral_trial_run_pair()`, which itself delegates behavioral interpretation to #245.
+
+The nested result remains descriptive:
+
+```text
+control first_action_id
+treatment first_action_id
+same_first_action
+```
+
+AB and BA execution order are both valid because arm identity comes from exact packet fingerprints, not vector position.
+
+This projection adds no success/correctness/effect semantics and always emits:
+
+```text
+automatic_effect_claim = false
+automatic_generalization = false
+```
+
+## Deterministic controls
+
+`tests/behavioral_trial_pair_classification.rs` covers:
+
+- admitted AB;
+- admitted BA;
+- same-arm `invalid_pair`;
+- worker identity drift;
+- harness identity drift;
+- affordance drift;
+- sampling-config drift;
+- reused session ID;
+- reused freshness receipt;
+- reused worker reference;
+- invalid sequence coverage;
+- multiple simultaneous confounds preserved together;
+- tampered individual receipt hard-rejects instead of becoming `confounded`.
+
+Synthetic tests exercise classification only. They are not represented as real external worker runs.
+
+## Research CLI
+
+Classify one already-materialized #269 run pair from stdin:
+
+```text
+cargo run --example behavioral_trial_pair_classify < RUN_PAIR.json
+```
+
+This performs no provider/model call and mutates nothing outside process memory.
+
+## Relationship to #267
+
+#267 remains the real execution task. A future external harness should:
+
+1. use the neutral #262 blind packet files;
+2. create genuinely fresh sessions;
+3. preserve raw outputs and freshness/config evidence;
+4. build #269 run receipts;
+5. submit the two receipts here for comparability classification.
+
+A green synthetic classifier suite is supporting evidence only. It does not mean the #267 worker pair has been executed.
+
+## Boundary
+
+- research only;
+- no new run-receipt schema;
+- no provider/model SDK;
+- no API key or secret handling;
+- no worker invocation;
+- no chain-of-thought;
+- no synthetic-as-real behavior;
+- no treatment-effect or causal claim;
+- no authority grant;
+- no primary product CLI/report change.
+
+North star:
+
+> Keep evidence authenticity, experimental comparability, and behavioral interpretation as three separate gates so each can fail for the right reason.
+
+Refs #137 #223 #245 #262 #264 #267 #269.

--- a/src/behavioral_trial_pair_classification.rs
+++ b/src/behavioral_trial_pair_classification.rs
@@ -1,0 +1,205 @@
+use std::error::Error;
+use std::fmt;
+
+use serde::Serialize;
+
+use crate::behavioral_trial::{
+    BehavioralTrialArmKind, fingerprint_plan, materialize_worker_packet,
+};
+use crate::behavioral_trial_run::{
+    BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION, BehavioralTrialRunPair,
+    BehavioralTrialRunPairEvaluation, BehavioralTrialRunReceipt,
+    build_behavioral_trial_run_receipt, evaluate_behavioral_trial_run_pair,
+};
+
+pub const BEHAVIORAL_TRIAL_PAIR_CLASSIFICATION_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BehavioralTrialPairVerdict {
+    Admitted,
+    Confounded,
+    InvalidPair,
+}
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BehavioralTrialPairReason {
+    SameArm,
+    WorkerIdentityDrift,
+    HarnessIdentityDrift,
+    AffordanceIdentityDrift,
+    SamplingConfigDrift,
+    ReusedSessionId,
+    ReusedFreshnessReceipt,
+    ReusedWorkerRef,
+    InvalidSequenceCoverage,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralTrialPairClassification {
+    pub schema_version: u32,
+    pub trial_id: String,
+    pub plan_fingerprint: String,
+    pub verdict: BehavioralTrialPairVerdict,
+    pub reasons: Vec<BehavioralTrialPairReason>,
+    pub evaluation: Option<BehavioralTrialRunPairEvaluation>,
+    pub automatic_effect_claim: bool,
+    pub automatic_generalization: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct BehavioralTrialPairClassificationError {
+    message: String,
+}
+
+impl BehavioralTrialPairClassificationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for BehavioralTrialPairClassificationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for BehavioralTrialPairClassificationError {}
+
+pub fn classify_behavioral_trial_run_pair(
+    pair: &BehavioralTrialRunPair,
+) -> Result<BehavioralTrialPairClassification, BehavioralTrialPairClassificationError> {
+    if pair.schema_version != BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION {
+        return Err(BehavioralTrialPairClassificationError::new(format!(
+            "unsupported behavioral-trial run-pair schema {}; expected {BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION}",
+            pair.schema_version
+        )));
+    }
+    if pair.runs.len() != 2 {
+        return Err(BehavioralTrialPairClassificationError::new(
+            "behavioral-trial pair classification requires exactly two run receipts",
+        ));
+    }
+
+    let plan = pair.plan.as_ref();
+    for receipt in &pair.runs {
+        validate_individual_receipt(plan, receipt)?;
+    }
+
+    let control = materialize_worker_packet(plan, BehavioralTrialArmKind::Control)
+        .map_err(source_error)?;
+    let treatment = materialize_worker_packet(plan, BehavioralTrialArmKind::Treatment)
+        .map_err(source_error)?;
+    let first_arm = arm_for_receipt(&pair.runs[0], &control, &treatment)?;
+    let second_arm = arm_for_receipt(&pair.runs[1], &control, &treatment)?;
+
+    let first = &pair.runs[0];
+    let second = &pair.runs[1];
+    let mut reasons = Vec::new();
+
+    if first_arm == second_arm {
+        reasons.push(BehavioralTrialPairReason::SameArm);
+    }
+    if first.metadata.worker_identity != second.metadata.worker_identity {
+        reasons.push(BehavioralTrialPairReason::WorkerIdentityDrift);
+    }
+    if first.metadata.harness_identity != second.metadata.harness_identity {
+        reasons.push(BehavioralTrialPairReason::HarnessIdentityDrift);
+    }
+    if first.metadata.affordance_identity != second.metadata.affordance_identity {
+        reasons.push(BehavioralTrialPairReason::AffordanceIdentityDrift);
+    }
+    if first.metadata.sampling_config_sha256 != second.metadata.sampling_config_sha256 {
+        reasons.push(BehavioralTrialPairReason::SamplingConfigDrift);
+    }
+    if first.metadata.session_id == second.metadata.session_id {
+        reasons.push(BehavioralTrialPairReason::ReusedSessionId);
+    }
+    if first.metadata.freshness_receipt == second.metadata.freshness_receipt {
+        reasons.push(BehavioralTrialPairReason::ReusedFreshnessReceipt);
+    }
+    if first.observation.worker_ref == second.observation.worker_ref {
+        reasons.push(BehavioralTrialPairReason::ReusedWorkerRef);
+    }
+    let mut sequence = [
+        first.metadata.sequence_index,
+        second.metadata.sequence_index,
+    ];
+    sequence.sort_unstable();
+    if sequence != [1, 2] {
+        reasons.push(BehavioralTrialPairReason::InvalidSequenceCoverage);
+    }
+    reasons.sort_unstable();
+    reasons.dedup();
+
+    let verdict = if reasons.contains(&BehavioralTrialPairReason::SameArm) {
+        BehavioralTrialPairVerdict::InvalidPair
+    } else if reasons.is_empty() {
+        BehavioralTrialPairVerdict::Admitted
+    } else {
+        BehavioralTrialPairVerdict::Confounded
+    };
+
+    let evaluation = if verdict == BehavioralTrialPairVerdict::Admitted {
+        Some(evaluate_behavioral_trial_run_pair(pair).map_err(source_error)?)
+    } else {
+        None
+    };
+
+    Ok(BehavioralTrialPairClassification {
+        schema_version: BEHAVIORAL_TRIAL_PAIR_CLASSIFICATION_SCHEMA_VERSION,
+        trial_id: plan.trial_id.clone(),
+        plan_fingerprint: fingerprint_plan(plan).map_err(source_error)?,
+        verdict,
+        reasons,
+        evaluation,
+        automatic_effect_claim: false,
+        automatic_generalization: false,
+    })
+}
+
+fn validate_individual_receipt(
+    plan: &crate::behavioral_trial::BehavioralTrialPlan,
+    receipt: &BehavioralTrialRunReceipt,
+) -> Result<(), BehavioralTrialPairClassificationError> {
+    let rebuilt = build_behavioral_trial_run_receipt(
+        plan,
+        receipt.metadata.clone(),
+        receipt.raw_worker_packet.as_bytes(),
+        receipt.raw_output.as_bytes(),
+    )
+    .map_err(source_error)?;
+    if rebuilt != *receipt {
+        return Err(BehavioralTrialPairClassificationError::new(
+            "behavioral-trial run receipt differs from the receipt rebuilt from its exact retained bytes",
+        ));
+    }
+    Ok(())
+}
+
+fn arm_for_receipt(
+    receipt: &BehavioralTrialRunReceipt,
+    control: &crate::behavioral_trial::BehavioralWorkerPacket,
+    treatment: &crate::behavioral_trial::BehavioralWorkerPacket,
+) -> Result<BehavioralTrialArmKind, BehavioralTrialPairClassificationError> {
+    let fingerprint = &receipt.observation.worker_packet_fingerprint;
+    if fingerprint == &control.worker_packet_fingerprint {
+        Ok(BehavioralTrialArmKind::Control)
+    } else if fingerprint == &treatment.worker_packet_fingerprint {
+        Ok(BehavioralTrialArmKind::Treatment)
+    } else {
+        Err(BehavioralTrialPairClassificationError::new(
+            "validated behavioral-trial receipt does not map to either frozen plan arm",
+        ))
+    }
+}
+
+fn source_error(error: impl fmt::Display) -> BehavioralTrialPairClassificationError {
+    BehavioralTrialPairClassificationError::new(format!(
+        "behavioral-trial pair source validation failed: {error}"
+    ))
+}

--- a/tests/behavioral_trial_pair_classification.rs
+++ b/tests/behavioral_trial_pair_classification.rs
@@ -1,0 +1,370 @@
+#[allow(dead_code)]
+#[path = "../src/behavioral_trial.rs"]
+mod behavioral_trial;
+#[allow(dead_code)]
+#[path = "../src/behavioral_trial_run.rs"]
+mod behavioral_trial_run;
+#[allow(dead_code)]
+#[path = "../src/behavioral_trial_pair_classification.rs"]
+mod behavioral_trial_pair_classification;
+
+use behavioral_trial::{
+    BEHAVIORAL_TRIAL_SCHEMA_VERSION, BehavioralTrialArmKind, BehavioralTrialObservation,
+    BehavioralTrialPlan, fingerprint_plan, materialize_worker_packet, parse_behavioral_trial_plan,
+};
+use behavioral_trial_pair_classification::{
+    BehavioralTrialPairReason, BehavioralTrialPairVerdict, classify_behavioral_trial_run_pair,
+};
+use behavioral_trial_run::{
+    BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION, BehavioralTrialExecutionOrigin, BehavioralTrialRunMetadata,
+    BehavioralTrialRunPair, BehavioralTrialRunReceipt, build_behavioral_trial_run_receipt,
+    canonical_materialized_worker_packet_bytes,
+};
+
+const PLAN: &[u8] =
+    include_bytes!("../research/behavioral-trials/stensibly-index-guard-detail.json");
+const SAMPLING: &str =
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OTHER_SAMPLING: &str =
+    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+fn plan() -> BehavioralTrialPlan {
+    parse_behavioral_trial_plan(PLAN).expect("retained neutral Stensibly plan should parse")
+}
+
+fn metadata(index: u8, session: &str, freshness: &str) -> BehavioralTrialRunMetadata {
+    BehavioralTrialRunMetadata {
+        schema_version: BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION,
+        execution_origin: BehavioralTrialExecutionOrigin::ExternalHarness,
+        sequence_index: index,
+        worker_identity: "fixed-worker@v1".into(),
+        harness_identity: "first-action-harness@v1".into(),
+        affordance_identity: "packet-only-choice@v1".into(),
+        sampling_config_sha256: SAMPLING.into(),
+        session_id: session.into(),
+        freshness_receipt: freshness.into(),
+        fresh_session: true,
+        prior_condition_exposure: false,
+    }
+}
+
+fn run(
+    plan: &BehavioralTrialPlan,
+    arm: BehavioralTrialArmKind,
+    index: u8,
+    session: &str,
+    freshness: &str,
+    worker_ref: &str,
+    first_action: &str,
+) -> BehavioralTrialRunReceipt {
+    let packet = materialize_worker_packet(plan, arm).unwrap();
+    let raw_packet = canonical_materialized_worker_packet_bytes(plan, arm).unwrap();
+    let observation = BehavioralTrialObservation {
+        schema_version: BEHAVIORAL_TRIAL_SCHEMA_VERSION,
+        trial_id: plan.trial_id.clone(),
+        plan_fingerprint: fingerprint_plan(plan).unwrap(),
+        worker_packet_fingerprint: packet.worker_packet_fingerprint,
+        worker_ref: worker_ref.into(),
+        first_action_id: first_action.into(),
+    };
+    let mut raw_output = serde_json::to_vec_pretty(&observation).unwrap();
+    raw_output.push(b'\n');
+    build_behavioral_trial_run_receipt(
+        plan,
+        metadata(index, session, freshness),
+        &raw_packet,
+        &raw_output,
+    )
+    .unwrap()
+}
+
+fn pair(
+    plan: &BehavioralTrialPlan,
+    first: BehavioralTrialRunReceipt,
+    second: BehavioralTrialRunReceipt,
+) -> BehavioralTrialRunPair {
+    BehavioralTrialRunPair {
+        schema_version: BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION,
+        plan: Box::new(plan.clone()),
+        runs: vec![first, second],
+    }
+}
+
+#[test]
+fn admitted_ab_pair_reuses_existing_descriptive_evaluation() {
+    let plan = plan();
+    let control = run(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        1,
+        "session-control",
+        "fresh-control",
+        "worker:control",
+        "inspect_accepted_guard_detail",
+    );
+    let treatment = run(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        2,
+        "session-treatment",
+        "fresh-treatment",
+        "worker:treatment",
+        "block_patch",
+    );
+
+    let result = classify_behavioral_trial_run_pair(&pair(&plan, control, treatment)).unwrap();
+    assert_eq!(result.verdict, BehavioralTrialPairVerdict::Admitted);
+    assert!(result.reasons.is_empty());
+    assert!(!result.automatic_effect_claim);
+    assert!(!result.automatic_generalization);
+    let evaluation = result.evaluation.expect("admitted pair should reconcile");
+    assert_eq!(
+        evaluation.trial.control.first_action_id,
+        "inspect_accepted_guard_detail"
+    );
+    assert_eq!(evaluation.trial.treatment.first_action_id, "block_patch");
+    assert!(!evaluation.trial.same_first_action);
+}
+
+#[test]
+fn admitted_ba_order_is_classified_by_packet_identity_not_vector_order() {
+    let plan = plan();
+    let treatment = run(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        1,
+        "session-treatment",
+        "fresh-treatment",
+        "worker:treatment",
+        "block_patch",
+    );
+    let control = run(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        2,
+        "session-control",
+        "fresh-control",
+        "worker:control",
+        "inspect_accepted_guard_detail",
+    );
+
+    let result = classify_behavioral_trial_run_pair(&pair(&plan, treatment, control)).unwrap();
+    assert_eq!(result.verdict, BehavioralTrialPairVerdict::Admitted);
+    let evaluation = result.evaluation.unwrap();
+    assert_eq!(
+        evaluation.trial.control.first_action_id,
+        "inspect_accepted_guard_detail"
+    );
+    assert_eq!(evaluation.trial.treatment.first_action_id, "block_patch");
+}
+
+#[test]
+fn same_arm_twice_is_invalid_pair_without_behavioral_evaluation() {
+    let plan = plan();
+    let first = run(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        1,
+        "session-one",
+        "fresh-one",
+        "worker:one",
+        "inspect_accepted_guard_detail",
+    );
+    let second = run(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        2,
+        "session-two",
+        "fresh-two",
+        "worker:two",
+        "approve_patch",
+    );
+
+    let result = classify_behavioral_trial_run_pair(&pair(&plan, first, second)).unwrap();
+    assert_eq!(result.verdict, BehavioralTrialPairVerdict::InvalidPair);
+    assert_eq!(result.reasons, vec![BehavioralTrialPairReason::SameArm]);
+    assert!(result.evaluation.is_none());
+}
+
+#[test]
+fn frozen_axis_drift_is_typed_confounded() {
+    let plan = plan();
+    let control = run(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        1,
+        "session-control",
+        "fresh-control",
+        "worker:control",
+        "inspect_accepted_guard_detail",
+    );
+
+    let cases: [(BehavioralTrialPairReason, fn(&mut BehavioralTrialRunReceipt)); 4] = [
+        (BehavioralTrialPairReason::WorkerIdentityDrift, |run| {
+            run.metadata.worker_identity = "other-worker@v1".into();
+        }),
+        (BehavioralTrialPairReason::HarnessIdentityDrift, |run| {
+            run.metadata.harness_identity = "other-harness@v1".into();
+        }),
+        (BehavioralTrialPairReason::AffordanceIdentityDrift, |run| {
+            run.metadata.affordance_identity = "other-affordance@v1".into();
+        }),
+        (BehavioralTrialPairReason::SamplingConfigDrift, |run| {
+            run.metadata.sampling_config_sha256 = OTHER_SAMPLING.into();
+        }),
+    ];
+
+    for (expected, mutate) in cases {
+        let mut treatment = run(
+            &plan,
+            BehavioralTrialArmKind::Treatment,
+            2,
+            "session-treatment",
+            "fresh-treatment",
+            "worker:treatment",
+            "block_patch",
+        );
+        mutate(&mut treatment);
+        let result = classify_behavioral_trial_run_pair(&pair(&plan, control.clone(), treatment))
+            .unwrap();
+        assert_eq!(result.verdict, BehavioralTrialPairVerdict::Confounded);
+        assert_eq!(result.reasons, vec![expected]);
+        assert!(result.evaluation.is_none());
+    }
+}
+
+#[test]
+fn session_freshness_worker_ref_and_sequence_reuse_are_typed_confounded() {
+    let plan = plan();
+    let control = run(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        1,
+        "session-control",
+        "fresh-control",
+        "worker:shared",
+        "inspect_accepted_guard_detail",
+    );
+
+    let mut treatment = run(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        2,
+        "session-control",
+        "fresh-treatment",
+        "worker:treatment",
+        "block_patch",
+    );
+    let result = classify_behavioral_trial_run_pair(&pair(&plan, control.clone(), treatment))
+        .unwrap();
+    assert_eq!(result.verdict, BehavioralTrialPairVerdict::Confounded);
+    assert_eq!(result.reasons, vec![BehavioralTrialPairReason::ReusedSessionId]);
+
+    treatment = run(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        2,
+        "session-treatment",
+        "fresh-control",
+        "worker:treatment",
+        "block_patch",
+    );
+    let result = classify_behavioral_trial_run_pair(&pair(&plan, control.clone(), treatment))
+        .unwrap();
+    assert_eq!(
+        result.reasons,
+        vec![BehavioralTrialPairReason::ReusedFreshnessReceipt]
+    );
+
+    treatment = run(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        2,
+        "session-treatment",
+        "fresh-treatment",
+        "worker:shared",
+        "block_patch",
+    );
+    let result = classify_behavioral_trial_run_pair(&pair(&plan, control.clone(), treatment))
+        .unwrap();
+    assert_eq!(result.reasons, vec![BehavioralTrialPairReason::ReusedWorkerRef]);
+
+    treatment = run(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        1,
+        "session-treatment",
+        "fresh-treatment",
+        "worker:treatment",
+        "block_patch",
+    );
+    let result = classify_behavioral_trial_run_pair(&pair(&plan, control, treatment)).unwrap();
+    assert_eq!(
+        result.reasons,
+        vec![BehavioralTrialPairReason::InvalidSequenceCoverage]
+    );
+}
+
+#[test]
+fn multiple_pair_confounds_are_preserved_together() {
+    let plan = plan();
+    let control = run(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        1,
+        "session-shared",
+        "fresh-shared",
+        "worker:shared",
+        "inspect_accepted_guard_detail",
+    );
+    let mut treatment = run(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        1,
+        "session-shared",
+        "fresh-shared",
+        "worker:shared",
+        "block_patch",
+    );
+    treatment.metadata.worker_identity = "other-worker@v1".into();
+
+    let result = classify_behavioral_trial_run_pair(&pair(&plan, control, treatment)).unwrap();
+    assert_eq!(result.verdict, BehavioralTrialPairVerdict::Confounded);
+    assert_eq!(
+        result.reasons,
+        vec![
+            BehavioralTrialPairReason::WorkerIdentityDrift,
+            BehavioralTrialPairReason::ReusedSessionId,
+            BehavioralTrialPairReason::ReusedFreshnessReceipt,
+            BehavioralTrialPairReason::ReusedWorkerRef,
+            BehavioralTrialPairReason::InvalidSequenceCoverage,
+        ]
+    );
+}
+
+#[test]
+fn tampered_individual_receipt_rejects_instead_of_becoming_confounded() {
+    let plan = plan();
+    let control = run(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        1,
+        "session-control",
+        "fresh-control",
+        "worker:control",
+        "inspect_accepted_guard_detail",
+    );
+    let mut treatment = run(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        2,
+        "session-treatment",
+        "fresh-treatment",
+        "worker:treatment",
+        "block_patch",
+    );
+    treatment.raw_output.push(' ');
+
+    let error = classify_behavioral_trial_run_pair(&pair(&plan, control, treatment)).unwrap_err();
+    assert!(error.to_string().contains("retained bytes"));
+}


### PR DESCRIPTION
Superseded by #275.

#275 composes directly on merged #269/#273 and includes the missing authentic-confound cases from this lane: `fresh_session=false` and `prior_condition_exposure=true` remain byte-authentic individual receipts and classify as `confounded` instead of becoming hard intake errors.

The useful `admitted | confounded | invalid_pair` projection continues there. No separate integration from this older branch is needed.