### PR TITLE
research: retain unresolved coordination source-loss counterexample

### DIFF
--- a/tests/unresolved_coordination_source_loss.rs
+++ b/tests/unresolved_coordination_source_loss.rs
@@ -72,7 +72,10 @@ fn resolved_endpoint_preserves_authorship_as_a_control() {
     assert_eq!(current_authored.coordination_edges.len(), 1);
     assert_eq!(current_authored.coordination_edges[0].from, "#748");
     assert_eq!(current_authored.coordination_edges[0].to, "#703");
-    assert_eq!(current_authored.source_receipts[0].source, "github:pull/748");
+    assert_eq!(
+        current_authored.source_receipts[0].source,
+        "github:pull/748"
+    );
 
     assert_eq!(other_authored.coordination_edges.len(), 1);
     assert_eq!(other_authored.coordination_edges[0].from, "#703");

--- a/tests/unresolved_coordination_source_loss.rs
+++ b/tests/unresolved_coordination_source_loss.rs
@@ -1,0 +1,81 @@
+#![allow(dead_code)]
+
+#[path = "../src/coordination_edges.rs"]
+mod coordination_edges;
+
+use serde_json::{Value, json};
+
+fn sha(byte: char) -> String {
+    std::iter::repeat_n(byte, 40).collect()
+}
+
+fn work(id: &str, body: &str) -> Value {
+    json!({
+        "id": id,
+        "kind": "pull_request",
+        "source": format!("github:pull/{}", &id[1..]),
+        "head_sha": sha('a'),
+        "updated_at": "2026-08-22T18:30:00Z",
+        "body": body,
+    })
+}
+
+fn snapshot(first: Value, second: Value) -> String {
+    serde_json::to_string(&json!({
+        "schema_version": 1,
+        "source": "test:unresolved-coordination-origin",
+        "work": [first, second],
+    }))
+    .unwrap()
+}
+
+#[test]
+fn unresolved_endpoint_erases_which_work_item_authored_the_clause() {
+    let current_authored = coordination_edges::extract_snapshot(&snapshot(
+        work("#748", "Do not merge while #999 is active\n"),
+        work("#703", ""),
+    ))
+    .unwrap();
+
+    let other_authored = coordination_edges::extract_snapshot(&snapshot(
+        work("#748", ""),
+        work("#703", "Do not merge while #999 is active\n"),
+    ))
+    .unwrap();
+
+    assert!(current_authored.coordination_edges.is_empty());
+    assert!(current_authored.source_receipts.is_empty());
+    assert_eq!(current_authored.stats.unresolved_endpoints_ignored, 1);
+
+    assert!(other_authored.coordination_edges.is_empty());
+    assert!(other_authored.source_receipts.is_empty());
+    assert_eq!(other_authored.stats.unresolved_endpoints_ignored, 1);
+
+    assert_eq!(current_authored, other_authored);
+}
+
+#[test]
+fn resolved_endpoint_preserves_authorship_as_a_control() {
+    let current_authored = coordination_edges::extract_snapshot(&snapshot(
+        work("#748", "Do not merge while #703 is active\n"),
+        work("#703", ""),
+    ))
+    .unwrap();
+
+    let other_authored = coordination_edges::extract_snapshot(&snapshot(
+        work("#748", ""),
+        work("#703", "Do not merge while #748 is active\n"),
+    ))
+    .unwrap();
+
+    assert_ne!(current_authored, other_authored);
+    assert_eq!(current_authored.coordination_edges.len(), 1);
+    assert_eq!(current_authored.coordination_edges[0].from, "#748");
+    assert_eq!(current_authored.coordination_edges[0].to, "#703");
+    assert_eq!(current_authored.source_receipts[0].source, "github:pull/748");
+
+    assert_eq!(other_authored.coordination_edges.len(), 1);
+    assert_eq!(other_authored.coordination_edges[0].from, "#703");
+    assert_eq!(other_authored.coordination_edges[0].to, "#748");
+    assert_eq!(other_authored.source_receipts[0].source, "github:pull/703");
+}


### PR DESCRIPTION
Progresses #300 with one isolated test-only negative control over the landed coordination extractor.

## Proven ambiguity

Two admitted metadata snapshots contain the same work IDs and exactly one reviewed operative clause targeting absent work `#999`.

Only the clause author changes:

```text
snapshot A
  #748: Do not merge while #999 ...
  #703: quiet

snapshot B
  #748: quiet
  #703: Do not merge while #999 ...
```

The current extractor drops the unresolved endpoint from `coordination_edges` and `source_receipts`, retaining only the aggregate `unresolved_endpoints_ignored = 1`. The test requires the two complete `ExtractionReport` values to compare equal.

That proves a downstream adapter cannot distinguish unresolved coordination originating from current work from the same unresolved clause on other work using the current report contract.

## Positive control

Resolve the endpoint between `#748` and `#703`. The reports then differ and preserve author/source identity through the ordinary edge/source receipt.

So the source loss is specific to unresolved-endpoint handling.

## Boundary

- one new test file only;
- no edit to #296 or its CI-advice repair;
- no provider fetch or completeness inference;
- no new status or coordination-edge vocabulary;
- unresolved endpoint remains unresolved;
- no wall-clock rule;
- no ownership, scheduling, merge, or mutation authority.

This is the proof artifact for #300. Any repair should be separate after review and should preserve unresolved clause/source coordinates without manufacturing a resolved edge.

Validation is GitHub-hosted Actions only on repository-owned `ubuntu-latest`.