### PR TITLE
research: protect exact selected scope evidence under byte budget

### DIFF
--- a/.github/workflows/scoped-selected-evidence-replay.yml
+++ b/.github/workflows/scoped-selected-evidence-replay.yml
@@ -1,0 +1,190 @@
+name: Stensibly selected scope evidence replay
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/scoped-selected-evidence-replay.yml"
+      - "examples/agent_context_packet.rs"
+      - "examples/scoped_agent_context_packet.rs"
+      - "examples/support/scoped_agent_context_packet_impl.rs"
+      - "examples/support/scoped_selected_evidence_impl.rs"
+
+permissions:
+  contents: read
+
+jobs:
+  replay:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Cultist
+        uses: actions/checkout@v4
+        with:
+          path: cultist
+          fetch-depth: 1
+
+      - name: Install stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Build scoped packet example
+        run: cargo build --release --example scoped_agent_context_packet --manifest-path cultist/Cargo.toml
+
+      - name: Checkout exact pre-guard Stensibly state
+        uses: actions/checkout@v4
+        with:
+          repository: teamleaderleo/stensibly
+          ref: 85cecf2608ad9e734a67518577fa85b9a08a550c
+          fetch-depth: 256
+          persist-credentials: false
+          path: target
+
+      - name: Replay selected-evidence budget discriminator
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          scoped="$PWD/cultist/target/release/examples/scoped_agent_context_packet"
+          target="$PWD/target/convex/schema.ts"
+
+          python - "$scoped" "$target" <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import subprocess
+          import sys
+
+          scoped, target = sys.argv[1:]
+          budgets = [32768, 16000, 15750, 4096, 3900]
+          selected_shas = [
+              "85cecf2608ad9e734a67518577fa85b9a08a550c",
+              "ca5d2c7fdf89666e523972ab6e81610d17b9611b",
+          ]
+          required_subjects = [
+              "Keep Gmail mailbox-disposition indexes deployable (#1573)",
+              "Keep Gmail semantic-admission indexes deployable (#1571)",
+          ]
+
+          def run(budget, protected):
+              env = os.environ.copy()
+              env["CARGO_CULTIST_PACKET_MAX_BYTES"] = str(budget)
+              args = [scoped, target, "--scope", "convex"]
+              if protected:
+                  for sha in selected_shas:
+                      args.extend(["--protect-scope-sha", sha])
+              completed = subprocess.run(args, env=env, capture_output=True, text=True)
+              if completed.returncode != 0:
+                  stderr = completed.stderr.strip()
+                  if "protected scoped packet evidence requires" not in stderr:
+                      raise SystemExit(f"unexpected failure at {budget}, protected={protected}: {stderr}")
+                  return {"status": "protected_core_too_large", "stderr": stderr}
+
+              envelope = json.loads(completed.stdout)
+              scope_rows = envelope["scope_recent_history"]
+              scope_shas = [row["sha"] for row in scope_rows]
+              scope_subjects = [row["subject"] for row in scope_rows]
+              presence = {
+                  subject: any(subject in observed for observed in scope_subjects)
+                  for subject in required_subjects
+              }
+              result = {
+                  "status": "selected",
+                  "candidate_serialized_bytes": envelope["candidate_serialized_bytes"],
+                  "serialized_bytes": envelope["serialized_bytes"],
+                  "scope_history_count": len(scope_rows),
+                  "scope_shas": scope_shas,
+                  "scope_semantic_evictions": envelope["semantic_evictions"],
+                  "file_packet_semantic_evictions": envelope["file_packet"]["semantic_evictions"],
+                  "target_recent_history_count": len(envelope["file_packet"]["recent_history"]),
+                  "lesson_presence": presence,
+                  "preserves_all_required": all(presence.values()),
+              }
+              if protected:
+                  result["protected_scope_shas"] = envelope.get("protected_scope_shas")
+              return result
+
+          rows = []
+          for budget in budgets:
+              rows.append({
+                  "budget": budget,
+                  "current": run(budget, False),
+                  "protected": run(budget, True),
+              })
+
+          def row(budget):
+              return next(item for item in rows if item["budget"] == budget)
+
+          if not row(16000)["current"].get("preserves_all_required"):
+              raise SystemExit("16,000-byte unprotected control no longer preserves both lessons")
+          if row(15750)["current"].get("preserves_all_required"):
+              raise SystemExit("15,750-byte unprotected control no longer reproduces selected-lesson loss")
+          if not row(15750)["protected"].get("preserves_all_required"):
+              raise SystemExit("15,750-byte protected policy did not preserve both lessons")
+          if row(4096)["protected"].get("status") != "selected" or not row(4096)["protected"].get("preserves_all_required"):
+              raise SystemExit("4,096-byte protected policy did not preserve both selected lessons")
+          if row(3900)["protected"].get("status") != "protected_core_too_large":
+              raise SystemExit("3,900-byte protected policy did not fail closed")
+
+          for budget in [32768, 16000, 15750, 4096]:
+              protected = row(budget)["protected"]
+              if protected.get("status") != "selected":
+                  raise SystemExit(f"protected run unexpectedly failed at {budget}")
+              if set(protected.get("protected_scope_shas") or []) != set(selected_shas):
+                  raise SystemExit(f"protected SHA receipt mismatch at {budget}")
+              if not set(selected_shas).issubset(set(protected["scope_shas"])):
+                  raise SystemExit(f"selected SHAs missing from scope history at {budget}")
+
+          receipt = {
+              "schema_version": 1,
+              "repository": "teamleaderleo/stensibly",
+              "revision": "85cecf2608ad9e734a67518577fa85b9a08a550c",
+              "target": "convex/schema.ts",
+              "scope": "convex",
+              "selected_scope_shas": selected_shas,
+              "required_history_subjects": required_subjects,
+              "rows": rows,
+              "summary": {
+                  "unprotected_15750_preserves_all_required": row(15750)["current"].get("preserves_all_required", False),
+                  "protected_15750_preserves_all_required": row(15750)["protected"].get("preserves_all_required", False),
+                  "protected_4096_preserves_all_required": row(4096)["protected"].get("preserves_all_required", False),
+                  "protected_3900_status": row(3900)["protected"]["status"],
+                  "protected_4096_serialized_bytes": row(4096)["protected"].get("serialized_bytes"),
+              },
+          }
+          Path("artifacts/stensibly-selected-scope-evidence-replay.json").write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(receipt["summary"], indent=2, sort_keys=True))
+          PY
+
+      - name: Write replay summary
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("artifacts/stensibly-selected-scope-evidence-replay.json")
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as out:
+              out.write("## Selected scope evidence replay\n\n")
+              if not path.is_file():
+                  out.write("Replay receipt unavailable.\n")
+                  raise SystemExit(0)
+              receipt = json.loads(path.read_text(encoding="utf-8"))
+              summary = receipt["summary"]
+              out.write(f"Unprotected 15,750 keeps both: `{summary['unprotected_15750_preserves_all_required']}`  \n")
+              out.write(f"Protected 15,750 keeps both: `{summary['protected_15750_preserves_all_required']}`  \n")
+              out.write(f"Protected 4,096 keeps both: `{summary['protected_4096_preserves_all_required']}`  \n")
+              out.write(f"Protected 4,096 selected bytes: `{summary['protected_4096_serialized_bytes']}`  \n")
+              out.write(f"Protected 3,900 status: `{summary['protected_3900_status']}`\n")
+          PY
+
+      - name: Upload replay receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stensibly-selected-scope-evidence-${{ github.run_id }}
+          path: artifacts/stensibly-selected-scope-evidence-replay.json
+          if-no-files-found: error

