### PR TITLE
feat: promote provider snapshot identity producer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ license = "MIT OR Apache-2.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.11"
 syn = { version = "2.0", features = ["full", "visit"] }
 walkdir = "2.5"
-
-[dev-dependencies]
-sha2 = "0.11"

--- a/src/provider_snapshot_applicability.rs
+++ b/src/provider_snapshot_applicability.rs
@@ -1,3 +1,7 @@
+#[allow(dead_code)]
+#[path = "provider_snapshot_applicability/identity.rs"]
+pub mod identity;
+
 use std::error::Error;
 use std::fmt;
 

--- a/src/provider_snapshot_applicability/identity.rs
+++ b/src/provider_snapshot_applicability/identity.rs
@@ -1,0 +1,571 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+use std::fmt::Write as _;
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use super::ProviderSnapshotIdentity;
+
+const SELECTION_SCHEMA_VERSION: u32 = 0;
+const WORK_FACT_SCHEMA_VERSION: u32 = 0;
+const SNAPSHOT_COMPOSITION_SCHEMA_VERSION: u32 = 0;
+const MAX_PATH_BYTES: usize = 4096;
+const MAX_SOURCE_BYTES: usize = 512;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderKind {
+    Github,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkKind {
+    PullRequest,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderState {
+    Open,
+    Closed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DraftPolicy {
+    Include,
+    Exclude,
+    Only,
+}
+
+impl DraftPolicy {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Include => "include",
+            Self::Exclude => "exclude",
+            Self::Only => "only",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TraversalMode {
+    Exhaustive,
+    Bounded,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OrderField {
+    UpdatedAt,
+    CreatedAt,
+}
+
+impl OrderField {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::UpdatedAt => "updated_at",
+            Self::CreatedAt => "created_at",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OrderDirection {
+    Asc,
+    Desc,
+}
+
+impl OrderDirection {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Asc => "asc",
+            Self::Desc => "desc",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TieBreakField {
+    LocalWorkNumber,
+}
+
+impl TieBreakField {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::LocalWorkNumber => "local_work_number",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TieBreak {
+    pub field: TieBreakField,
+    pub direction: OrderDirection,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderSelection {
+    pub provider_kind: ProviderKind,
+    pub provider_instance: String,
+    pub collection: String,
+    pub work_kind: WorkKind,
+    pub states: Vec<ProviderState>,
+    pub draft_policy: DraftPolicy,
+    pub traversal_mode: TraversalMode,
+    pub page_size: u32,
+    pub max_items: Option<u32>,
+    pub order_field: OrderField,
+    pub order_direction: OrderDirection,
+    pub tie_break: Option<TieBreak>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Activity {
+    ConfirmedActive,
+    Preparation,
+    Unresolved,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoordinationKind {
+    DependsOn,
+    Blocks,
+    HoldMergeWhile,
+    Supersedes,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderWorkFact {
+    pub id: String,
+    pub head_sha: String,
+    pub activity: Activity,
+    pub changed_paths: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderCoordination {
+    pub kind: CoordinationKind,
+    pub from: String,
+    pub to: String,
+    pub source: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderSnapshotFacts {
+    pub selection: ProviderSelection,
+    pub work: Vec<ProviderWorkFact>,
+    pub coordination_edges: Vec<ProviderCoordination>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ProviderSnapshotIdentityBuildError {
+    message: String,
+}
+
+impl ProviderSnapshotIdentityBuildError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ProviderSnapshotIdentityBuildError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for ProviderSnapshotIdentityBuildError {}
+
+#[derive(Debug, Serialize)]
+struct SelectionDocument {
+    schema_version: u32,
+    provider_kind: ProviderKind,
+    provider_instance: String,
+    collection: String,
+    work_kind: WorkKind,
+    states: Vec<ProviderState>,
+    draft_policy: String,
+    coverage: CoverageIdentity,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+enum CoverageIdentity {
+    Exhaustive,
+    Bounded {
+        max_items: u32,
+        order_field: String,
+        order_direction: String,
+        tie_break_field: String,
+        tie_break_direction: String,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct CanonicalWorkFact {
+    id: String,
+    head_sha: String,
+    activity: Activity,
+    changed_paths: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+struct SemanticCoordinationEdge {
+    kind: CoordinationKind,
+    from: String,
+    to: String,
+}
+
+#[derive(Serialize)]
+struct WorkFactDocument {
+    schema_version: u32,
+    work: Vec<CanonicalWorkFact>,
+    coordination_edges: Vec<SemanticCoordinationEdge>,
+}
+
+#[derive(Serialize)]
+struct ProviderSnapshotDocument<'a> {
+    schema_version: u32,
+    selection_identity: &'a str,
+    work_fact_identity: &'a str,
+}
+
+pub fn build_provider_snapshot_identity(
+    facts: &ProviderSnapshotFacts,
+) -> Result<ProviderSnapshotIdentity, ProviderSnapshotIdentityBuildError> {
+    let selection_identity = selection_identity(&facts.selection)?;
+    let work_fact_identity = work_fact_identity(&facts.work, &facts.coordination_edges)?;
+    let digest = digest_hex(&ProviderSnapshotDocument {
+        schema_version: SNAPSHOT_COMPOSITION_SCHEMA_VERSION,
+        selection_identity: &selection_identity,
+        work_fact_identity: &work_fact_identity,
+    })?;
+    ProviderSnapshotIdentity::parse(format!("sha256:{digest}"))
+        .map_err(|error| ProviderSnapshotIdentityBuildError::new(error.to_string()))
+}
+
+fn selection_identity(
+    input: &ProviderSelection,
+) -> Result<String, ProviderSnapshotIdentityBuildError> {
+    digest_hex(&selection_document(input)?)
+}
+
+fn selection_document(
+    input: &ProviderSelection,
+) -> Result<SelectionDocument, ProviderSnapshotIdentityBuildError> {
+    if input.page_size == 0 {
+        return Err(ProviderSnapshotIdentityBuildError::new(
+            "page size must be positive",
+        ));
+    }
+
+    let provider_instance = canonical_host(&input.provider_instance)?;
+    let collection = canonical_collection(&input.collection)?;
+
+    let mut states = BTreeSet::new();
+    for state in &input.states {
+        if !states.insert(*state) {
+            return Err(ProviderSnapshotIdentityBuildError::new(format!(
+                "duplicate provider state `{state:?}`"
+            )));
+        }
+    }
+    if states.is_empty() {
+        return Err(ProviderSnapshotIdentityBuildError::new(
+            "selection contract must contain at least one provider state",
+        ));
+    }
+
+    let coverage = match (input.traversal_mode, input.max_items, input.tie_break) {
+        (TraversalMode::Exhaustive, None, None) => CoverageIdentity::Exhaustive,
+        (TraversalMode::Exhaustive, Some(_), _) => {
+            return Err(ProviderSnapshotIdentityBuildError::new(
+                "exhaustive traversal must not declare max_items",
+            ));
+        }
+        (TraversalMode::Exhaustive, None, Some(_)) => {
+            return Err(ProviderSnapshotIdentityBuildError::new(
+                "exhaustive traversal must not declare a tie-break",
+            ));
+        }
+        (TraversalMode::Bounded, None, _) => {
+            return Err(ProviderSnapshotIdentityBuildError::new(
+                "bounded traversal requires max_items",
+            ));
+        }
+        (TraversalMode::Bounded, Some(0), _) => {
+            return Err(ProviderSnapshotIdentityBuildError::new(
+                "bounded max_items must be positive",
+            ));
+        }
+        (TraversalMode::Bounded, Some(_), None) => {
+            return Err(ProviderSnapshotIdentityBuildError::new(
+                "bounded traversal requires a deterministic tie-break",
+            ));
+        }
+        (TraversalMode::Bounded, Some(max_items), Some(tie_break)) => CoverageIdentity::Bounded {
+            max_items,
+            order_field: input.order_field.as_str().to_string(),
+            order_direction: input.order_direction.as_str().to_string(),
+            tie_break_field: tie_break.field.as_str().to_string(),
+            tie_break_direction: tie_break.direction.as_str().to_string(),
+        },
+    };
+
+    Ok(SelectionDocument {
+        schema_version: SELECTION_SCHEMA_VERSION,
+        provider_kind: input.provider_kind,
+        provider_instance,
+        collection,
+        work_kind: input.work_kind,
+        states: states.into_iter().collect(),
+        draft_policy: input.draft_policy.as_str().to_string(),
+        coverage,
+    })
+}
+
+fn work_fact_identity(
+    work: &[ProviderWorkFact],
+    coordination: &[ProviderCoordination],
+) -> Result<String, ProviderSnapshotIdentityBuildError> {
+    let mut work_by_id = BTreeMap::new();
+    for input in work {
+        let item = canonical_work(input)?;
+        if work_by_id.insert(item.id.clone(), item).is_some() {
+            return Err(ProviderSnapshotIdentityBuildError::new(format!(
+                "duplicate work id `{}`",
+                input.id
+            )));
+        }
+    }
+
+    let mut exact_coordination_inputs = BTreeSet::new();
+    let mut semantic_edges = BTreeSet::new();
+    for input in coordination {
+        let edge = semantic_edge(input)?;
+        if !work_by_id.contains_key(&edge.from) {
+            return Err(ProviderSnapshotIdentityBuildError::new(format!(
+                "coordination edge references missing work `{}`",
+                edge.from
+            )));
+        }
+        if !work_by_id.contains_key(&edge.to) {
+            return Err(ProviderSnapshotIdentityBuildError::new(format!(
+                "coordination edge references missing work `{}`",
+                edge.to
+            )));
+        }
+
+        let exact = (
+            input.kind,
+            edge.from.clone(),
+            edge.to.clone(),
+            input.source.clone(),
+        );
+        if !exact_coordination_inputs.insert(exact) {
+            return Err(ProviderSnapshotIdentityBuildError::new(format!(
+                "duplicate coordination evidence for `{}` -> `{}`",
+                edge.from, edge.to
+            )));
+        }
+        semantic_edges.insert(edge);
+    }
+
+    digest_hex(&WorkFactDocument {
+        schema_version: WORK_FACT_SCHEMA_VERSION,
+        work: work_by_id.into_values().collect(),
+        coordination_edges: semantic_edges.into_iter().collect(),
+    })
+}
+
+fn canonical_collection_component(
+    value: &str,
+    label: &str,
+) -> Result<String, ProviderSnapshotIdentityBuildError> {
+    if value.is_empty()
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        return Err(ProviderSnapshotIdentityBuildError::new(format!(
+            "{label} must be a non-empty canonical ASCII repository component"
+        )));
+    }
+    Ok(value.to_ascii_lowercase())
+}
+
+fn canonical_host(value: &str) -> Result<String, ProviderSnapshotIdentityBuildError> {
+    let value = value.strip_suffix('.').unwrap_or(value);
+    if value.is_empty() {
+        return Err(ProviderSnapshotIdentityBuildError::new(
+            "provider instance must be a canonical host name",
+        ));
+    }
+    for label in value.split('.') {
+        if label.is_empty()
+            || label.len() > 63
+            || !label
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+            || !label
+                .as_bytes()
+                .first()
+                .is_some_and(u8::is_ascii_alphanumeric)
+            || !label
+                .as_bytes()
+                .last()
+                .is_some_and(u8::is_ascii_alphanumeric)
+        {
+            return Err(ProviderSnapshotIdentityBuildError::new(
+                "provider instance must be a canonical host name",
+            ));
+        }
+    }
+    Ok(value.to_ascii_lowercase())
+}
+
+fn canonical_collection(value: &str) -> Result<String, ProviderSnapshotIdentityBuildError> {
+    let (owner, repository) = value.split_once('/').ok_or_else(|| {
+        ProviderSnapshotIdentityBuildError::new("collection must be `owner/repository`")
+    })?;
+    if repository.contains('/') {
+        return Err(ProviderSnapshotIdentityBuildError::new(
+            "collection must contain exactly one `/` separator",
+        ));
+    }
+    let owner = canonical_collection_component(owner, "collection owner")?;
+    let repository = canonical_collection_component(repository, "collection repository")?;
+    Ok(format!("{owner}/{repository}"))
+}
+
+fn canonical_work_id(raw: &str) -> Result<String, ProviderSnapshotIdentityBuildError> {
+    let digits = raw.strip_prefix("pull/").ok_or_else(|| {
+        ProviderSnapshotIdentityBuildError::new(format!(
+            "work id `{raw}` must use canonical `pull/<number>` form"
+        ))
+    })?;
+    if digits.is_empty()
+        || digits.starts_with('0')
+        || !digits.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Err(ProviderSnapshotIdentityBuildError::new(format!(
+            "work id `{raw}` must use a positive canonical decimal number"
+        )));
+    }
+    Ok(format!("pull/{digits}"))
+}
+
+fn canonical_head_sha(raw: &str) -> Result<String, ProviderSnapshotIdentityBuildError> {
+    if raw.len() != 40 || !raw.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(ProviderSnapshotIdentityBuildError::new(
+            "head sha must contain exactly 40 hexadecimal characters",
+        ));
+    }
+    Ok(raw.to_ascii_lowercase())
+}
+
+fn canonical_path(raw: &str) -> Result<String, ProviderSnapshotIdentityBuildError> {
+    if raw.is_empty() || raw.len() > MAX_PATH_BYTES {
+        return Err(ProviderSnapshotIdentityBuildError::new(format!(
+            "changed path must contain 1..={MAX_PATH_BYTES} bytes"
+        )));
+    }
+    if raw.contains('\\') {
+        return Err(ProviderSnapshotIdentityBuildError::new(format!(
+            "changed path `{raw}` must use `/` separators"
+        )));
+    }
+    if raw.chars().any(char::is_control) {
+        return Err(ProviderSnapshotIdentityBuildError::new(format!(
+            "changed path `{raw}` contains a control character"
+        )));
+    }
+
+    let mut parts = 0usize;
+    for part in raw.split('/') {
+        if part.is_empty() || part == "." || part == ".." {
+            return Err(ProviderSnapshotIdentityBuildError::new(format!(
+                "changed path `{raw}` must be a canonical relative path without traversal"
+            )));
+        }
+        parts += 1;
+    }
+    if parts == 0 {
+        return Err(ProviderSnapshotIdentityBuildError::new(format!(
+            "changed path `{raw}` is not canonical"
+        )));
+    }
+    Ok(raw.to_string())
+}
+
+fn validate_source(source: &str) -> Result<(), ProviderSnapshotIdentityBuildError> {
+    if source.is_empty() || source.len() > MAX_SOURCE_BYTES {
+        return Err(ProviderSnapshotIdentityBuildError::new(format!(
+            "coordination source must contain 1..={MAX_SOURCE_BYTES} bytes"
+        )));
+    }
+    if source.chars().any(char::is_control) {
+        return Err(ProviderSnapshotIdentityBuildError::new(
+            "coordination source contains a control character",
+        ));
+    }
+    Ok(())
+}
+
+fn canonical_work(
+    input: &ProviderWorkFact,
+) -> Result<CanonicalWorkFact, ProviderSnapshotIdentityBuildError> {
+    let id = canonical_work_id(&input.id)?;
+    let head_sha = canonical_head_sha(&input.head_sha)?;
+    let mut paths = BTreeSet::new();
+    for raw_path in &input.changed_paths {
+        let path = canonical_path(raw_path)?;
+        if !paths.insert(path.clone()) {
+            return Err(ProviderSnapshotIdentityBuildError::new(format!(
+                "work `{id}` contains duplicate path `{path}`"
+            )));
+        }
+    }
+
+    Ok(CanonicalWorkFact {
+        id,
+        head_sha,
+        activity: input.activity,
+        changed_paths: paths.into_iter().collect(),
+    })
+}
+
+fn semantic_edge(
+    input: &ProviderCoordination,
+) -> Result<SemanticCoordinationEdge, ProviderSnapshotIdentityBuildError> {
+    validate_source(&input.source)?;
+    let from = canonical_work_id(&input.from)?;
+    let to = canonical_work_id(&input.to)?;
+    if from == to {
+        return Err(ProviderSnapshotIdentityBuildError::new(
+            "coordination edge endpoints must be distinct",
+        ));
+    }
+    Ok(SemanticCoordinationEdge {
+        kind: input.kind,
+        from,
+        to,
+    })
+}
+
+fn digest_hex<T: Serialize>(value: &T) -> Result<String, ProviderSnapshotIdentityBuildError> {
+    let bytes = serde_json::to_vec(value)
+        .map_err(|error| ProviderSnapshotIdentityBuildError::new(error.to_string()))?;
+    let digest = Sha256::digest(bytes);
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut encoded, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    Ok(encoded)
+}

--- a/tests/provider_snapshot_identity.rs
+++ b/tests/provider_snapshot_identity.rs
@@ -1,0 +1,366 @@
+#[allow(dead_code)]
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[allow(dead_code)]
+#[path = "../src/provider_snapshot_applicability.rs"]
+mod provider_snapshot_applicability;
+
+use provider_snapshot_applicability::identity::{
+    Activity, CoordinationKind, DraftPolicy, OrderDirection, OrderField, ProviderCoordination,
+    ProviderKind, ProviderSelection, ProviderSnapshotFacts, ProviderState, ProviderWorkFact,
+    TieBreak, TieBreakField, TraversalMode, WorkKind, build_provider_snapshot_identity,
+};
+
+const HEAD_604: &str = "63eece80df17a97a8544c4d716feca4fad1970ea";
+const HEAD_608: &str = "515c60f694664f3b691bfd7f920e4740d75226d1";
+
+fn baseline_selection() -> ProviderSelection {
+    ProviderSelection {
+        provider_kind: ProviderKind::Github,
+        provider_instance: "github.com".to_string(),
+        collection: "teamleaderleo/cultist".to_string(),
+        work_kind: WorkKind::PullRequest,
+        states: vec![ProviderState::Open],
+        draft_policy: DraftPolicy::Include,
+        traversal_mode: TraversalMode::Exhaustive,
+        page_size: 100,
+        max_items: None,
+        order_field: OrderField::UpdatedAt,
+        order_direction: OrderDirection::Desc,
+        tie_break: None,
+    }
+}
+
+fn bounded_selection(max_items: u32) -> ProviderSelection {
+    let mut selection = baseline_selection();
+    selection.traversal_mode = TraversalMode::Bounded;
+    selection.max_items = Some(max_items);
+    selection.tie_break = Some(TieBreak {
+        field: TieBreakField::LocalWorkNumber,
+        direction: OrderDirection::Asc,
+    });
+    selection
+}
+
+fn baseline_work() -> Vec<ProviderWorkFact> {
+    vec![
+        ProviderWorkFact {
+            id: "pull/604".to_string(),
+            head_sha: HEAD_604.to_string(),
+            activity: Activity::ConfirmedActive,
+            changed_paths: vec![
+                "AGENTS.md".to_string(),
+                "docs/agent-native-operating-mode.md".to_string(),
+            ],
+        },
+        ProviderWorkFact {
+            id: "pull/608".to_string(),
+            head_sha: HEAD_608.to_string(),
+            activity: Activity::ConfirmedActive,
+            changed_paths: vec![
+                "src/quarry/research_ir.py".to_string(),
+                "tests/test_research_ir.py".to_string(),
+            ],
+        },
+    ]
+}
+
+fn edge(source: &str) -> ProviderCoordination {
+    ProviderCoordination {
+        kind: CoordinationKind::DependsOn,
+        from: "pull/604".to_string(),
+        to: "pull/608".to_string(),
+        source: source.to_string(),
+    }
+}
+
+fn facts(
+    selection: ProviderSelection,
+    work: Vec<ProviderWorkFact>,
+    coordination_edges: Vec<ProviderCoordination>,
+) -> ProviderSnapshotFacts {
+    ProviderSnapshotFacts {
+        selection,
+        work,
+        coordination_edges,
+    }
+}
+
+fn identity(facts: &ProviderSnapshotFacts) -> String {
+    build_provider_snapshot_identity(facts)
+        .unwrap()
+        .as_str()
+        .to_string()
+}
+
+fn baseline_facts() -> ProviderSnapshotFacts {
+    facts(baseline_selection(), baseline_work(), Vec::new())
+}
+
+#[test]
+fn baseline_identity_matches_reviewed_research_encoding() {
+    assert_eq!(
+        identity(&baseline_facts()),
+        "sha256:c1fcc24846686703386dcf32d257ca6d752df4685ab57d873d86c17f07d9a62d"
+    );
+}
+
+#[test]
+fn provider_scope_case_trailing_dot_and_state_order_are_canonical() {
+    let mut first = baseline_facts();
+    first.selection.states = vec![ProviderState::Open, ProviderState::Closed];
+
+    let mut second = baseline_facts();
+    second.selection.provider_instance = "GITHUB.COM.".to_string();
+    second.selection.collection = "TeamLeaderLeo/Cultist".to_string();
+    second.selection.states = vec![ProviderState::Closed, ProviderState::Open];
+
+    assert_eq!(identity(&first), identity(&second));
+}
+
+#[test]
+fn exhaustive_transport_order_and_page_size_do_not_change_identity() {
+    let first = baseline_facts();
+    let mut second = baseline_facts();
+    second.selection.page_size = 50;
+    second.selection.order_field = OrderField::CreatedAt;
+    second.selection.order_direction = OrderDirection::Asc;
+
+    assert_eq!(identity(&first), identity(&second));
+}
+
+#[test]
+fn bounded_page_size_is_transport_only_but_limit_and_order_are_identity() {
+    let first = facts(bounded_selection(100), baseline_work(), Vec::new());
+
+    let mut other_page = first.clone();
+    other_page.selection.page_size = 20;
+    assert_eq!(identity(&first), identity(&other_page));
+
+    let different_limit = facts(bounded_selection(50), baseline_work(), Vec::new());
+    assert_ne!(identity(&first), identity(&different_limit));
+
+    let mut different_order = first.clone();
+    different_order.selection.order_field = OrderField::CreatedAt;
+    different_order.selection.order_direction = OrderDirection::Asc;
+    assert_ne!(identity(&first), identity(&different_order));
+
+    let mut different_tie_break = first.clone();
+    different_tie_break.selection.tie_break = Some(TieBreak {
+        field: TieBreakField::LocalWorkNumber,
+        direction: OrderDirection::Desc,
+    });
+    assert_ne!(identity(&first), identity(&different_tie_break));
+}
+
+#[test]
+fn work_path_and_edge_order_are_identity_invariant() {
+    let first_edges = vec![
+        edge("provider:pull/604"),
+        ProviderCoordination {
+            kind: CoordinationKind::Blocks,
+            from: "pull/608".to_string(),
+            to: "pull/604".to_string(),
+            source: "provider:pull/608".to_string(),
+        },
+    ];
+    let first = facts(baseline_selection(), baseline_work(), first_edges.clone());
+
+    let mut second_work = baseline_work();
+    second_work.reverse();
+    second_work[0].changed_paths.reverse();
+    let mut second_edges = first_edges;
+    second_edges.reverse();
+    let second = facts(baseline_selection(), second_work, second_edges);
+
+    assert_eq!(identity(&first), identity(&second));
+}
+
+#[test]
+fn equivalent_head_hex_case_preserves_identity() {
+    let first = baseline_facts();
+    let mut second = baseline_facts();
+    second.work[0].head_sha = HEAD_604.to_ascii_uppercase();
+
+    assert_eq!(identity(&first), identity(&second));
+}
+
+#[test]
+fn membership_head_activity_and_path_movement_change_identity() {
+    let baseline = baseline_facts();
+    let baseline_identity = identity(&baseline);
+
+    let mut membership = baseline.clone();
+    membership.work.push(ProviderWorkFact {
+        id: "pull/627".to_string(),
+        head_sha: "769ded20439efe0567d4553141598cfd3965a013".to_string(),
+        activity: Activity::ConfirmedActive,
+        changed_paths: vec!["tests/test_research_610_strict_carrier.py".to_string()],
+    });
+
+    let mut head = baseline.clone();
+    head.work[0].head_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string();
+
+    let mut activity = baseline.clone();
+    activity.work[0].activity = Activity::Unresolved;
+
+    let mut path = baseline.clone();
+    path.work[0].changed_paths = vec![
+        "AGENTS.md".to_string(),
+        "src/new_collision_surface.rs".to_string(),
+    ];
+
+    for changed in [membership, head, activity, path] {
+        assert_ne!(baseline_identity, identity(&changed));
+    }
+}
+
+#[test]
+fn coordination_provenance_is_omitted_while_semantics_change_identity() {
+    let first = facts(
+        baseline_selection(),
+        baseline_work(),
+        vec![edge("provider:pull/604")],
+    );
+    let moved_source = facts(
+        baseline_selection(),
+        baseline_work(),
+        vec![edge("provider:reviewed-metadata")],
+    );
+    assert_eq!(identity(&first), identity(&moved_source));
+
+    let multiple_sources = facts(
+        baseline_selection(),
+        baseline_work(),
+        vec![
+            edge("provider:pull/604"),
+            edge("provider:reviewed-metadata"),
+        ],
+    );
+    assert_eq!(identity(&first), identity(&multiple_sources));
+
+    let changed_semantics = facts(
+        baseline_selection(),
+        baseline_work(),
+        vec![ProviderCoordination {
+            kind: CoordinationKind::HoldMergeWhile,
+            from: "pull/604".to_string(),
+            to: "pull/608".to_string(),
+            source: "provider:pull/604".to_string(),
+        }],
+    );
+    assert_ne!(identity(&first), identity(&changed_semantics));
+}
+
+#[test]
+fn malformed_selection_contracts_fail_closed() {
+    let mut malformed_collection = baseline_facts();
+    malformed_collection.selection.collection = "teamleaderleo/cultist/extra".to_string();
+    assert!(build_provider_snapshot_identity(&malformed_collection).is_err());
+
+    let mut malformed_host = baseline_facts();
+    malformed_host.selection.provider_instance = "https://github.com".to_string();
+    assert!(build_provider_snapshot_identity(&malformed_host).is_err());
+
+    let mut duplicate_states = baseline_facts();
+    duplicate_states.selection.states = vec![ProviderState::Open, ProviderState::Open];
+    assert!(build_provider_snapshot_identity(&duplicate_states).is_err());
+
+    let mut empty_states = baseline_facts();
+    empty_states.selection.states.clear();
+    assert!(build_provider_snapshot_identity(&empty_states).is_err());
+
+    let mut zero_page = baseline_facts();
+    zero_page.selection.page_size = 0;
+    assert!(build_provider_snapshot_identity(&zero_page).is_err());
+
+    let mut exhaustive_with_bound = baseline_facts();
+    exhaustive_with_bound.selection.max_items = Some(100);
+    assert!(build_provider_snapshot_identity(&exhaustive_with_bound).is_err());
+
+    let mut bounded_without_bound = baseline_facts();
+    bounded_without_bound.selection.traversal_mode = TraversalMode::Bounded;
+    assert!(build_provider_snapshot_identity(&bounded_without_bound).is_err());
+
+    let mut bounded_without_tie = baseline_facts();
+    bounded_without_tie.selection.traversal_mode = TraversalMode::Bounded;
+    bounded_without_tie.selection.max_items = Some(100);
+    assert!(build_provider_snapshot_identity(&bounded_without_tie).is_err());
+}
+
+#[test]
+fn malformed_work_facts_and_coordination_fail_closed() {
+    for malformed in ["#604", "pull/0604", "pull/0", "PULL/604", "pull/604 "] {
+        let mut candidate = baseline_facts();
+        candidate.work[0].id = malformed.to_string();
+        assert!(
+            build_provider_snapshot_identity(&candidate).is_err(),
+            "accepted malformed work id `{malformed}`"
+        );
+    }
+
+    for malformed in [
+        "./src/lib.rs",
+        "src//lib.rs",
+        "src/../lib.rs",
+        "src/./lib.rs",
+        "src\\lib.rs",
+        "/src/lib.rs",
+        "src/lib.rs/",
+    ] {
+        let mut candidate = baseline_facts();
+        candidate.work[0].changed_paths = vec![malformed.to_string()];
+        assert!(
+            build_provider_snapshot_identity(&candidate).is_err(),
+            "accepted malformed path `{malformed}`"
+        );
+    }
+
+    let mut bad_head = baseline_facts();
+    bad_head.work[0].head_sha = "abc".to_string();
+    assert!(build_provider_snapshot_identity(&bad_head).is_err());
+
+    let mut duplicate_path = baseline_facts();
+    duplicate_path.work[0].changed_paths = vec!["src/lib.rs".to_string(), "src/lib.rs".to_string()];
+    assert!(build_provider_snapshot_identity(&duplicate_path).is_err());
+
+    let mut duplicate_work = baseline_facts();
+    duplicate_work.work.push(ProviderWorkFact {
+        id: "pull/604".to_string(),
+        head_sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        activity: Activity::Preparation,
+        changed_paths: Vec::new(),
+    });
+    assert!(build_provider_snapshot_identity(&duplicate_work).is_err());
+
+    let exact_duplicate = facts(
+        baseline_selection(),
+        baseline_work(),
+        vec![edge("provider:pull/604"), edge("provider:pull/604")],
+    );
+    assert!(build_provider_snapshot_identity(&exact_duplicate).is_err());
+
+    let missing_endpoint = facts(
+        baseline_selection(),
+        baseline_work(),
+        vec![ProviderCoordination {
+            kind: CoordinationKind::Supersedes,
+            from: "pull/604".to_string(),
+            to: "pull/999".to_string(),
+            source: "provider:pull/604".to_string(),
+        }],
+    );
+    assert!(build_provider_snapshot_identity(&missing_endpoint).is_err());
+
+    let self_edge = facts(
+        baseline_selection(),
+        baseline_work(),
+        vec![ProviderCoordination {
+            kind: CoordinationKind::Blocks,
+            from: "pull/604".to_string(),
+            to: "pull/604".to_string(),
+            source: "provider:pull/604".to_string(),
+        }],
+    );
+    assert!(build_provider_snapshot_identity(&self_edge).is_err());
+}


### PR DESCRIPTION
Closes #334 with the first product-core producer for the provider-population snapshot identity already consumed by #329.

## Change

- adds a provider-agnostic typed Rust producer under `provider_snapshot_applicability::identity`;
- preserves the reviewed #298 selection-contract canonicalization;
- preserves the reviewed #305 work-fact / semantic-coordination canonicalization;
- composes those component digests with the reviewed #308 schema-v0 document;
- returns the existing product `ProviderSnapshotIdentity` (`sha256:<digest>`) instead of defining another status or identity type;
- promotes `sha2` from a dev-only dependency to a regular runtime dependency because identity construction now executes in a product module.

The module accepts already-fetched provider facts only. It performs no network access and grants no scheduling, merge, mutation, or ownership authority.

## Parity controls

The product tests pin the exact reviewed baseline identity:

```text
sha256:c1fcc24846686703386dcf32d257ca6d752df4685ab57d873d86c17f07d9a62d
```

They also replay the earned discriminators:

- provider host/repository case and state ordering canonicalize;
- exhaustive page size/order and bounded page size are transport-only;
- bounded limit/primary order/tie-break alter identity;
- work/path/edge ordering is invariant;
- equivalent head hex case preserves identity;
- work membership/head/activity/path/semantic-edge movement alters identity;
- coordination provenance-source-only movement preserves identity;
- malformed selection scope/coverage, work IDs, paths, duplicate facts, missing endpoints, self edges, and exact duplicate coordination evidence fail closed.

## Hosted validation

Exact product head:

```text
86ab83c945cfc3c7d1ae3cd7df813f284c64f8d8
```

Ordinary GitHub-hosted CI run `32658810589` passed format, Clippy, adapter controls, full tests, and dogfood. Generated provenance review dogfood run `32658810630` also passed.

## Boundary

This PR promotes identity production only. The live GitHub adapter remains unchanged here. A later adapter patch can derive both frozen and independently re-read current population identities through this same Rust producer and pass the current result to #329; unavailable/inconsistent re-enumeration remains UNKNOWN.

An independently active `fix/292-active-work-ci-provider-snapshot` lane already explores that adapter step. Its GitHub fetch/translation work can consume this producer after promotion instead of owning a second canonical hash implementation.

Validation authority is ordinary GitHub-hosted CI on repository-owned runners.