### PR TITLE
research: classify behavioral trial pair comparability after authentic intake

### DIFF
--- a/examples/behavioral_trial_pair_admission.rs
+++ b/examples/behavioral_trial_pair_admission.rs
@@ -1,0 +1,28 @@
+#![allow(dead_code)]
+
+use std::io::{self, Read};
+
+#[path = "../src/behavioral_trial.rs"]
+mod behavioral_trial;
+#[path = "../src/behavioral_trial_pair_admission.rs"]
+mod behavioral_trial_pair_admission;
+#[path = "../src/behavioral_trial_run.rs"]
+mod behavioral_trial_run;
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("behavioral-trial-pair-admission: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let mut input = Vec::new();
+    io::stdin().read_to_end(&mut input)?;
+    let pair = behavioral_trial_run::parse_behavioral_trial_run_pair(&input)?;
+    let evaluation =
+        behavioral_trial_pair_admission::evaluate_behavioral_trial_pair_admission(&pair)
+            .map_err(io::Error::other)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}

--- a/research/behavioral-trial-pair-admission.md
+++ b/research/behavioral-trial-pair-admission.md
@@ -1,0 +1,124 @@
+# Behavioral-trial pair comparability projection
+
+Tracking: #264. This lane composes strictly after merged #269/#273 byte-authentic individual run receipts.
+
+## Ownership boundary
+
+```text
+#269 / #273
+  exact canonical worker-packet bytes
+  exact raw worker-output bytes
+  typed observation binding
+  authentic run metadata, including freshness/exposure facts
+
+this lane
+  admitted | confounded | invalid_pair
+  + typed pair-level reasons
+
+#245
+  descriptive control/treatment first actions for admitted pairs only
+```
+
+This module defines no second run-receipt schema and performs no packet serialization or raw-output capture of its own.
+
+## Authenticity before comparability
+
+Every supplied `BehavioralTrialRunReceipt` is rebuilt through merged `build_behavioral_trial_run_receipt()` using its retained raw packet/output bytes and metadata. Any tampered or internally drifted receipt rejects before a comparability verdict.
+
+Authentic receipts may truthfully record:
+
+```text
+fresh_session = false
+prior_condition_exposure = true
+```
+
+because #273 separates receipt authenticity from strict admitted-pair freshness.
+
+## Verdicts and reasons
+
+The projection preserves every observed pair-level reason in a sorted `reasons[]` vector:
+
+```text
+same_arm
+worker_identity_drift
+harness_identity_drift
+affordance_identity_drift
+sampling_config_drift
+non_fresh_session
+prior_condition_exposure
+reused_session_id
+reused_freshness_receipt
+reused_worker_ref
+invalid_sequence_coverage
+```
+
+Several reasons may coexist on one authentic pair. The projection retains them together instead of collapsing the evidence to one first failure.
+
+### `invalid_pair`
+
+Both receipts are individually authentic, but they do not cover one control plus one treatment for the frozen plan. `same_arm` has verdict precedence, while any additional pair-level reasons remain visible.
+
+### `confounded`
+
+The two authentic receipts cover distinct arms, but one or more execution/session reasons remain. No behavioral interpretation is emitted for a confounded pair.
+
+### `admitted`
+
+The two authentic receipts cover one control and one treatment and `reasons[]` is empty. Only this verdict calls merged `evaluate_behavioral_trial_run_pair()` and retains its descriptive #245 result.
+
+AB and BA vector order are both valid. Recorded sequence indexes determine execution order; packet fingerprints determine semantic arm identity.
+
+## Output boundary
+
+The projection retains the evidence needed to audit every pair:
+
+```text
+trial_id
+plan_fingerprint
+execution-order packet fingerprints
+sequence indexes
+session ids
+freshness receipts
+worker refs
+verdict
+reasons[]
+frozen_identity_match
+fresh_uncontaminated_sessions
+distinct_arm_coverage
+```
+
+and keeps:
+
+```text
+automatic_effect_claim = false
+automatic_generalization = false
+```
+
+No success, improvement, treatment-effect, capability-retirement, promotion, or causal label is introduced.
+
+## Controls
+
+`tests/behavioral_trial_pair_admission.rs` covers:
+
+- admitted AB order with empty reasons;
+- admitted BA vector order while preserving recorded execution sequence;
+- admitted same and different first actions;
+- each worker/harness/affordance/sampling drift reason;
+- authentic non-fresh, prior-exposed, session-reused, freshness-reused, worker-ref-reused, and duplicate-sequence reasons;
+- simultaneous confounds preserved together;
+- same authentic arm twice -> `invalid_pair` + `same_arm`;
+- tampered individual receipt -> hard rejection before comparability classification.
+
+Synthetic receipts in the test are built through the canonical #269 receipt builder from actual current neutral Stensibly packet bytes. They are validator fixtures only, never represented as observed worker behavior.
+
+## Research CLI
+
+```text
+cargo run --example behavioral_trial_pair_admission < RUN_PAIR.json
+```
+
+The CLI parses the canonical #269 run-pair schema and prints this projection. It performs no worker/model/provider invocation.
+
+This reason-preserving surface supersedes the useful pair-reason idea from stale #274 while keeping the current #273 authenticity boundary.
+
+Refs #137 #245 #262 #264 #265 #267 #269 #271 #273 #274.

