### PR TITLE
fix: preserve unresolved active-work activity

### DIFF
--- a/src/active_changes.rs
+++ b/src/active_changes.rs
@@ -46,7 +46,34 @@ struct WorkItem {
     head_sha: String,
     updated_at: String,
     draft: bool,
+    #[serde(default)]
+    activity: WorkActivity,
     changed_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum WorkActivity {
+    #[default]
+    ConfirmedActive,
+    Preparation,
+    Unresolved,
+}
+
+impl WorkActivity {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ConfirmedActive => "confirmed_active",
+            Self::Preparation => "preparation",
+            Self::Unresolved => "unresolved",
+        }
+    }
+}
+
+impl WorkItem {
+    fn activity(&self) -> WorkActivity {
+        self.activity
+    }
 }
 
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Deserialize)]
@@ -167,44 +194,23 @@ fn analyze_inventory(
         for path in current_paths.intersection(&other_paths) {
             direct_overlap_count += 1;
             let display = path.to_string_lossy().into_owned();
-            analysis.findings.push(
-                Finding::new(
-                    "preflight-inventory-path-overlap",
-                    "Active-change path overlap",
-                )
-                .at(Location::new(display.clone(), None))
-                .with_claim(
-                    Claim::new(
-                        ClaimKind::Observed,
-                        format!(
-                            "The admitted inventory records both `{}` and `{}` modifying `{display}`.",
-                            inventory.current.id, work.id
-                        ),
-                    )
-                    .with_evidence(Evidence::new(format!(
-                        "Other active work: `{}` — `{}` at head `{}` (updated `{}`).",
-                        work.id, work.title, work.head_sha, work.updated_at
-                    )))
-                    .with_evidence(Evidence::new(format!("Provider reference: `{}`.", work.url))),
-                )
-                .with_question(
-                    "Is there anything worth reconciling before continuing on this path?",
-                ),
-            );
+            analysis
+                .findings
+                .push(path_overlap_finding(&inventory.current, work, display));
         }
     }
 
     analysis.claims.push(Claim::new(
         ClaimKind::Observed,
         format!(
-            "Examined {candidates_examined} active candidate(s) and excluded {self_candidates_excluded} self candidate(s)."
+            "Examined {candidates_examined} supplied work candidate(s) and excluded {self_candidates_excluded} self candidate(s)."
         ),
     ));
 
     if direct_overlap_count == 0 {
         analysis.claims.push(Claim::new(
             ClaimKind::Observed,
-            "The admitted inventory records no direct path overlap between the current work and the other active work in the selected scope.",
+            "The admitted inventory records no direct path overlap between the current work and the other supplied work in the selected scope.",
         ));
     }
 
@@ -243,8 +249,12 @@ fn analyze_inventory(
                 edge.source
             )))
             .with_evidence(Evidence::new(format!(
-                "Related active work: `{}` — `{}` at head `{}` (updated `{}`).",
-                other.id, other.title, other.head_sha, other.updated_at
+                "Related supplied work: `{}` — `{}` at head `{}` (updated `{}`, activity={}).",
+                other.id,
+                other.title,
+                other.head_sha,
+                other.updated_at,
+                other.activity().as_str()
             ))),
         );
 
@@ -256,6 +266,10 @@ fn analyze_inventory(
                     inventory.current.id
                 ),
             ));
+        }
+
+        if other.activity() == WorkActivity::Unresolved {
+            finding = finding.with_claim(activity_unknown_claim(other));
         }
 
         finding = finding
