### PR TITLE
research: retain active-inventory provider-snapshot gap

### DIFF
--- a/tests/active_inventory_provider_snapshot_gap.rs
+++ b/tests/active_inventory_provider_snapshot_gap.rs
@@ -1,0 +1,204 @@
+#![allow(dead_code)]
+
+#[path = "../src/active_changes.rs"]
+mod active_changes;
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/finding.rs"]
+mod finding;
+#[path = "../src/provider_snapshot_applicability.rs"]
+mod provider_snapshot_applicability;
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use provider_snapshot_applicability::{
+    ProviderSnapshotIdentity, evaluate_provider_snapshot,
+};
+use serde::Serialize;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+mod selection_contract {
+    #![allow(dead_code)]
+
+    include!("provider_selection_contract.rs");
+
+    pub(super) fn frozen_identity() -> String {
+        selection_identity(&baseline()).unwrap()
+    }
+}
+
+mod work_fact_contract {
+    #![allow(dead_code)]
+
+    include!("provider_work_fact_contract.rs");
+
+    const HEAD_10: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const HEAD_20: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const HEAD_30: &str = "cccccccccccccccccccccccccccccccccccccccc";
+
+    fn frozen_work() -> Vec<WorkInput<'static>> {
+        vec![
+            WorkInput {
+                id: "pull/10",
+                head_sha: HEAD_10,
+                activity: ActivityInput::ConfirmedActive,
+                changed_paths: vec!["src/lib.rs"],
+            },
+            WorkInput {
+                id: "pull/20",
+                head_sha: HEAD_20,
+                activity: ActivityInput::ConfirmedActive,
+                changed_paths: vec!["src/lib.rs"],
+            },
+        ]
+    }
+
+    pub(super) fn frozen_identity() -> String {
+        fingerprint(&frozen_work(), &[]).unwrap()
+    }
+
+    pub(super) fn current_with_new_work_identity() -> String {
+        let mut work = frozen_work();
+        work.push(WorkInput {
+            id: "pull/30",
+            head_sha: HEAD_30,
+            activity: ActivityInput::ConfirmedActive,
+            changed_paths: vec!["src/new.rs"],
+        });
+        fingerprint(&work, &[]).unwrap()
+    }
+}
+
+const SNAPSHOT_COMPOSITION_SCHEMA_VERSION: u32 = 0;
+
+#[derive(Serialize)]
+struct ProviderSnapshotDocument<'a> {
+    schema_version: u32,
+    selection_identity: &'a str,
+    work_fact_identity: &'a str,
+}
+
+fn snapshot_identity(selection_identity: &str, work_fact_identity: &str) -> String {
+    let document = ProviderSnapshotDocument {
+        schema_version: SNAPSHOT_COMPOSITION_SCHEMA_VERSION,
+        selection_identity,
+        work_fact_identity,
+    };
+    let bytes = serde_json::to_vec(&document).unwrap();
+    let digest = Sha256::digest(bytes);
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut encoded, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    encoded
+}
+
+fn product_identity(work_fact_identity: &str) -> ProviderSnapshotIdentity {
+    let digest = snapshot_identity(
+        &selection_contract::frozen_identity(),
+        work_fact_identity,
+    );
+    ProviderSnapshotIdentity::parse(format!("sha256:{digest}")).unwrap()
+}
+
+fn required_snapshot() -> ProviderSnapshotIdentity {
+    product_identity(&work_fact_contract::frozen_identity())
+}
+
+fn current_snapshot_with_new_work() -> ProviderSnapshotIdentity {
+    product_identity(&work_fact_contract::current_with_new_work_identity())
+}
+
+fn test_root() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "cultist-active-inventory-provider-snapshot-gap-{}-{nonce}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).unwrap();
+    root
+}
+
+fn frozen_inventory(root: &std::path::Path) -> PathBuf {
+    let path = root.join("inventory.json");
+    let document = json!({
+        "schema_version": 1,
+        "source": "test:provider-snapshot-gap",
+        "observed_at": "2026-08-22T19:10:00Z",
+        "current": {
+            "id": "pull/10",
+            "kind": "pull_request",
+            "title": "current work",
+            "url": "https://example.invalid/pull/10",
+            "head_ref": "feature/current",
+            "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "updated_at": "2026-08-22T19:09:00Z",
+            "draft": false,
+            "activity": "confirmed_active",
+            "changed_paths": ["src/lib.rs"]
+        },
+        "active_work": [{
+            "id": "pull/20",
+            "kind": "pull_request",
+            "title": "other work",
+            "url": "https://example.invalid/pull/20",
+            "head_ref": "feature/other",
+            "head_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "updated_at": "2026-08-22T19:09:30Z",
+            "draft": false,
+            "activity": "confirmed_active",
+            "changed_paths": ["src/lib.rs"]
+        }]
+    });
+    fs::write(&path, serde_json::to_vec_pretty(&document).unwrap()).unwrap();
+    path
+}
+
+fn analyzer_still_emits_strong_overlap() {
+    let root = test_root();
+    let inventory = frozen_inventory(&root);
+    let report = active_changes::build_active_inventory_analysis_report(&root, &inventory, None)
+        .unwrap();
+
+    assert!(report.findings.iter().any(|finding| {
+        finding.kind == "preflight-inventory-path-overlap"
+            && finding.title == "Active-change path overlap"
+    }));
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn new_provider_work_invalidates_snapshot_without_gating_frozen_inventory_collision() {
+    let required = required_snapshot();
+    let current = current_snapshot_with_new_work();
+    let applicability = evaluate_provider_snapshot(&required, Some(&current));
+
+    assert_eq!(applicability.status, applicability::ApplicabilityStatus::Invalid);
+    analyzer_still_emits_strong_overlap();
+}
+
+#[test]
+fn unavailable_provider_snapshot_does_not_preserve_unknown_in_consumer() {
+    let required = required_snapshot();
+    let applicability = evaluate_provider_snapshot(&required, None);
+
+    assert_eq!(applicability.status, applicability::ApplicabilityStatus::Unknown);
+    analyzer_still_emits_strong_overlap();
+}
+
+#[test]
+fn exact_same_provider_snapshot_applies_as_control() {
+    let required = required_snapshot();
+    let current = required_snapshot();
+    let applicability = evaluate_provider_snapshot(&required, Some(&current));
+
+    assert_eq!(applicability.status, applicability::ApplicabilityStatus::Applies);
+}

--- a/tests/active_inventory_provider_snapshot_gap.rs
+++ b/tests/active_inventory_provider_snapshot_gap.rs
@@ -14,9 +14,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use provider_snapshot_applicability::{
-    ProviderSnapshotIdentity, evaluate_provider_snapshot,
-};
+use provider_snapshot_applicability::{ProviderSnapshotIdentity, evaluate_provider_snapshot};
 use serde::Serialize;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -98,10 +96,7 @@ fn snapshot_identity(selection_identity: &str, work_fact_identity: &str) -> Stri
 }
 
 fn product_identity(work_fact_identity: &str) -> ProviderSnapshotIdentity {
-    let digest = snapshot_identity(
-        &selection_contract::frozen_identity(),
-        work_fact_identity,
-    );
+    let digest = snapshot_identity(&selection_contract::frozen_identity(), work_fact_identity);
     ProviderSnapshotIdentity::parse(format!("sha256:{digest}")).unwrap()
 }
 
