### PR TITLE
DO NOT MERGE: Mako Quarry #563 preflight

### DIFF
--- a/tests/quarry_mako_563_preflight.rs
+++ b/tests/quarry_mako_563_preflight.rs
@@ -1,0 +1,195 @@
+use std::fs;
+use std::process::Command;
+
+use serde_json::Value;
+
+#[test]
+fn quarry_mako_563_preflight_has_no_direct_path_collision() {
+    let root = std::env::temp_dir().join(format!("cultist-quarry-mako-root-{}", std::process::id()));
+    let inventory_path = std::env::temp_dir().join(format!(
+        "cultist-quarry-mako-inventory-{}.json",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).expect("create empty Quarry analysis root");
+
+    let inventory = r#"{
+  "schema_version": 1,
+  "source": "github:manual-bounded-mako-2026-08-22T18:31Z",
+  "observed_at": "2026-08-22T18:31:00Z",
+  "current": {
+    "id": "mako/quarry-563-post-merge-review",
+    "kind": "planned_review",
+    "title": "Mako post-merge adversarial review of Quarry #637",
+    "url": "https://github.com/Coreys-Quarry/quarry/pull/637",
+    "head_ref": "main",
+    "head_sha": "2b072b6ab6f01060e67c11b4306a3338e164700b",
+    "updated_at": "2026-08-22T18:31:00Z",
+    "draft": false,
+    "changed_paths": [
+      "src/quarry/research_supergraph.py",
+      "tests/test_research_supergraph_mako_adversarial.py"
+    ]
+  },
+  "active_work": [
+    {
+      "id": "pull/671",
+      "kind": "pull_request",
+      "title": "feat: retain durable exact research abstain decisions",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/671",
+      "head_ref": "kiln/633-durable-abstain-final",
+      "head_sha": "0a95dcd52e282bbeabfbcd9662c44f472ca029f5",
+      "updated_at": "2026-08-22T18:26:35Z",
+      "draft": false,
+      "changed_paths": [
+        "src/quarry/_exact_research_engine.py",
+        "src/quarry/_exact_research_execution.py",
+        "src/quarry/exact_research_contract.py",
+        "src/quarry/exact_research_result_artifact.py",
+        "tests/test_exact_research_abstain.py",
+        "tests/test_exact_research_result_artifact_abstain.py"
+      ]
+    },
+    {
+      "id": "pull/682",
+      "kind": "pull_request",
+      "title": "research: retain #656 memory read-through data blocker",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/682",
+      "head_ref": "research/656-mu-memory-readthrough-v1-current",
+      "head_sha": "cdf41a6fee86aff63b5d2ea7e75bbb442e8c3866",
+      "updated_at": "2026-08-22T18:26:30Z",
+      "draft": false,
+      "changed_paths": [
+        "research/experiments/semiconductor-memory-readthrough-v1-data-blocker.json",
+        "research/programs/semiconductor-memory-readthrough-v1.json",
+        "tests/test_semiconductor_memory_readthrough_program.py"
+      ]
+    },
+    {
+      "id": "pull/683",
+      "kind": "pull_request",
+      "title": "[research] #658 frozen defense replenishment event-study carrier",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/683",
+      "head_ref": "research/658-defense-replenishment-event-study-v1",
+      "head_sha": "45e5c8e1ec21f1dda03f9cf23b2b81e19518bb80",
+      "updated_at": "2026-08-22T18:30:41Z",
+      "draft": false,
+      "changed_paths": [
+        "tests/test_research_658_carrier.py",
+        "tests/test_research_658_receipt.py"
+      ]
+    },
+    {
+      "id": "pull/684",
+      "kind": "pull_request",
+      "title": "Research carrier: #661 daily volatility compression pilot",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/684",
+      "head_ref": "research/661-daily-compression-pilot-r2",
+      "head_sha": "519640d38f5de8341d99ab798ce138e6f172b33b",
+      "updated_at": "2026-08-22T18:27:31Z",
+      "draft": false,
+      "changed_paths": ["tests/test_research_661_carrier.py"]
+    },
+    {
+      "id": "pull/685",
+      "kind": "pull_request",
+      "title": "WIP carrier: harden #633 frozen prospective BTC momentum ledger",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/685",
+      "head_ref": "wip/633-prospective-hardening-current",
+      "head_sha": "a6f35d47ec9487899d719627b95cc79eb5cedb6f",
+      "updated_at": "2026-08-22T18:28:59Z",
+      "draft": false,
+      "changed_paths": [
+        "src/quarry/btc_momentum_prospective.py",
+        "src/quarry/btc_momentum_prospective_campaign.py",
+        "tests/test_btc_momentum_prospective.py",
+        "tests/test_btc_momentum_prospective_campaign.py"
+      ]
+    },
+    {
+      "id": "pull/686",
+      "kind": "pull_request",
+      "title": "research: add #663 deterministic news-cycle novelty baseline",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/686",
+      "head_ref": "codex/issue-663-news-cycle-novelty-baseline",
+      "head_sha": "b2ae98130994b7a2e30ee4169f33313cb674655d",
+      "updated_at": "2026-08-22T18:29:00Z",
+      "draft": false,
+      "changed_paths": [
+        "research/news_cycle/issue_663_inventory.json",
+        "src/quarry/news_cycle.py",
+        "tests/test_news_cycle.py"
+      ]
+    },
+    {
+      "id": "pull/688",
+      "kind": "pull_request",
+      "title": "research: recompose alpha with owned result sources",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/688",
+      "head_ref": "research/563-combined-alpha-owned-source",
+      "head_sha": "c432880fd52e9a76b64bb224917b9c32bb09a3f3",
+      "updated_at": "2026-08-22T18:30:31Z",
+      "draft": true,
+      "changed_paths": [
+        ".github/workflows/research-563-combined-alpha-owned-source.yml",
+        "scripts/research_563_combined_alpha_composition.py",
+        "scripts/research_563_combined_alpha_owned_source.py",
+        "src/quarry/_exact_regime_attribution_receipts.py"
+      ]
+    },
+    {
+      "id": "pull/689",
+      "kind": "pull_request",
+      "title": "research: admit frozen #645 BTC hourly source",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/689",
+      "head_ref": "agent/645-hourly-btc-campaign-20260823",
+      "head_sha": "f4d3881e3b8c75a44f97cc3231d12bea28904865",
+      "updated_at": "2026-08-22T18:30:56Z",
+      "draft": true,
+      "changed_paths": [
+        ".github/workflows/hourly-btc-source.yml",
+        "configs/research/hourly_btc_baselines_v1.json",
+        "src/quarry/hourly_source.py",
+        "tests/test_hourly_source.py"
+      ]
+    }
+  ],
+  "coordination_edges": []
+}"#;
+    fs::write(&inventory_path, inventory).expect("write bounded active-work inventory");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-cultist"))
+        .args([
+            "preflight",
+            "--inventory",
+            inventory_path.to_str().expect("inventory path is utf-8"),
+            "--format",
+            "json",
+            root.to_str().expect("root path is utf-8"),
+        ])
+        .output()
+        .expect("run current Cultist preflight binary");
+
+    assert!(
+        output.status.success(),
+        "preflight failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("preflight output is utf-8");
+    let report: Value = serde_json::from_str(&stdout).expect("preflight output is json");
+    let findings = report["findings"].as_array().expect("findings array");
+    let active_collisions = findings
+        .iter()
+        .filter(|finding| {
+            finding["kind"]
+                .as_str()
+                .is_some_and(|kind| kind.starts_with("preflight-inventory"))
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        active_collisions.is_empty(),
+        "unexpected direct active-work collision: {stdout}"
+    );
+
+    fs::remove_file(&inventory_path).ok();
+    fs::remove_dir_all(&root).ok();
+}

--- a/tests/quarry_mako_563_preflight.rs
+++ b/tests/quarry_mako_563_preflight.rs
@@ -1,35 +1,31 @@
 use std::fs;
+use std::path::PathBuf;
 use std::process::Command;
 
 use serde_json::Value;
 
 #[test]
 fn quarry_mako_563_preflight_has_no_direct_path_collision() {
-    let root =
-        std::env::temp_dir().join(format!("cultist-quarry-mako-root-{}", std::process::id()));
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let inventory_path = std::env::temp_dir().join(format!(
         "cultist-quarry-mako-inventory-{}.json",
         std::process::id()
     ));
-    fs::create_dir_all(&root).expect("create empty Quarry analysis root");
 
     let inventory = r#"{
   "schema_version": 1,
-  "source": "github:manual-bounded-mako-2026-08-22T18:36:50Z",
-  "observed_at": "2026-08-22T18:36:50Z",
+  "source": "github:manual-bounded-mako-2026-08-22T18:40:50Z",
+  "observed_at": "2026-08-22T18:40:50Z",
   "current": {
     "id": "mako/quarry-563-post-merge-review",
     "kind": "planned_review",
     "title": "Mako post-merge adversarial review of Quarry #637",
     "url": "https://github.com/Coreys-Quarry/quarry/pull/637",
     "head_ref": "main",
-    "head_sha": "2b072b6ab6f01060e67c11b4306a3338e164700b",
-    "updated_at": "2026-08-22T18:36:50Z",
+    "head_sha": "c570b460869933c31b2b9f81b88f688aced3eb56",
+    "updated_at": "2026-08-22T18:40:50Z",
     "draft": false,
-    "changed_paths": [
-      "src/quarry/research_supergraph.py",
-      "tests/test_research_supergraph_mako_adversarial.py"
-    ]
+    "changed_paths": ["tests/test_research_supergraph_mako_adversarial.py"]
   },
   "active_work": [
     {
@@ -38,8 +34,8 @@ fn quarry_mako_563_preflight_has_no_direct_path_collision() {
       "title": "feat: retain durable exact research abstain decisions",
       "url": "https://github.com/Coreys-Quarry/quarry/pull/671",
       "head_ref": "kiln/633-durable-abstain-final",
-      "head_sha": "0a95dcd52e282bbeabfbcd9662c44f472ca029f5",
-      "updated_at": "2026-08-22T18:32:39Z",
+      "head_sha": "4ef102243e6026618e410d1f781809817fe8238d",
+      "updated_at": "2026-08-22T18:40:43Z",
       "draft": false,
       "changed_paths": [
         "src/quarry/_exact_research_engine.py",
@@ -48,21 +44,6 @@ fn quarry_mako_563_preflight_has_no_direct_path_collision() {
         "src/quarry/exact_research_result_artifact.py",
         "tests/test_exact_research_abstain.py",
         "tests/test_exact_research_result_artifact_abstain.py"
-      ]
-    },
-    {
-      "id": "pull/682",
-      "kind": "pull_request",
-      "title": "research: retain #656 memory read-through data blocker",
-      "url": "https://github.com/Coreys-Quarry/quarry/pull/682",
-      "head_ref": "research/656-mu-memory-readthrough-v1-current",
-      "head_sha": "5bd7087e5719dd8123ffaf0a72affbb5cf895cc0",
-      "updated_at": "2026-08-22T18:32:56Z",
-      "draft": false,
-      "changed_paths": [
-        "research/experiments/semiconductor-memory-readthrough-v1-data-blocker.json",
-        "research/programs/semiconductor-memory-readthrough-v1.json",
-        "tests/test_semiconductor_memory_readthrough_program.py"
       ]
     },
     {
@@ -83,7 +64,7 @@ fn quarry_mako_563_preflight_has_no_direct_path_collision() {
       "url": "https://github.com/Coreys-Quarry/quarry/pull/685",
       "head_ref": "wip/633-prospective-hardening-current",
       "head_sha": "a4adef30f72b8f5ac2891c7481509dbeb8075bbe",
-      "updated_at": "2026-08-22T18:34:05Z",
+      "updated_at": "2026-08-22T18:38:55Z",
       "draft": false,
       "changed_paths": [
         "src/quarry/btc_momentum_prospective.py",
@@ -98,8 +79,8 @@ fn quarry_mako_563_preflight_has_no_direct_path_collision() {
       "title": "research: add #663 deterministic news-cycle novelty baseline",
       "url": "https://github.com/Coreys-Quarry/quarry/pull/686",
       "head_ref": "codex/issue-663-news-cycle-novelty-baseline",
-      "head_sha": "b2ae98130994b7a2e30ee4169f33313cb674655d",
-      "updated_at": "2026-08-22T18:29:00Z",
+      "head_sha": "9fbc5f81e111cb04a6c742cf2239162db412a607",
+      "updated_at": "2026-08-22T18:39:31Z",
       "draft": false,
       "changed_paths": [
         "research/news_cycle/issue_663_inventory.json",
@@ -124,24 +105,13 @@ fn quarry_mako_563_preflight_has_no_direct_path_collision() {
       ]
     },
     {
-      "id": "pull/690",
-      "kind": "pull_request",
-      "title": "[dogfood] Echo one-shot Cultist preflight carrier",
-      "url": "https://github.com/Coreys-Quarry/quarry/pull/690",
-      "head_ref": "echo/cultist-preflight-20260823",
-      "head_sha": "edc0f895d14b2f2f19459187eb59935e9f5b590e",
-      "updated_at": "2026-08-22T18:34:40Z",
-      "draft": true,
-      "changed_paths": [".github/workflows/echo-cultist-preflight.yml"]
-    },
-    {
       "id": "pull/691",
       "kind": "pull_request",
       "title": "feat: add transparent corporate event study baseline",
       "url": "https://github.com/Coreys-Quarry/quarry/pull/691",
       "head_ref": "research/659-corporate-event-study-v1",
       "head_sha": "6a4afd0780eb30043098aa2a885f37c0f586b742",
-      "updated_at": "2026-08-22T18:36:48Z",
+      "updated_at": "2026-08-22T18:37:01Z",
       "draft": false,
       "changed_paths": [
         "research/programs/corporate-event-study-659-v1.json",
@@ -156,13 +126,38 @@ fn quarry_mako_563_preflight_has_no_direct_path_collision() {
       "title": "research: freeze #665 stock-selection v1 admission gate",
       "url": "https://github.com/Coreys-Quarry/quarry/pull/692",
       "head_ref": "research/665-stock-selection-v1",
-      "head_sha": "a4aa9f7c5c6f49b83c084d3628f6ebe6a05af2c9",
-      "updated_at": "2026-08-22T18:34:28Z",
+      "head_sha": "7cbf7c03e4f53490c830c6702d56017bd008c73e",
+      "updated_at": "2026-08-22T18:40:50Z",
       "draft": false,
       "changed_paths": [
         "docs/stock-selection-research.md",
         "src/quarry/stock_selection_research.py",
         "tests/test_stock_selection_research.py"
+      ]
+    },
+    {
+      "id": "pull/693",
+      "kind": "pull_request",
+      "title": "[research] #658 Yahoo defense replenishment event-study carrier",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/693",
+      "head_ref": "research/658-defense-replenishment-yahoo-v2",
+      "head_sha": "5b508375598240ad06842cb917e08c5ee5f505a4",
+      "updated_at": "2026-08-22T18:39:06Z",
+      "draft": false,
+      "changed_paths": ["tests/test_research_658_yahoo_carrier.py"]
+    },
+    {
+      "id": "pull/694",
+      "kind": "pull_request",
+      "title": "research: measure scorecard bound-parent admission",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/694",
+      "head_ref": "research/563-scorecard-bound-parent-admission",
+      "head_sha": "1d9ffb1796fa77b7999e31e507f425fbe700804b",
+      "updated_at": "2026-08-22T18:40:48Z",
+      "draft": true,
+      "changed_paths": [
+        ".github/workflows/research-563-scorecard-bound-parent-admission.yml",
+        "scripts/research_563_scorecard_bound_parent_admission.py"
       ]
     }
   ],
@@ -188,6 +183,7 @@ fn quarry_mako_563_preflight_has_no_direct_path_collision() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8(output.stdout).expect("preflight output is utf-8");
+    println!("Mako Cultist preflight report: {stdout}");
     let report: Value = serde_json::from_str(&stdout).expect("preflight output is json");
     let findings = report["findings"].as_array().expect("findings array");
     let active_collisions = findings
@@ -204,5 +200,4 @@ fn quarry_mako_563_preflight_has_no_direct_path_collision() {
     );
 
     fs::remove_file(&inventory_path).ok();
-    fs::remove_dir_all(&root).ok();
 }

--- a/tests/quarry_mako_563_preflight.rs
+++ b/tests/quarry_mako_563_preflight.rs
@@ -5,7 +5,10 @@ use serde_json::Value;
 
 #[test]
 fn quarry_mako_563_preflight_has_no_direct_path_collision() {
-    let root = std::env::temp_dir().join(format!("cultist-quarry-mako-root-{}", std::process::id()));
+    let root = std::env::temp_dir().join(format!(
+        "cultist-quarry-mako-root-{}",
+        std::process::id()
+    ));
     let inventory_path = std::env::temp_dir().join(format!(
         "cultist-quarry-mako-inventory-{}.json",
         std::process::id()

--- a/tests/quarry_mako_563_preflight.rs
+++ b/tests/quarry_mako_563_preflight.rs
@@ -5,10 +5,8 @@ use serde_json::Value;
 
 #[test]
 fn quarry_mako_563_preflight_has_no_direct_path_collision() {
-    let root = std::env::temp_dir().join(format!(
-        "cultist-quarry-mako-root-{}",
-        std::process::id()
-    ));
+    let root =
+        std::env::temp_dir().join(format!("cultist-quarry-mako-root-{}", std::process::id()));
     let inventory_path = std::env::temp_dir().join(format!(
         "cultist-quarry-mako-inventory-{}.json",
         std::process::id()
@@ -17,8 +15,8 @@ fn quarry_mako_563_preflight_has_no_direct_path_collision() {
 
     let inventory = r#"{
   "schema_version": 1,
-  "source": "github:manual-bounded-mako-2026-08-22T18:31Z",
-  "observed_at": "2026-08-22T18:31:00Z",
+  "source": "github:manual-bounded-mako-2026-08-22T18:36:50Z",
+  "observed_at": "2026-08-22T18:36:50Z",
   "current": {
     "id": "mako/quarry-563-post-merge-review",
     "kind": "planned_review",
@@ -26,7 +24,7 @@ fn quarry_mako_563_preflight_has_no_direct_path_collision() {
     "url": "https://github.com/Coreys-Quarry/quarry/pull/637",
     "head_ref": "main",
     "head_sha": "2b072b6ab6f01060e67c11b4306a3338e164700b",
-    "updated_at": "2026-08-22T18:31:00Z",
+    "updated_at": "2026-08-22T18:36:50Z",
     "draft": false,
     "changed_paths": [
       "src/quarry/research_supergraph.py",
@@ -41,7 +39,7 @@ fn quarry_mako_563_preflight_has_no_direct_path_collision() {
       "url": "https://github.com/Coreys-Quarry/quarry/pull/671",
       "head_ref": "kiln/633-durable-abstain-final",
       "head_sha": "0a95dcd52e282bbeabfbcd9662c44f472ca029f5",
-      "updated_at": "2026-08-22T18:26:35Z",
+      "updated_at": "2026-08-22T18:32:39Z",
       "draft": false,
       "changed_paths": [
         "src/quarry/_exact_research_engine.py",
@@ -58,27 +56,13 @@ fn quarry_mako_563_preflight_has_no_direct_path_collision() {
       "title": "research: retain #656 memory read-through data blocker",
       "url": "https://github.com/Coreys-Quarry/quarry/pull/682",
       "head_ref": "research/656-mu-memory-readthrough-v1-current",
-      "head_sha": "cdf41a6fee86aff63b5d2ea7e75bbb442e8c3866",
-      "updated_at": "2026-08-22T18:26:30Z",
+      "head_sha": "5bd7087e5719dd8123ffaf0a72affbb5cf895cc0",
+      "updated_at": "2026-08-22T18:32:56Z",
       "draft": false,
       "changed_paths": [
         "research/experiments/semiconductor-memory-readthrough-v1-data-blocker.json",
         "research/programs/semiconductor-memory-readthrough-v1.json",
         "tests/test_semiconductor_memory_readthrough_program.py"
-      ]
-    },
-    {
-      "id": "pull/683",
-      "kind": "pull_request",
-      "title": "[research] #658 frozen defense replenishment event-study carrier",
-      "url": "https://github.com/Coreys-Quarry/quarry/pull/683",
-      "head_ref": "research/658-defense-replenishment-event-study-v1",
-      "head_sha": "45e5c8e1ec21f1dda03f9cf23b2b81e19518bb80",
-      "updated_at": "2026-08-22T18:30:41Z",
-      "draft": false,
-      "changed_paths": [
-        "tests/test_research_658_carrier.py",
-        "tests/test_research_658_receipt.py"
       ]
     },
     {
@@ -98,8 +82,8 @@ fn quarry_mako_563_preflight_has_no_direct_path_collision() {
       "title": "WIP carrier: harden #633 frozen prospective BTC momentum ledger",
       "url": "https://github.com/Coreys-Quarry/quarry/pull/685",
       "head_ref": "wip/633-prospective-hardening-current",
-      "head_sha": "a6f35d47ec9487899d719627b95cc79eb5cedb6f",
-      "updated_at": "2026-08-22T18:28:59Z",
+      "head_sha": "a4adef30f72b8f5ac2891c7481509dbeb8075bbe",
+      "updated_at": "2026-08-22T18:34:05Z",
       "draft": false,
       "changed_paths": [
         "src/quarry/btc_momentum_prospective.py",
@@ -124,35 +108,61 @@ fn quarry_mako_563_preflight_has_no_direct_path_collision() {
       ]
     },
     {
-      "id": "pull/688",
-      "kind": "pull_request",
-      "title": "research: recompose alpha with owned result sources",
-      "url": "https://github.com/Coreys-Quarry/quarry/pull/688",
-      "head_ref": "research/563-combined-alpha-owned-source",
-      "head_sha": "c432880fd52e9a76b64bb224917b9c32bb09a3f3",
-      "updated_at": "2026-08-22T18:30:31Z",
-      "draft": true,
-      "changed_paths": [
-        ".github/workflows/research-563-combined-alpha-owned-source.yml",
-        "scripts/research_563_combined_alpha_composition.py",
-        "scripts/research_563_combined_alpha_owned_source.py",
-        "src/quarry/_exact_regime_attribution_receipts.py"
-      ]
-    },
-    {
       "id": "pull/689",
       "kind": "pull_request",
       "title": "research: admit frozen #645 BTC hourly source",
       "url": "https://github.com/Coreys-Quarry/quarry/pull/689",
       "head_ref": "agent/645-hourly-btc-campaign-20260823",
-      "head_sha": "f4d3881e3b8c75a44f97cc3231d12bea28904865",
-      "updated_at": "2026-08-22T18:30:56Z",
-      "draft": true,
+      "head_sha": "a91e0133ee228f826c1b4a54ba6a05ee7e9dac6e",
+      "updated_at": "2026-08-22T18:32:17Z",
+      "draft": false,
       "changed_paths": [
         ".github/workflows/hourly-btc-source.yml",
         "configs/research/hourly_btc_baselines_v1.json",
         "src/quarry/hourly_source.py",
         "tests/test_hourly_source.py"
+      ]
+    },
+    {
+      "id": "pull/690",
+      "kind": "pull_request",
+      "title": "[dogfood] Echo one-shot Cultist preflight carrier",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/690",
+      "head_ref": "echo/cultist-preflight-20260823",
+      "head_sha": "edc0f895d14b2f2f19459187eb59935e9f5b590e",
+      "updated_at": "2026-08-22T18:34:40Z",
+      "draft": true,
+      "changed_paths": [".github/workflows/echo-cultist-preflight.yml"]
+    },
+    {
+      "id": "pull/691",
+      "kind": "pull_request",
+      "title": "feat: add transparent corporate event study baseline",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/691",
+      "head_ref": "research/659-corporate-event-study-v1",
+      "head_sha": "6a4afd0780eb30043098aa2a885f37c0f586b742",
+      "updated_at": "2026-08-22T18:36:48Z",
+      "draft": false,
+      "changed_paths": [
+        "research/programs/corporate-event-study-659-v1.json",
+        "research/results/corporate-event-study-659-v1-data-blocked.json",
+        "src/quarry/company_event_study.py",
+        "tests/test_company_event_study.py"
+      ]
+    },
+    {
+      "id": "pull/692",
+      "kind": "pull_request",
+      "title": "research: freeze #665 stock-selection v1 admission gate",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/692",
+      "head_ref": "research/665-stock-selection-v1",
+      "head_sha": "a4aa9f7c5c6f49b83c084d3628f6ebe6a05af2c9",
+      "updated_at": "2026-08-22T18:34:28Z",
+      "draft": false,
+      "changed_paths": [
+        "docs/stock-selection-research.md",
+        "src/quarry/stock_selection_research.py",
+        "tests/test_stock_selection_research.py"
       ]
     }
   ],


### PR DESCRIPTION
Disposable dogfood receipt for Mako 🦈 before Quarry #563/#566/#595 review work.

## Hosted receipt

- exact carrier head: `6bc0cb7062bd581b9f77820feb6ae5ca61eb5f67`
- GitHub-hosted Actions run/job: `32591501591` / `97075954022`
- hosted runner: Ubuntu 24.04
- checked-out PR merge ref: `ec2178fca9666b56bdd3ff25a841ba618601e5eb`; the merge ref used Cultist base parent `32257dfd037643384e66bceefbf35746bfeb71af`
- format, clippy, active-work adapter controls, full `cargo test`, the Mako supplied-inventory preflight test, and dogfood scans all passed.

## Bounded Quarry inventory

The final supplied snapshot was observed at 2026-08-22T18:40:50Z with Quarry `main@c570b460869933c31b2b9f81b88f688aced3eb56` and nine open provider work items: #671, #684, #685, #686, #689, #691, #692, #693, #694, each recorded with exact provider head and changed paths.

Declared Mako write territory was narrowed to one disposable path: `tests/test_research_supergraph_mako_adversarial.py`.

The current admitted `preflight --inventory --format json` binary reported zero `preflight-inventory*` direct-path findings for that territory. The same hosted suite passed `preflight::tests::disjoint_paths_remain_explicitly_unknown_semantically`, so disjoint paths carry no semantic-independence grant.

## Consequence

Cultist surfaced a quiet direct-path result and retained semantic uncertainty. Manual provider membership/currentness checks changed the actionable interpretation: #694 owned scorecard-parent profiling during the bounded snapshot; after the snapshot #694 closed and #695 opened at `20037eab903a9b27118b0f42b2efbf3a3b7ebcd1` to own the fresh #563 recomposition lane while Quarry main remained `c570b460...`.

Mako therefore proceeds only with independent post-merge #637 adversarial review. No competing performance implementation is authorized by this receipt.

Dogfood receipt: surfaced; consulted; **changed action / narrowed write territory**. Provider-currentness required stronger evidence than the supplied snapshot alone.

Exact provider population/head race preserved on #293 in comment `5382009766`.

Disposable. Close unmerged after this receipt; no Cultist product change.