### PR TITLE
fix: preserve unresolved coordination endpoint uncertainty

### DIFF
--- a/scripts/active_work_heads_up_ci.py
+++ b/scripts/active_work_heads_up_ci.py
@@ -278,6 +278,34 @@ def edge_involves_current(inventory: dict[str, object], edge: dict[str, object])
     return str(edge.get("from", "")) == current_id or str(edge.get("to", "")) == current_id
 
 
+def unresolved_endpoint_receipts_involving_current(
+    inventory: dict[str, object], extraction_report: dict[str, object]
+) -> list[dict[str, object]]:
+    receipts = extraction_report.get("unresolved_endpoint_receipts")
+    if not isinstance(receipts, list) or any(
+        not isinstance(receipt, dict) for receipt in receipts
+    ):
+        raise RuntimeError(
+            "coordination extractor did not return unresolved endpoint receipts"
+        )
+    return [
+        receipt
+        for receipt in receipts
+        if edge_involves_current(inventory, receipt)
+    ]
+
+
+def unresolved_endpoint_note(receipts: list[dict[str, object]]) -> str | None:
+    if not receipts:
+        return None
+    count = len(receipts)
+    noun = "endpoint" if count == 1 else "endpoints"
+    return (
+        "Reviewed coordination metadata for current work references "
+        f"{count} {noun} absent from the supplied work inventory; "
+        "current coordination relevance remains unresolved."
+    )
+
 def quiet_status_line(metadata_note: str | None = None) -> str:
     if metadata_note:
         return "Coordination metadata: UNKNOWN; direct path evidence found no overlap."
