### PR TITLE
fix: revalidate current observation frontier at consumption

### DIFF
--- a/src/observation_probe_bridge.rs
+++ b/src/observation_probe_bridge.rs
@@ -4,7 +4,10 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use crate::applicability::{EvaluationContext, EvidenceRequirements};
+use crate::applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, evaluate_query,
+};
 use crate::durable_obligation::{
     ClearingCondition, DURABLE_OBLIGATION_SCHEMA_VERSION, DiscriminatorKey, DurableObligation,
 };
@@ -14,7 +17,7 @@ use crate::evidence_planner::{
 };
 use crate::observation_frontier::{ObservationFrontierReceipt, ObservationFrontierStatus};
 
-pub const OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION: u32 = 1;
+pub const OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION: u32 = 2;
 pub const MAX_OBSERVATION_PROBE_PLAN_REQUEST_BYTES: usize = 1024 * 1024;
 const MAX_BRIDGES: usize = 128;
 const MAX_ID_BYTES: usize = 256;
@@ -36,6 +39,7 @@ pub struct ObservationProbeBridge {
 pub struct ObservationProbePlanRequest {
     pub schema_version: u32,
     pub frontier: ObservationFrontierReceipt,
+    pub frontier_requirements: EvidenceRequirements,
     pub bridges: Vec<ObservationProbeBridge>,
     pub context: EvaluationContext,
     pub probes: Vec<EvidenceProbe>,
@@ -58,6 +62,7 @@ pub struct ObservationProbePlan {
     pub observation_discriminator_id: String,
     pub observation_subject_ref: String,
     pub frontier_status: ObservationFrontierStatus,
+    pub applicability_status: ApplicabilityStatus,
     pub status: ObservationProbePlanStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bridge_id: Option<String>,
@@ -109,9 +114,13 @@ pub fn plan_observation_probe(
     validate_request(request)?;
 
     let frontier = &request.frontier;
-    if frontier.status == ObservationFrontierStatus::Current {
+    let applicability_status = evaluate_frontier_applicability(request)?;
+    if frontier.status == ObservationFrontierStatus::Current
+        && applicability_status == ApplicabilityStatus::Applies
+    {
         return Ok(base_plan(
             frontier,
+            applicability_status,
             ObservationProbePlanStatus::AlreadyCurrent,
         ));
     }
@@ -125,6 +134,7 @@ pub fn plan_observation_probe(
     let Some(bridge) = matching.first().copied() else {
         return Ok(base_plan(
             frontier,
+            applicability_status,
             ObservationProbePlanStatus::NoAdmittedMapping,
         ));
     };
@@ -162,6 +172,7 @@ pub fn plan_observation_probe(
         observation_discriminator_id: frontier.discriminator_id.clone(),
         observation_subject_ref: frontier.subject_ref.clone(),
         frontier_status: frontier.status,
+        applicability_status,
         status: ObservationProbePlanStatus::Planned,
         bridge_id: Some(bridge.bridge_id.clone()),
         bridge_source_receipt: Some(bridge.source_receipt.clone()),
@@ -169,8 +180,25 @@ pub fn plan_observation_probe(
     })
 }
 
+fn evaluate_frontier_applicability(
+    request: &ObservationProbePlanRequest,
+) -> Result<ApplicabilityStatus, ObservationProbeBridgeError> {
+    evaluate_query(&ApplicabilityQuery {
+        schema_version: APPLICABILITY_SCHEMA_VERSION,
+        requirements: request.frontier_requirements.clone(),
+        context: request.context.clone(),
+    })
+    .map(|evaluation| evaluation.status)
+    .map_err(|error| {
+        ObservationProbeBridgeError::new(format!(
+            "frontier applicability evaluation failed: {error}"
+        ))
+    })
+}
+
 fn base_plan(
     frontier: &ObservationFrontierReceipt,
+    applicability_status: ApplicabilityStatus,
     status: ObservationProbePlanStatus,
 ) -> ObservationProbePlan {
     ObservationProbePlan {
@@ -178,6 +206,7 @@ fn base_plan(
         observation_discriminator_id: frontier.discriminator_id.clone(),
         observation_subject_ref: frontier.subject_ref.clone(),
         frontier_status: frontier.status,
+        applicability_status,
         status,
         bridge_id: None,
         bridge_source_receipt: None,
@@ -203,6 +232,7 @@ fn validate_request(
         )));
     }
     validate_frontier(&request.frontier)?;
+    evaluate_frontier_applicability(request)?;
     if request.bridges.len() > MAX_BRIDGES {
         return Err(ObservationProbeBridgeError::new(
             "observation probe bridges exceed the admitted boundary",

--- a/tests/observation_probe_bridge.rs
+++ b/tests/observation_probe_bridge.rs
@@ -15,7 +15,7 @@ mod observation_frontier;
 #[path = "../src/observation_probe_bridge.rs"]
 mod observation_probe_bridge;
 
-use applicability::{EvaluationContext, EvidenceRequirements};
+use applicability::{ApplicabilityStatus, EvaluationContext, EvidenceRequirements};
 use durable_obligation::DiscriminatorKey;
 use evidence_planner::{
     EvidencePlanStatus, EvidenceProbe, ProbeCandidateStatus, ProbeCost, ProbeEffect,
@@ -158,6 +158,7 @@ fn request(
     ObservationProbePlanRequest {
         schema_version: OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION,
         frontier,
+        frontier_requirements: requirements(Some("head-a")),
         bridges,
         context,
         probes,
@@ -200,6 +201,7 @@ fn exact_source_bridge_selects_capable_probe_and_rejects_similar_name_as_incapab
     .unwrap();
 
     assert_eq!(plan.status, ObservationProbePlanStatus::Planned);
+    assert_eq!(plan.applicability_status, ApplicabilityStatus::Applies);
     let evidence = plan.evidence_plan.unwrap();
     assert_eq!(evidence.status, EvidencePlanStatus::Selected);
     assert_eq!(evidence.selected.unwrap().id, "mapped-source-probe");
@@ -236,6 +238,7 @@ fn similarly_named_probe_without_explicit_bridge_leaves_frontier_unmapped() {
     .unwrap();
 
     assert_eq!(plan.status, ObservationProbePlanStatus::NoAdmittedMapping);
+    assert_eq!(plan.applicability_status, ApplicabilityStatus::Applies);
     assert!(plan.evidence_plan.is_none());
 }
 
@@ -257,10 +260,11 @@ fn bridge_for_wrong_subject_does_not_map_required_frontier() {
     .unwrap();
 
     assert_eq!(plan.status, ObservationProbePlanStatus::NoAdmittedMapping);
+    assert_eq!(plan.applicability_status, ApplicabilityStatus::Applies);
 }
 
 #[test]
-fn current_frontier_needs_no_acquisition_plan() {
+fn current_frontier_needs_no_acquisition_plan_while_applicability_still_applies() {
     let subject = "commit:subject-a";
     let plan = plan_observation_probe(&request(
         current_frontier(subject),
@@ -278,7 +282,35 @@ fn current_frontier_needs_no_acquisition_plan() {
     .unwrap();
 
     assert_eq!(plan.status, ObservationProbePlanStatus::AlreadyCurrent);
+    assert_eq!(plan.applicability_status, ApplicabilityStatus::Applies);
     assert!(plan.evidence_plan.is_none());
+}
+
+#[test]
+fn current_frontier_with_moved_context_can_plan_refresh() {
+    let subject = "commit:subject-a";
+    let plan = plan_observation_probe(&request(
+        current_frontier(subject),
+        vec![bridge(subject, "head-b")],
+        context(Some("head-b")),
+        vec![probe(
+            "refresh-current-head",
+            probe_key(),
+            Some("head-b"),
+            ProbeEffect::ReadOnly,
+            ProbeCost::default(),
+        )],
+        false,
+    ))
+    .unwrap();
+
+    assert_eq!(plan.frontier_status, ObservationFrontierStatus::Current);
+    assert_eq!(plan.applicability_status, ApplicabilityStatus::Invalid);
+    assert_eq!(plan.status, ObservationProbePlanStatus::Planned);
+    assert_eq!(
+        plan.evidence_plan.unwrap().selected.unwrap().id,
+        "refresh-current-head"
+    );
 }
 
 #[test]
@@ -300,6 +332,7 @@ fn unknown_value_with_current_coordinate_can_plan_deeper_acquisition() {
     .unwrap();
 
     assert_eq!(plan.frontier_status, ObservationFrontierStatus::Unknown);
+    assert_eq!(plan.applicability_status, ApplicabilityStatus::Applies);
     assert_eq!(
         plan.evidence_plan.unwrap().status,
         EvidencePlanStatus::Selected
@@ -325,6 +358,7 @@ fn invalid_old_value_can_plan_current_head_refresh_without_becoming_current() {
     .unwrap();
 
     assert_eq!(plan.frontier_status, ObservationFrontierStatus::Invalid);
+    assert_eq!(plan.applicability_status, ApplicabilityStatus::Invalid);
     let evidence = plan.evidence_plan.unwrap();
     assert_eq!(evidence.status, EvidencePlanStatus::Selected);
     assert_eq!(evidence.selected.unwrap().id, "refresh-current-head");
@@ -348,6 +382,7 @@ fn missing_current_coordinate_stays_blocked_in_existing_planner() {
     ))
     .unwrap();
 
+    assert_eq!(plan.applicability_status, ApplicabilityStatus::Unknown);
     let evidence = plan.evidence_plan.unwrap();
     assert_eq!(evidence.status, EvidencePlanStatus::Blocked);
     assert_eq!(
@@ -416,6 +451,26 @@ fn incoherent_frontier_receipt_rejects_before_planning() {
     .unwrap_err();
 
     assert!(error.to_string().contains("status disagrees"));
+}
+
+#[test]
+fn empty_frontier_requirements_fail_closed() {
+    let subject = "commit:subject-a";
+    let mut request = request(
+        current_frontier(subject),
+        Vec::new(),
+        context(Some("head-a")),
+        Vec::new(),
+        false,
+    );
+    request.frontier_requirements = EvidenceRequirements::default();
+
+    let error = plan_observation_probe(&request).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("at least one explicit applicability requirement")
+    );
 }
 
 #[test]

--- a/tests/stale_observation_probe_frontier.rs
+++ b/tests/stale_observation_probe_frontier.rs
@@ -107,6 +107,7 @@ fn consume_frontier(
     plan_observation_probe(&ObservationProbePlanRequest {
         schema_version: OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION,
         frontier,
+        frontier_requirements: requirements(),
         bridges: Vec::new(),
         context: context(revision),
         probes: Vec::new(),
@@ -117,7 +118,7 @@ fn consume_frontier(
 }
 
 #[test]
-fn current_frontier_short_circuit_outlives_moved_consumption_revision() {
+fn moved_consumption_revision_invalidates_old_current_frontier() {
     let frontier = current_frontier_produced_at_head_a();
 
     assert_eq!(
@@ -127,18 +128,31 @@ fn current_frontier_short_circuit_outlives_moved_consumption_revision() {
 
     let plan = consume_frontier(frontier, Some("head-b"));
     assert_eq!(plan.frontier_status, ObservationFrontierStatus::Current);
-    assert_eq!(plan.status, ObservationProbePlanStatus::AlreadyCurrent);
+    assert_eq!(plan.applicability_status, ApplicabilityStatus::Invalid);
+    assert_eq!(plan.status, ObservationProbePlanStatus::NoAdmittedMapping);
     assert!(plan.evidence_plan.is_none());
 }
 
 #[test]
-fn current_frontier_short_circuit_outlives_missing_consumption_revision() {
+fn missing_consumption_revision_preserves_unknown_for_old_current_frontier() {
     let frontier = current_frontier_produced_at_head_a();
 
     assert_eq!(shared_applicability(None), ApplicabilityStatus::Unknown);
 
     let plan = consume_frontier(frontier, None);
     assert_eq!(plan.frontier_status, ObservationFrontierStatus::Current);
+    assert_eq!(plan.applicability_status, ApplicabilityStatus::Unknown);
+    assert_eq!(plan.status, ObservationProbePlanStatus::NoAdmittedMapping);
+    assert!(plan.evidence_plan.is_none());
+}
+
+#[test]
+fn unchanged_consumption_context_keeps_current_short_circuit() {
+    let frontier = current_frontier_produced_at_head_a();
+
+    let plan = consume_frontier(frontier, Some("head-a"));
+    assert_eq!(plan.frontier_status, ObservationFrontierStatus::Current);
+    assert_eq!(plan.applicability_status, ApplicabilityStatus::Applies);
     assert_eq!(plan.status, ObservationProbePlanStatus::AlreadyCurrent);
     assert!(plan.evidence_plan.is_none());
 }


### PR DESCRIPTION
Closes #295 after the landed #297 stale-frontier counterexample.

## Repair

Bump the research observation-probe request contract to v2 and carry typed `frontier_requirements` separately from source-probe `clearing_requirements`.

`plan_observation_probe` now reuses the shared #123 applicability evaluator against the request's current `EvaluationContext` before honoring a CURRENT frontier:

- CURRENT + APPLIES -> `AlreadyCurrent` as before;
- CURRENT + INVALID/UNKNOWN -> skip the stale short-circuit and continue through exact bridge lookup / existing evidence planning;
- with no admitted bridge, return `NoAdmittedMapping` while preserving the exact shared applicability status in the plan;
- noncurrent frontiers also expose the consumption-time applicability status without changing their original frontier status.

`ObservationProbePlan` therefore adds `applicability_status: ApplicabilityStatus`. No second freshness taxonomy is introduced.

## Controls

- unchanged production/consumption revision stays CURRENT + APPLIES + AlreadyCurrent;
- moved consumption revision turns the landed #297 counterexample into CURRENT receipt + INVALID consumption applicability + NoAdmittedMapping when no bridge exists;
- missing consumption revision preserves UNKNOWN instead of AlreadyCurrent;
- a stale CURRENT frontier with an exact current-context bridge can plan a refresh while retaining original frontier status CURRENT and applicability INVALID;
- existing MISSING/UNKNOWN/INVALID planning, effect authority, wrong-subject mapping, duplicate mapping, byte bounds, and request round-trip remain covered;
- empty typed frontier requirements fail closed through the shared applicability evaluator.

## Boundary

- research consumer only;
- no wall-clock TTL or new freshness heuristic;
- no implicit bridge/source inference;
- frontier applicability requirements remain distinct from probe-clearing requirements;
- no source execution, ownership, scheduling, merge, or mutation authority.

Validation authority is ordinary GitHub-hosted CI.