@@ -276,7 +290,7 @@ fn analyze_inventory(
 
     analysis.claims.push(Claim::new(
         ClaimKind::Unknown,
-        "No direct path overlap is not evidence that active work is semantically independent.",
+        "No direct path overlap is not evidence that supplied work is semantically independent.",
     ));
     analysis.claims.push(Claim::new(
         ClaimKind::Unknown,
@@ -284,6 +298,59 @@ fn analyze_inventory(
     ));
 
     analysis
+}
+
+fn path_overlap_finding(current: &WorkItem, other: &WorkItem, display: String) -> Finding {
+    let observed = Claim::new(
+        ClaimKind::Observed,
+        format!(
+            "The admitted inventory records both `{}` and `{}` modifying `{display}`.",
+            current.id, other.id
+        ),
+    )
+    .with_evidence(Evidence::new(format!(
+        "Other supplied work: `{}` — `{}` at head `{}` (updated `{}`, activity={}).",
+        other.id,
+        other.title,
+        other.head_sha,
+        other.updated_at,
+        other.activity().as_str()
+    )))
+    .with_evidence(Evidence::new(format!(
+        "Provider reference: `{}`.",
+        other.url
+    )));
+
+    if other.activity() == WorkActivity::Unresolved {
+        Finding::new(
+            "preflight-inventory-path-overlap-activity-unknown",
+            "Path overlap with unresolved activity",
+        )
+        .at(Location::new(display, None))
+        .with_claim(observed)
+        .with_claim(activity_unknown_claim(other))
+        .with_question(
+            "Refresh or resolve current activity before treating this path overlap as an active collision.",
+        )
+    } else {
+        Finding::new(
+            "preflight-inventory-path-overlap",
+            "Active-change path overlap",
+        )
+        .at(Location::new(display, None))
+        .with_claim(observed)
+        .with_question("Is there anything worth reconciling before continuing on this path?")
+    }
+}
+
+fn activity_unknown_claim(work: &WorkItem) -> Claim {
+    Claim::new(
+        ClaimKind::Unknown,
+        format!(
+            "The admitted inventory does not establish that `{}` is currently active or owned.",
+            work.id
+        ),
+    )
 }
 
 fn same_work(current: &WorkItem, other: &WorkItem) -> bool {
@@ -515,6 +582,17 @@ mod tests {
         })
     }
 
