### PR TITLE
fix: preserve UNKNOWN when coordination metadata fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,12 @@ jobs:
           python scripts/external_github_reference_guard.py \
             --repository "$GITHUB_REPOSITORY" \
             --base "$CULTIST_BASE"
+      - name: Active work heads-up adapter controls
+        run: |
+          python -m py_compile \
+            scripts/active_work_heads_up_ci.py \
+            scripts/active_work_heads_up_ci_test.py
+          python scripts/active_work_heads_up_ci_test.py
       - name: Active work heads-up
         if: github.event_name == 'pull_request'
         continue-on-error: true

--- a/scripts/active_work_heads_up_ci.py
+++ b/scripts/active_work_heads_up_ci.py
@@ -278,6 +278,12 @@ def edge_involves_current(inventory: dict[str, object], edge: dict[str, object])
     return str(edge.get("from", "")) == current_id or str(edge.get("to", "")) == current_id
 
 
+def quiet_status_line(metadata_note: str | None = None) -> str:
+    if metadata_note:
+        return "Coordination metadata: UNKNOWN; direct path evidence found no overlap."
+    return "No active-work coordination signal worth surfacing."
+
+
 def quiet_summary(
     inventory: dict[str, object],
     metadata_note: str | None = None,
@@ -287,12 +293,21 @@ def quiet_summary(
         "",
         f"Observed `{inventory['observed_at']}` from `{inventory['source']}`.",
         "",
-        "No active-work coordination signal worth surfacing.",
+        quiet_status_line(metadata_note),
         "",
-        "> Advisory only. Disjoint paths and absent reviewed metadata edges do not prove semantic independence.",
     ]
     if metadata_note:
-        lines.extend(["", f"> {metadata_note}"])
+        lines.extend(
+            [
+                "> Direct path evidence is quiet; reviewed coordination metadata remains unresolved because its analyzer did not complete.",
+                "",
+                f"> {metadata_note}",
+            ]
+        )
+    else:
+        lines.append(
+            "> Advisory only. Disjoint paths and absent reviewed metadata edges do not prove semantic independence."
+        )
     lines.append("")
     return "\n".join(lines)
 
@@ -434,7 +449,7 @@ def main() -> None:
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not direct_overlap and not relevant_edges:
-        print("No active-work coordination signal worth surfacing.")
+        print(quiet_status_line(metadata_note))
         print(
             f"timing: inventory {inventory_seconds:.2f}s; "
             f"coordination {coordination_seconds:.2f}s; product 0.00s"

--- a/scripts/active_work_heads_up_ci_test.py
+++ b/scripts/active_work_heads_up_ci_test.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+from active_work_heads_up_ci import quiet_status_line, quiet_summary
+
+INVENTORY = {
+    "observed_at": "2026-08-23T00:00:00Z",
+    "source": "test_provider_snapshot",
+}
+
+
+def main() -> int:
+    clean_status = quiet_status_line()
+    assert clean_status == "No active-work coordination signal worth surfacing."
+    clean_summary = quiet_summary(INVENTORY)
+    assert clean_status in clean_summary
+    assert "UNKNOWN" not in clean_summary
+
+    failure_note = (
+        "Reviewed coordination metadata could not be fully analyzed; "
+        "direct path evidence remains usable. Detail: synthetic extractor failure"
+    )
+    unknown_status = quiet_status_line(failure_note)
+    assert unknown_status == (
+        "Coordination metadata: UNKNOWN; direct path evidence found no overlap."
+    )
+    assert "No active-work coordination signal worth surfacing." not in unknown_status
+
+    unknown_summary = quiet_summary(INVENTORY, failure_note)
+    assert unknown_status in unknown_summary
+    assert failure_note in unknown_summary
+    assert "No active-work coordination signal worth surfacing." not in unknown_summary
+    assert "reviewed coordination metadata remains unresolved" in unknown_summary
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Refs #105.

## Trigger

The live active-work CI adapter had one failure path that could render a stronger quiet conclusion than its evidence supported:

```text
direct path overlap = false
reviewed coordination metadata candidate = present
coordination extractor = unavailable / malformed result
relevant coordination edges = unresolved
```

The adapter retained the extractor failure in a note, but both stdout and the job summary still led with `No active-work coordination signal worth surfacing.`

That combines a clean direct-path result with an UNKNOWN coordination-metadata result as though the whole check were quiet.

## Change

- centralize the quiet-path status line;
- keep the existing quiet wording when direct paths are disjoint and coordination metadata was successfully absent/quiet;
- when coordination metadata analysis fails, render `Coordination metadata: UNKNOWN; direct path evidence found no overlap.`;
- retain the exact analyzer-failure note and say that reviewed coordination metadata remains unresolved;
- add a paired Python control for the clean quiet path and the UNKNOWN failure path;
- run that control in ordinary CI on `ubuntu-latest`.

## Boundary

This changes CI advice rendering only. It does not change active-work inventory semantics, coordination extraction, provider fetching, product preflight findings, activity certainty, repository/work applicability, provider snapshot identity, ownership, scheduling, merge authority, or any wall-clock rule.

Validation is intentionally GitHub-hosted Actions only.