--- a/examples/scoped_agent_context_packet.rs
+++ b/examples/scoped_agent_context_packet.rs
@@ -2,10 +2,11 @@
 mod packet {
     include!("agent_context_packet.rs");
     include!("support/scoped_agent_context_packet_impl.rs");
+    include!("support/scoped_selected_evidence_impl.rs");
 }
 
 fn main() {
-    if let Err(error) = packet::run_scoped() {
+    if let Err(error) = packet::run_scoped_with_optional_protection() {
         eprintln!("scoped-agent-context-packet: {error}");
         std::process::exit(1);
     }

--- a/examples/support/scoped_selected_evidence_impl.rs
+++ b/examples/support/scoped_selected_evidence_impl.rs
@@ -1,0 +1,397 @@
+use std::collections::BTreeSet as SelectedScopeBTreeSet;
+
+use serde::Serialize as SelectedScopeSerialize;
+
+#[derive(Debug, SelectedScopeSerialize)]
+struct SelectedScopedEnvelope {
+    protected_scope_shas: Vec<String>,
+    #[serde(flatten)]
+    envelope: ScopedAgentContextEnvelope,
+}
+
+pub fn run_scoped_with_optional_protection() -> Result<(), Box<dyn Error>> {
+    if !env::args().any(|arg| arg == "--protect-scope-sha") {
+        return run_scoped();
+    }
+
+    let (target_arg, scope_arg, protected_scope_shas) =
+        parse_selected_scope_args(env::args().skip(1))?;
+
+    let requested = PathBuf::from(target_arg);
+    let requested = if requested.is_absolute() {
+        requested
+    } else {
+        env::current_dir()?.join(requested)
+    };
+    let target = requested.canonicalize()?;
+    if !target.is_file() {
+        return Err(format!("target must be an existing file: {}", target.display()).into());
+    }
+
+    let probe = target
+        .parent()
+        .ok_or("could not determine target parent directory")?;
+    let root = git_repo_root(probe)?;
+    let relative_target = target
+        .strip_prefix(&root)
+        .map_err(|_| "target is outside the resolved Git repository")?
+        .to_path_buf();
+
+    let scope = resolve_explicit_scope(&root, &target, &scope_arg)?;
+    let relative_scope = scope.strip_prefix(&root)?.to_path_buf();
+    let budget = packet_budget_from_env()?;
+    let mut file_packet = build_file_packet(&root, &target, &relative_target, budget)?;
+    stabilize_candidate_size(&mut file_packet)?;
+
+    let (scope_history, scope_history_truncated) =
+        scoped_recent_commits(&root, &relative_scope, DEFAULT_MAX_SCOPE_HISTORY)?;
+    let scope_recent_history = dedupe_scope_history(scope_history, &file_packet.recent_history);
+    validate_selected_scope_shas(&scope_recent_history, &protected_scope_shas)?;
+
+    let envelope = ScopedAgentContextEnvelope {
+        schema_version: SCOPED_SCHEMA_VERSION,
+        analysis: "scoped_agent_context",
+        repository: root.display().to_string(),
+        target: relative_target.display().to_string(),
+        scope: relative_scope.display().to_string(),
+        budget: ScopedEnvelopeBudget {
+            max_serialized_bytes: budget.max_serialized_bytes,
+            max_scope_history_commits: DEFAULT_MAX_SCOPE_HISTORY,
+        },
+        candidate_serialized_bytes: 0,
+        serialized_bytes: 0,
+        semantic_evictions: Vec::new(),
+        file_packet,
+        scope_recent_history,
+        scope_history_truncated,
+        unknowns: vec![
+            "Scope chronology is not semantic proof; exact protected scope SHAs were selected upstream."
+                .to_string(),
+        ],
+    };
+    let mut selected = SelectedScopedEnvelope {
+        protected_scope_shas: protected_scope_shas.iter().cloned().collect(),
+        envelope,
+    };
+
+    println!("{}", compile_selected_scoped_to_budget(&mut selected)?);
+    Ok(())
+}
+
+fn parse_selected_scope_args<I>(
+    mut args: I,
+) -> Result<(String, String, SelectedScopeBTreeSet<String>), Box<dyn Error>>
+where
+    I: Iterator<Item = String>,
+{
+    let usage = "usage: cargo run --example scoped_agent_context_packet -- FILE --scope DIR --protect-scope-sha SHA [--protect-scope-sha SHA ...]";
+    let target = args.next().ok_or(usage)?;
+    if args.next().as_deref() != Some("--scope") {
+        return Err(usage.into());
+    }
+    let scope = args.next().ok_or(usage)?;
+    validate_scope_text(&scope)?;
+
+    let mut protected = SelectedScopeBTreeSet::new();
+    while let Some(flag) = args.next() {
+        if flag != "--protect-scope-sha" {
+            return Err(usage.into());
+        }
+        let sha = args.next().ok_or(usage)?;
+        validate_selected_scope_sha(&sha)?;
+        protected.insert(sha);
+    }
+    if protected.is_empty() {
+        return Err("at least one --protect-scope-sha is required in protected mode".into());
+    }
+    Ok((target, scope, protected))
+}
+
+fn validate_selected_scope_sha(sha: &str) -> Result<(), Box<dyn Error>> {
+    if sha.len() != 40
+        || !sha
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err("protected scope evidence refs must be exact lowercase 40-hex Git SHAs".into());
+    }
+    Ok(())
+}
+
+fn validate_selected_scope_shas(
+    scope_recent_history: &[CommitSummary],
+    protected_scope_shas: &SelectedScopeBTreeSet<String>,
+) -> Result<(), Box<dyn Error>> {
+    let available = scope_recent_history
+        .iter()
+        .map(|commit| commit.sha.as_str())
+        .collect::<SelectedScopeBTreeSet<_>>();
+    for protected in protected_scope_shas {
+        if !available.contains(protected.as_str()) {
+            return Err(format!(
+                "selected scope evidence `{protected}` is absent from the admitted deduplicated scope-history window"
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn compile_selected_scoped_to_budget(
+    selected: &mut SelectedScopedEnvelope,
+) -> Result<String, ScopedBudgetError> {
+    selected.envelope.semantic_evictions.clear();
+    selected.envelope.candidate_serialized_bytes = 0;
+    selected.envelope.serialized_bytes = 0;
+    stabilize_selected_candidate_size(selected)?;
+
+    loop {
+        let rendered = render_selected_with_exact_size(selected)?;
+        if rendered.len() <= selected.envelope.budget.max_serialized_bytes {
+            return Ok(rendered);
+        }
+
+        if let Some(index) = selected
+            .envelope
+            .scope_recent_history
+            .iter()
+            .rposition(|commit| !selected.protected_scope_shas.contains(&commit.sha))
+        {
+            selected.envelope.scope_recent_history.remove(index);
+            record_scoped_eviction(&mut selected.envelope, "scope_recent_history_summary");
+            selected.envelope.serialized_bytes = 0;
+            continue;
+        }
+
+        if let Some(class) = evict_one_semantic_detail(&mut selected.envelope.file_packet) {
+            record_semantic_eviction(&mut selected.envelope.file_packet, class);
+            selected.envelope.file_packet.serialized_bytes = 0;
+            let _ = render_packet_with_exact_size(&mut selected.envelope.file_packet)?;
+            selected.envelope.serialized_bytes = 0;
+            continue;
+        }
+
+        return Err(ScopedBudgetError::ProtectedCoreTooLarge {
+            max_serialized_bytes: selected.envelope.budget.max_serialized_bytes,
+            required_serialized_bytes: rendered.len(),
+        });
+    }
+}
+
+fn stabilize_selected_candidate_size(
+    selected: &mut SelectedScopedEnvelope,
+) -> Result<(), serde_json::Error> {
+    loop {
+        let rendered = serde_json::to_string_pretty(selected)?;
+        let serialized_bytes = rendered.len();
+        if selected.envelope.candidate_serialized_bytes == serialized_bytes
+            && selected.envelope.serialized_bytes == serialized_bytes
+        {
+            return Ok(());
+        }
+        selected.envelope.candidate_serialized_bytes = serialized_bytes;
+        selected.envelope.serialized_bytes = serialized_bytes;
+    }
+}
+
+fn render_selected_with_exact_size(
+    selected: &mut SelectedScopedEnvelope,
+) -> Result<String, serde_json::Error> {
+    loop {
+        let rendered = serde_json::to_string_pretty(selected)?;
+        let serialized_bytes = rendered.len();
+        if selected.envelope.serialized_bytes == serialized_bytes {
+            return Ok(rendered);
+        }
+        selected.envelope.serialized_bytes = serialized_bytes;
+    }
+}
+
+#[cfg(test)]
+mod selected_scope_tests {
+    use super::*;
+
+    fn summary(sha: &str, subject: &str) -> CommitSummary {
+        CommitSummary {
+            sha: sha.to_string(),
+            date: "2026-08-19T00:00:00Z".to_string(),
+            subject: subject.to_string(),
+        }
+    }
+
+    fn minimal_file_packet(max_serialized_bytes: usize) -> AgentContextPacket {
+        let budget = PacketBudget {
+            max_serialized_bytes,
+            ..PacketBudget::default()
+        };
+        AgentContextPacket {
+            schema_version: SCHEMA_VERSION,
+            analysis: "agent_context",
+            repository: "/repo".to_string(),
+            target: PacketTarget {
+                path: "src/target.rs".to_string(),
+            },
+            budget,
+            candidate_serialized_bytes: 0,
+            serialized_bytes: 0,
+            semantic_evictions: Vec::new(),
+            direct_evidence: vec![EvidenceItem {
+                claim_kind: "proven",
+                message: "target identity".to_string(),
+                source: EvidenceSource {
+                    kind: "filesystem",
+                    path: "src/target.rs".to_string(),
+                },
+            }],
+            guidance: Vec::new(),
+            reviewed_decisions: Vec::new(),
+            recent_history: vec![summary(
+                "1111111111111111111111111111111111111111",
+                "target history",
+            )],
+            historical_companions: Vec::new(),
+            companion_exclusions: Vec::new(),
+            unknowns: vec!["material unknown".to_string()],
+            truncation: Vec::new(),
+        }
+    }
+
+    fn selected_envelope(max_serialized_bytes: usize) -> SelectedScopedEnvelope {
+        let mut file_packet = minimal_file_packet(max_serialized_bytes);
+        stabilize_candidate_size(&mut file_packet).unwrap();
+        SelectedScopedEnvelope {
+            protected_scope_shas: vec![
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+            ],
+            envelope: ScopedAgentContextEnvelope {
+                schema_version: SCOPED_SCHEMA_VERSION,
+                analysis: "scoped_agent_context",
+                repository: "/repo".to_string(),
+                target: "src/target.rs".to_string(),
+                scope: "src".to_string(),
+                budget: ScopedEnvelopeBudget {
+                    max_serialized_bytes,
+                    max_scope_history_commits: DEFAULT_MAX_SCOPE_HISTORY,
+                },
+                candidate_serialized_bytes: 0,
+                serialized_bytes: 0,
+                semantic_evictions: Vec::new(),
+                file_packet,
+                scope_recent_history: vec![
+                    summary(
+                        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        &format!("unprotected {}", "x".repeat(700)),
+                    ),
+                    summary(
+                        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        &format!("protected {}", "x".repeat(700)),
+                    ),
+                ],
+                scope_history_truncated: true,
+                unknowns: vec!["selected scope refs supplied upstream".to_string()],
+            },
+        }
+    }
+
+    #[test]
+    fn exact_sha_parser_and_duplicate_flags_are_deterministic() {
+        let (_, _, protected) = parse_selected_scope_args(
+            [
+                "src/target.rs",
+                "--scope",
+                "src",
+                "--protect-scope-sha",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "--protect-scope-sha",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ]
+            .into_iter()
+            .map(str::to_string),
+        )
+        .unwrap();
+        assert_eq!(protected.len(), 1);
+
+        for invalid in [
+            "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "gggggggggggggggggggggggggggggggggggggggg",
+        ] {
+            assert!(validate_selected_scope_sha(invalid).is_err());
+        }
+    }
+
+    #[test]
+    fn selected_sha_must_exist_after_target_history_deduplication() {
+        let scope = vec![summary(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "selected",
+        )];
+        let present = SelectedScopeBTreeSet::from([
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+        ]);
+        assert!(validate_selected_scope_shas(&scope, &present).is_ok());
+
+        let missing = SelectedScopeBTreeSet::from([
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        ]);
+        assert!(validate_selected_scope_shas(&scope, &missing).is_err());
+    }
+
+    #[test]
+    fn protected_scope_row_survives_before_unprotected_sibling() {
+        let mut selected = selected_envelope(usize::MAX);
+        stabilize_selected_candidate_size(&mut selected).unwrap();
+        let candidate = selected.envelope.candidate_serialized_bytes;
+        selected.envelope.budget.max_serialized_bytes = candidate - 200;
+        selected.envelope.file_packet.budget.max_serialized_bytes = candidate - 200;
+
+        let rendered = compile_selected_scoped_to_budget(&mut selected).unwrap();
+        assert!(rendered.len() <= selected.envelope.budget.max_serialized_bytes);
+        assert!(
+            selected
+                .envelope
+                .scope_recent_history
+                .iter()
+                .any(|commit| commit.sha == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+        );
+        assert!(
+            selected
+                .envelope
+                .scope_recent_history
+                .iter()
+                .all(|commit| commit.sha != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
+        assert_eq!(
+            selected.envelope.semantic_evictions.first(),
+            Some(&SemanticEviction {
+                class: "scope_recent_history_summary",
+                count: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn protected_selection_is_budgeted_and_fail_closed() {
+        let mut selected = selected_envelope(1);
+        let error = compile_selected_scoped_to_budget(&mut selected).unwrap_err();
+        assert!(matches!(error, ScopedBudgetError::ProtectedCoreTooLarge { .. }));
+        assert!(
+            selected
+                .envelope
+                .scope_recent_history
+                .iter()
+                .any(|commit| commit.sha == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+        );
+    }
+
+    #[test]
+    fn protected_output_receipts_selected_shas() {
+        let mut selected = selected_envelope(usize::MAX);
+        let rendered = render_selected_with_exact_size(&mut selected).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(
+            json["protected_scope_shas"][0],
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+    }
+}

--- a/research/scoped-selected-evidence-protection-v2.md
+++ b/research/scoped-selected-evidence-protection-v2.md
@@ -1,0 +1,221 @@
+# Selected scope evidence protection under byte budget
+
+Tracking: #281. Builds on #191 scoped packet compilation, the #196/#197 pressure test, the #205 exact-ref comparator, and merged #280 final-visible-counterexample preservation.
+
+## Earned policy
+
+Selection and byte budgeting are separate authorities:
+
+```text
+upstream selector
+  -> exact selected evidence identities
+
+byte-budget compiler
+  -> may evict unselected evidence
+  -> preserves supplied selected evidence
+  -> fails closed when selected evidence + independently protected core cannot fit
+```
+
+The compiler does not infer selection from chronology, locality, path ancestry, commit subjects, or a scalar relevance score.
+
+## Promoted scoped surface
+
+The existing command remains the owner:
+
+```text
+cargo run --example scoped_agent_context_packet -- FILE --scope DIR
+```
+
+Protected mode adds repeated exact refs:
+
+```text
+--protect-scope-sha <lowercase-40-hex-sha>
+```
+
+When no protection flag is present, the wrapper calls the original `run_scoped()` implementation directly. The default serialized behavior therefore follows the existing #191 path unchanged.
+
+Protected mode:
+
+1. canonicalizes duplicate requested SHAs through a sorted set;
+2. requires each selected SHA to exist in the admitted scope-history window after target-history deduplication;
+3. receipts the exact selected SHA list under `protected_scope_shas`;
+4. evicts unprotected scope rows first;
+5. then uses the ordinary nested file-packet semantic eviction ladder;
+6. retains every selected scope row while the packet survives;
+7. returns `ProtectedCoreTooLarge` when further compliant compression is impossible.
+
+Merged #280 remains independently active inside step 5: a retained historical relation keeps one visible counterexample until that relation itself is evicted.
+
+## Exact external replay
+
+The durable workflow:
+
+```text
+.github/workflows/scoped-selected-evidence-replay.yml
+```
+
+executes against the pinned pre-guard Stensibly state:
+
+```text
+repository  teamleaderleo/stensibly
+revision    85cecf2608ad9e734a67518577fa85b9a08a550c
+target      convex/schema.ts
+scope       convex
+```
+
+Upstream-selected exact evidence:
+
+```text
+85cecf2608ad9e734a67518577fa85b9a08a550c
+  Keep Gmail mailbox-disposition indexes deployable (#1573)
+
+ca5d2c7fdf89666e523972ab6e81610d17b9611b
+  Keep Gmail semantic-admission indexes deployable (#1571)
+```
+
+Executed receipt:
+
+```text
+run       32279758262
+job       96155475185
+artifact  9375390884
+archive   sha256:85eb9cf53137fb09dbda07f3aa9e6f26c9a294137f21b6c58d4f33eee9b320df
+result    success
+```
+
+## Budget discriminator
+
+### 32,768 bytes
+
+Both ordinary and protected modes retain the full 18-row deduplicated scope history.
+
+```text
+ordinary   18,794 bytes
+protected  18,894 bytes
+```
+
+Protected mode receipts both selected SHAs explicitly.
+
+### 16,000 bytes
+
+The ordinary control still retains the two selected scope rows:
+
+```text
+ordinary
+  serialized_bytes      15,956
+  scope rows             2
+  scope evictions        16
+  selected lessons       both present
+```
+
+Protected mode also keeps both selected rows and spends one nested historical-support example to absorb the explicit protection receipt:
+
+```text
+protected
+  serialized_bytes      15,938
+  scope rows             2
+  scope evictions        16
+  file evictions         historical_support_example x1
+  selected lessons       both present
+```
+
+### 15,750 bytes — positive discriminator
+
+The landed unprotected policy removes all scope history and loses both selected lessons:
+
+```text
+ordinary
+  serialized_bytes      15,575
+  scope rows             0
+  scope evictions        18
+  selected lessons       both absent
+```
+
+The promoted protected policy keeps exactly the selected scope rows:
+
+```text
+protected
+  serialized_bytes      15,721
+  scope rows             2
+  scope evictions        16
+  file evictions         historical_support_example x2
+  selected lessons       both present
+  protected_scope_shas   exact two requested SHAs
+```
+
+This is the executed counterexample to `scope-history age/locality order alone is sufficient for byte eviction`.
+
+### 4,096 bytes — compressed selected floor
+
+The ordinary control fits at 4,044 bytes only by deleting every scope row, including the selected lessons.
+
+Its nested file packet retains two target-history rows after:
+
+```text
+historical_support_example      x16
+historical_counterexample        x8
+historical_companion_relation    x8
+recent_history_summary          x15
+```
+
+Protected mode fits at **3,911 bytes** while preserving both exact selected scope rows and receipts:
+
+```text
+protected
+  serialized_bytes               3911
+  scope rows                         2
+  scope evictions                   16
+  selected lessons                both present
+  target recent-history rows         0
+
+nested file evictions
+  historical_support_example      x16
+  historical_counterexample        x8
+  historical_companion_relation    x8
+  recent_history_summary          x17
+  companion_exclusion_detail       x1
+```
+
+This is the current measured protected selected-evidence floor for the retained replay.
+
+### 3,900 bytes — fail-closed control
+
+The ordinary policy still emits a 3,856-byte packet after losing both selected lessons.
+
+Protected mode refuses to erase selected evidence:
+
+```text
+scoped-agent-context-packet: protected scoped packet evidence requires 3911 bytes, exceeding max_serialized_bytes=3900
+```
+
+The new exact protected floor is therefore 3,911 bytes for this retained case. The earlier #205 comparator measured 3,953 bytes; the promoted wrapper is smaller while retaining an explicit SHA receipt.
+
+## Admission controls
+
+Local compiler tests require:
+
+- exact lowercase 40-hex protected SHAs;
+- duplicate flags canonicalize deterministically;
+- selected SHA must exist after target-history deduplication;
+- unprotected sibling scope rows evict before protected rows;
+- selected core remains present on fail-closed paths;
+- protected output receipts the exact requested SHA set.
+
+The unprotected command path delegates to the original scoped compiler directly, avoiding a parallel default implementation.
+
+## Boundary
+
+- research/compiler promotion only;
+- exact Git SHA identifies the selected evidence object for this execution, not durable semantic lineage;
+- protected refs grant preservation only, not correctness or authority;
+- no automatic scope inference;
+- no automatic evidence selection;
+- no scalar relevance score;
+- no model/provider invocation;
+- no claim that all selected evidence should always fit a caller's byte budget.
+
+North star:
+
+> Once upstream research has explicitly selected exact evidence, byte budgeting may compress around that evidence or fail closed; it may not silently delete the selected evidence.
+
+Refs #67 #106 #125 #137 #139 #158 #182 #186 #189 #191 #196 #197 #205 #238 #280 #281 #282.


### PR DESCRIPTION
Closes #281 by promoting exact upstream-selected scope evidence protection into the existing scoped agent-context compiler.

## Same command, opt-in selected evidence

Ordinary calls keep the merged #191 path verbatim:

```text
cargo run --example scoped_agent_context_packet -- FILE --scope DIR
```

`run_scoped_with_optional_protection()` delegates directly to the original `run_scoped()` whenever no protection flag is present.

Protected mode adds repeated exact refs:

```text
--protect-scope-sha <lowercase-40-hex-sha>
```

Duplicates canonicalize deterministically. Every selected SHA must exist in the admitted scope-history window after target-history deduplication.

## Selection / byte-budget boundary

The compiler does not infer selection from chronology, locality, paths, subjects, or a scalar relevance score.

Protected mode receipts the exact SHA set and uses this pressure order:

```text
unprotected scope rows
-> ordinary nested file-packet semantic detail
-> protected_core_too_large
```

Selected scope rows remain intact while the packet survives. Merged #280 independently guarantees that retained historical relations keep one visible counterexample until the relation itself is evicted.

## Exact Stensibly replay

Pinned external replay:

```text
repository  teamleaderleo/stensibly
revision    85cecf2608ad9e734a67518577fa85b9a08a550c
target      convex/schema.ts
scope       convex
```

Selected exact evidence:

```text
85cecf2608ad9e734a67518577fa85b9a08a550c  #1573
ca5d2c7fdf89666e523972ab6e81610d17b9611b  #1571
```

Executed run:

```text
run       32279758262
job       96155475185
artifact  9375390884
archive   sha256:85eb9cf53137fb09dbda07f3aa9e6f26c9a294137f21b6c58d4f33eee9b320df
result    success
```

Discriminator:

```text
unprotected 16000 -> both lessons present, 15956 bytes
unprotected 15750 -> both lessons lost,    15575 bytes
protected   15750 -> both lessons present, 15721 bytes
protected    4096 -> both lessons present,  3911 bytes
protected    3900 -> fail closed; required protected floor = 3911 bytes
```

At 4 KiB the protected packet retains exactly the two selected scope rows after evicting 16 unprotected scope rows and compressing the nested file packet down to zero target-history summaries. It still receipts both exact selected SHAs.

The machine-readable execution record is described in `research/scoped-selected-evidence-protection-v2.md`; the durable workflow is `.github/workflows/scoped-selected-evidence-replay.yml`.

## Local controls

The additive wrapper tests require:

- exact lowercase 40-hex selected refs;
- deterministic duplicate canonicalization;
- selected SHA exists after target-history dedup;
- protected row survives before an unprotected sibling;
- selected core remains intact on fail-closed paths;
- output receipts the exact selected SHA set.

Ordinary CI on the semantic compiler composition passed run `32279509419` with rustfmt, strict Clippy, full tests, and dogfood.

## Clean checkpoint

Current head:

```text
dad633c909bfaf12fd802abfe2d9da70fcab93fe
```

One connector-authored commit on merged #280, four durable files only:

```text
.github/workflows/scoped-selected-evidence-replay.yml
examples/scoped_agent_context_packet.rs
examples/support/scoped_selected_evidence_impl.rs
research/scoped-selected-evidence-protection-v2.md
```

The temporary repair workflow/trigger are absent. Per #279, merge-view CI plus the external replay are the promotion authority from here.

No automatic evidence selection, scope inference, relevance score, semantic-lineage claim, or authority grant.

Refs #67 #106 #125 #137 #139 #158 #182 #186 #189 #191 #196 #197 #205 #238 #279 #280 #281.