+    fn work_with_activity(
+        id: &str,
+        sha: &str,
+        paths: &[&str],
+        activity: &str,
+    ) -> serde_json::Value {
+        let mut value = work(id, sha, paths);
+        value["activity"] = serde_json::json!(activity);
+        value
+    }
+
     fn document(
         current: serde_json::Value,
         active_work: Vec<serde_json::Value>,
@@ -657,6 +735,130 @@ mod tests {
             .find(|finding| finding.kind == "preflight-inventory-path-overlap")
             .unwrap();
         assert_eq!(overlap.claims[0].kind, ClaimKind::Observed);
+    }
+
+    #[test]
+    fn confirmed_active_overlap_keeps_active_collision_finding() {
+        let current = work("#1", "aaa", &["src/a.rs"]);
+        let other = work_with_activity("#2", "bbb", &["src/a.rs"], "confirmed_active");
+        let inventory = parse(document(current, vec![other], Vec::new())).unwrap();
+        let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
+
+        assert!(analysis.findings.iter().any(|finding| {
+            finding.kind == "preflight-inventory-path-overlap"
+                && finding.title == "Active-change path overlap"
+        }));
+    }
+
+    #[test]
+    fn preparation_overlap_keeps_active_collision_finding() {
+        let current = work("#1", "aaa", &["src/a.rs"]);
+        let other = work_with_activity("#2", "bbb", &["src/a.rs"], "preparation");
+        let inventory = parse(document(current, vec![other], Vec::new())).unwrap();
+        let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
+
+        assert!(analysis.findings.iter().any(|finding| {
+            finding.kind == "preflight-inventory-path-overlap"
+                && finding.title == "Active-change path overlap"
+        }));
+    }
+
+    #[test]
+    fn unresolved_overlap_preserves_path_fact_and_activity_unknown() {
+        let current = work("#1", "aaa", &["tests/regression.rs"]);
+        let other = work_with_activity("branch-old", "bbb", &["tests/regression.rs"], "unresolved");
+        let inventory = parse(document(current, vec![other], Vec::new())).unwrap();
+        let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
+
+        assert!(
+            analysis
+                .findings
+                .iter()
+                .all(|finding| { finding.kind != "preflight-inventory-path-overlap" })
+        );
+        let finding = analysis
+            .findings
+            .iter()
+            .find(|finding| finding.kind == "preflight-inventory-path-overlap-activity-unknown")
+            .unwrap();
+        assert_eq!(finding.title, "Path overlap with unresolved activity");
+        assert!(finding.claims.iter().any(|claim| {
+            claim.kind == ClaimKind::Observed
+                && claim.message.contains("modifying `tests/regression.rs`")
+        }));
+        assert!(finding.claims.iter().any(|claim| {
+            claim.kind == ClaimKind::Unknown && claim.message.contains("currently active or owned")
+        }));
+        assert!(
+            finding
+                .question
+                .as_deref()
+                .is_some_and(|question| question.contains("Refresh or resolve current activity"))
+        );
+    }
+
+    #[test]
+    fn unresolved_disjoint_work_stays_quiet() {
+        let current = work("#1", "aaa", &["src/a.rs"]);
+        let other = work_with_activity("branch-old", "bbb", &["src/b.rs"], "unresolved");
+        let inventory = parse(document(current, vec![other], Vec::new())).unwrap();
+        let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
+
+        assert!(analysis.findings.is_empty());
+    }
+
+    #[test]
+    fn kind_spelling_alone_does_not_make_activity_unresolved() {
+        let current = work("#1", "aaa", &["src/a.rs"]);
+        let mut other = work("#2", "bbb", &["src/a.rs"]);
+        other["kind"] = serde_json::json!("branch_observation_ambiguous");
+        let inventory = parse(document(current, vec![other], Vec::new())).unwrap();
+        let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
+
+        assert!(
+            analysis
+                .findings
+                .iter()
+                .any(|finding| { finding.kind == "preflight-inventory-path-overlap" })
+        );
+    }
+
+    #[test]
+    fn explicit_coordination_survives_unresolved_activity() {
+        let current = work("#1", "aaa", &["src/a.rs"]);
+        let other = work_with_activity("#2", "bbb", &["src/b.rs"], "unresolved");
+        let edge = serde_json::json!({
+            "kind": "depends_on",
+            "from": "#1",
+            "to": "#2",
+            "source": "fixture"
+        });
+        let inventory = parse(document(current, vec![other], vec![edge])).unwrap();
+        let analysis = analyze_inventory(Path::new("/repo"), &inventory, None);
+
+        let finding = analysis
+            .findings
+            .iter()
+            .find(|finding| finding.kind == "preflight-explicit-coordination")
+            .unwrap();
+        assert!(finding.claims.iter().any(|claim| {
+            claim.kind == ClaimKind::Unknown && claim.message.contains("currently active or owned")
+        }));
+    }
+
+    #[test]
+    fn rejects_null_activity_state() {
+        let current = work("#1", "aaa", &["src/a.rs"]);
+        let mut other = work("#2", "bbb", &["src/a.rs"]);
+        other["activity"] = serde_json::Value::Null;
+        assert!(parse(document(current, vec![other], Vec::new())).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_activity_state() {
+        let current = work("#1", "aaa", &["src/a.rs"]);
+        let other = work_with_activity("#2", "bbb", &["src/a.rs"], "maybe_active");
+        assert!(parse(document(current, vec![other], Vec::new())).is_err());
     }
 
     #[test]

--- a/tests/quarry_active_work_activity_replay.rs
+++ b/tests/quarry_active_work_activity_replay.rs
@@ -1,0 +1,229 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{Value, json};
+
+const QUARRY_MAIN: &str = "26f3ab7e4dc223b91524b94595592eee5cb7ed1a";
+const OBSERVED_AT: &str = "2026-08-22T16:40:14Z";
+
+#[allow(clippy::too_many_arguments)]
+fn work(
+    id: &str,
+    kind: &str,
+    activity: &str,
+    title: &str,
+    url: &str,
+    head_ref: &str,
+    head_sha: &str,
+    updated_at: &str,
+    draft: bool,
+    changed_paths: &[&str],
+) -> Value {
+    json!({
+        "id": id,
+        "kind": kind,
+        "activity": activity,
+        "title": title,
+        "url": url,
+        "head_ref": head_ref,
+        "head_sha": head_sha,
+        "updated_at": updated_at,
+        "draft": draft,
+        "changed_paths": changed_paths,
+    })
+}
+
+fn quarry_work() -> Vec<Value> {
+    vec![
+        work(
+            "quarry-pr-604",
+            "delivery_candidate",
+            "confirmed_active",
+            "Pilot agent-native outcome ownership on current main",
+            "https://github.com/Coreys-Quarry/quarry/pull/604",
+            "kiln/530-agent-native-current-v2",
+            "63eece80df17a97a8544c4d716feca4fad1970ea",
+            "2026-08-22T16:25:52Z",
+            false,
+            &["AGENTS.md", "docs/agent-native-operating-mode.md"],
+        ),
+        work(
+            "quarry-pr-608",
+            "delivery_candidate",
+            "confirmed_active",
+            "perf: add minimal exact research IR envelope",
+            "https://github.com/Coreys-Quarry/quarry/pull/608",
+            "perf/564-minimal-research-ir",
+            "515c60f694664f3b691bfd7f920e4740d75226d1",
+            "2026-08-22T16:26:25Z",
+            false,
+            &["src/quarry/research_ir.py", "tests/test_research_ir.py"],
+        ),
+        work(
+            "quarry-prep-532",
+            "preparation_branch",
+            "preparation",
+            "Issue 532 private continuation work-ahead",
+            "https://github.com/Coreys-Quarry/quarry/issues/532",
+            "wip/532-agent-continuation-context",
+            "5e353896a3fa383866b0398125ce8409fd0ddb2b",
+            "2026-08-16T10:02:56Z",
+            true,
+            &[
+                "src/quarry/agent_continuation_context.py",
+                "tests/test_agent_continuation_context.py",
+                "tests/test_agent_continuation_context_direct_object.py",
+                "tests/test_agent_continuation_context_visibility.py",
+            ],
+        ),
+        work(
+            "quarry-branch-391",
+            "branch_observation_ambiguous",
+            "unresolved",
+            "Issue 391 branch observation; current activity unresolved",
+            "https://github.com/Coreys-Quarry/quarry/issues/391",
+            "codex/391-control-dirty-consumers-current",
+            "bac4be013432f1386756028bfcc4bf1c2c6aa637",
+            "2026-08-16T05:39:09Z",
+            true,
+            &["tests/test_control_dirty_receipt_consumers.py"],
+        ),
+        work(
+            "quarry-branch-471",
+            "branch_observation_ambiguous",
+            "unresolved",
+            "Issue 471 branch observation; current activity unresolved",
+            "https://github.com/Coreys-Quarry/quarry/issues/471",
+            "codex/471-target-decision-id-current-v3",
+            "66a5ae7b6dbf6005377821cb2920e8638c2494f0",
+            "2026-08-16T05:36:43Z",
+            true,
+            &["tests/test_exact_research_target_decision_identity_types.py"],
+        ),
+    ]
+}
+
+fn unique_inventory(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "cultist-quarry-activity-replay-{name}-{}-{nanos}.json",
+        std::process::id()
+    ))
+}
+
+fn run_case(name: &str, paths: &[&str]) -> Value {
+    let inventory_path = unique_inventory(name);
+    let inventory = json!({
+        "schema_version": 1,
+        "source": "Quarry #596 public Phase-0 replay observed 2026-08-22T16:40:14Z",
+        "observed_at": OBSERVED_AT,
+        "current": {
+            "id": format!("chat-{name}"),
+            "kind": "chat_lane",
+            "activity": "confirmed_active",
+            "title": name,
+            "url": "https://github.com/Coreys-Quarry/quarry/issues/596",
+            "head_ref": "main",
+            "head_sha": QUARRY_MAIN,
+            "updated_at": OBSERVED_AT,
+            "draft": false,
+            "changed_paths": paths,
+        },
+        "active_work": quarry_work(),
+        "coordination_edges": [],
+    });
+    fs::write(
+        &inventory_path,
+        serde_json::to_vec_pretty(&inventory).unwrap(),
+    )
+    .unwrap();
+
+    let root = std::env::current_dir().unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-cultist"))
+        .args(["preflight", "--inventory"])
+        .arg(&inventory_path)
+        .args(["--format", "json"])
+        .arg(root)
+        .output()
+        .unwrap();
+    let _ = fs::remove_file(&inventory_path);
+    assert!(
+        output.status.success(),
+        "{name} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+fn finding_kinds(report: &Value) -> Vec<&str> {
+    report["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|finding| finding["kind"].as_str().unwrap())
+        .collect()
+}
+
+#[test]
+fn quarry_phase0_activity_replay_preserves_decision_boundary() {
+    for (name, paths) in [
+        ("confirmed-policy", &["AGENTS.md"][..]),
+        ("confirmed-ir", &["src/quarry/research_ir.py"][..]),
+        (
+            "preparation-532",
+            &["src/quarry/agent_continuation_context.py"][..],
+        ),
+    ] {
+        let report = run_case(name, paths);
+        assert!(
+            finding_kinds(&report).contains(&"preflight-inventory-path-overlap"),
+            "{name}: {report}"
+        );
+    }
+
+    for (name, path) in [
+        (
+            "unresolved-391",
+            "tests/test_control_dirty_receipt_consumers.py",
+        ),
+        (
+            "unresolved-471",
+            "tests/test_exact_research_target_decision_identity_types.py",
+        ),
+    ] {
+        let report = run_case(name, &[path]);
+        let kinds = finding_kinds(&report);
+        assert!(
+            kinds.contains(&"preflight-inventory-path-overlap-activity-unknown"),
+            "{name}: {report}"
+        );
+        assert!(!kinds.contains(&"preflight-inventory-path-overlap"));
+        let finding = report["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|finding| finding["kind"] == "preflight-inventory-path-overlap-activity-unknown")
+            .unwrap();
+        assert!(finding["claims"].as_array().unwrap().iter().any(|claim| {
+            claim["kind"] == "unknown"
+                && claim["message"]
+                    .as_str()
+                    .unwrap()
+                    .contains("currently active or owned")
+        }));
+        assert!(
+            finding["question"]
+                .as_str()
+                .unwrap()
+                .contains("Refresh or resolve current activity")
+        );
+    }
+
+    let quiet = run_case("quiet-control", &["docs/cultist-290-quiet-control.md"]);
+    assert_eq!(quiet["findings"].as_array().unwrap().len(), 0);
+}


### PR DESCRIPTION
Closes #289.

## Trigger

Two real Quarry #596 Phase-0 waves reproduced the same false coordination interruption: exact path coincidence with a provider-known branch observation whose current activity remained unresolved rendered as the same `Active-change path overlap` finding used for confirmed live PRs.

## Change

Keep active-work inventory schema v1 backward-compatible and add one optional typed `activity` field to `WorkItem`:

```text
confirmed_active
preparation
unresolved
```

Missing `activity` retains legacy schema-v1 behavior as `confirmed_active`.

For `confirmed_active` and `preparation`, direct path overlap keeps the existing `preflight-inventory-path-overlap` / `Active-change path overlap` result.

For `unresolved`, the exact supplied path coincidence remains OBSERVED but renders as:

```text
preflight-inventory-path-overlap-activity-unknown
Path overlap with unresolved activity
UNKNOWN current activity / ownership
NEXT refresh or resolve activity before treating it as an active collision
```

An explicit coordination edge remains independently visible and carries the activity UNKNOWN when its related work is unresolved. Disjoint unresolved work remains quiet apart from the existing report-level semantic-independence/provider limits.

## Controls

- legacy v1 inventory unchanged in behavior;
- confirmed-active overlap retains existing finding;
- preparation overlap retains existing finding;
- unresolved overlap preserves path fact + UNKNOWN activity;
- unresolved disjoint work emits no finding;
- `kind` spelling alone cannot manufacture unresolved activity;
- unknown activity value fails closed;
- explicit coordination survives unresolved activity.

No wall-clock age or branch-divergence heuristic. No provider fetching, ownership assignment, scheduling, merge, or mutation authority.

The first freshness-repair experiment from Quarry dogfood was rejected separately because PR `headRefOid` and Actions merge-view `HEAD` are distinct coordinates; that result is retained on #123 and is outside this patch.

Validation policy: ordinary Cultist CI only, on repository-owned GitHub-hosted `ubuntu-latest`.