### PR TITLE
feat: add provider snapshot applicability primitive

### DIFF
--- a/src/applicability.rs
+++ b/src/applicability.rs
@@ -120,6 +120,14 @@ impl fmt::Display for ApplicabilityError {
 
 impl Error for ApplicabilityError {}
 
+pub fn evaluate_exact_coordinate(required: &str, actual: Option<&str>) -> ApplicabilityStatus {
+    match actual {
+        Some(actual) if actual == required => ApplicabilityStatus::Applies,
+        Some(_) => ApplicabilityStatus::Invalid,
+        None => ApplicabilityStatus::Unknown,
+    }
+}
+
 pub fn evaluate_query(
     query: &ApplicabilityQuery,
 ) -> Result<EvidenceApplicability, ApplicabilityError> {
@@ -189,25 +197,16 @@ fn evaluate_exact_dimension(
     required: &str,
     actual: Option<&str>,
 ) -> DimensionEvaluation {
-    match actual {
-        Some(actual) if actual == required => DimensionEvaluation {
-            dimension,
-            status: DimensionStatus::Matched,
-            required: required.to_string(),
-            actual: Some(actual.to_string()),
-        },
-        Some(actual) => DimensionEvaluation {
-            dimension,
-            status: DimensionStatus::Mismatched,
-            required: required.to_string(),
-            actual: Some(actual.to_string()),
-        },
-        None => DimensionEvaluation {
-            dimension,
-            status: DimensionStatus::Missing,
-            required: required.to_string(),
-            actual: None,
-        },
+    let status = match evaluate_exact_coordinate(required, actual) {
+        ApplicabilityStatus::Applies => DimensionStatus::Matched,
+        ApplicabilityStatus::Invalid => DimensionStatus::Mismatched,
+        ApplicabilityStatus::Unknown => DimensionStatus::Missing,
+    };
+    DimensionEvaluation {
+        dimension,
+        status,
+        required: required.to_string(),
+        actual: actual.map(str::to_string),
     }
 }
 

--- a/src/provider_snapshot_applicability.rs
+++ b/src/provider_snapshot_applicability.rs
@@ -1,0 +1,136 @@
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::applicability::{ApplicabilityStatus, evaluate_exact_coordinate};
+
+pub const PROVIDER_SNAPSHOT_APPLICABILITY_SCHEMA_VERSION: u32 = 1;
+const SHA256_PREFIX: &str = "sha256:";
+const SHA256_HEX_BYTES: usize = 64;
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct ProviderSnapshotIdentity(String);
+
+impl ProviderSnapshotIdentity {
+    pub fn parse(value: impl Into<String>) -> Result<Self, ProviderSnapshotIdentityError> {
+        let value = value.into();
+        validate_identity(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for ProviderSnapshotIdentity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(value).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ProviderSnapshotApplicability {
+    pub schema_version: u32,
+    pub status: ApplicabilityStatus,
+    pub required: ProviderSnapshotIdentity,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actual: Option<ProviderSnapshotIdentity>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProviderSnapshotApplicabilityWire {
+    schema_version: u32,
+    status: ApplicabilityStatus,
+    required: ProviderSnapshotIdentity,
+    #[serde(default)]
+    actual: Option<ProviderSnapshotIdentity>,
+}
+
+impl<'de> Deserialize<'de> for ProviderSnapshotApplicability {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = ProviderSnapshotApplicabilityWire::deserialize(deserializer)?;
+        if wire.schema_version != PROVIDER_SNAPSHOT_APPLICABILITY_SCHEMA_VERSION {
+            return Err(<D::Error as serde::de::Error>::custom(format!(
+                "unsupported provider snapshot applicability schema {}; expected {PROVIDER_SNAPSHOT_APPLICABILITY_SCHEMA_VERSION}",
+                wire.schema_version
+            )));
+        }
+
+        let expected = evaluate_provider_snapshot(&wire.required, wire.actual.as_ref());
+        if wire.status != expected.status {
+            return Err(<D::Error as serde::de::Error>::custom(
+                "provider snapshot applicability status is inconsistent with required/actual identities",
+            ));
+        }
+        Ok(expected)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ProviderSnapshotIdentityError {
+    message: String,
+}
+
+impl ProviderSnapshotIdentityError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ProviderSnapshotIdentityError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for ProviderSnapshotIdentityError {}
+
+pub fn evaluate_provider_snapshot(
+    required: &ProviderSnapshotIdentity,
+    current: Option<&ProviderSnapshotIdentity>,
+) -> ProviderSnapshotApplicability {
+    let status = evaluate_exact_coordinate(
+        required.as_str(),
+        current.map(ProviderSnapshotIdentity::as_str),
+    );
+
+    ProviderSnapshotApplicability {
+        schema_version: PROVIDER_SNAPSHOT_APPLICABILITY_SCHEMA_VERSION,
+        status,
+        required: required.clone(),
+        actual: current.cloned(),
+    }
+}
+
+fn validate_identity(value: &str) -> Result<(), ProviderSnapshotIdentityError> {
+    let Some(digest) = value.strip_prefix(SHA256_PREFIX) else {
+        return Err(ProviderSnapshotIdentityError::new(
+            "provider snapshot identity must use `sha256:<digest>`",
+        ));
+    };
+
+    if digest.len() != SHA256_HEX_BYTES
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(ProviderSnapshotIdentityError::new(
+            "provider snapshot sha256 digest must contain exactly 64 lowercase hexadecimal characters",
+        ));
+    }
+
+    Ok(())
+}

--- a/tests/provider_snapshot_applicability.rs
+++ b/tests/provider_snapshot_applicability.rs
@@ -1,0 +1,158 @@
+#[allow(dead_code)]
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/provider_snapshot_applicability.rs"]
+mod provider_snapshot_applicability;
+
+use applicability::ApplicabilityStatus;
+use provider_snapshot_applicability::{
+    PROVIDER_SNAPSHOT_APPLICABILITY_SCHEMA_VERSION, ProviderSnapshotApplicability,
+    ProviderSnapshotIdentity, evaluate_provider_snapshot,
+};
+
+fn identity(hex: char) -> ProviderSnapshotIdentity {
+    ProviderSnapshotIdentity::parse(format!("sha256:{}", hex.to_string().repeat(64))).unwrap()
+}
+
+#[test]
+fn exact_provider_snapshot_identity_applies() {
+    let required = identity('a');
+    let current = identity('a');
+    assert_eq!(required.as_str(), format!("sha256:{}", "a".repeat(64)));
+    let evaluation = evaluate_provider_snapshot(&required, Some(&current));
+
+    assert_eq!(evaluation.status, ApplicabilityStatus::Applies);
+    assert_eq!(evaluation.required, required);
+    assert_eq!(evaluation.actual, Some(current));
+}
+
+#[test]
+fn known_provider_snapshot_movement_invalidates() {
+    let required = identity('a');
+    let current = identity('b');
+    let evaluation = evaluate_provider_snapshot(&required, Some(&current));
+
+    assert_eq!(evaluation.status, ApplicabilityStatus::Invalid);
+    assert_eq!(evaluation.actual, Some(current));
+}
+
+#[test]
+fn unavailable_current_provider_snapshot_is_unknown() {
+    let required = identity('a');
+    let evaluation = evaluate_provider_snapshot(&required, None);
+
+    assert_eq!(evaluation.status, ApplicabilityStatus::Unknown);
+    assert_eq!(evaluation.actual, None);
+}
+
+#[test]
+fn canonical_identity_parser_fails_closed() {
+    let uppercase = format!("sha256:{}", "A".repeat(64));
+    let malformed = [
+        "a".repeat(64),
+        "sha256:".to_string(),
+        format!("sha256:{}", "a".repeat(63)),
+        format!("sha256:{}", "a".repeat(65)),
+        format!("sha256:{}g", "a".repeat(63)),
+        uppercase,
+        format!(" sha256:{}", "a".repeat(64)),
+        format!("sha256:{} ", "a".repeat(64)),
+    ];
+
+    for value in malformed {
+        assert!(
+            ProviderSnapshotIdentity::parse(&value).is_err(),
+            "accepted malformed identity `{value}`"
+        );
+    }
+}
+
+#[test]
+fn identity_and_evaluation_round_trip_as_machine_objects() {
+    let required = identity('a');
+    let current = identity('b');
+
+    let identity_json = serde_json::to_string(&required).unwrap();
+    assert_eq!(
+        serde_json::from_str::<ProviderSnapshotIdentity>(&identity_json).unwrap(),
+        required
+    );
+
+    let evaluation = evaluate_provider_snapshot(&required, Some(&current));
+    let evaluation_json = serde_json::to_string(&evaluation).unwrap();
+    let decoded: ProviderSnapshotApplicability = serde_json::from_str(&evaluation_json).unwrap();
+    assert_eq!(decoded, evaluation);
+    assert_eq!(
+        decoded.schema_version,
+        PROVIDER_SNAPSHOT_APPLICABILITY_SCHEMA_VERSION
+    );
+}
+
+#[test]
+fn malformed_machine_identity_is_rejected_during_deserialization() {
+    let json = format!("\"sha256:{}\"", "A".repeat(64));
+    let error = serde_json::from_str::<ProviderSnapshotIdentity>(&json).unwrap_err();
+    assert!(error.to_string().contains("lowercase hexadecimal"));
+}
+
+#[test]
+fn evaluation_deserialization_rejects_unsupported_schema() {
+    let json = format!(
+        r#"{{
+            "schema_version": 2,
+            "status": "applies",
+            "required": "sha256:{}",
+            "actual": "sha256:{}"
+        }}"#,
+        "a".repeat(64),
+        "a".repeat(64)
+    );
+    let error = serde_json::from_str::<ProviderSnapshotApplicability>(&json).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("unsupported provider snapshot applicability schema")
+    );
+}
+
+#[test]
+fn evaluation_deserialization_rejects_inconsistent_status() {
+    let different_actual = format!(
+        r#"{{
+            "schema_version": 1,
+            "status": "applies",
+            "required": "sha256:{}",
+            "actual": "sha256:{}"
+        }}"#,
+        "a".repeat(64),
+        "b".repeat(64)
+    );
+    let missing_actual = format!(
+        r#"{{
+            "schema_version": 1,
+            "status": "applies",
+            "required": "sha256:{}"
+        }}"#,
+        "a".repeat(64)
+    );
+
+    for json in [different_actual, missing_actual] {
+        let error = serde_json::from_str::<ProviderSnapshotApplicability>(&json).unwrap_err();
+        assert!(error.to_string().contains("status is inconsistent"));
+    }
+}
+
+#[test]
+fn unknown_evaluation_fields_fail_closed() {
+    let json = format!(
+        r#"{{
+            "schema_version": 1,
+            "status": "applies",
+            "required": "sha256:{}",
+            "future_semantics": true
+        }}"#,
+        "a".repeat(64)
+    );
+    let error = serde_json::from_str::<ProviderSnapshotApplicability>(&json).unwrap_err();
+    assert!(error.to_string().contains("unknown field"));
+}