--- a/src/behavioral_trial_pair_admission.rs
+++ b/src/behavioral_trial_pair_admission.rs
@@ -1,0 +1,235 @@
+use serde::{Deserialize, Serialize};
+
+use crate::behavioral_trial::{
+    BehavioralTrialArmKind, BehavioralTrialPlan, fingerprint_plan, materialize_worker_packet,
+};
+use crate::behavioral_trial_run::{
+    BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION, BehavioralTrialRunPair, BehavioralTrialRunPairEvaluation,
+    BehavioralTrialRunReceipt, build_behavioral_trial_run_receipt,
+    evaluate_behavioral_trial_run_pair,
+};
+
+pub const BEHAVIORAL_TRIAL_PAIR_ADMISSION_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BehavioralTrialPairAdmissionVerdict {
+    Admitted,
+    Confounded,
+    InvalidPair,
+}
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BehavioralTrialPairAdmissionReason {
+    SameArm,
+    WorkerIdentityDrift,
+    HarnessIdentityDrift,
+    AffordanceIdentityDrift,
+    SamplingConfigDrift,
+    NonFreshSession,
+    PriorConditionExposure,
+    ReusedSessionId,
+    ReusedFreshnessReceipt,
+    ReusedWorkerRef,
+    InvalidSequenceCoverage,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehavioralTrialPairAdmissionEvaluation {
+    pub schema_version: u32,
+    pub trial_id: String,
+    pub plan_fingerprint: String,
+    pub execution_order_packet_fingerprints: Vec<String>,
+    pub sequence_indexes: Vec<u8>,
+    pub session_ids: Vec<String>,
+    pub freshness_receipts: Vec<String>,
+    pub worker_refs: Vec<String>,
+    pub verdict: BehavioralTrialPairAdmissionVerdict,
+    pub reasons: Vec<BehavioralTrialPairAdmissionReason>,
+    pub frozen_identity_match: bool,
+    pub fresh_uncontaminated_sessions: bool,
+    pub distinct_arm_coverage: bool,
+    pub behavioral_evaluation: Option<BehavioralTrialRunPairEvaluation>,
+    pub automatic_effect_claim: bool,
+    pub automatic_generalization: bool,
+}
+
+pub fn evaluate_behavioral_trial_pair_admission(
+    pair: &BehavioralTrialRunPair,
+) -> Result<BehavioralTrialPairAdmissionEvaluation, String> {
+    if pair.schema_version != BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported behavioral-trial run-pair schema {}; expected {BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION}",
+            pair.schema_version
+        ));
+    }
+    if pair.runs.len() != 2 {
+        return Err("behavioral-trial pair admission requires exactly two run receipts".into());
+    }
+
+    let plan = pair.plan.as_ref();
+    for receipt in &pair.runs {
+        authenticate_receipt(plan, receipt)?;
+    }
+
+    let first = &pair.runs[0];
+    let second = &pair.runs[1];
+    let first_arm = receipt_arm(plan, first)?;
+    let second_arm = receipt_arm(plan, second)?;
+
+    let mut reasons = Vec::new();
+    if first_arm == second_arm {
+        reasons.push(BehavioralTrialPairAdmissionReason::SameArm);
+    }
+    if first.metadata.worker_identity != second.metadata.worker_identity {
+        reasons.push(BehavioralTrialPairAdmissionReason::WorkerIdentityDrift);
+    }
+    if first.metadata.harness_identity != second.metadata.harness_identity {
+        reasons.push(BehavioralTrialPairAdmissionReason::HarnessIdentityDrift);
+    }
+    if first.metadata.affordance_identity != second.metadata.affordance_identity {
+        reasons.push(BehavioralTrialPairAdmissionReason::AffordanceIdentityDrift);
+    }
+    if first.metadata.sampling_config_sha256 != second.metadata.sampling_config_sha256 {
+        reasons.push(BehavioralTrialPairAdmissionReason::SamplingConfigDrift);
+    }
+    if !first.metadata.fresh_session || !second.metadata.fresh_session {
+        reasons.push(BehavioralTrialPairAdmissionReason::NonFreshSession);
+    }
+    if first.metadata.prior_condition_exposure || second.metadata.prior_condition_exposure {
+        reasons.push(BehavioralTrialPairAdmissionReason::PriorConditionExposure);
+    }
+    if first.metadata.session_id == second.metadata.session_id {
+        reasons.push(BehavioralTrialPairAdmissionReason::ReusedSessionId);
+    }
+    if first.metadata.freshness_receipt == second.metadata.freshness_receipt {
+        reasons.push(BehavioralTrialPairAdmissionReason::ReusedFreshnessReceipt);
+    }
+    if first.observation.worker_ref == second.observation.worker_ref {
+        reasons.push(BehavioralTrialPairAdmissionReason::ReusedWorkerRef);
+    }
+    let mut sequence = [
+        first.metadata.sequence_index,
+        second.metadata.sequence_index,
+    ];
+    sequence.sort_unstable();
+    if sequence != [1, 2] {
+        reasons.push(BehavioralTrialPairAdmissionReason::InvalidSequenceCoverage);
+    }
+    reasons.sort_unstable();
+    reasons.dedup();
+
+    let distinct_arm_coverage = !reasons.contains(&BehavioralTrialPairAdmissionReason::SameArm);
+    let frozen_identity_match = !reasons.iter().any(|reason| {
+        matches!(
+            reason,
+            BehavioralTrialPairAdmissionReason::WorkerIdentityDrift
+                | BehavioralTrialPairAdmissionReason::HarnessIdentityDrift
+                | BehavioralTrialPairAdmissionReason::AffordanceIdentityDrift
+                | BehavioralTrialPairAdmissionReason::SamplingConfigDrift
+        )
+    });
+    let fresh_uncontaminated_sessions = !reasons.iter().any(|reason| {
+        matches!(
+            reason,
+            BehavioralTrialPairAdmissionReason::NonFreshSession
+                | BehavioralTrialPairAdmissionReason::PriorConditionExposure
+                | BehavioralTrialPairAdmissionReason::ReusedSessionId
+                | BehavioralTrialPairAdmissionReason::ReusedFreshnessReceipt
+                | BehavioralTrialPairAdmissionReason::ReusedWorkerRef
+                | BehavioralTrialPairAdmissionReason::InvalidSequenceCoverage
+        )
+    });
+
+    let verdict = if !distinct_arm_coverage {
+        BehavioralTrialPairAdmissionVerdict::InvalidPair
+    } else if reasons.is_empty() {
+        BehavioralTrialPairAdmissionVerdict::Admitted
+    } else {
+        BehavioralTrialPairAdmissionVerdict::Confounded
+    };
+
+    let behavioral_evaluation = if verdict == BehavioralTrialPairAdmissionVerdict::Admitted {
+        Some(evaluate_behavioral_trial_run_pair(pair).map_err(|error| error.to_string())?)
+    } else {
+        None
+    };
+
+    Ok(BehavioralTrialPairAdmissionEvaluation {
+        schema_version: BEHAVIORAL_TRIAL_PAIR_ADMISSION_SCHEMA_VERSION,
+        trial_id: plan.trial_id.clone(),
+        plan_fingerprint: fingerprint_plan(plan).map_err(|error| error.to_string())?,
+        execution_order_packet_fingerprints: pair
+            .runs
+            .iter()
+            .map(|receipt| receipt.observation.worker_packet_fingerprint.clone())
+            .collect(),
+        sequence_indexes: pair
+            .runs
+            .iter()
+            .map(|receipt| receipt.metadata.sequence_index)
+            .collect(),
+        session_ids: pair
+            .runs
+            .iter()
+            .map(|receipt| receipt.metadata.session_id.clone())
+            .collect(),
+        freshness_receipts: pair
+            .runs
+            .iter()
+            .map(|receipt| receipt.metadata.freshness_receipt.clone())
+            .collect(),
+        worker_refs: pair
+            .runs
+            .iter()
+            .map(|receipt| receipt.observation.worker_ref.clone())
+            .collect(),
+        verdict,
+        reasons,
+        frozen_identity_match,
+        fresh_uncontaminated_sessions,
+        distinct_arm_coverage,
+        behavioral_evaluation,
+        automatic_effect_claim: false,
+        automatic_generalization: false,
+    })
+}
+
+fn authenticate_receipt(
+    plan: &BehavioralTrialPlan,
+    receipt: &BehavioralTrialRunReceipt,
+) -> Result<(), String> {
+    let rebuilt = build_behavioral_trial_run_receipt(
+        plan,
+        receipt.metadata.clone(),
+        receipt.raw_worker_packet.as_bytes(),
+        receipt.raw_output.as_bytes(),
+    )
+    .map_err(|error| error.to_string())?;
+    if &rebuilt != receipt {
+        return Err(
+            "behavioral-trial run receipt fields do not match the byte-authentic rebuild".into(),
+        );
+    }
+    Ok(())
+}
+
+fn receipt_arm(
+    plan: &BehavioralTrialPlan,
+    receipt: &BehavioralTrialRunReceipt,
+) -> Result<BehavioralTrialArmKind, String> {
+    let control = materialize_worker_packet(plan, BehavioralTrialArmKind::Control)
+        .map_err(|error| error.to_string())?;
+    let treatment = materialize_worker_packet(plan, BehavioralTrialArmKind::Treatment)
+        .map_err(|error| error.to_string())?;
+    let fingerprint = &receipt.observation.worker_packet_fingerprint;
+    if fingerprint == &control.worker_packet_fingerprint {
+        Ok(BehavioralTrialArmKind::Control)
+    } else if fingerprint == &treatment.worker_packet_fingerprint {
+        Ok(BehavioralTrialArmKind::Treatment)
+    } else {
+        Err("authenticated run receipt names a packet outside the frozen plan".into())
+    }
+}

