### PR TITLE
fix: bind active-work CI to provider-current head

### DIFF
--- a/scripts/active_work_heads_up_ci.py
+++ b/scripts/active_work_heads_up_ci.py
@@ -55,6 +55,17 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
 }
 """
 
+CURRENT_PR_QUERY = r"""
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      number
+      headRefOid
+    }
+  }
+}
+"""
+
 
 def gh_json(args: list[str]) -> object:
     output = subprocess.check_output(["gh", *args], text=True)
@@ -223,6 +234,100 @@ def build_inventory(repo: str, current_number: int) -> dict[str, object]:
     return inventory
 
 
+def current_provider_work_from_response(
+    repo: str,
+    current_number: int,
+    result: dict[str, object],
+) -> dict[str, object]:
+    data = result.get("data")
+    repository = data.get("repository") if isinstance(data, dict) else None
+    pull_request = repository.get("pullRequest") if isinstance(repository, dict) else None
+    if pull_request is None:
+        return {
+            "repository": repo,
+            "work_id": f"#{current_number}",
+            "head_sha": None,
+        }
+    if not isinstance(pull_request, dict):
+        raise RuntimeError("current pull-request response has unexpected type")
+
+    number = int(pull_request["number"])
+    if number != current_number:
+        raise RuntimeError(
+            f"current pull-request re-read returned #{number}; expected #{current_number}"
+        )
+    head = pull_request.get("headRefOid")
+    return {
+        "repository": repo,
+        "work_id": f"#{number}",
+        "head_sha": str(head) if head else None,
+    }
+
+
+def read_current_provider_work(
+    repo: str,
+    current_number: int,
+) -> dict[str, object]:
+    owner, name = repo.split("/", 1)
+    try:
+        result = graphql(
+            CURRENT_PR_QUERY,
+            {"owner": owner, "name": name, "number": current_number},
+        )
+        return current_provider_work_from_response(repo, current_number, result)
+    except (
+        subprocess.CalledProcessError,
+        json.JSONDecodeError,
+        KeyError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as error:
+        print(f"provider-current work unavailable: {error}")
+        return {
+            "repository": repo,
+            "work_id": f"#{current_number}",
+            "head_sha": None,
+        }
+
+
+def provider_current_matches_inventory(
+    inventory: dict[str, object],
+    required_repository: str,
+    provider_current: dict[str, object],
+) -> bool:
+    current = inventory.get("current")
+    if not isinstance(current, dict):
+        raise RuntimeError("current work item must be an object")
+    head = provider_current.get("head_sha")
+    return (
+        str(provider_current.get("repository", "")) == required_repository
+        and str(provider_current.get("work_id", "")) == str(current.get("id", ""))
+        and isinstance(head, str)
+        and bool(head)
+        and head == str(current.get("head_sha", ""))
+    )
+
+
+def provider_current_environment(
+    base: dict[str, str],
+    required_repository: str,
+    provider_current: dict[str, object],
+) -> dict[str, str]:
+    environment = dict(base)
+    environment["CULTIST_REQUIRED_PROVIDER_REPOSITORY"] = required_repository
+    environment["CULTIST_CURRENT_PROVIDER_REPOSITORY"] = str(
+        provider_current["repository"]
+    )
+    environment["CULTIST_CURRENT_PROVIDER_WORK"] = str(provider_current["work_id"])
+    head = provider_current.get("head_sha")
+    if isinstance(head, str) and head:
+        environment["CULTIST_CURRENT_PROVIDER_HEAD"] = head
+    else:
+        environment.pop("CULTIST_CURRENT_PROVIDER_HEAD", None)
+    return environment
+
+
 def potential_direct_overlap(inventory: dict[str, object]) -> bool:
     current = inventory["current"]
     active_work = inventory["active_work"]
@@ -305,6 +410,7 @@ def unresolved_endpoint_note(receipts: list[dict[str, object]]) -> str | None:
         f"{count} {noun} absent from the supplied work inventory; "
         "current coordination relevance remains unresolved."
     )
+
 
 def quiet_status_line(metadata_note: str | None = None) -> str:
     if metadata_note:
@@ -402,10 +508,17 @@ def render_product_summary(
     return "\n".join(lines)
 
 
-def run_product_preflight(inventory: dict[str, object]) -> dict[str, object]:
+def run_product_preflight(
+    inventory: dict[str, object],
+    required_repository: str,
+    provider_current: dict[str, object],
+) -> dict[str, object]:
     with tempfile.TemporaryDirectory(prefix="cultist-active-work-") as temporary:
         inventory_path = Path(temporary, "inventory.json")
         inventory_path.write_text(json.dumps(inventory, indent=2) + "\n")
+        environment = provider_current_environment(
+            dict(os.environ), required_repository, provider_current
+        )
         output = subprocess.check_output(
             [
                 "cargo",
@@ -420,6 +533,7 @@ def run_product_preflight(inventory: dict[str, object]) -> dict[str, object]:
                 ".",
             ],
             text=True,
+            env=environment,
         )
     report = json.loads(output)
     if not isinstance(report, dict):
@@ -434,6 +548,7 @@ def main() -> None:
     inventory_started = time.monotonic()
     inventory, metadata = build_inventory_and_metadata(repo, current_number)
     inventory_seconds = time.monotonic() - inventory_started
+    provider_current = read_current_provider_work(repo, current_number)
 
     current = inventory["current"]
     if not isinstance(current, dict):
@@ -442,9 +557,15 @@ def main() -> None:
     if not isinstance(active_work, list):
         raise RuntimeError("active_work must be a list")
 
+    current_head = provider_current.get("head_sha")
+    current_head_label = str(current_head) if current_head else "<unavailable>"
     print(
         f"inventory: {len(active_work)} open PR(s), current #{current_number}, "
         f"{len(current['changed_paths'])} current path(s)"
+    )
+    print(
+        "provider-current work: "
+        f"{provider_current['repository']} {provider_current['work_id']} @ {current_head_label}"
     )
 
     direct_overlap = potential_direct_overlap(inventory)
@@ -485,7 +606,10 @@ def main() -> None:
         coordination_seconds = time.monotonic() - started
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
-    if not direct_overlap and not relevant_edges:
+    exact_current_work = provider_current_matches_inventory(
+        inventory, repo, provider_current
+    )
+    if not direct_overlap and not relevant_edges and exact_current_work:
         print(quiet_status_line(metadata_note))
         print(
             f"timing: inventory {inventory_seconds:.2f}s; "
@@ -500,7 +624,7 @@ def main() -> None:
         inventory["coordination_edges"] = relevant_edges
 
     product_started = time.monotonic()
-    report = run_product_preflight(inventory)
+    report = run_product_preflight(inventory, repo, provider_current)
     product_seconds = time.monotonic() - product_started
     findings = report.get("findings")
     finding_count = len(findings) if isinstance(findings, list) else 0

--- a/scripts/active_work_heads_up_ci_test.py
+++ b/scripts/active_work_heads_up_ci_test.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 
 from active_work_heads_up_ci import (
+    current_provider_work_from_response,
+    provider_current_environment,
+    provider_current_matches_inventory,
     quiet_status_line,
     quiet_summary,
     unresolved_endpoint_note,
@@ -10,8 +13,24 @@ from active_work_heads_up_ci import (
 INVENTORY = {
     "observed_at": "2026-08-23T00:00:00Z",
     "source": "test_provider_snapshot",
-    "current": {"id": "#10"},
+    "current": {
+        "id": "#10",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    },
 }
+
+
+def provider_response(number: int, head: str | None) -> dict[str, object]:
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "number": number,
+                    "headRefOid": head,
+                }
+            }
+        }
+    }
 
 
 def main() -> int:
@@ -63,6 +82,75 @@ def main() -> int:
     assert unrelated == []
     assert unresolved_endpoint_note(unrelated) is None
     assert quiet_status_line(unresolved_endpoint_note(unrelated)) == clean_status
+
+    exact = current_provider_work_from_response(
+        "owner/repo",
+        10,
+        provider_response(10, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+    )
+    assert exact == {
+        "repository": "owner/repo",
+        "work_id": "#10",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    }
+    assert provider_current_matches_inventory(INVENTORY, "owner/repo", exact)
+
+    moved = dict(exact)
+    moved["head_sha"] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    assert not provider_current_matches_inventory(INVENTORY, "owner/repo", moved)
+
+    unavailable = current_provider_work_from_response(
+        "owner/repo",
+        10,
+        {"data": {"repository": {"pullRequest": None}}},
+    )
+    assert unavailable == {
+        "repository": "owner/repo",
+        "work_id": "#10",
+        "head_sha": None,
+    }
+    assert not provider_current_matches_inventory(
+        INVENTORY, "owner/repo", unavailable
+    )
+
+    wrong_repository = dict(exact)
+    wrong_repository["repository"] = "owner/other"
+    assert not provider_current_matches_inventory(
+        INVENTORY, "owner/repo", wrong_repository
+    )
+
+    wrong_work = dict(exact)
+    wrong_work["work_id"] = "#11"
+    assert not provider_current_matches_inventory(INVENTORY, "owner/repo", wrong_work)
+
+    try:
+        current_provider_work_from_response(
+            "owner/repo",
+            10,
+            provider_response(11, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        )
+    except RuntimeError as error:
+        assert "returned #11; expected #10" in str(error)
+    else:
+        raise AssertionError("wrong provider work identity must fail closed")
+
+    stale_environment = {
+        "PATH": "/bin",
+        "CULTIST_CURRENT_PROVIDER_HEAD": "checkout-or-stale-head",
+    }
+    exact_environment = provider_current_environment(
+        stale_environment, "owner/repo", exact
+    )
+    assert exact_environment["CULTIST_REQUIRED_PROVIDER_REPOSITORY"] == "owner/repo"
+    assert exact_environment["CULTIST_CURRENT_PROVIDER_REPOSITORY"] == "owner/repo"
+    assert exact_environment["CULTIST_CURRENT_PROVIDER_WORK"] == "#10"
+    assert exact_environment["CULTIST_CURRENT_PROVIDER_HEAD"] == exact["head_sha"]
+
+    unknown_environment = provider_current_environment(
+        stale_environment, "owner/repo", unavailable
+    )
+    assert "CULTIST_CURRENT_PROVIDER_HEAD" not in unknown_environment
+    assert unknown_environment["CULTIST_CURRENT_PROVIDER_WORK"] == "#10"
 
     return 0
 


### PR DESCRIPTION
Closes #332 with the smallest live-adapter use of the merged #327 work-current gate.

## Change

The GitHub active-work CI adapter now performs one independent final GraphQL re-read of the current PR after building the frozen open-PR inventory.

It passes that re-read into the existing product through the exact #327 environment contract:

```text
CULTIST_REQUIRED_PROVIDER_REPOSITORY
CULTIST_CURRENT_PROVIDER_REPOSITORY
CULTIST_CURRENT_PROVIDER_WORK
CULTIST_CURRENT_PROVIDER_HEAD   # omitted when unavailable -> UNKNOWN
```

No checkout or Actions merge-view HEAD is used as provider work identity.

The existing cheap quiet prefilter remains only when the final provider-current repository/work/head exactly matches the frozen current inventory coordinate. A moved or unavailable final head escalates into product preflight even when frozen direct paths/coordination metadata looked quiet, allowing the merged gate to emit INVALID/UNKNOWN before a strong quiet/routing conclusion survives.

## Controls

The Python adapter controls cover:

- exact provider-current work response and exact-match prefilter admission;
- moved head -> prefilter denied;
- unavailable current PR/head -> prefilter denied;
- wrong repository/work -> prefilter denied;
- provider response with wrong work number fails closed;
- explicit product environment contains repository/work/head from provider context;
- an unavailable provider head removes any stale inherited `CULTIST_CURRENT_PROVIDER_HEAD` value.

The PR event itself provides the hosted integration replay: the live adapter will enumerate this PR and independently re-read its final provider head before invoking current merged product behavior when product analysis is needed.

## Boundary

- provider-current work axis only;
- no provider-population snapshot hash reimplementation in Python;
- #292's provider-population adapter/producer identity remains a separate follow-up;
- pagination consistency / mixed head-path reads remain UNKNOWN;
- no wall-clock TTL, checkout-HEAD inference, ownership, scheduling, merge, or mutation authority.

Validation authority is ordinary GitHub-hosted CI on repository-owned runners.