@@ -164,8 +159,8 @@ fn frozen_inventory(root: &std::path::Path) -> PathBuf {
 fn analyzer_still_emits_strong_overlap() {
     let root = test_root();
     let inventory = frozen_inventory(&root);
-    let report = active_changes::build_active_inventory_analysis_report(&root, &inventory, None)
-        .unwrap();
+    let report =
+        active_changes::build_active_inventory_analysis_report(&root, &inventory, None).unwrap();
 
     assert!(report.findings.iter().any(|finding| {
         finding.kind == "preflight-inventory-path-overlap"
@@ -181,7 +176,10 @@ fn new_provider_work_invalidates_snapshot_without_gating_frozen_inventory_collis
     let current = current_snapshot_with_new_work();
     let applicability = evaluate_provider_snapshot(&required, Some(&current));
 
-    assert_eq!(applicability.status, applicability::ApplicabilityStatus::Invalid);
+    assert_eq!(
+        applicability.status,
+        applicability::ApplicabilityStatus::Invalid
+    );
     analyzer_still_emits_strong_overlap();
 }
 
@@ -190,7 +188,10 @@ fn unavailable_provider_snapshot_does_not_preserve_unknown_in_consumer() {
     let required = required_snapshot();
     let applicability = evaluate_provider_snapshot(&required, None);
 
-    assert_eq!(applicability.status, applicability::ApplicabilityStatus::Unknown);
+    assert_eq!(
+        applicability.status,
+        applicability::ApplicabilityStatus::Unknown
+    );
     analyzer_still_emits_strong_overlap();
 }
 
@@ -200,5 +201,8 @@ fn exact_same_provider_snapshot_applies_as_control() {
     let current = required_snapshot();
     let applicability = evaluate_provider_snapshot(&required, Some(&current));
 
-    assert_eq!(applicability.status, applicability::ApplicabilityStatus::Applies);
+    assert_eq!(
+        applicability.status,
+        applicability::ApplicabilityStatus::Applies
+    );
 }


### PR DESCRIPTION
Progresses #313 with one isolated test-only consumer counterexample over the real active-inventory analyzer plus the landed #298/#305/#308/#310 provider-snapshot contracts.

## Frozen work facts + explicit selection contract

The carrier reuses the landed selection and work-fact contracts. Its required snapshot combines:

```text
explicit provider selection contract
  github.com / teamleaderleo/cultist
  open pull requests, include drafts, exhaustive

frozen work facts supplied to the analyzer
  pull/10 @ aaaa... confirmed_active -> src/lib.rs
  pull/20 @ bbbb... confirmed_active -> src/lib.rs
```

The work-fact half exactly matches the frozen inventory consumed by `build_active_inventory_analysis_report`. Inventory schema v1 does **not** itself bind provider instance/collection/selection identity; that missing producer-to-inventory binding remains part of the product gap. The test supplies the reviewed #298 selection contract independently and wraps the resulting #308 composition in #310's product `sha256:` identity.

## Current population movement

An independently derived current snapshot keeps the same explicit selection contract and frozen work facts but adds:

```text
pull/30 @ cccc... confirmed_active -> src/new.rs
```

#310 therefore returns `INVALID` for required snapshot A versus current snapshot B. If the current snapshot is unavailable, #310 returns `UNKNOWN`.

In both cases the actual current `build_active_inventory_analysis_report` still consumes the frozen inventory and emits the strong `preflight-inventory-path-overlap` / `Active-change path overlap` finding because inventory schema v1 and the analyzer entrypoint carry no provider-snapshot requirement/current applicability input.

A same-snapshot APPLIES control is retained.

## Boundary

- one new test file only;
- no product/schema/CLI behavior change;
- reuse #298 selection identity, #305 work-fact identity, #308 composition document, and #310 product evaluator;
- no second snapshot hash/status model;
- no claim that inventory v1 can derive or authenticate its own selection/provider-scope identity;
- no provider fetch or adapter;
- no wall-clock TTL;
- repository/work revision applicability, per-item activity certainty, and unresolved coordination metadata remain separate;
- no ownership, scheduling, merge, or mutation authority.

This is the proof artifact for #313. Any repair should be chosen separately after independent review. A repair needs both an explicit frozen provider-snapshot requirement bound to the inventory and an independently supplied/re-read current snapshot identity; it must not infer provider population currentness from repository revision or `observed_at`.

Validation is GitHub-hosted Actions only on repository-owned `ubuntu-latest`.