--- a/tests/behavioral_trial_pair_admission.rs
+++ b/tests/behavioral_trial_pair_admission.rs
@@ -1,0 +1,457 @@
+#![allow(dead_code)]
+
+#[path = "../src/behavioral_trial.rs"]
+mod behavioral_trial;
+#[path = "../src/behavioral_trial_pair_admission.rs"]
+mod behavioral_trial_pair_admission;
+#[path = "../src/behavioral_trial_run.rs"]
+mod behavioral_trial_run;
+
+use behavioral_trial::{
+    BEHAVIORAL_TRIAL_SCHEMA_VERSION, BehavioralTrialArmKind, BehavioralTrialObservation,
+    BehavioralTrialPlan, fingerprint_plan, materialize_worker_packet, parse_behavioral_trial_plan,
+};
+use behavioral_trial_pair_admission::{
+    BehavioralTrialPairAdmissionReason, BehavioralTrialPairAdmissionVerdict,
+    evaluate_behavioral_trial_pair_admission,
+};
+use behavioral_trial_run::{
+    BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION, BehavioralTrialExecutionOrigin,
+    BehavioralTrialRunMetadata, BehavioralTrialRunPair, BehavioralTrialRunReceipt,
+    build_behavioral_trial_run_receipt,
+};
+
+const PLAN: &[u8] =
+    include_bytes!("../research/behavioral-trials/stensibly-index-guard-detail.json");
+const SAMPLING_SHA: &str =
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OTHER_SAMPLING_SHA: &str =
+    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+fn plan() -> BehavioralTrialPlan {
+    parse_behavioral_trial_plan(PLAN).expect("retained neutral Stensibly plan should parse")
+}
+
+fn metadata(
+    sequence_index: u8,
+    session_id: &str,
+    freshness_receipt: &str,
+) -> BehavioralTrialRunMetadata {
+    BehavioralTrialRunMetadata {
+        schema_version: BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION,
+        execution_origin: BehavioralTrialExecutionOrigin::ExternalHarness,
+        sequence_index,
+        worker_identity: "fixed-worker@v1".into(),
+        harness_identity: "first-action-harness@v1".into(),
+        affordance_identity: "packet-only-choice@v1".into(),
+        sampling_config_sha256: SAMPLING_SHA.into(),
+        session_id: session_id.into(),
+        freshness_receipt: freshness_receipt.into(),
+        fresh_session: true,
+        prior_condition_exposure: false,
+    }
+}
+
+fn packet_bytes(plan: &BehavioralTrialPlan, arm: BehavioralTrialArmKind) -> Vec<u8> {
+    let packet = materialize_worker_packet(plan, arm).unwrap();
+    let mut bytes = serde_json::to_vec_pretty(&packet).unwrap();
+    bytes.push(b'\n');
+    bytes
+}
+
+fn output_bytes(
+    plan: &BehavioralTrialPlan,
+    arm: BehavioralTrialArmKind,
+    worker_ref: &str,
+    first_action_id: &str,
+) -> Vec<u8> {
+    let packet = materialize_worker_packet(plan, arm).unwrap();
+    let observation = BehavioralTrialObservation {
+        schema_version: BEHAVIORAL_TRIAL_SCHEMA_VERSION,
+        trial_id: plan.trial_id.clone(),
+        plan_fingerprint: fingerprint_plan(plan).unwrap(),
+        worker_packet_fingerprint: packet.worker_packet_fingerprint,
+        worker_ref: worker_ref.into(),
+        first_action_id: first_action_id.into(),
+    };
+    let mut bytes = serde_json::to_vec_pretty(&observation).unwrap();
+    bytes.push(b'\n');
+    bytes
+}
+
+fn receipt(
+    plan: &BehavioralTrialPlan,
+    arm: BehavioralTrialArmKind,
+    metadata: BehavioralTrialRunMetadata,
+    worker_ref: &str,
+    first_action_id: &str,
+) -> BehavioralTrialRunReceipt {
+    build_behavioral_trial_run_receipt(
+        plan,
+        metadata,
+        &packet_bytes(plan, arm),
+        &output_bytes(plan, arm, worker_ref, first_action_id),
+    )
+    .unwrap()
+}
+
+fn pair(
+    plan: &BehavioralTrialPlan,
+    first: BehavioralTrialRunReceipt,
+    second: BehavioralTrialRunReceipt,
+) -> BehavioralTrialRunPair {
+    BehavioralTrialRunPair {
+        schema_version: BEHAVIORAL_TRIAL_RUN_SCHEMA_VERSION,
+        plan: Box::new(plan.clone()),
+        runs: vec![first, second],
+    }
+}
+
+#[test]
+fn admitted_ab_pair_reuses_strict_descriptive_evaluator() {
+    let plan = plan();
+    let control = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        metadata(1, "session:control", "freshness:control"),
+        "worker:control",
+        "inspect_accepted_guard_detail",
+    );
+    let treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        metadata(2, "session:treatment", "freshness:treatment"),
+        "worker:treatment",
+        "block_patch",
+    );
+
+    let result =
+        evaluate_behavioral_trial_pair_admission(&pair(&plan, control, treatment)).unwrap();
+    assert_eq!(
+        result.verdict,
+        BehavioralTrialPairAdmissionVerdict::Admitted
+    );
+    assert!(result.reasons.is_empty());
+    assert!(result.frozen_identity_match);
+    assert!(result.fresh_uncontaminated_sessions);
+    assert!(result.distinct_arm_coverage);
+    assert!(!result.automatic_effect_claim);
+    assert!(!result.automatic_generalization);
+
+    let behavioral = result.behavioral_evaluation.unwrap();
+    assert_eq!(
+        behavioral.trial.control.first_action_id,
+        "inspect_accepted_guard_detail"
+    );
+    assert_eq!(behavioral.trial.treatment.first_action_id, "block_patch");
+    assert!(!behavioral.trial.same_first_action);
+}
+
+#[test]
+fn admitted_ba_vector_order_preserves_recorded_execution_sequence_and_arm_mapping() {
+    let plan = plan();
+    let treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        metadata(1, "session:treatment", "freshness:treatment"),
+        "worker:treatment",
+        "block_patch",
+    );
+    let control = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        metadata(2, "session:control", "freshness:control"),
+        "worker:control",
+        "inspect_accepted_guard_detail",
+    );
+
+    let result =
+        evaluate_behavioral_trial_pair_admission(&pair(&plan, treatment, control)).unwrap();
+    assert_eq!(
+        result.verdict,
+        BehavioralTrialPairAdmissionVerdict::Admitted
+    );
+    assert!(result.reasons.is_empty());
+    assert_eq!(result.sequence_indexes, vec![1, 2]);
+    let behavioral = result.behavioral_evaluation.unwrap();
+    assert_eq!(behavioral.treatment_sequence_index, 1);
+    assert_eq!(behavioral.control_sequence_index, 2);
+    assert_eq!(behavioral.trial.treatment.first_action_id, "block_patch");
+    assert_eq!(
+        behavioral.trial.control.first_action_id,
+        "inspect_accepted_guard_detail"
+    );
+}
+
+#[test]
+fn admitted_pair_can_preserve_same_first_action_without_effect_claim() {
+    let plan = plan();
+    let control = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        metadata(1, "session:control", "freshness:control"),
+        "worker:control",
+        "inspect_more_repository_context",
+    );
+    let treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        metadata(2, "session:treatment", "freshness:treatment"),
+        "worker:treatment",
+        "inspect_more_repository_context",
+    );
+
+    let result =
+        evaluate_behavioral_trial_pair_admission(&pair(&plan, control, treatment)).unwrap();
+    assert_eq!(
+        result.verdict,
+        BehavioralTrialPairAdmissionVerdict::Admitted
+    );
+    assert!(result.reasons.is_empty());
+    assert!(
+        result
+            .behavioral_evaluation
+            .unwrap()
+            .trial
+            .same_first_action
+    );
+    assert!(!result.automatic_effect_claim);
+    assert!(!result.automatic_generalization);
+}
+
+#[test]
+fn frozen_execution_axis_drift_is_confounded_with_exact_reason() {
+    let plan = plan();
+    let control = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        metadata(1, "session:control", "freshness:control"),
+        "worker:control",
+        "inspect_accepted_guard_detail",
+    );
+
+    let mut variants = Vec::new();
+    let mut worker = metadata(2, "session:treatment-a", "freshness:treatment-a");
+    worker.worker_identity = "other-worker@v1".into();
+    variants.push((
+        worker,
+        BehavioralTrialPairAdmissionReason::WorkerIdentityDrift,
+    ));
+    let mut harness = metadata(2, "session:treatment-b", "freshness:treatment-b");
+    harness.harness_identity = "other-harness@v1".into();
+    variants.push((
+        harness,
+        BehavioralTrialPairAdmissionReason::HarnessIdentityDrift,
+    ));
+    let mut affordance = metadata(2, "session:treatment-c", "freshness:treatment-c");
+    affordance.affordance_identity = "other-affordance@v1".into();
+    variants.push((
+        affordance,
+        BehavioralTrialPairAdmissionReason::AffordanceIdentityDrift,
+    ));
+    let mut sampling = metadata(2, "session:treatment-d", "freshness:treatment-d");
+    sampling.sampling_config_sha256 = OTHER_SAMPLING_SHA.into();
+    variants.push((
+        sampling,
+        BehavioralTrialPairAdmissionReason::SamplingConfigDrift,
+    ));
+
+    for (metadata, expected_reason) in variants {
+        let treatment = receipt(
+            &plan,
+            BehavioralTrialArmKind::Treatment,
+            metadata,
+            "worker:treatment",
+            "block_patch",
+        );
+        let result =
+            evaluate_behavioral_trial_pair_admission(&pair(&plan, control.clone(), treatment))
+                .unwrap();
+        assert_eq!(
+            result.verdict,
+            BehavioralTrialPairAdmissionVerdict::Confounded
+        );
+        assert_eq!(result.reasons, vec![expected_reason]);
+        assert!(!result.frozen_identity_match);
+        assert!(result.behavioral_evaluation.is_none());
+    }
+}
+
+#[test]
+fn authentic_session_confounds_preserve_exact_reasons() {
+    let plan = plan();
+    let control = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        metadata(1, "session:control", "freshness:control"),
+        "worker:control",
+        "inspect_accepted_guard_detail",
+    );
+
+    let mut nonfresh = metadata(2, "session:nonfresh", "freshness:nonfresh");
+    nonfresh.fresh_session = false;
+    let mut preexposed = metadata(2, "session:preexposed", "freshness:preexposed");
+    preexposed.prior_condition_exposure = true;
+    let reused_session = metadata(2, "session:control", "freshness:other");
+    let reused_freshness = metadata(2, "session:other", "freshness:control");
+    let duplicate_sequence = metadata(1, "session:other-two", "freshness:other-two");
+
+    for (metadata, expected_reason) in [
+        (
+            nonfresh,
+            BehavioralTrialPairAdmissionReason::NonFreshSession,
+        ),
+        (
+            preexposed,
+            BehavioralTrialPairAdmissionReason::PriorConditionExposure,
+        ),
+        (
+            reused_session,
+            BehavioralTrialPairAdmissionReason::ReusedSessionId,
+        ),
+        (
+            reused_freshness,
+            BehavioralTrialPairAdmissionReason::ReusedFreshnessReceipt,
+        ),
+        (
+            duplicate_sequence,
+            BehavioralTrialPairAdmissionReason::InvalidSequenceCoverage,
+        ),
+    ] {
+        let treatment = receipt(
+            &plan,
+            BehavioralTrialArmKind::Treatment,
+            metadata,
+            "worker:treatment",
+            "block_patch",
+        );
+        let result =
+            evaluate_behavioral_trial_pair_admission(&pair(&plan, control.clone(), treatment))
+                .unwrap();
+        assert_eq!(
+            result.verdict,
+            BehavioralTrialPairAdmissionVerdict::Confounded
+        );
+        assert_eq!(result.reasons, vec![expected_reason]);
+        assert!(!result.fresh_uncontaminated_sessions);
+        assert!(result.behavioral_evaluation.is_none());
+    }
+
+    let treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        metadata(2, "session:unique", "freshness:unique"),
+        "worker:control",
+        "block_patch",
+    );
+    let result =
+        evaluate_behavioral_trial_pair_admission(&pair(&plan, control, treatment)).unwrap();
+    assert_eq!(
+        result.verdict,
+        BehavioralTrialPairAdmissionVerdict::Confounded
+    );
+    assert_eq!(
+        result.reasons,
+        vec![BehavioralTrialPairAdmissionReason::ReusedWorkerRef]
+    );
+    assert!(!result.fresh_uncontaminated_sessions);
+}
+
+#[test]
+fn same_authentic_arm_twice_is_invalid_pair_even_if_execution_axes_match() {
+    let plan = plan();
+    let first = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        metadata(1, "session:first", "freshness:first"),
+        "worker:first",
+        "inspect_accepted_guard_detail",
+    );
+    let second = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        metadata(2, "session:second", "freshness:second"),
+        "worker:second",
+        "approve_patch",
+    );
+
+    let result = evaluate_behavioral_trial_pair_admission(&pair(&plan, first, second)).unwrap();
+    assert_eq!(
+        result.verdict,
+        BehavioralTrialPairAdmissionVerdict::InvalidPair
+    );
+    assert_eq!(
+        result.reasons,
+        vec![BehavioralTrialPairAdmissionReason::SameArm]
+    );
+    assert!(!result.distinct_arm_coverage);
+    assert!(result.behavioral_evaluation.is_none());
+}
+
+#[test]
+fn simultaneous_confounds_are_preserved_together() {
+    let plan = plan();
+    let control = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        metadata(1, "session:shared", "freshness:shared"),
+        "worker:shared",
+        "inspect_accepted_guard_detail",
+    );
+    let mut treatment_metadata = metadata(1, "session:shared", "freshness:shared");
+    treatment_metadata.worker_identity = "other-worker@v1".into();
+    treatment_metadata.fresh_session = false;
+    let treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        treatment_metadata,
+        "worker:shared",
+        "block_patch",
+    );
+
+    let result =
+        evaluate_behavioral_trial_pair_admission(&pair(&plan, control, treatment)).unwrap();
+    assert_eq!(
+        result.verdict,
+        BehavioralTrialPairAdmissionVerdict::Confounded
+    );
+    assert_eq!(
+        result.reasons,
+        vec![
+            BehavioralTrialPairAdmissionReason::WorkerIdentityDrift,
+            BehavioralTrialPairAdmissionReason::NonFreshSession,
+            BehavioralTrialPairAdmissionReason::ReusedSessionId,
+            BehavioralTrialPairAdmissionReason::ReusedFreshnessReceipt,
+            BehavioralTrialPairAdmissionReason::ReusedWorkerRef,
+            BehavioralTrialPairAdmissionReason::InvalidSequenceCoverage,
+        ]
+    );
+    assert!(!result.frozen_identity_match);
+    assert!(!result.fresh_uncontaminated_sessions);
+    assert!(result.behavioral_evaluation.is_none());
+}
+
+#[test]
+fn tampered_individual_receipt_rejects_before_comparability_verdict() {
+    let plan = plan();
+    let control = receipt(
+        &plan,
+        BehavioralTrialArmKind::Control,
+        metadata(1, "session:control", "freshness:control"),
+        "worker:control",
+        "inspect_accepted_guard_detail",
+    );
+    let mut treatment = receipt(
+        &plan,
+        BehavioralTrialArmKind::Treatment,
+        metadata(2, "session:treatment", "freshness:treatment"),
+        "worker:treatment",
+        "block_patch",
+    );
+    treatment.raw_output_sha256 =
+        "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc".into();
+
+    let error =
+        evaluate_behavioral_trial_pair_admission(&pair(&plan, control, treatment)).unwrap_err();
+    assert!(error.contains("fields do not match the byte-authentic rebuild"));
+}


