### PR TITLE
research: preserve divergent base lineage in promotion receipts

### DIFF
--- a/examples/promotion_base_lineage.rs
+++ b/examples/promotion_base_lineage.rs
@@ -1,0 +1,27 @@
+#[allow(dead_code)]
+#[path = "../src/promotion_base_lineage.rs"]
+mod promotion_base_lineage;
+#[allow(dead_code)]
+#[path = "../src/promotion_receipt.rs"]
+mod promotion_receipt;
+
+use std::error::Error;
+use std::io::{self, Read};
+
+use promotion_base_lineage::{PromotionBaseLineageRequest, evaluate_promotion_base_lineage};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("promotion-base-lineage: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin().read_to_end(&mut bytes)?;
+    let request: PromotionBaseLineageRequest = serde_json::from_slice(&bytes)?;
+    let evaluation = evaluate_promotion_base_lineage(&request)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}

--- a/research/promotion-base-lineage.md
+++ b/research/promotion-base-lineage.md
@@ -1,0 +1,249 @@
+# Promotion base-lineage receipts
+
+Tracking: #278. Child of merged #284 promotion receipt reuse.
+
+## Trigger
+
+The first complete historical reconstruction of #194 exposed a case the initial forward-range model cannot honestly represent.
+
+Early successful merge-view receipt:
+
+```text
+run          32249440070
+branch head  b54ed3213994c96ec818ef36bb9728b0dc1f7eb6
+base         a6026e084ae6f1d88e8d7f2322473872f82c3278
+```
+
+Final exact-main run:
+
+```text
+run          32269578803
+branch head  6706755e434a9bb533d77655587b01cbdd3fa1e8
+base         0c7da4f3ad148c4d14bce127c75cfe4b03b658c8
+```
+
+The two bases diverge at:
+
+```text
+c2133131038f33a98f7bc7d206ca6e4284be420a
+```
+
+with:
+
+```text
+tested-base-only commits   4
+current-base-only commits 34
+```
+
+A single forward `intervening_commits[]` list would erase which side owned a changed object.
+
+## Two kinds of divergent evidence
+
+This child keeps merged #284's `PromotionReceiptRequest` as the branch/check identity object and adds two independent base-compatibility receipts.
+
+### 1. Complete base-range path receipts
+
+```text
+merge_base_sha
+base_path_receipts_complete = true
+
+tested_base_only?
+  base_sha
+  head_sha
+  commit_count
+  changed_paths[]
+
+current_base_only?
+  base_sha
+  head_sha
+  commit_count
+  changed_paths[]
+```
+
+The derived relation is:
+
+```text
+same_tree
+forward
+rewind
+diverged
+```
+
+Range endpoints bind the declared common ancestor to the exact tested/current base commits. When base trees differ, `base_path_receipts_complete=true` is mandatory caller evidence that the supplied compare-range path inventories are complete. A changed-base request without that attestation rejects before promotion interpretation.
+
+Range paths answer one bounded question in v0:
+
+> Did either base lineage side touch a path owned by the branch change set itself?
+
+Every branch-path overlap preserves its side:
+
+```text
+tested_base_only | current_base_only
+range_head_sha
+changed_path
+declared_path
+kind = branch_path
+```
+
+### 2. Exact endpoint compatibility-object receipts
+
+Consumed contracts and applicable policy gates use exact tested/current Git object identity instead of merge-base changed-path union:
+
+```text
+compatibility_objects[]
+  path
+  kind = consumed_contract | applicable_policy
+  tested_object_sha?
+  current_object_sha?
+```
+
+The object list must exactly cover every declared:
+
+```text
+promotion.consumed_contract_paths[]
+promotion.applicable_policy_paths[]
+```
+
+A state may have one missing endpoint to represent an added or removed object. At least one endpoint must exist. Equal base trees cannot claim different compatibility-object identities.
+
+A compatibility object changes only when:
+
+```text
+tested_object_sha != current_object_sha
+```
+
+This distinction is necessary under divergent ancestry. The same file may appear in both merge-base delta path sets because each side independently carried it, while the final tested/current objects are still byte-identical.
+
+## Decision priority
+
+The disposition remains compatible with merged #284:
+
+```text
+conflict / nonmergeable
+change-set fingerprint changed
+exact effective merge-tree identity
+same base tree
+branch-owned path collision OR endpoint compatibility-object change
+complete compatibility scope with no relevant change
+semantic independence UNKNOWN
+```
+
+Exact effective merge-tree identity remains the strongest receipt and can transfer across divergent ancestry. Otherwise:
+
+```text
+branch path collision
+  -> rerun_required / branch_path_overlap
+
+changed consumed endpoint object
+  -> rerun_required / consumed_contract_overlap
+
+changed policy endpoint object
+  -> rerun_required / applicable_policy_overlap
+```
+
+A divergent changed-path occurrence alone cannot claim a contract/policy change; endpoint object identity owns that judgment.
+
+## First real #194 finding
+
+The #194 branch compatibility payload remained byte-equivalent across the reanchor.
+
+Its direct consumed discriminator contract remained exact across both base endpoints:
+
+```text
+src/discriminator_observation.rs
+
+tested base a6026e08...
+  6f370c3ba20ebb7220c8c075f2c2df56f650fd83
+
+current base 0c7da4f3...
+  6f370c3ba20ebb7220c8c075f2c2df56f650fd83
+```
+
+That path also appears in both divergent compare ranges. Endpoint identity proves the contract itself stayed unchanged.
+
+The applicable CI policy changed:
+
+```text
+.github/workflows/ci.yml
+
+tested base
+  26c4f3e3b4dc68bc5e166c72eab394a6548c9ceb
+
+current base
+  7e1f1b966fcd1e45930d0ff12a68532cba802502
+```
+
+So the final #194 rerun was justified by an actual compatibility input change:
+
+```text
+same branch compatibility payload
++ same consumed discriminator contract
++ changed applicable CI policy
+-> rerun_required
+  reason = applicable_policy_overlap
+```
+
+The evidence does not reduce to `main moved`.
+
+## Controls
+
+`tests/promotion_base_lineage.rs` covers:
+
+- divergent disjoint base delta + unchanged endpoint compatibility objects -> `inspect_semantic_overlap`;
+- the same contract path touched on both divergent sides with equal endpoint object IDs -> no false contract-change reason;
+- changed policy endpoint object -> rerun for policy only;
+- removed tested-side consumed contract -> rerun for consumed contract;
+- actual branch-owned path collision -> rerun and preserve divergent side;
+- explicitly complete compatibility scope + no relevant change -> reusable;
+- exact effective merge-tree identity -> reusable even when endpoint object changes remain visible;
+- explicit forward and rewind relations;
+- equal base trees require equal compatibility-object receipts;
+- compatibility-object list must exactly cover declared contracts/policies;
+- incomplete changed-base path receipt attestation -> reject;
+- range endpoint mismatch -> reject.
+
+## Reader
+
+```text
+cargo run --example promotion_base_lineage < request.json
+```
+
+The reader is pure evaluation. A later GitHub adapter can collect:
+
+```text
+Actions merge-view tested/current base commits
+GitHub compare merge-base + side ranges
+complete changed-path inventories
+exact contract/policy object IDs at both endpoints
+canonical branch change-set fingerprints
+```
+
+## Next dogfood
+
+#201 remains the next retained target. Its one-file compatibility payload is already proven byte-identical across retained early/final heads. A complete historical classification requires exact later one-file merge-view receipts rather than treating the earlier stacked #194 child as a current-main rerun.
+
+After enough retained cases, #278 can report:
+
+```text
+receipt_reusable count
+rerun_required count + exact reasons
+inspect_semantic_overlap count
+```
+
+without crediting path disjointness or ancestry churn as proof.
+
+## Boundary
+
+- research only;
+- exact compare-range receipts, no invented commit story;
+- complete range-path attestation is explicit caller evidence;
+- compatibility object identity is exact Git object identity, not semantic equivalence;
+- complete compatibility scope remains explicit caller evidence;
+- no merge/rebase/rerun side effect;
+- no automatic use of commit ancestry as semantic authority.
+
+North star:
+
+> Preserve both sides of a rewritten base, compare the exact compatibility objects that reached each endpoint, and rerun only when a compatibility input actually changed or remains unresolved.
+
+Refs #96 #137 #194 #201 #278 #279 #284.

