### PR TITLE
DO NOT MERGE: Mako source admission A/B preflight

### DIFF
--- a/tests/quarry_mako_source_admission_ab_preflight.rs
+++ b/tests/quarry_mako_source_admission_ab_preflight.rs
@@ -1,0 +1,114 @@
+use std::fs;
+use std::process::Command;
+
+use serde_json::Value;
+
+#[test]
+fn quarry_mako_source_admission_ab_is_path_quiet() {
+    let root = std::env::temp_dir().join(format!(
+        "cultist-quarry-mako-source-admission-root-{}",
+        std::process::id()
+    ));
+    let inventory_path = std::env::temp_dir().join(format!(
+        "cultist-quarry-mako-source-admission-inventory-{}.json",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).expect("create analysis root");
+    fs::write(root.join(".gitignore"), "\n").expect("write seed file");
+    for args in [
+        vec!["init", "-q"],
+        vec!["config", "user.email", "mako@example.invalid"],
+        vec!["config", "user.name", "Mako"],
+        vec!["add", ".gitignore"],
+        vec!["commit", "-q", "-m", "seed"],
+    ] {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(args)
+            .status()
+            .expect("run git setup command");
+        assert!(status.success(), "git setup command failed");
+    }
+
+    let inventory = r#"{
+  "schema_version": 1,
+  "source": "github:bounded-performance-family-mako-2026-08-22T21:08:00Z",
+  "observed_at": "2026-08-22T21:08:00Z",
+  "current": {
+    "id": "mako/source-admission-ab",
+    "kind": "planned_work",
+    "title": "Mako measure source-specific replay-parent admission",
+    "url": "https://github.com/Coreys-Quarry/quarry/issues/563",
+    "head_ref": "main",
+    "head_sha": "3fe608a24d673a606e385070e21b05b164af6a22",
+    "updated_at": "2026-08-22T21:08:00Z",
+    "draft": false,
+    "activity": "preparation",
+    "changed_paths": [
+      ".github/workflows/research-563-source-admission-ab.yml",
+      "scripts/research_563_source_admission_ab.py",
+      "src/quarry/_exact_regime_attribution_receipts.py"
+    ]
+  },
+  "active_work": [
+    {
+      "id": "pull/737",
+      "kind": "pull_request",
+      "title": "fix: fail closed on unproven research fanout isolation",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/737",
+      "head_ref": "mako/637-fanout-isolation-repair-20260823",
+      "head_sha": "267ddd480095625712ca81135f721f97f020f24a",
+      "updated_at": "2026-08-22T19:54:47Z",
+      "draft": false,
+      "activity": "confirmed_active",
+      "changed_paths": [
+        "src/quarry/research_supergraph.py",
+        "tests/test_research_supergraph.py"
+      ]
+    }
+  ],
+  "coordination_edges": []
+}"#;
+    fs::write(&inventory_path, inventory).expect("write bounded inventory");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-cultist"))
+        .args([
+            "preflight",
+            "--inventory",
+            inventory_path.to_str().expect("inventory path is utf-8"),
+            "--format",
+            "json",
+            root.to_str().expect("root path is utf-8"),
+        ])
+        .output()
+        .expect("run current Cultist preflight binary");
+    assert!(
+        output.status.success(),
+        "preflight failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("preflight output is utf-8");
+    let report: Value = serde_json::from_str(&stdout).expect("preflight output is json");
+    let findings = report["findings"].as_array().expect("findings array");
+    let overlaps = findings
+        .iter()
+        .filter(|finding| finding["kind"].as_str() == Some("preflight-inventory-path-overlap"))
+        .collect::<Vec<_>>();
+    assert!(
+        overlaps.is_empty(),
+        "source admission A/B unexpectedly overlaps active work: {stdout}"
+    );
+
+    let claims = report["claims"].as_array().expect("claims array");
+    assert!(claims.iter().any(|claim| {
+        claim["kind"].as_str() == Some("unknown")
+            && claim["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("semantically independent"))
+    }));
+
+    fs::remove_file(&inventory_path).ok();
+    fs::remove_dir_all(&root).ok();
+}


### PR DESCRIPTION
Disposable Mako 🦈 collision preflight before one Quarry #563/#566/#595 source-specific replay-parent admission A/B carrier. Closed unmerged after hosted receipt.

## Planned Quarry write paths
- `.github/workflows/research-563-source-admission-ab.yml`
- `scripts/research_563_source_admission_ab.py`
- `src/quarry/_exact_regime_attribution_receipts.py`

Question from #770: eight pooled-source dictionary comparisons consume `0.172685492s` and six individual `LegacyTrendSourceSpec` comparisons another `0.042934629s`. Can a closed source-schema comparator preserve exact nested-type admission while letting native source/bar/timing equality carry value comparison?

The candidate keeps current `_exact_graph_equal` for policy/fitted/schedule values and dispatches only exact pooled-source dict/source-spec pairs through a source schema covering snapshot JSON container types, exact `MarketBar`/leaf types including availability fields, exact timing dataclass/scalar types, and exact InstrumentRules types, followed by ordinary equality.

## Exact Cultist coordinate
- parent: `7b520bf4c9ccba017baacba67208b490cc170aac`
- carrier head: `bc10f54188707fd94049523feb741757a091cf8c`
- hosted run/job: `32598809672` / `97093829363`
- format, clippy, active-work controls, full Rust suite, and all dogfood stages: PASS

## Terminal provider reread
- Quarry main remained `3fe608a24d673a606e385070e21b05b164af6a22`
- bounded family remained only #737 `267ddd480095625712ca81135f721f97f020f24a`
- #737 paths are disjoint from all planned source-admission paths
- no open PR claims a source-admission/fingerprint lane
- semantic independence remains UNKNOWN

## Consequence
Proceed with one disposable source-specific component A/B only. Safety controls must refuse equal-value subtype substitutions before any speed result can advance.

Dogfood receipt: **surfaced; consulted; same action after provider-current verification; semantic independence remains UNKNOWN.**

No Cultist product change.