### PR TITLE
research: promote exact selected-refinement subject mappings on current main

### DIFF
--- a/examples/refinement_observation_requirements.rs
+++ b/examples/refinement_observation_requirements.rs
@@ -1,0 +1,45 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+#[allow(dead_code)]
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[allow(dead_code)]
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[allow(dead_code)]
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+#[allow(dead_code)]
+#[path = "../src/refinement_observation_requirement.rs"]
+mod refinement_observation_requirement;
+
+use refinement_observation_requirement::{
+    MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES,
+    evaluate_selected_observation_requirements, parse_refinement_observation_requirement_request,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("refinement-observation-requirements: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES {
+        return Err(format!(
+            "refinement observation requirement request exceeds the {MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let request = parse_refinement_observation_requirement_request(&bytes)?;
+    let evaluation = evaluate_selected_observation_requirements(&request)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}

--- a/research/refinement-observation-requirements.md
+++ b/research/refinement-observation-requirements.md
@@ -1,0 +1,189 @@
+# Exact refinement observation requirements
+
+Tracking: #227. Builds on #179, #185, #210, #221, and the green wrong-subject control in #228.
+
+## Trigger
+
+#228 proved an executable mismatch between two already-earned semantics.
+
+The Oxc selected refinement says only:
+
+```text
+discriminator_refs = ["edit_class"]
+```
+
+When its exact current observation is replaced by a KNOWN+APPLIES `edit_class` for another subject, the existing #187-style ID-only coverage still says the selected candidate has current `edit_class` evidence.
+
+The exact #210 frontier for the earned Oxc subject simultaneously says:
+
+```text
+MISSING
+other_subject = [wrong edit_class observation]
+```
+
+The refinement candidate therefore needs an explicit way to say which source observation requirement applies to this candidate/application.
+
+## Why the subject stays outside the discriminator definition
+
+The Oxc `edit_class` discriminator is a reusable classifier, not a fact with one intrinsic subject. The same discriminator appears in both the selected forward cohort candidate and the rejected reverse control, and the #54 source producer classifies many different commits.
+
+Adding one subject directly to the admitted discriminator would conflate:
+
+```text
+what classifier/refinement dimension exists
+```
+
+with:
+
+```text
+which exact observation subject this candidate currently needs
+```
+
+V0 keeps those separate.
+
+## Source-owned mapping
+
+`src/refinement_observation_requirement.rs` adds one bounded receipt:
+
+```text
+RefinementObservationRequirementMapping
+  id
+  episode_id
+  candidate_id
+  discriminator_id
+  subject_ref
+  source_receipt
+```
+
+The tuple:
+
+```text
+(episode_id, candidate_id, discriminator_id)
+```
+
+may have at most one v0 subject mapping. The source receipt owns the claim that this exact candidate/discriminator needs this exact observation subject.
+
+The mapping must reference:
+
+- an existing refinement episode;
+- an existing candidate in that episode;
+- a discriminator actually named by that candidate.
+
+No subject is inferred from the current observation corpus.
+
+## Selected requirement compilation
+
+For each episode with a selected transition, the evaluator resolves the selected candidate's discriminator refs through the source-owned mappings and emits ordinary #210:
+
+```text
+ObservationRequirement
+  discriminator_id
+  subject_ref
+```
+
+It also preserves the exact mapping receipts used.
+
+Missing mapping stays explicit:
+
+```text
+missing_discriminator_refs[]
+```
+
+An empty mapping set therefore produces zero resolved requirements and exposes every selected discriminator ref as missing mapping evidence. The evaluator never searches the observation corpus for a convenient current subject.
+
+## Retained three-family mappings
+
+The first corpus covers every selected #179 candidate.
+
+### Justification
+
+```text
+justification/open-obligation-v1
+allow-open-zero-edge
+clearing_evidence_presence
+-> refinement:justification/open-obligation-v1
+```
+
+### Oxc
+
+```text
+history/oxc-edit-class-v1
+syntax-changing-current-cohort
+edit_class
+-> oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs
+```
+
+This is the exact focused source observation earned by #221.
+
+### Project memory
+
+```text
+project-memory/primary-case-contract-collision-v1
+split-primary-case-admission
+primary_case_evidence_form
+same_repository_issue_target
+-> refinement:project-memory/primary-case-contract-collision-v1
+```
+
+The two discriminator requirements share the same episode-local subject while remaining separate exact requirements.
+
+## Controls
+
+The standard test carrier requires:
+
+1. all three selected candidates compile with zero missing mappings;
+2. every compiled requirement is CURRENT in the retained v2 observation corpus;
+3. wrong-subject Oxc `edit_class` leaves the compiled exact requirement MISSING;
+4. removing the Oxc mapping exposes `edit_class` under `missing_discriminator_refs` even when observations exist elsewhere;
+5. a mapping for a discriminator absent from the candidate rejects;
+6. multiple subject mappings for one exact episode/candidate/discriminator reject;
+7. the same reusable discriminator may have a different mapping for another candidate without changing the selected candidate mapping;
+8. request round-trip and a 512 KiB input bound are explicit;
+9. an empty mapping batch is valid and exposes every selected requirement as unresolved mapping evidence.
+
+## Reader
+
+```text
+cargo run --example refinement_observation_requirements < request.json
+```
+
+The request carries the validated refinement episode batch plus the source-owned mapping batch. The reader revalidates both before compiling selected exact requirements.
+
+## Boundary
+
+- research only;
+- #179 replay ledger schema remains unchanged;
+- mapping subject identity grants no observation value, evidence strength, or authority;
+- #210 frontier currentness remains unchanged;
+- #216 probe mapping remains a later acquisition step after an exact observation requirement exists;
+- no implicit first/current observation selection;
+- no automatic refinement promotion.
+
+## Execution receipt
+
+The first CI attempt stopped at `cargo fmt --check`; the formatter delta changed wrapping/order only. The next run reached Clippy and exposed a standalone-reader dependency: `observation_frontier.rs` imports `discriminator_observation`, so the research example needed that sibling module in its crate root. Adding that import changed no mapping semantics.
+
+Formatted semantic head:
+
+```text
+95f614c079de09358f1865bab34399235a512844
+```
+
+GitHub Actions CI run `32259965516` / run number `1597` completed successfully. It passed:
+
+- `cargo fmt --check`;
+- strict Clippy;
+- active-work preflight;
+- full tests, including all three retained selected-family requirement mappings;
+- exact retained D@S requirements CURRENT;
+- wrong-subject Oxc edit class MISSING with `other_subject` receipt;
+- missing mapping explicit despite other current observations;
+- duplicate/invalid mapping controls;
+- deterministic round-trip and input bound;
+- repository/history/CI-filter/diff dogfood.
+
+The result preserves the chosen boundary: refinement candidates keep reusable discriminator IDs, while source-owned candidate/application receipts bind those IDs to exact observation subjects before currentness or acquisition is evaluated.
+
+North star:
+
+> Let the refinement ledger say which discriminator a candidate uses, and let explicit source evidence say which exact observation subject this candidate currently requires.

--- a/research/refinement-observation-requirements/cultist-v1.json
+++ b/research/refinement-observation-requirements/cultist-v1.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "mappings": [
+    {
+      "id": "justification/open-obligation-v1:allow-open-zero-edge:clearing-evidence-presence",
+      "episode_id": "justification/open-obligation-v1",
+      "candidate_id": "allow-open-zero-edge",
+      "discriminator_id": "clearing_evidence_presence",
+      "subject_ref": "refinement:justification/open-obligation-v1",
+      "source_receipt": "github:pull/159@1c1a0086a199168fd0e21445d103936183063dc7"
+    },
+    {
+      "id": "history/oxc-edit-class-v1:syntax-changing-current-cohort:edit-class",
+      "episode_id": "history/oxc-edit-class-v1",
+      "candidate_id": "syntax-changing-current-cohort",
+      "discriminator_id": "edit_class",
+      "subject_ref": "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs",
+      "source_receipt": "github-actions:run/32257998359#focused-oxc-edit-class"
+    },
+    {
+      "id": "project-memory/primary-case-contract-collision-v1:split-primary-case-admission:evidence-form",
+      "episode_id": "project-memory/primary-case-contract-collision-v1",
+      "candidate_id": "split-primary-case-admission",
+      "discriminator_id": "primary_case_evidence_form",
+      "subject_ref": "refinement:project-memory/primary-case-contract-collision-v1",
+      "source_receipt": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca"
+    },
+    {
+      "id": "project-memory/primary-case-contract-collision-v1:split-primary-case-admission:target-relation",
+      "episode_id": "project-memory/primary-case-contract-collision-v1",
+      "candidate_id": "split-primary-case-admission",
+      "discriminator_id": "same_repository_issue_target",
+      "subject_ref": "refinement:project-memory/primary-case-contract-collision-v1",
+      "source_receipt": "github:pull/174@e1196c553ab496df13a230535de997f30c2d63ca"
+    }
+  ]
+}

--- a/research/refinement-observation-requirements/oxc-focused-edit-class-v1.json
+++ b/research/refinement-observation-requirements/oxc-focused-edit-class-v1.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 2,
+  "observations": [
+    {
+      "observation_id": "history/oxc-edit-class-v1:current-edit-class",
+      "discriminator_id": "edit_class",
+      "subject_ref": "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs",
+      "source_receipt": "github-actions:run/32257998359#focused-oxc-edit-class",
+      "value_state": {
+        "state": "known",
+        "value_ref": "syntax_changed"
+      },
+      "applicability": {
+        "status": "applies",
+        "receipt_ref": "github-actions:run/32257998359#focused-oxc-applicability"
+      }
+    }
+  ]
+}

--- a/src/refinement_observation_requirement.rs
+++ b/src/refinement_observation_requirement.rs
@@ -1,0 +1,291 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::observation_frontier::ObservationRequirement;
+use crate::refinement_episode::{RefinementEpisodeBatch, validate_refinement_episode_batch};
+
+pub const REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION: u32 = 1;
+pub const MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES: usize = 512 * 1024;
+const MAX_MAPPINGS: usize = 512;
+const MAX_ID_BYTES: usize = 512;
+const MAX_REFERENCE_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementObservationRequirementMapping {
+    pub id: String,
+    pub episode_id: String,
+    pub candidate_id: String,
+    pub discriminator_id: String,
+    pub subject_ref: String,
+    pub source_receipt: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementObservationRequirementBatch {
+    pub schema_version: u32,
+    pub mappings: Vec<RefinementObservationRequirementMapping>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementObservationRequirementRequest {
+    pub schema_version: u32,
+    pub refinements: RefinementEpisodeBatch,
+    pub mappings: RefinementObservationRequirementBatch,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SelectedRefinementObservationRequirements {
+    pub episode_id: String,
+    pub candidate_id: String,
+    pub requirements: Vec<ObservationRequirement>,
+    pub mappings: Vec<RefinementObservationRequirementMapping>,
+    pub missing_discriminator_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementObservationRequirementEvaluation {
+    pub schema_version: u32,
+    pub selected: Vec<SelectedRefinementObservationRequirements>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RefinementObservationRequirementError {
+    message: String,
+}
+
+impl RefinementObservationRequirementError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for RefinementObservationRequirementError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for RefinementObservationRequirementError {}
+
+pub fn parse_refinement_observation_requirement_request(
+    bytes: &[u8],
+) -> Result<RefinementObservationRequirementRequest, RefinementObservationRequirementError> {
+    if bytes.len() > MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES {
+        return Err(RefinementObservationRequirementError::new(format!(
+            "refinement observation requirement request exceeds the {MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES}-byte limit"
+        )));
+    }
+    let request: RefinementObservationRequirementRequest =
+        serde_json::from_slice(bytes).map_err(|error| {
+            RefinementObservationRequirementError::new(format!(
+                "invalid refinement observation requirement JSON: {error}"
+            ))
+        })?;
+    validate_request(&request)?;
+    Ok(request)
+}
+
+pub fn evaluate_selected_observation_requirements(
+    request: &RefinementObservationRequirementRequest,
+) -> Result<RefinementObservationRequirementEvaluation, RefinementObservationRequirementError> {
+    validate_request(request)?;
+
+    let mut selected = Vec::new();
+    for episode in &request.refinements.episodes {
+        let Some(selected_id) = episode.selected_transition.as_ref() else {
+            continue;
+        };
+        let candidate = episode
+            .candidate_refinements
+            .iter()
+            .find(|candidate| candidate.id == *selected_id)
+            .ok_or_else(|| {
+                RefinementObservationRequirementError::new(format!(
+                    "selected candidate {selected_id} is missing from episode {}",
+                    episode.id
+                ))
+            })?;
+
+        let mut requirements = Vec::new();
+        let mut mappings = Vec::new();
+        let mut missing_discriminator_refs = Vec::new();
+        for discriminator_id in &candidate.discriminator_refs {
+            if let Some(mapping) = request.mappings.mappings.iter().find(|mapping| {
+                mapping.episode_id == episode.id
+                    && mapping.candidate_id == candidate.id
+                    && mapping.discriminator_id == *discriminator_id
+            }) {
+                requirements.push(ObservationRequirement {
+                    discriminator_id: discriminator_id.clone(),
+                    subject_ref: mapping.subject_ref.clone(),
+                });
+                mappings.push(mapping.clone());
+            } else {
+                missing_discriminator_refs.push(discriminator_id.clone());
+            }
+        }
+
+        requirements.sort_by(|left, right| {
+            left.discriminator_id
+                .cmp(&right.discriminator_id)
+                .then_with(|| left.subject_ref.cmp(&right.subject_ref))
+        });
+        mappings.sort_by(|left, right| left.id.cmp(&right.id));
+        missing_discriminator_refs.sort();
+        selected.push(SelectedRefinementObservationRequirements {
+            episode_id: episode.id.clone(),
+            candidate_id: candidate.id.clone(),
+            requirements,
+            mappings,
+            missing_discriminator_refs,
+        });
+    }
+    selected.sort_by(|left, right| left.episode_id.cmp(&right.episode_id));
+
+    Ok(RefinementObservationRequirementEvaluation {
+        schema_version: REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION,
+        selected,
+    })
+}
+
+fn validate_request(
+    request: &RefinementObservationRequirementRequest,
+) -> Result<(), RefinementObservationRequirementError> {
+    if request.schema_version != REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION {
+        return Err(RefinementObservationRequirementError::new(format!(
+            "unsupported refinement observation requirement schema {}; expected {REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION}",
+            request.schema_version
+        )));
+    }
+    validate_refinement_episode_batch(&request.refinements).map_err(|error| {
+        RefinementObservationRequirementError::new(format!(
+            "invalid refinement episode batch: {error}"
+        ))
+    })?;
+    validate_mapping_batch(&request.mappings)?;
+    validate_mapping_references(&request.refinements, &request.mappings)
+}
+
+fn validate_mapping_batch(
+    batch: &RefinementObservationRequirementBatch,
+) -> Result<(), RefinementObservationRequirementError> {
+    if batch.schema_version != REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION {
+        return Err(RefinementObservationRequirementError::new(format!(
+            "unsupported refinement observation mapping schema {}; expected {REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION}",
+            batch.schema_version
+        )));
+    }
+    if batch.mappings.len() > MAX_MAPPINGS {
+        return Err(RefinementObservationRequirementError::new(
+            "refinement observation mappings exceed the admitted boundary",
+        ));
+    }
+
+    let mut ids = BTreeSet::new();
+    let mut keys = BTreeSet::new();
+    for mapping in &batch.mappings {
+        validate_atom(&mapping.id, "mapping id", MAX_ID_BYTES)?;
+        validate_atom(&mapping.episode_id, "mapping episode_id", MAX_ID_BYTES)?;
+        validate_atom(&mapping.candidate_id, "mapping candidate_id", MAX_ID_BYTES)?;
+        validate_atom(
+            &mapping.discriminator_id,
+            "mapping discriminator_id",
+            MAX_ID_BYTES,
+        )?;
+        validate_atom(
+            &mapping.subject_ref,
+            "mapping subject_ref",
+            MAX_REFERENCE_BYTES,
+        )?;
+        validate_atom(
+            &mapping.source_receipt,
+            "mapping source_receipt",
+            MAX_REFERENCE_BYTES,
+        )?;
+        if !ids.insert(mapping.id.clone()) {
+            return Err(RefinementObservationRequirementError::new(format!(
+                "duplicate refinement observation mapping id {}",
+                mapping.id
+            )));
+        }
+        let key = (
+            mapping.episode_id.clone(),
+            mapping.candidate_id.clone(),
+            mapping.discriminator_id.clone(),
+        );
+        if !keys.insert(key) {
+            return Err(RefinementObservationRequirementError::new(format!(
+                "multiple subject mappings for refinement {} / {} / {}",
+                mapping.episode_id, mapping.candidate_id, mapping.discriminator_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_mapping_references(
+    refinements: &RefinementEpisodeBatch,
+    mappings: &RefinementObservationRequirementBatch,
+) -> Result<(), RefinementObservationRequirementError> {
+    for mapping in &mappings.mappings {
+        let episode = refinements
+            .episodes
+            .iter()
+            .find(|episode| episode.id == mapping.episode_id)
+            .ok_or_else(|| {
+                RefinementObservationRequirementError::new(format!(
+                    "mapping {} references missing episode {}",
+                    mapping.id, mapping.episode_id
+                ))
+            })?;
+        let candidate = episode
+            .candidate_refinements
+            .iter()
+            .find(|candidate| candidate.id == mapping.candidate_id)
+            .ok_or_else(|| {
+                RefinementObservationRequirementError::new(format!(
+                    "mapping {} references missing candidate {} in episode {}",
+                    mapping.id, mapping.candidate_id, mapping.episode_id
+                ))
+            })?;
+        if !candidate
+            .discriminator_refs
+            .iter()
+            .any(|discriminator| discriminator == &mapping.discriminator_id)
+        {
+            return Err(RefinementObservationRequirementError::new(format!(
+                "mapping {} discriminator {} is not required by candidate {}",
+                mapping.id, mapping.discriminator_id, mapping.candidate_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_atom(
+    value: &str,
+    field: &str,
+    max_bytes: usize,
+) -> Result<(), RefinementObservationRequirementError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > max_bytes
+        || value.contains('\0')
+        || value.contains(['\n', '\r'])
+    {
+        return Err(RefinementObservationRequirementError::new(format!(
+            "{field} must be bounded canonical single-line text"
+        )));
+    }
+    Ok(())
+}

--- a/tests/refinement_discriminator_subject.rs
+++ b/tests/refinement_discriminator_subject.rs
@@ -1,0 +1,140 @@
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+
+use discriminator_observation::{
+    DiscriminatorValueState, enumerate_discriminator_partitions,
+    parse_discriminator_observation_batch,
+};
+use observation_frontier::{
+    OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierRequest, ObservationFrontierStatus,
+    ObservationRequirement, evaluate_observation_frontiers,
+};
+use refinement_episode::parse_refinement_episode_batch;
+
+const OBSERVATIONS: &[u8] =
+    include_bytes!("../research/discriminator-observations/cultist-v1.json");
+const FOCUSED_OXC_OBSERVATION: &[u8] = include_bytes!(
+    "../research/refinement-observation-requirements/oxc-focused-edit-class-v1.json"
+);
+const REFINEMENTS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+
+fn focused_oxc_observation() -> discriminator_observation::DiscriminatorObservation {
+    let batch = parse_discriminator_observation_batch(FOCUSED_OXC_OBSERVATION).unwrap();
+    assert_eq!(batch.observations.len(), 1);
+    batch.observations[0].clone()
+}
+
+#[test]
+fn id_only_refinement_coverage_can_accept_wrong_subject_while_exact_frontier_is_missing() {
+    let original = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    let exact = focused_oxc_observation();
+    assert_eq!(
+        exact.subject_ref,
+        "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs"
+    );
+
+    let refinements = parse_refinement_episode_batch(REFINEMENTS).unwrap();
+    let episode = refinements
+        .episodes
+        .iter()
+        .find(|episode| episode.id == "history/oxc-edit-class-v1")
+        .expect("retained Oxc refinement episode");
+    let selected_id = episode
+        .selected_transition
+        .as_ref()
+        .expect("retained Oxc transition is selected");
+    let selected = episode
+        .candidate_refinements
+        .iter()
+        .find(|candidate| candidate.id == *selected_id)
+        .expect("selected candidate exists");
+    assert_eq!(selected.discriminator_refs, vec!["edit_class"]);
+
+    let mut wrong_subject = exact.clone();
+    wrong_subject.observation_id = "history/oxc-edit-class-v1:wrong-subject-control".to_string();
+    wrong_subject.subject_ref =
+        "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/other.rs"
+            .to_string();
+    wrong_subject.source_receipt = "research:wrong-subject-control".to_string();
+    wrong_subject.value_state = DiscriminatorValueState::Known {
+        value_ref: "syntax_changed".to_string(),
+    };
+
+    let mut observations = original.clone();
+    observations
+        .observations
+        .retain(|observation| observation.discriminator_id != "edit_class");
+    observations.observations.push(wrong_subject);
+
+    // This is the current #187 cross-object sufficiency species: availability
+    // is collapsed to discriminator ID before selected candidate refs are checked.
+    let enumeration = enumerate_discriminator_partitions(&observations).unwrap();
+    let current_by_id = enumeration
+        .discriminators
+        .iter()
+        .map(|discriminator| {
+            (
+                discriminator.discriminator_id.as_str(),
+                !discriminator.known_partitions.is_empty(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    for discriminator_id in &selected.discriminator_refs {
+        assert_eq!(
+            current_by_id.get(discriminator_id.as_str()),
+            Some(&true),
+            "ID-only coverage currently treats any current subject as sufficient"
+        );
+    }
+
+    // The exact v2 frontier disagrees: the earned Oxc subject has no current
+    // observation, and the same discriminator on another subject stays visible.
+    let evaluation = evaluate_observation_frontiers(&ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements: vec![ObservationRequirement {
+            discriminator_id: "edit_class".to_string(),
+            subject_ref: exact.subject_ref.clone(),
+        }],
+        observations,
+    })
+    .unwrap();
+    let frontier = &evaluation.frontiers[0];
+    assert_eq!(frontier.status, ObservationFrontierStatus::Missing);
+    assert!(frontier.current.is_empty());
+    assert_eq!(frontier.other_subject.len(), 1);
+    assert_eq!(
+        frontier.other_subject[0].subject_ref,
+        "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/other.rs"
+    );
+}
+
+#[test]
+fn exact_focused_subject_is_current_control() {
+    let exact = focused_oxc_observation();
+    let observations = discriminator_observation::DiscriminatorObservationBatch {
+        schema_version: discriminator_observation::DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+        observations: vec![exact.clone()],
+    };
+    let evaluation = evaluate_observation_frontiers(&ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements: vec![ObservationRequirement {
+            discriminator_id: exact.discriminator_id.clone(),
+            subject_ref: exact.subject_ref.clone(),
+        }],
+        observations,
+    })
+    .unwrap();
+    assert_eq!(
+        evaluation.frontiers[0].status,
+        ObservationFrontierStatus::Current
+    );
+    assert_eq!(evaluation.frontiers[0].other_subject.len(), 0);
+}

--- a/tests/refinement_observation_requirement.rs
+++ b/tests/refinement_observation_requirement.rs
@@ -1,0 +1,268 @@
+#![allow(dead_code)]
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+#[path = "../src/refinement_observation_requirement.rs"]
+mod refinement_observation_requirement;
+
+use discriminator_observation::{DiscriminatorValueState, parse_discriminator_observation_batch};
+use observation_frontier::{
+    OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierRequest, ObservationFrontierStatus,
+    evaluate_observation_frontiers,
+};
+use refinement_episode::parse_refinement_episode_batch;
+use refinement_observation_requirement::{
+    MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES,
+    REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION, RefinementObservationRequirementBatch,
+    RefinementObservationRequirementMapping, RefinementObservationRequirementRequest,
+    evaluate_selected_observation_requirements, parse_refinement_observation_requirement_request,
+};
+
+const OBSERVATIONS: &[u8] =
+    include_bytes!("../research/discriminator-observations/cultist-v1.json");
+const FOCUSED_OXC_OBSERVATION: &[u8] = include_bytes!(
+    "../research/refinement-observation-requirements/oxc-focused-edit-class-v1.json"
+);
+const REFINEMENTS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+const MAPPINGS: &[u8] =
+    include_bytes!("../research/refinement-observation-requirements/cultist-v1.json");
+
+fn request() -> RefinementObservationRequirementRequest {
+    RefinementObservationRequirementRequest {
+        schema_version: REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION,
+        refinements: parse_refinement_episode_batch(REFINEMENTS).unwrap(),
+        mappings: serde_json::from_slice(MAPPINGS).unwrap(),
+    }
+}
+
+fn observations_with_focused_oxc() -> discriminator_observation::DiscriminatorObservationBatch {
+    let mut observations = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    observations
+        .observations
+        .retain(|observation| observation.discriminator_id != "edit_class");
+    let focused = parse_discriminator_observation_batch(FOCUSED_OXC_OBSERVATION).unwrap();
+    assert_eq!(focused.observations.len(), 1);
+    observations.observations.extend(focused.observations);
+    observations
+}
+
+#[test]
+fn retained_selected_candidates_compile_exact_observation_requirements() {
+    let evaluation = evaluate_selected_observation_requirements(&request()).unwrap();
+    assert_eq!(evaluation.selected.len(), 3);
+    assert!(
+        evaluation
+            .selected
+            .iter()
+            .all(|selected| selected.missing_discriminator_refs.is_empty())
+    );
+
+    let justification = evaluation
+        .selected
+        .iter()
+        .find(|selected| selected.episode_id == "justification/open-obligation-v1")
+        .unwrap();
+    assert_eq!(justification.requirements.len(), 1);
+    assert_eq!(
+        justification.requirements[0].subject_ref,
+        "refinement:justification/open-obligation-v1"
+    );
+
+    let oxc = evaluation
+        .selected
+        .iter()
+        .find(|selected| selected.episode_id == "history/oxc-edit-class-v1")
+        .unwrap();
+    assert_eq!(oxc.candidate_id, "syntax-changing-current-cohort");
+    assert_eq!(oxc.requirements.len(), 1);
+    assert_eq!(oxc.requirements[0].discriminator_id, "edit_class");
+    assert_eq!(
+        oxc.requirements[0].subject_ref,
+        "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs"
+    );
+
+    let project_memory = evaluation
+        .selected
+        .iter()
+        .find(|selected| selected.episode_id == "project-memory/primary-case-contract-collision-v1")
+        .unwrap();
+    assert_eq!(project_memory.requirements.len(), 2);
+    assert!(project_memory.requirements.iter().all(|requirement| {
+        requirement.subject_ref == "refinement:project-memory/primary-case-contract-collision-v1"
+    }));
+}
+
+#[test]
+fn compiled_selected_requirements_are_current_in_retained_observation_corpus() {
+    let observations = observations_with_focused_oxc();
+    let evaluation = evaluate_selected_observation_requirements(&request()).unwrap();
+
+    for selected in evaluation.selected {
+        let frontiers = evaluate_observation_frontiers(&ObservationFrontierRequest {
+            schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+            requirements: selected.requirements,
+            observations: observations.clone(),
+        })
+        .unwrap();
+        assert!(
+            frontiers
+                .frontiers
+                .iter()
+                .all(|frontier| frontier.status == ObservationFrontierStatus::Current),
+            "selected refinement {} has a noncurrent exact requirement",
+            selected.episode_id
+        );
+    }
+}
+
+#[test]
+fn wrong_subject_edit_class_cannot_satisfy_compiled_oxc_requirement() {
+    let mut observations = observations_with_focused_oxc();
+    let exact = observations
+        .observations
+        .iter_mut()
+        .find(|observation| observation.discriminator_id == "edit_class")
+        .unwrap();
+    exact.observation_id = "history/oxc-edit-class-v1:wrong-subject-repair-control".to_string();
+    exact.subject_ref =
+        "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/other.rs"
+            .to_string();
+    exact.source_receipt = "research:wrong-subject-repair-control".to_string();
+    exact.value_state = DiscriminatorValueState::Known {
+        value_ref: "syntax_changed".to_string(),
+    };
+
+    let compiled = evaluate_selected_observation_requirements(&request()).unwrap();
+    let oxc = compiled
+        .selected
+        .into_iter()
+        .find(|selected| selected.episode_id == "history/oxc-edit-class-v1")
+        .unwrap();
+    let frontiers = evaluate_observation_frontiers(&ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements: oxc.requirements,
+        observations,
+    })
+    .unwrap();
+    assert_eq!(
+        frontiers.frontiers[0].status,
+        ObservationFrontierStatus::Missing
+    );
+    assert_eq!(frontiers.frontiers[0].other_subject.len(), 1);
+}
+
+#[test]
+fn missing_candidate_subject_mapping_stays_explicit() {
+    let mut request = request();
+    request.mappings.mappings.retain(|mapping| {
+        !(mapping.episode_id == "history/oxc-edit-class-v1"
+            && mapping.candidate_id == "syntax-changing-current-cohort"
+            && mapping.discriminator_id == "edit_class")
+    });
+
+    let evaluation = evaluate_selected_observation_requirements(&request).unwrap();
+    let oxc = evaluation
+        .selected
+        .iter()
+        .find(|selected| selected.episode_id == "history/oxc-edit-class-v1")
+        .unwrap();
+    assert!(oxc.requirements.is_empty());
+    assert!(oxc.mappings.is_empty());
+    assert_eq!(oxc.missing_discriminator_refs, vec!["edit_class"]);
+}
+
+#[test]
+fn mapping_for_discriminator_not_required_by_candidate_rejects() {
+    let mut request = request();
+    request
+        .mappings
+        .mappings
+        .push(RefinementObservationRequirementMapping {
+            id: "invalid-extra-discriminator".to_string(),
+            episode_id: "history/oxc-edit-class-v1".to_string(),
+            candidate_id: "syntax-changing-current-cohort".to_string(),
+            discriminator_id: "commit_identity".to_string(),
+            subject_ref: "commit:irrelevant".to_string(),
+            source_receipt: "research:invalid-control".to_string(),
+        });
+    let error = evaluate_selected_observation_requirements(&request).unwrap_err();
+    assert!(error.to_string().contains("is not required by candidate"));
+}
+
+#[test]
+fn duplicate_candidate_discriminator_mapping_rejects() {
+    let mut request = request();
+    let original = request
+        .mappings
+        .mappings
+        .iter()
+        .find(|mapping| mapping.episode_id == "history/oxc-edit-class-v1")
+        .unwrap()
+        .clone();
+    let mut duplicate = original;
+    duplicate.id = "duplicate-oxc-edit-class".to_string();
+    duplicate.subject_ref = "commit:another-subject".to_string();
+    request.mappings.mappings.push(duplicate);
+    let error = evaluate_selected_observation_requirements(&request).unwrap_err();
+    assert!(error.to_string().contains("multiple subject mappings"));
+}
+
+#[test]
+fn same_discriminator_can_have_candidate_specific_subject_mapping() {
+    let mut request = request();
+    request
+        .mappings
+        .mappings
+        .push(RefinementObservationRequirementMapping {
+            id: "history/oxc-edit-class-v1:reverse-control:edit-class".to_string(),
+            episode_id: "history/oxc-edit-class-v1".to_string(),
+            candidate_id: "reverse-edit-class-control".to_string(),
+            discriminator_id: "edit_class".to_string(),
+            subject_ref: "oxc-project/oxc:reverse-generated-history".to_string(),
+            source_receipt: "research:rust-syntax-cohort-replay.md#reverse-control".to_string(),
+        });
+
+    let evaluation = evaluate_selected_observation_requirements(&request).unwrap();
+    let oxc = evaluation
+        .selected
+        .iter()
+        .find(|selected| selected.episode_id == "history/oxc-edit-class-v1")
+        .unwrap();
+    assert_eq!(oxc.candidate_id, "syntax-changing-current-cohort");
+    assert_eq!(
+        oxc.requirements[0].subject_ref,
+        "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs"
+    );
+}
+
+#[test]
+fn request_round_trip_and_byte_bound_are_explicit() {
+    let request = request();
+    let encoded = serde_json::to_vec(&request).unwrap();
+    let decoded = parse_refinement_observation_requirement_request(&encoded).unwrap();
+    assert_eq!(decoded, request);
+
+    let oversized = vec![b' '; MAX_REFINEMENT_OBSERVATION_REQUIREMENT_REQUEST_BYTES + 1];
+    let error = parse_refinement_observation_requirement_request(&oversized).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}
+
+#[test]
+fn empty_mapping_batch_is_valid_and_exposes_every_selected_requirement_as_missing() {
+    let mut request = request();
+    request.mappings = RefinementObservationRequirementBatch {
+        schema_version: REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION,
+        mappings: Vec::new(),
+    };
+    let evaluation = evaluate_selected_observation_requirements(&request).unwrap();
+    assert_eq!(evaluation.selected.len(), 3);
+    assert!(evaluation.selected.iter().all(|selected| {
+        selected.requirements.is_empty()
+            && selected.mappings.is_empty()
+            && !selected.missing_discriminator_refs.is_empty()
+    }));
+}


### PR DESCRIPTION
Progresses #227 by replaying the earned #228/#231 subject-identity seam directly on current main, without the historical 40+ commit stack.

## Counterexample + repair together

The included wrong-subject regression proves discriminator ID alone is insufficient:

```text
selected Oxc candidate requires edit_class
exact earned rules.rs observation removed
same discriminator/value supplied for other.rs

ID-only availability      -> appears available
exact discriminator@subject frontier -> MISSING
wrong observation         -> other_subject
```

The promoted mapping layer keeps the replay ledger source-agnostic and adds a separate source-owned relation:

```text
(episode_id, candidate_id, discriminator_id)
-> exact subject_ref
+ source_receipt
```

It validates episode/candidate/discriminator membership and unique exact mappings, then compiles selected transitions into ordinary exact observation requirements.

## Retained three-family mappings

The copied retained corpus binds:

- justification `clearing_evidence_presence` -> episode-local obligation subject;
- Oxc `edit_class` -> exact focused `228e8e0f...:rules.rs` subject;
- project-memory `primary_case_evidence_form` and `same_repository_issue_target` -> episode-local project-memory subject.

Missing mappings remain explicit; the evaluator never substitutes whichever current observation happens to exist elsewhere.

## Focused Oxc source receipt

Current main intentionally still carries the older generic `8783524...:rules.rs` observation as historical/source evidence. This replay does not rewrite that coordinate.

The exact-subject test instead retains a focused one-observation fixture copied from #221's earned source adapter result:

```text
subject = oxc-project/oxc@228e8e0f...:rules.rs
value = syntax_changed
applicability = APPLIES
source = hosted focused Oxc run 32257998359
```

The wrong-subject control removes generic `edit_class` observations before inserting `other.rs`, while the current control uses only the focused source-owned observation. This preserves the distinction between historical generic evidence and the exact source coordinate required by the mapping.

## Current-main replay

The branch now carries seven files: the six mapping/replay files plus the focused Oxc source receipt fixture.

No source probe execution, automatic candidate selection/promotion, or product CLI/report change.

Supersedes historical #228/#231 after certification.

Refs #148 #179 #185 #190 #194 #210 #216 #220 #221 #227 #228 #231 #278 #279.