--- a/src/promotion_base_lineage.rs
+++ b/src/promotion_base_lineage.rs
@@ -1,0 +1,505 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::promotion_receipt::{
+    InterveningCommit, PromotionPathOverlapKind, PromotionReceiptDisposition,
+    PromotionReceiptReason, PromotionReceiptRequest, evaluate_promotion_receipt,
+};
+
+pub const PROMOTION_BASE_LINEAGE_SCHEMA_VERSION: u32 = 1;
+const MAX_RANGE_COMMITS: usize = 4096;
+const MAX_COMPATIBILITY_OBJECTS: usize = 4096;
+const GIT_SHA_HEX_BYTES: usize = 40;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PromotionBaseLineageRequest {
+    pub schema_version: u32,
+    pub promotion: PromotionReceiptRequest,
+    pub merge_base_sha: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tested_base_only: Option<PromotionBaseRange>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_base_only: Option<PromotionBaseRange>,
+    pub compatibility_objects: Vec<PromotionCompatibilityObjectState>,
+    pub base_path_receipts_complete: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PromotionBaseRange {
+    pub base_sha: String,
+    pub head_sha: String,
+    pub commit_count: usize,
+    pub changed_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromotionBaseRelation {
+    SameTree,
+    Forward,
+    Rewind,
+    Diverged,
+}
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromotionBaseDeltaSide {
+    TestedBaseOnly,
+    CurrentBaseOnly,
+}
+
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PromotionBasePathOverlap {
+    pub side: PromotionBaseDeltaSide,
+    pub range_head_sha: String,
+    pub changed_path: String,
+    pub declared_path: String,
+    pub kind: PromotionPathOverlapKind,
+}
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromotionCompatibilityObjectKind {
+    ConsumedContract,
+    ApplicablePolicy,
+}
+
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PromotionCompatibilityObjectState {
+    pub path: String,
+    pub kind: PromotionCompatibilityObjectKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tested_object_sha: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_object_sha: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PromotionCompatibilityObjectChange {
+    pub path: String,
+    pub kind: PromotionCompatibilityObjectKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tested_object_sha: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_object_sha: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PromotionBaseLineageEvaluation {
+    pub schema_version: u32,
+    pub base_relation: PromotionBaseRelation,
+    pub disposition: PromotionReceiptDisposition,
+    pub reasons: Vec<PromotionReceiptReason>,
+    pub merge_base_sha: String,
+    pub tested_base_sha: String,
+    pub tested_base_tree_sha: String,
+    pub current_base_sha: String,
+    pub current_base_tree_sha: String,
+    pub tested_change_set_sha256: String,
+    pub current_change_set_sha256: String,
+    pub successful_check_refs: Vec<String>,
+    pub tested_base_only: Option<PromotionBaseRange>,
+    pub current_base_only: Option<PromotionBaseRange>,
+    pub branch_path_overlaps: Vec<PromotionBasePathOverlap>,
+    pub compatibility_objects: Vec<PromotionCompatibilityObjectState>,
+    pub compatibility_changes: Vec<PromotionCompatibilityObjectChange>,
+    pub base_path_receipts_complete: bool,
+    pub compatibility_scope_complete: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct PromotionBaseLineageError {
+    message: String,
+}
+
+impl PromotionBaseLineageError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for PromotionBaseLineageError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for PromotionBaseLineageError {}
+
+pub fn evaluate_promotion_base_lineage(
+    request: &PromotionBaseLineageRequest,
+) -> Result<PromotionBaseLineageEvaluation, PromotionBaseLineageError> {
+    let relation = validate_request(request)?;
+    let mut branch_path_overlaps = collect_branch_path_overlaps(request);
+    branch_path_overlaps.sort();
+    branch_path_overlaps.dedup();
+    let compatibility_changes = collect_compatibility_changes(request);
+
+    let promotion = &request.promotion;
+    let mut reasons = Vec::new();
+    let disposition = if promotion.current.conflict {
+        reasons.push(PromotionReceiptReason::MergeConflict);
+        PromotionReceiptDisposition::RerunRequired
+    } else if !promotion.current.mergeable {
+        reasons.push(PromotionReceiptReason::NotMergeable);
+        PromotionReceiptDisposition::RerunRequired
+    } else if promotion.tested.change_set_sha256 != promotion.current.change_set_sha256 {
+        reasons.push(PromotionReceiptReason::ChangeSetChanged);
+        PromotionReceiptDisposition::RerunRequired
+    } else if promotion.tested.effective_merge_tree_sha
+        == promotion.current.effective_merge_tree_sha
+    {
+        reasons.push(PromotionReceiptReason::ExactEffectiveMergeTreeIdentity);
+        PromotionReceiptDisposition::ReceiptReusable
+    } else if promotion.tested.base_tree_sha == promotion.current.base_tree_sha {
+        reasons.push(PromotionReceiptReason::EquivalentChangeSetSameBaseTree);
+        PromotionReceiptDisposition::ReceiptReusable
+    } else if !branch_path_overlaps.is_empty() || !compatibility_changes.is_empty() {
+        if !branch_path_overlaps.is_empty() {
+            reasons.push(PromotionReceiptReason::BranchPathOverlap);
+        }
+        if compatibility_changes
+            .iter()
+            .any(|change| change.kind == PromotionCompatibilityObjectKind::ConsumedContract)
+        {
+            reasons.push(PromotionReceiptReason::ConsumedContractOverlap);
+        }
+        if compatibility_changes
+            .iter()
+            .any(|change| change.kind == PromotionCompatibilityObjectKind::ApplicablePolicy)
+        {
+            reasons.push(PromotionReceiptReason::ApplicablePolicyOverlap);
+        }
+        PromotionReceiptDisposition::RerunRequired
+    } else if promotion.compatibility_scope_complete {
+        reasons.push(PromotionReceiptReason::CompleteCompatibilityScopeNoRelevantChange);
+        PromotionReceiptDisposition::ReceiptReusable
+    } else {
+        reasons.push(PromotionReceiptReason::SemanticIndependenceUnknown);
+        PromotionReceiptDisposition::InspectSemanticOverlap
+    };
+    reasons.sort();
+    reasons.dedup();
+
+    Ok(PromotionBaseLineageEvaluation {
+        schema_version: PROMOTION_BASE_LINEAGE_SCHEMA_VERSION,
+        base_relation: relation,
+        disposition,
+        reasons,
+        merge_base_sha: request.merge_base_sha.clone(),
+        tested_base_sha: promotion.tested.base_sha.clone(),
+        tested_base_tree_sha: promotion.tested.base_tree_sha.clone(),
+        current_base_sha: promotion.current.base_sha.clone(),
+        current_base_tree_sha: promotion.current.base_tree_sha.clone(),
+        tested_change_set_sha256: promotion.tested.change_set_sha256.clone(),
+        current_change_set_sha256: promotion.current.change_set_sha256.clone(),
+        successful_check_refs: promotion.tested.successful_check_refs.clone(),
+        tested_base_only: request.tested_base_only.clone(),
+        current_base_only: request.current_base_only.clone(),
+        branch_path_overlaps,
+        compatibility_objects: request.compatibility_objects.clone(),
+        compatibility_changes,
+        base_path_receipts_complete: request.base_path_receipts_complete,
+        compatibility_scope_complete: promotion.compatibility_scope_complete,
+    })
+}
+
+fn validate_request(
+    request: &PromotionBaseLineageRequest,
+) -> Result<PromotionBaseRelation, PromotionBaseLineageError> {
+    if request.schema_version != PROMOTION_BASE_LINEAGE_SCHEMA_VERSION {
+        return Err(PromotionBaseLineageError::new(format!(
+            "unsupported promotion base-lineage schema {}; expected {PROMOTION_BASE_LINEAGE_SCHEMA_VERSION}",
+            request.schema_version
+        )));
+    }
+    validate_git_sha(&request.merge_base_sha, "merge_base_sha")?;
+    if !request.promotion.intervening_commits.is_empty() {
+        return Err(PromotionBaseLineageError::new(
+            "base-lineage request owns base delta receipts; promotion.intervening_commits must be empty",
+        ));
+    }
+
+    validate_compatibility_objects(request)?;
+    if request.promotion.tested.base_tree_sha != request.promotion.current.base_tree_sha
+        && !request.base_path_receipts_complete
+    {
+        return Err(PromotionBaseLineageError::new(
+            "changed base lineage requires complete base-range changed-path receipts",
+        ));
+    }
+
+    let relation =
+        if request.promotion.tested.base_tree_sha == request.promotion.current.base_tree_sha {
+            if request.tested_base_only.is_some() || request.current_base_only.is_some() {
+                return Err(PromotionBaseLineageError::new(
+                    "equal base trees must not carry base-only range receipts",
+                ));
+            }
+            if request
+                .compatibility_objects
+                .iter()
+                .any(|state| state.tested_object_sha != state.current_object_sha)
+            {
+                return Err(PromotionBaseLineageError::new(
+                    "equal base trees cannot carry changed compatibility-object receipts",
+                ));
+            }
+            PromotionBaseRelation::SameTree
+        } else {
+            match (&request.tested_base_only, &request.current_base_only) {
+                (None, Some(current)) => {
+                    validate_range(
+                        current,
+                        &request.merge_base_sha,
+                        &request.promotion.current.base_sha,
+                        "current_base_only",
+                    )?;
+                    if request.merge_base_sha != request.promotion.tested.base_sha {
+                        return Err(PromotionBaseLineageError::new(
+                            "forward base lineage requires merge_base_sha to equal tested base_sha",
+                        ));
+                    }
+                    PromotionBaseRelation::Forward
+                }
+                (Some(tested), None) => {
+                    validate_range(
+                        tested,
+                        &request.merge_base_sha,
+                        &request.promotion.tested.base_sha,
+                        "tested_base_only",
+                    )?;
+                    if request.merge_base_sha != request.promotion.current.base_sha {
+                        return Err(PromotionBaseLineageError::new(
+                            "rewind base lineage requires merge_base_sha to equal current base_sha",
+                        ));
+                    }
+                    PromotionBaseRelation::Rewind
+                }
+                (Some(tested), Some(current)) => {
+                    validate_range(
+                        tested,
+                        &request.merge_base_sha,
+                        &request.promotion.tested.base_sha,
+                        "tested_base_only",
+                    )?;
+                    validate_range(
+                        current,
+                        &request.merge_base_sha,
+                        &request.promotion.current.base_sha,
+                        "current_base_only",
+                    )?;
+                    PromotionBaseRelation::Diverged
+                }
+                (None, None) => {
+                    return Err(PromotionBaseLineageError::new(
+                        "changed base trees require a forward, rewind, or divergent range receipt",
+                    ));
+                }
+            }
+        };
+
+    let mut synthetic = request.promotion.clone();
+    if let Some(range) = &request.tested_base_only {
+        synthetic.intervening_commits.push(InterveningCommit {
+            sha: range.head_sha.clone(),
+            changed_paths: range.changed_paths.clone(),
+        });
+    }
+    if let Some(range) = &request.current_base_only {
+        synthetic.intervening_commits.push(InterveningCommit {
+            sha: range.head_sha.clone(),
+            changed_paths: range.changed_paths.clone(),
+        });
+    }
+    evaluate_promotion_receipt(&synthetic).map_err(|error| {
+        PromotionBaseLineageError::new(format!("promotion receipt validation failed: {error}"))
+    })?;
+
+    Ok(relation)
+}
+
+fn validate_compatibility_objects(
+    request: &PromotionBaseLineageRequest,
+) -> Result<(), PromotionBaseLineageError> {
+    if request.compatibility_objects.len() > MAX_COMPATIBILITY_OBJECTS {
+        return Err(PromotionBaseLineageError::new(
+            "compatibility_objects exceeds the admitted bound",
+        ));
+    }
+
+    let expected = request
+        .promotion
+        .consumed_contract_paths
+        .iter()
+        .map(|path| {
+            (
+                path.as_str(),
+                PromotionCompatibilityObjectKind::ConsumedContract,
+            )
+        })
+        .chain(
+            request
+                .promotion
+                .applicable_policy_paths
+                .iter()
+                .map(|path| {
+                    (
+                        path.as_str(),
+                        PromotionCompatibilityObjectKind::ApplicablePolicy,
+                    )
+                }),
+        )
+        .collect::<BTreeSet<_>>();
+
+    let mut observed = BTreeSet::new();
+    for state in &request.compatibility_objects {
+        let key = (state.path.as_str(), state.kind);
+        if !expected.contains(&key) {
+            return Err(PromotionBaseLineageError::new(format!(
+                "unexpected compatibility-object receipt for {}",
+                state.path
+            )));
+        }
+        if !observed.insert(key) {
+            return Err(PromotionBaseLineageError::new(format!(
+                "duplicate compatibility-object receipt for {}",
+                state.path
+            )));
+        }
+        if state.tested_object_sha.is_none() && state.current_object_sha.is_none() {
+            return Err(PromotionBaseLineageError::new(format!(
+                "compatibility-object receipt {} must exist on at least one base",
+                state.path
+            )));
+        }
+        if let Some(sha) = &state.tested_object_sha {
+            validate_git_sha(sha, "compatibility_object.tested_object_sha")?;
+        }
+        if let Some(sha) = &state.current_object_sha {
+            validate_git_sha(sha, "compatibility_object.current_object_sha")?;
+        }
+    }
+
+    if observed != expected {
+        return Err(PromotionBaseLineageError::new(
+            "compatibility_objects must exactly cover every declared consumed contract and applicable policy path",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_range(
+    range: &PromotionBaseRange,
+    expected_base_sha: &str,
+    expected_head_sha: &str,
+    field: &str,
+) -> Result<(), PromotionBaseLineageError> {
+    validate_git_sha(&range.base_sha, &format!("{field}.base_sha"))?;
+    validate_git_sha(&range.head_sha, &format!("{field}.head_sha"))?;
+    if range.base_sha != expected_base_sha || range.head_sha != expected_head_sha {
+        return Err(PromotionBaseLineageError::new(format!(
+            "{field} must bind the declared merge base to the exact corresponding promotion base"
+        )));
+    }
+    if range.commit_count == 0 || range.commit_count > MAX_RANGE_COMMITS {
+        return Err(PromotionBaseLineageError::new(format!(
+            "{field}.commit_count must be within the admitted non-empty bound"
+        )));
+    }
+    Ok(())
+}
+
+fn collect_branch_path_overlaps(
+    request: &PromotionBaseLineageRequest,
+) -> Vec<PromotionBasePathOverlap> {
+    let mut overlaps = Vec::new();
+    if let Some(range) = &request.tested_base_only {
+        collect_range_branch_overlaps(
+            &mut overlaps,
+            PromotionBaseDeltaSide::TestedBaseOnly,
+            range,
+            &request.promotion.branch_changed_paths,
+        );
+    }
+    if let Some(range) = &request.current_base_only {
+        collect_range_branch_overlaps(
+            &mut overlaps,
+            PromotionBaseDeltaSide::CurrentBaseOnly,
+            range,
+            &request.promotion.branch_changed_paths,
+        );
+    }
+    overlaps
+}
+
+fn collect_range_branch_overlaps(
+    overlaps: &mut Vec<PromotionBasePathOverlap>,
+    side: PromotionBaseDeltaSide,
+    range: &PromotionBaseRange,
+    branch_changed_paths: &[String],
+) {
+    for changed_path in &range.changed_paths {
+        for declared_path in branch_changed_paths {
+            if paths_overlap(changed_path, declared_path) {
+                overlaps.push(PromotionBasePathOverlap {
+                    side,
+                    range_head_sha: range.head_sha.clone(),
+                    changed_path: changed_path.clone(),
+                    declared_path: declared_path.clone(),
+                    kind: PromotionPathOverlapKind::BranchPath,
+                });
+            }
+        }
+    }
+}
+
+fn collect_compatibility_changes(
+    request: &PromotionBaseLineageRequest,
+) -> Vec<PromotionCompatibilityObjectChange> {
+    request
+        .compatibility_objects
+        .iter()
+        .filter(|state| state.tested_object_sha != state.current_object_sha)
+        .map(|state| PromotionCompatibilityObjectChange {
+            path: state.path.clone(),
+            kind: state.kind,
+            tested_object_sha: state.tested_object_sha.clone(),
+            current_object_sha: state.current_object_sha.clone(),
+        })
+        .collect()
+}
+
+fn paths_overlap(left: &str, right: &str) -> bool {
+    left == right
+        || left
+            .strip_prefix(right)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+        || right
+            .strip_prefix(left)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+fn validate_git_sha(value: &str, field: &str) -> Result<(), PromotionBaseLineageError> {
+    if value.len() != GIT_SHA_HEX_BYTES
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(PromotionBaseLineageError::new(format!(
+            "{field} must be an exact lowercase 40-hex Git object id"
+        )));
+    }
+    Ok(())
+}

--- a/tests/promotion_base_lineage.rs
+++ b/tests/promotion_base_lineage.rs
@@ -1,0 +1,360 @@
+#[allow(dead_code)]
+#[path = "../src/promotion_base_lineage.rs"]
+mod promotion_base_lineage;
+#[allow(dead_code)]
+#[path = "../src/promotion_receipt.rs"]
+mod promotion_receipt;
+
+use promotion_base_lineage::{
+    PROMOTION_BASE_LINEAGE_SCHEMA_VERSION, PromotionBaseDeltaSide, PromotionBaseLineageRequest,
+    PromotionBaseRange, PromotionBaseRelation, PromotionCompatibilityObjectKind,
+    PromotionCompatibilityObjectState, evaluate_promotion_base_lineage,
+};
+use promotion_receipt::{
+    CurrentPromotionState, PROMOTION_RECEIPT_SCHEMA_VERSION, PromotionPathOverlapKind,
+    PromotionReceiptDisposition, PromotionReceiptReason, PromotionReceiptRequest,
+    TestedPromotionState,
+};
+
+fn sha(byte: char) -> String {
+    std::iter::repeat_n(byte, 40).collect()
+}
+
+fn digest(byte: char) -> String {
+    format!(
+        "sha256:{}",
+        std::iter::repeat_n(byte, 64).collect::<String>()
+    )
+}
+
+fn object_state(
+    path: &str,
+    kind: PromotionCompatibilityObjectKind,
+    tested: Option<&str>,
+    current: Option<&str>,
+) -> PromotionCompatibilityObjectState {
+    PromotionCompatibilityObjectState {
+        path: path.to_string(),
+        kind,
+        tested_object_sha: tested.map(str::to_string),
+        current_object_sha: current.map(str::to_string),
+    }
+}
+
+fn promotion() -> PromotionReceiptRequest {
+    PromotionReceiptRequest {
+        schema_version: PROMOTION_RECEIPT_SCHEMA_VERSION,
+        tested: TestedPromotionState {
+            head_sha: sha('a'),
+            tree_sha: sha('b'),
+            change_set_sha256: digest('a'),
+            base_sha: sha('c'),
+            base_tree_sha: sha('d'),
+            effective_merge_tree_sha: sha('e'),
+            successful_check_refs: vec!["github-actions:ci/tested".to_string()],
+        },
+        current: CurrentPromotionState {
+            head_sha: sha('f'),
+            tree_sha: sha('1'),
+            change_set_sha256: digest('a'),
+            base_sha: sha('2'),
+            base_tree_sha: sha('3'),
+            effective_merge_tree_sha: sha('4'),
+            mergeable: true,
+            conflict: false,
+        },
+        branch_changed_paths: vec!["src/feature.rs".to_string()],
+        consumed_contract_paths: vec!["src/contracts".to_string()],
+        applicable_policy_paths: vec![".github/workflows/ci.yml".to_string()],
+        intervening_commits: Vec::new(),
+        compatibility_scope_complete: false,
+    }
+}
+
+fn unchanged_objects() -> Vec<PromotionCompatibilityObjectState> {
+    vec![
+        object_state(
+            "src/contracts",
+            PromotionCompatibilityObjectKind::ConsumedContract,
+            Some(&sha('6')),
+            Some(&sha('6')),
+        ),
+        object_state(
+            ".github/workflows/ci.yml",
+            PromotionCompatibilityObjectKind::ApplicablePolicy,
+            Some(&sha('7')),
+            Some(&sha('7')),
+        ),
+    ]
+}
+
+fn divergent() -> PromotionBaseLineageRequest {
+    PromotionBaseLineageRequest {
+        schema_version: PROMOTION_BASE_LINEAGE_SCHEMA_VERSION,
+        promotion: promotion(),
+        merge_base_sha: sha('5'),
+        tested_base_only: Some(PromotionBaseRange {
+            base_sha: sha('5'),
+            head_sha: sha('c'),
+            commit_count: 4,
+            changed_paths: vec!["docs/old-only.md".to_string()],
+        }),
+        current_base_only: Some(PromotionBaseRange {
+            base_sha: sha('5'),
+            head_sha: sha('2'),
+            commit_count: 34,
+            changed_paths: vec!["docs/current-only.md".to_string()],
+        }),
+        compatibility_objects: unchanged_objects(),
+        base_path_receipts_complete: true,
+    }
+}
+
+#[test]
+fn divergent_disjoint_base_delta_preserves_unknown_semantic_independence() {
+    let request = divergent();
+    let evaluation = evaluate_promotion_base_lineage(&request).unwrap();
+
+    assert_eq!(evaluation.base_relation, PromotionBaseRelation::Diverged);
+    assert_eq!(
+        evaluation.disposition,
+        PromotionReceiptDisposition::InspectSemanticOverlap
+    );
+    assert_eq!(
+        evaluation.reasons,
+        vec![PromotionReceiptReason::SemanticIndependenceUnknown]
+    );
+    assert!(evaluation.branch_path_overlaps.is_empty());
+    assert!(evaluation.compatibility_changes.is_empty());
+    assert_eq!(
+        evaluation.tested_base_only.as_ref().unwrap().commit_count,
+        4
+    );
+    assert_eq!(
+        evaluation.current_base_only.as_ref().unwrap().commit_count,
+        34
+    );
+}
+
+#[test]
+fn identical_endpoint_contract_is_not_changed_just_because_both_sides_touched_path() {
+    let mut request = divergent();
+    request.tested_base_only.as_mut().unwrap().changed_paths =
+        vec!["src/contracts/schema.rs".to_string()];
+    request.current_base_only.as_mut().unwrap().changed_paths =
+        vec!["src/contracts/schema.rs".to_string()];
+
+    let evaluation = evaluate_promotion_base_lineage(&request).unwrap();
+    assert_eq!(
+        evaluation.disposition,
+        PromotionReceiptDisposition::InspectSemanticOverlap
+    );
+    assert!(evaluation.compatibility_changes.is_empty());
+    assert!(evaluation.branch_path_overlaps.is_empty());
+}
+
+#[test]
+fn policy_endpoint_change_requires_rerun_without_false_contract_reason() {
+    let mut request = divergent();
+    let policy = request
+        .compatibility_objects
+        .iter_mut()
+        .find(|state| state.kind == PromotionCompatibilityObjectKind::ApplicablePolicy)
+        .unwrap();
+    policy.current_object_sha = Some(sha('8'));
+
+    let evaluation = evaluate_promotion_base_lineage(&request).unwrap();
+    assert_eq!(evaluation.base_relation, PromotionBaseRelation::Diverged);
+    assert_eq!(
+        evaluation.disposition,
+        PromotionReceiptDisposition::RerunRequired
+    );
+    assert_eq!(
+        evaluation.reasons,
+        vec![PromotionReceiptReason::ApplicablePolicyOverlap]
+    );
+    assert_eq!(evaluation.compatibility_changes.len(), 1);
+    assert_eq!(
+        evaluation.compatibility_changes[0].kind,
+        PromotionCompatibilityObjectKind::ApplicablePolicy
+    );
+}
+
+#[test]
+fn removed_tested_side_consumed_contract_requires_rerun() {
+    let mut request = divergent();
+    let contract = request
+        .compatibility_objects
+        .iter_mut()
+        .find(|state| state.kind == PromotionCompatibilityObjectKind::ConsumedContract)
+        .unwrap();
+    contract.current_object_sha = None;
+
+    let evaluation = evaluate_promotion_base_lineage(&request).unwrap();
+    assert_eq!(
+        evaluation.disposition,
+        PromotionReceiptDisposition::RerunRequired
+    );
+    assert_eq!(
+        evaluation.reasons,
+        vec![PromotionReceiptReason::ConsumedContractOverlap]
+    );
+    assert_eq!(evaluation.compatibility_changes.len(), 1);
+}
+
+#[test]
+fn branch_path_collision_still_uses_divergent_range_receipt() {
+    let mut request = divergent();
+    request.current_base_only.as_mut().unwrap().changed_paths = vec!["src/feature.rs".to_string()];
+
+    let evaluation = evaluate_promotion_base_lineage(&request).unwrap();
+    assert_eq!(
+        evaluation.disposition,
+        PromotionReceiptDisposition::RerunRequired
+    );
+    assert_eq!(
+        evaluation.reasons,
+        vec![PromotionReceiptReason::BranchPathOverlap]
+    );
+    assert_eq!(evaluation.branch_path_overlaps.len(), 1);
+    assert_eq!(
+        evaluation.branch_path_overlaps[0].side,
+        PromotionBaseDeltaSide::CurrentBaseOnly
+    );
+    assert_eq!(
+        evaluation.branch_path_overlaps[0].kind,
+        PromotionPathOverlapKind::BranchPath
+    );
+}
+
+#[test]
+fn complete_compatibility_scope_can_reuse_divergent_disjoint_base() {
+    let mut request = divergent();
+    request.promotion.compatibility_scope_complete = true;
+
+    let evaluation = evaluate_promotion_base_lineage(&request).unwrap();
+    assert_eq!(evaluation.base_relation, PromotionBaseRelation::Diverged);
+    assert_eq!(
+        evaluation.disposition,
+        PromotionReceiptDisposition::ReceiptReusable
+    );
+    assert_eq!(
+        evaluation.reasons,
+        vec![PromotionReceiptReason::CompleteCompatibilityScopeNoRelevantChange]
+    );
+}
+
+#[test]
+fn exact_effective_merge_tree_identity_overrides_endpoint_policy_change() {
+    let mut request = divergent();
+    request.promotion.current.effective_merge_tree_sha =
+        request.promotion.tested.effective_merge_tree_sha.clone();
+    let policy = request
+        .compatibility_objects
+        .iter_mut()
+        .find(|state| state.kind == PromotionCompatibilityObjectKind::ApplicablePolicy)
+        .unwrap();
+    policy.current_object_sha = Some(sha('8'));
+
+    let evaluation = evaluate_promotion_base_lineage(&request).unwrap();
+    assert_eq!(
+        evaluation.disposition,
+        PromotionReceiptDisposition::ReceiptReusable
+    );
+    assert_eq!(
+        evaluation.reasons,
+        vec![PromotionReceiptReason::ExactEffectiveMergeTreeIdentity]
+    );
+    assert_eq!(evaluation.compatibility_changes.len(), 1);
+}
+
+#[test]
+fn forward_and_rewind_relations_are_explicit() {
+    let mut forward = PromotionBaseLineageRequest {
+        schema_version: PROMOTION_BASE_LINEAGE_SCHEMA_VERSION,
+        promotion: promotion(),
+        merge_base_sha: sha('c'),
+        tested_base_only: None,
+        current_base_only: Some(PromotionBaseRange {
+            base_sha: sha('c'),
+            head_sha: sha('2'),
+            commit_count: 3,
+            changed_paths: vec!["docs/forward.md".to_string()],
+        }),
+        compatibility_objects: unchanged_objects(),
+        base_path_receipts_complete: true,
+    };
+    let evaluation = evaluate_promotion_base_lineage(&forward).unwrap();
+    assert_eq!(evaluation.base_relation, PromotionBaseRelation::Forward);
+
+    forward.promotion.tested.base_sha = sha('6');
+    forward.promotion.current.base_sha = sha('c');
+    forward.merge_base_sha = sha('c');
+    forward.current_base_only = None;
+    forward.tested_base_only = Some(PromotionBaseRange {
+        base_sha: sha('c'),
+        head_sha: sha('6'),
+        commit_count: 2,
+        changed_paths: vec!["docs/rewind.md".to_string()],
+    });
+    let evaluation = evaluate_promotion_base_lineage(&forward).unwrap();
+    assert_eq!(evaluation.base_relation, PromotionBaseRelation::Rewind);
+}
+
+#[test]
+fn equal_base_trees_are_same_tree_and_require_equal_compatibility_objects() {
+    let mut request = divergent();
+    request.promotion.current.base_tree_sha = request.promotion.tested.base_tree_sha.clone();
+    request.tested_base_only = None;
+    request.current_base_only = None;
+    let evaluation = evaluate_promotion_base_lineage(&request).unwrap();
+    assert_eq!(evaluation.base_relation, PromotionBaseRelation::SameTree);
+    assert_eq!(
+        evaluation.disposition,
+        PromotionReceiptDisposition::ReceiptReusable
+    );
+
+    let policy = request
+        .compatibility_objects
+        .iter_mut()
+        .find(|state| state.kind == PromotionCompatibilityObjectKind::ApplicablePolicy)
+        .unwrap();
+    policy.current_object_sha = Some(sha('8'));
+    assert!(evaluate_promotion_base_lineage(&request).is_err());
+}
+
+#[test]
+fn compatibility_object_receipts_must_exactly_cover_declared_contracts_and_policies() {
+    let mut request = divergent();
+    request.compatibility_objects.pop();
+    let error = evaluate_promotion_base_lineage(&request).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("must exactly cover every declared consumed contract")
+    );
+}
+
+#[test]
+fn changed_base_lineage_rejects_incomplete_path_receipt_attestation() {
+    let mut request = divergent();
+    request.base_path_receipts_complete = false;
+    let error = evaluate_promotion_base_lineage(&request).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("requires complete base-range changed-path receipts")
+    );
+}
+
+#[test]
+fn range_endpoints_must_bind_exact_declared_bases() {
+    let mut request = divergent();
+    request.current_base_only.as_mut().unwrap().head_sha = sha('7');
+    let error = evaluate_promotion_base_lineage(&request).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("exact corresponding promotion base")
+    );
+}


### PR DESCRIPTION
Progresses #278 as the divergence-aware child of merged #284.

## Trigger from real #194 history

#194's early successful merge-view run `32249440070` used branch head `b54ed321...` on base `a6026e08...`. Final run `32269578803` used head `6706755e...` on base `0c7da4f3...`.

Those bases diverge at `c213313...`:

```text
tested-base-only commits   4
current-base-only commits 34
```

A one-way intervening-commit list cannot represent that ancestry honestly.

## Two compatibility receipts

### Complete base-range paths

```text
merge_base_sha
base_path_receipts_complete = true

tested_base_only?
  base_sha / head_sha / commit_count / changed_paths[]

current_base_only?
  base_sha / head_sha / commit_count / changed_paths[]
```

Derived relation: `same_tree | forward | rewind | diverged`.

When base trees differ, complete path-range attestation is mandatory. Range paths own branch-path collision detection only.

### Exact endpoint compatibility objects

Every declared consumed contract and applicable policy path must have one exact endpoint receipt:

```text
path
kind = consumed_contract | applicable_policy
tested_object_sha?
current_object_sha?
```

Contract/policy change is decided by exact tested/current Git object inequality, not merge-base changed-path union. Added/removed objects use one missing endpoint.

This avoids a concrete false positive from #194: `src/discriminator_observation.rs` appears in both divergent ranges but has the same endpoint blob `6f370c3b...` on both bases.

## #194 dogfood result

Branch compatibility payload stayed byte-equivalent. Consumed discriminator contract stayed exact:

```text
src/discriminator_observation.rs
  tested  6f370c3ba20ebb7220c8c075f2c2df56f650fd83
  current 6f370c3ba20ebb7220c8c075f2c2df56f650fd83
```

Applicable CI policy changed:

```text
.github/workflows/ci.yml
  tested  26c4f3e3b4dc68bc5e166c72eab394a6548c9ceb
  current 7e1f1b966fcd1e45930d0ff12a68532cba802502
```

Therefore #194 was a genuine rerun for `applicable_policy_overlap`; the reason was a compatibility input change, not generic `main moved` ancestry churn.

## Decision priority

Aligned with #284:

```text
conflict / nonmergeable
change-set changed
exact effective merge-tree identity
same base tree
branch path collision OR endpoint compatibility-object change
complete compatibility scope + no relevant change
semantic independence UNKNOWN
```

Exact effective merge-tree identity remains strongest and may transfer a receipt across divergent ancestry while still preserving observed compatibility-object differences for audit.

## Controls

Focused tests cover:

- divergent disjoint base + unchanged endpoint objects -> UNKNOWN inspection;
- same contract path touched on both sides + equal endpoint object -> no false contract reason;
- changed policy endpoint -> rerun policy only;
- removed consumed contract -> rerun contract;
- actual branch path collision -> rerun with divergent side;
- complete compatibility scope + clean divergence -> reusable;
- exact effective merge tree across divergence -> reusable;
- forward/rewind/same-tree relations;
- equal trees require equal endpoint objects;
- endpoint object list exactly covers declared contracts/policies;
- incomplete base path receipt attestation -> reject;
- range endpoint mismatch -> reject.

## Clean checkpoint

Current head:

```text
bcc7d2ba33814391da58a2281b4ffceeb6782d40
```

One connector-authored commit on merged #284 checkpoint `adf4d1e...`, four files only:

```text
src/promotion_base_lineage.rs
tests/promotion_base_lineage.rs
examples/promotion_base_lineage.rs
research/promotion-base-lineage.md
```

Temporary formatter/trigger files are absent. Merge-view CI/provenance are the final authority per #279.

#201 remains the next dogfood target, but only once an exact later single-file merge-view receipt can be recovered; the retained early success is stacked on #194 and will not be misrepresented as a current-main rerun.

Research only; no GitHub mutation or automatic promotion side effect.

Refs #96 #137 #194 #201 #278 #279 #284.