@@ -299,7 +327,7 @@ def quiet_summary(
     if metadata_note:
         lines.extend(
             [
-                "> Direct path evidence is quiet; reviewed coordination metadata remains unresolved because its analyzer did not complete.",
+                "> Direct path evidence is quiet; reviewed coordination metadata remains unresolved.",
                 "",
                 f"> {metadata_note}",
             ]
@@ -436,9 +464,18 @@ def main() -> None:
                 "coordination metadata: "
                 f"{len(edges)} extracted edge(s), {len(relevant_edges)} involving current work"
             )
+            current_unresolved = unresolved_endpoint_receipts_involving_current(
+                inventory, extraction_report
+            )
+            notes: list[str] = []
+            unresolved_note = unresolved_endpoint_note(current_unresolved)
+            if unresolved_note:
+                notes.append(unresolved_note)
             unknowns = extraction_report.get("unknowns")
             if relevant_edges and isinstance(unknowns, list) and unknowns:
-                metadata_note = str(unknowns[0])
+                notes.append(str(unknowns[0]))
+            if notes:
+                metadata_note = " ".join(notes)
         except (subprocess.CalledProcessError, json.JSONDecodeError, RuntimeError) as error:
             metadata_note = (
                 "Reviewed coordination metadata could not be fully analyzed; "

--- a/scripts/active_work_heads_up_ci_test.py
+++ b/scripts/active_work_heads_up_ci_test.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
 
-from active_work_heads_up_ci import quiet_status_line, quiet_summary
+from active_work_heads_up_ci import (
+    quiet_status_line,
+    quiet_summary,
+    unresolved_endpoint_note,
+    unresolved_endpoint_receipts_involving_current,
+)
 
 INVENTORY = {
     "observed_at": "2026-08-23T00:00:00Z",
     "source": "test_provider_snapshot",
+    "current": {"id": "#10"},
 }
 
 
@@ -30,6 +36,33 @@ def main() -> int:
     assert failure_note in unknown_summary
     assert "No active-work coordination signal worth surfacing." not in unknown_summary
     assert "reviewed coordination metadata remains unresolved" in unknown_summary
+
+    extraction_report = {
+        "unresolved_endpoint_receipts": [
+            {"from": "#10", "to": "#999"},
+            {"from": "#20", "to": "#998"},
+        ]
+    }
+    current_unresolved = unresolved_endpoint_receipts_involving_current(
+        INVENTORY, extraction_report
+    )
+    assert current_unresolved == [{"from": "#10", "to": "#999"}]
+    endpoint_note = unresolved_endpoint_note(current_unresolved)
+    assert endpoint_note is not None
+    assert "1 endpoint absent from the supplied work inventory" in endpoint_note
+    endpoint_summary = quiet_summary(INVENTORY, endpoint_note)
+    assert "Coordination metadata: UNKNOWN" in endpoint_summary
+    assert "No active-work coordination signal worth surfacing." not in endpoint_summary
+
+    unrelated_report = {
+        "unresolved_endpoint_receipts": [{"from": "#20", "to": "#998"}]
+    }
+    unrelated = unresolved_endpoint_receipts_involving_current(
+        INVENTORY, unrelated_report
+    )
+    assert unrelated == []
+    assert unresolved_endpoint_note(unrelated) is None
+    assert quiet_status_line(unresolved_endpoint_note(unrelated)) == clean_status
 
     return 0
 

--- a/src/coordination_edges.rs
+++ b/src/coordination_edges.rs
@@ -69,7 +69,7 @@ pub struct CoordinationEdge {
     pub source: String,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct SourceReceipt {
     pub kind: CoordinationKind,
     pub from: String,
@@ -96,6 +96,7 @@ pub struct ExtractionReport {
     pub source: String,
     pub coordination_edges: Vec<CoordinationEdge>,
     pub source_receipts: Vec<SourceReceipt>,
+    pub unresolved_endpoint_receipts: Vec<SourceReceipt>,
     pub stats: ExtractionStats,
     pub unknowns: Vec<String>,
 }
@@ -120,6 +121,7 @@ pub fn extract_snapshot(input: &str) -> Result<ExtractionReport, EdgeError> {
         .collect::<BTreeSet<_>>();
 
     let mut edge_receipts = BTreeMap::<CoordinationEdge, SourceReceipt>::new();
+    let mut unresolved_endpoint_receipts = BTreeSet::<SourceReceipt>::new();
     let mut stats = ExtractionStats {
         work_items_examined: snapshot.work.len(),
         ..ExtractionStats::default()
@@ -158,6 +160,20 @@ pub fn extract_snapshot(input: &str) -> Result<ExtractionReport, EdgeError> {
             }
             if !known_ids.contains(target.as_str()) {
                 stats.unresolved_endpoints_ignored += 1;
+                unresolved_endpoint_receipts.insert(SourceReceipt {
+                    kind: CoordinationKind::HoldMergeWhile,
+                    from: work.id.clone(),
+                    to: target.clone(),
+                    source: work.source.clone(),
+                    source_head_sha: work.head_sha.clone(),
+                    source_updated_at: work.updated_at.clone(),
+                    matched_clause: line.to_string(),
+                });
+                if unresolved_endpoint_receipts.len() > MAX_EDGES {
+                    return Err(EdgeError::new(format!(
+                        "unresolved coordination endpoint receipt count exceeds maximum {MAX_EDGES}"
+                    )));
+                }
                 continue;
             }
 
@@ -190,6 +206,7 @@ pub fn extract_snapshot(input: &str) -> Result<ExtractionReport, EdgeError> {
 
     let coordination_edges = edge_receipts.keys().cloned().collect::<Vec<_>>();
     let source_receipts = edge_receipts.values().cloned().collect::<Vec<_>>();
+    let unresolved_endpoint_receipts = unresolved_endpoint_receipts.into_iter().collect();
 
     Ok(ExtractionReport {
         schema_version: SNAPSHOT_SCHEMA_VERSION,
@@ -197,6 +214,7 @@ pub fn extract_snapshot(input: &str) -> Result<ExtractionReport, EdgeError> {
         source: snapshot.source,
         coordination_edges,
         source_receipts,
+        unresolved_endpoint_receipts,
         stats,
         unknowns: vec![
             "A body-derived edge proves only that the admitted source metadata contained the reviewed operative clause at the recorded head/update coordinates; implementation intent or continued applicability beyond that clause remains unknown without independent evidence.".to_string(),
@@ -426,6 +444,17 @@ mod tests {
         assert!(report.coordination_edges.is_empty());
         assert_eq!(report.stats.self_references_ignored, 1);
         assert_eq!(report.stats.unresolved_endpoints_ignored, 1);
+        assert_eq!(report.unresolved_endpoint_receipts.len(), 1);
+        let unresolved = &report.unresolved_endpoint_receipts[0];
+        assert_eq!(unresolved.from, "#748");
+        assert_eq!(unresolved.to, "#999");
+        assert_eq!(unresolved.source, "github:pull/748");
+        assert_eq!(unresolved.source_head_sha, sha('a'));
+        assert_eq!(unresolved.source_updated_at, "2026-08-19T00:00:00Z");
+        assert_eq!(
+            unresolved.matched_clause,
+            "Do not merge while #999 is active"
+        );
     }
 
     #[test]

--- a/tests/unresolved_coordination_source_loss.rs
+++ b/tests/unresolved_coordination_source_loss.rs
@@ -30,7 +30,7 @@ fn snapshot(first: Value, second: Value) -> String {
 }
 
 #[test]
-fn unresolved_endpoint_erases_which_work_item_authored_the_clause() {
+fn unresolved_endpoint_preserves_which_work_item_authored_the_clause() {
     let current_authored = coordination_edges::extract_snapshot(&snapshot(
         work("#748", "Do not merge while #999 is active\n"),
         work("#703", ""),
@@ -51,7 +51,24 @@ fn unresolved_endpoint_erases_which_work_item_authored_the_clause() {
     assert!(other_authored.source_receipts.is_empty());
     assert_eq!(other_authored.stats.unresolved_endpoints_ignored, 1);
 
-    assert_eq!(current_authored, other_authored);
+    assert_ne!(current_authored, other_authored);
+    assert_eq!(current_authored.unresolved_endpoint_receipts.len(), 1);
+    assert_eq!(
+        current_authored.unresolved_endpoint_receipts[0].from,
+        "#748"
+    );
+    assert_eq!(current_authored.unresolved_endpoint_receipts[0].to, "#999");
+    assert_eq!(
+        current_authored.unresolved_endpoint_receipts[0].source,
+        "github:pull/748"
+    );
+    assert_eq!(other_authored.unresolved_endpoint_receipts.len(), 1);
+    assert_eq!(other_authored.unresolved_endpoint_receipts[0].from, "#703");
+    assert_eq!(other_authored.unresolved_endpoint_receipts[0].to, "#999");
+    assert_eq!(
+        other_authored.unresolved_endpoint_receipts[0].source,
+        "github:pull/703"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Refs #105 #300 #302.

## Trigger

Merged #302 proves the current coordination extractor loses the author/source coordinate when an operative `Do not merge while #N ...` clause targets work absent from the admitted provider set. The report keeps only an aggregate `unresolved_endpoints_ignored` count, so the CI adapter cannot distinguish unresolved coordination authored by the current PR from the same unresolved clause on unrelated work.

## Repair target

- keep an unresolved endpoint unresolved; do not manufacture a coordination edge;
- retain an exact source-owned unresolved-clause receipt with author, target, source, source head/update coordinate, and matched clause;
- let the active-work CI adapter surface `UNKNOWN` when such a receipt involves current work;
- keep unresolved endpoint receipts authored only by other PRs quiet;
- preserve #296's existing extractor-failure UNKNOWN behavior;
- convert the merged #302 source-loss counterexample into the lasting source-preservation regression.

## Boundary

No provider completeness inference, activity inference, wall-clock rule, ownership, scheduling, merge, or mutation authority. Validation and patch execution are GitHub-hosted Actions only.