### PR DESCRIPTION
Progresses #264 with the post-#269/#273 pair-comparability projection.

## One canonical receipt type

This PR defines no individual run-receipt schema. Every supplied `behavioral_trial_run::BehavioralTrialRunReceipt` is rebuilt through the canonical byte-authentic builder before pair interpretation.

```text
#269/#273 authentic individual receipts
-> this projection: admitted | confounded | invalid_pair + reasons[]
-> #245 descriptive first-action reconciliation only for admitted
```

Tampered/drifted individual receipts reject before a comparability verdict.

## Typed pair reasons

The evaluation preserves every observed pair-level reason in deterministic order:

```text
same_arm
worker_identity_drift
harness_identity_drift
affordance_identity_drift
sampling_config_drift
non_fresh_session
prior_condition_exposure
reused_session_id
reused_freshness_receipt
reused_worker_ref
invalid_sequence_coverage
```

Several reasons may coexist. This retains the useful multi-confound idea from stale #274 while updating it for #273's authentic non-fresh/prior-exposure receipts.

Verdict precedence:

```text
same_arm present -> invalid_pair
other reason(s)  -> confounded
reasons empty    -> admitted
```

Only `admitted` calls merged `evaluate_behavioral_trial_run_pair()` and reaches #245 descriptive control/treatment first-action reconciliation.

## Controls

Tests construct all synthetic runs through the canonical #269 builder from current neutral Stensibly packet bytes and require:

- admitted AB/BA with empty reasons;
- admitted same/different first action;
- exact reason for each worker/harness/affordance/sampling drift;
- exact reasons for non-fresh, prior exposure, session/freshness/worker-ref reuse, and invalid sequence coverage;
- simultaneous confounds preserved together;
- same authentic arm twice -> `invalid_pair + same_arm`;
- tampered retained receipt -> hard intake rejection before classification.

Every output retains `automatic_effect_claim=false` and `automatic_generalization=false`.

## Clean checkpoint

Current branch is one connector-authored commit on the promotion-policy main checkpoint with exactly four files:

```text
src/behavioral_trial_pair_admission.rs
tests/behavioral_trial_pair_admission.rs
examples/behavioral_trial_pair_admission.rs
research/behavioral-trial-pair-admission.md
```

The temporary formatting/repair carrier is absent. Per #279, merge-view CI is the normal promotion authority from here; unrelated main movement does not require repeated rebasing.

Supersedes closed duplicate-schema #265 and, once certified, stale #274.

Refs #245 #262 #264 #265 #267 #269 #271 #273 #274 #279.