### PR DESCRIPTION
Progresses #292 with the smallest provider-agnostic product primitive earned by the merged research chain (#294, #298, #305, #308).

## Change

Add `src/provider_snapshot_applicability.rs` with:

- canonical `ProviderSnapshotIdentity` encoded as `sha256:<64 lowercase hex>`;
- serde validation that rejects alternate spellings/malformed identities;
- `evaluate_provider_snapshot(required, current)` returning the existing `ApplicabilityStatus::{Applies, Invalid, Unknown}` vocabulary;
- a machine-readable evaluation envelope with required/actual identities.

Controls cover exact match -> APPLIES, known movement -> INVALID, unavailable current -> UNKNOWN, malformed/case/whitespace identities failing closed, machine round-trip, and unknown evaluation fields failing closed.

## Why this is separate

The active-work inventory schema still needs to bind the required provider-snapshot identity, and consumption needs an independently supplied/re-read current identity. That wiring belongs in `src/active_changes.rs`, currently owned by #290, so this PR deliberately avoids that file.

The product core performs no provider/network fetch. A future adapter supplies the current snapshot identity after an exact bounded re-read; if any required current component is unavailable, the adapter supplies no current identity and this primitive returns UNKNOWN.

## Boundary

- no active-work inventory/CLI behavior change;
- no provider fetch or adapter;
- no wall-clock TTL;
- no new status taxonomy;
- no inference from repository revision, branch existence, or checkout HEAD;
- SHA-256 is the explicit v1 identity algorithm. A different algorithm needs a versioned extension rather than alternate spelling;
- snapshot APPLIES means exact identity equality only; it does not establish repository revision applicability, per-item activity certainty, ownership, or authority.