### PR TITLE
DO NOT MERGE: Mako source-admission composition preflight

### DIFF
--- a/tests/quarry_mako_source_admission_composition_preflight.rs
+++ b/tests/quarry_mako_source_admission_composition_preflight.rs
@@ -1,0 +1,118 @@
+use std::fs;
+use std::process::Command;
+
+use serde_json::Value;
+
+#[test]
+fn quarry_mako_source_admission_composition_is_path_quiet() {
+    let root = std::env::temp_dir().join(format!(
+        "cultist-quarry-mako-source-composition-root-{}",
+        std::process::id()
+    ));
+    let inventory_path = std::env::temp_dir().join(format!(
+        "cultist-quarry-mako-source-composition-inventory-{}.json",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).expect("create analysis root");
+    fs::write(root.join(".gitignore"), "\n").expect("write seed file");
+    for args in [
+        vec!["init", "-q"],
+        vec!["config", "user.email", "mako@example.invalid"],
+        vec!["config", "user.name", "Mako"],
+        vec!["add", ".gitignore"],
+        vec!["commit", "-q", "-m", "seed"],
+    ] {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(args)
+            .status()
+            .expect("run git setup command");
+        assert!(status.success(), "git setup command failed");
+    }
+
+    let inventory = r#"{
+  "schema_version": 1,
+  "source": "github:bounded-performance-family-mako-2026-08-22T21:19:00Z",
+  "observed_at": "2026-08-22T21:19:00Z",
+  "current": {
+    "id": "mako/source-admission-composition",
+    "kind": "planned_work",
+    "title": "Mako compose source-specific attribution admission into direct-timing alpha carrier",
+    "url": "https://github.com/Coreys-Quarry/quarry/issues/563",
+    "head_ref": "main",
+    "head_sha": "3fe608a24d673a606e385070e21b05b164af6a22",
+    "updated_at": "2026-08-22T21:19:00Z",
+    "draft": false,
+    "activity": "preparation",
+    "changed_paths": [
+      ".github/workflows/research-563-combined-alpha-source-admission.yml",
+      "scripts/research_563_combined_alpha_composition.py",
+      "scripts/research_563_combined_alpha_owned_source.py",
+      "scripts/research_563_combined_alpha_timing_parent.py",
+      "scripts/research_563_combined_alpha_direct_timing.py",
+      "scripts/research_563_combined_alpha_source_admission.py",
+      "src/quarry/_exact_regime_attribution_receipts.py"
+    ]
+  },
+  "active_work": [
+    {
+      "id": "pull/737",
+      "kind": "pull_request",
+      "title": "fix: fail closed on unproven research fanout isolation",
+      "url": "https://github.com/Coreys-Quarry/quarry/pull/737",
+      "head_ref": "mako/637-fanout-isolation-repair-20260823",
+      "head_sha": "267ddd480095625712ca81135f721f97f020f24a",
+      "updated_at": "2026-08-22T19:54:47Z",
+      "draft": false,
+      "activity": "confirmed_active",
+      "changed_paths": [
+        "src/quarry/research_supergraph.py",
+        "tests/test_research_supergraph.py"
+      ]
+    }
+  ],
+  "coordination_edges": []
+}"#;
+    fs::write(&inventory_path, inventory).expect("write bounded inventory");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-cultist"))
+        .args([
+            "preflight",
+            "--inventory",
+            inventory_path.to_str().expect("inventory path is utf-8"),
+            "--format",
+            "json",
+            root.to_str().expect("root path is utf-8"),
+        ])
+        .output()
+        .expect("run current Cultist preflight binary");
+    assert!(
+        output.status.success(),
+        "preflight failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("preflight output is utf-8");
+    let report: Value = serde_json::from_str(&stdout).expect("preflight output is json");
+    let findings = report["findings"].as_array().expect("findings array");
+    let overlaps = findings
+        .iter()
+        .filter(|finding| finding["kind"].as_str() == Some("preflight-inventory-path-overlap"))
+        .collect::<Vec<_>>();
+    assert!(
+        overlaps.is_empty(),
+        "source-admission composition unexpectedly overlaps active work: {stdout}"
+    );
+
+    let claims = report["claims"].as_array().expect("claims array");
+    assert!(claims.iter().any(|claim| {
+        claim["kind"].as_str() == Some("unknown")
+            && claim["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("semantically independent"))
+    }));
+
+    fs::remove_file(&inventory_path).ok();
+    fs::remove_dir_all(&root).ok();
+}


### PR DESCRIPTION
Disposable Mako 🦈 collision preflight before one Quarry #563/#566/#595/#576 same-host macro composition of #772 source admission into #765 direct timing. Closed unmerged after hosted receipt.

## Planned Quarry write paths
- `.github/workflows/research-563-combined-alpha-source-admission.yml`
- `scripts/research_563_combined_alpha_composition.py`
- `scripts/research_563_combined_alpha_owned_source.py`
- `scripts/research_563_combined_alpha_timing_parent.py`
- `scripts/research_563_combined_alpha_direct_timing.py`
- `scripts/research_563_combined_alpha_source_admission.py`
- `src/quarry/_exact_regime_attribution_receipts.py`

Question: #772 reduced heavy attribution source admission `0.354938655s -> 0.109146641s` and full private attribution `1.357512884s -> 1.034870271s`. Does that closed source schema materially improve the strongest #765 direct-timing alpha composition?

The existing composition/owned-source/timing/direct-timing/private-receipt files remain byte-exact research evidence from #714/#765. The new wrapper scopes the #772 source comparator to `combined._build_candidate` only, restoring the current comparator before the built-in public baseline executes. Same-host candidate runs first, byte-exact #765 direct-timing reference second.

## Exact Cultist coordinate
- parent: `7b520bf4c9ccba017baacba67208b490cc170aac`
- carrier head: `7eefa135fa0691c8cb4b04f59335bea91cc3fe8e`
- hosted run/job: `32599254522` / `97094956524`
- format, clippy, active-work controls, full Rust suite, and all dogfood stages: PASS

## Terminal provider reread
- Quarry main remained `3fe608a24d673a606e385070e21b05b164af6a22`
- bounded family remained only #737 `267ddd480095625712ca81135f721f97f020f24a`
- #737 paths are disjoint from all seven planned macro paths
- no open PR claims a source-admission composition lane
- semantic independence remains UNKNOWN

## Consequence
Proceed with one disposable same-host macro A/B only. Exact macro identity and material full-candidate gain are required before the source schema advances toward delivery.

Dogfood receipt: **surfaced; consulted; same action after provider-current verification; semantic independence remains UNKNOWN.**

No Cultist product change.