### PR TITLE
fix: bind active-work CI to provider snapshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,15 +77,21 @@ jobs:
         run: |
           python -m py_compile \
             scripts/active_work_heads_up_ci.py \
-            scripts/active_work_heads_up_ci_test.py
+            scripts/active_work_heads_up_ci_test.py \
+            scripts/active_work_heads_up_snapshot_ci.py \
+            scripts/active_work_heads_up_snapshot_ci_test.py \
+            scripts/github_provider_snapshot_ci.py \
+            scripts/github_provider_snapshot_ci_test.py
           python scripts/active_work_heads_up_ci_test.py
+          python scripts/active_work_heads_up_snapshot_ci_test.py
+          python scripts/github_provider_snapshot_ci_test.py
       - name: Active work heads-up
         if: github.event_name == 'pull_request'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           CURRENT_PR: ${{ github.event.pull_request.number }}
-        run: python scripts/active_work_heads_up_ci.py
+        run: python scripts/active_work_heads_up_snapshot_ci.py
       - name: Test
         run: cargo test
       - name: Dogfood repository scan

--- a/examples/github_provider_snapshot.rs
+++ b/examples/github_provider_snapshot.rs
@@ -1,0 +1,203 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+use serde::{Deserialize, Serialize};
+
+#[allow(dead_code)]
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[allow(dead_code)]
+#[path = "../src/provider_snapshot_applicability.rs"]
+mod provider_snapshot_applicability;
+
+use provider_snapshot_applicability::identity::{
+    Activity, CoordinationKind, DraftPolicy, OrderDirection, OrderField, ProviderCoordination,
+    ProviderKind, ProviderSelection, ProviderSnapshotFacts, ProviderState, ProviderWorkFact,
+    TraversalMode, WorkKind, build_provider_snapshot_identity,
+};
+
+const REQUEST_SCHEMA_VERSION: u32 = 1;
+const OUTPUT_SCHEMA_VERSION: u32 = 1;
+const MAX_REQUEST_BYTES: usize = 1024 * 1024;
+const MAX_SNAPSHOTS: usize = 4;
+
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum WireActivity {
+    #[default]
+    ConfirmedActive,
+    Preparation,
+    Unresolved,
+}
+
+impl From<WireActivity> for Activity {
+    fn from(value: WireActivity) -> Self {
+        match value {
+            WireActivity::ConfirmedActive => Self::ConfirmedActive,
+            WireActivity::Preparation => Self::Preparation,
+            WireActivity::Unresolved => Self::Unresolved,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum WireCoordinationKind {
+    DependsOn,
+    Blocks,
+    HoldMergeWhile,
+    Supersedes,
+}
+
+impl From<WireCoordinationKind> for CoordinationKind {
+    fn from(value: WireCoordinationKind) -> Self {
+        match value {
+            WireCoordinationKind::DependsOn => Self::DependsOn,
+            WireCoordinationKind::Blocks => Self::Blocks,
+            WireCoordinationKind::HoldMergeWhile => Self::HoldMergeWhile,
+            WireCoordinationKind::Supersedes => Self::Supersedes,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireWork {
+    number: u64,
+    head_sha: String,
+    #[serde(default)]
+    activity: WireActivity,
+    changed_paths: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireCoordination {
+    kind: WireCoordinationKind,
+    from_number: u64,
+    to_number: u64,
+    source: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireSnapshot {
+    provider_instance: String,
+    collection: String,
+    work: Vec<WireWork>,
+    #[serde(default)]
+    coordination_edges: Vec<WireCoordination>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireRequest {
+    schema_version: u32,
+    snapshots: Vec<WireSnapshot>,
+}
+
+#[derive(Serialize)]
+struct WireReceipt {
+    provider_snapshot_identity: String,
+}
+
+#[derive(Serialize)]
+struct WireOutput {
+    schema_version: u32,
+    snapshots: Vec<WireReceipt>,
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("github-provider-snapshot: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_REQUEST_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_REQUEST_BYTES {
+        return Err(format!(
+            "GitHub provider snapshot request exceeds the {MAX_REQUEST_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let request: WireRequest = serde_json::from_slice(&bytes)?;
+    if request.schema_version != REQUEST_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported GitHub provider snapshot request schema {}; expected {REQUEST_SCHEMA_VERSION}",
+            request.schema_version
+        )
+        .into());
+    }
+    if request.snapshots.is_empty() || request.snapshots.len() > MAX_SNAPSHOTS {
+        return Err(format!(
+            "GitHub provider snapshot request must contain 1..={MAX_SNAPSHOTS} snapshots"
+        )
+        .into());
+    }
+
+    let snapshots = request
+        .snapshots
+        .into_iter()
+        .map(fingerprint_snapshot)
+        .collect::<Result<Vec<_>, _>>()?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&WireOutput {
+            schema_version: OUTPUT_SCHEMA_VERSION,
+            snapshots,
+        })?
+    );
+    Ok(())
+}
+
+fn fingerprint_snapshot(snapshot: WireSnapshot) -> Result<WireReceipt, Box<dyn Error>> {
+    let work = snapshot
+        .work
+        .into_iter()
+        .map(|work| ProviderWorkFact {
+            id: format!("pull/{}", work.number),
+            head_sha: work.head_sha,
+            activity: work.activity.into(),
+            changed_paths: work.changed_paths,
+        })
+        .collect();
+    let coordination_edges = snapshot
+        .coordination_edges
+        .into_iter()
+        .map(|edge| ProviderCoordination {
+            kind: edge.kind.into(),
+            from: format!("pull/{}", edge.from_number),
+            to: format!("pull/{}", edge.to_number),
+            source: edge.source,
+        })
+        .collect();
+
+    let identity = build_provider_snapshot_identity(&ProviderSnapshotFacts {
+        selection: ProviderSelection {
+            provider_kind: ProviderKind::Github,
+            provider_instance: snapshot.provider_instance,
+            collection: snapshot.collection,
+            work_kind: WorkKind::PullRequest,
+            states: vec![ProviderState::Open],
+            draft_policy: DraftPolicy::Include,
+            traversal_mode: TraversalMode::Exhaustive,
+            page_size: 100,
+            max_items: None,
+            order_field: OrderField::UpdatedAt,
+            order_direction: OrderDirection::Desc,
+            tie_break: None,
+        },
+        work,
+        coordination_edges,
+    })?;
+
+    Ok(WireReceipt {
+        provider_snapshot_identity: identity.as_str().to_string(),
+    })
+}

--- a/scripts/active_work_heads_up_snapshot_ci.py
+++ b/scripts/active_work_heads_up_snapshot_ci.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Run the active-work advisory with both provider-current applicability axes."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import time
+
+import active_work_heads_up_ci as base
+from github_provider_snapshot_ci import derive_provider_snapshot_identities
+
+
+def coordination_for_snapshot(
+    inventory: dict[str, object],
+    metadata: dict[str, object],
+    *,
+    retain_note: bool,
+) -> tuple[list[dict[str, object]], str | None, float]:
+    if not base.potential_coordination_clause(metadata):
+        return [], None, 0.0
+
+    started = time.monotonic()
+    try:
+        edges, extraction_report = base.extract_coordination_edges(metadata)
+        relevant_edges = [
+            edge for edge in edges if base.edge_involves_current(inventory, edge)
+        ]
+        if not retain_note:
+            return relevant_edges, None, time.monotonic() - started
+
+        notes: list[str] = []
+        current_unresolved = base.unresolved_endpoint_receipts_involving_current(
+            inventory, extraction_report
+        )
+        unresolved_note = base.unresolved_endpoint_note(current_unresolved)
+        if unresolved_note:
+            notes.append(unresolved_note)
+        unknowns = extraction_report.get("unknowns")
+        if relevant_edges and isinstance(unknowns, list) and unknowns:
+            notes.append(str(unknowns[0]))
+        return relevant_edges, " ".join(notes) or None, time.monotonic() - started
+    except (subprocess.CalledProcessError, json.JSONDecodeError, RuntimeError) as error:
+        if retain_note:
+            note = (
+                "Reviewed coordination metadata could not be fully analyzed; "
+                f"direct path evidence remains usable. Detail: {error}"
+            )
+            print(f"coordination metadata unavailable: {error}")
+            return [], note, time.monotonic() - started
+        raise
+
+
+def read_current_provider_snapshot(
+    repo: str,
+    current_number: int,
+) -> tuple[dict[str, object], list[dict[str, object]]] | None:
+    try:
+        inventory, metadata = base.build_inventory_and_metadata(repo, current_number)
+        edges, _note, _seconds = coordination_for_snapshot(
+            inventory, metadata, retain_note=False
+        )
+        return inventory, edges
+    except (
+        subprocess.CalledProcessError,
+        json.JSONDecodeError,
+        KeyError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as error:
+        print(f"provider-current population unavailable: {error}")
+        return None
+
+
+def can_skip_product(
+    *,
+    direct_overlap: bool,
+    relevant_edges: list[dict[str, object]],
+    exact_current_work: bool,
+    required_provider_snapshot: str,
+    current_provider_snapshot: str | None,
+) -> bool:
+    return (
+        not direct_overlap
+        and not relevant_edges
+        and exact_current_work
+        and current_provider_snapshot == required_provider_snapshot
+    )
+
+
+def run_product_preflight(
+    inventory: dict[str, object],
+    required_repository: str,
+    provider_current: dict[str, object],
+    current_provider_snapshot: str | None,
+) -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="cultist-active-work-") as temporary:
+        inventory_path = Path(temporary, "inventory.json")
+        inventory_path.write_text(json.dumps(inventory, indent=2) + "\n")
+        environment = base.provider_current_environment(
+            dict(os.environ), required_repository, provider_current
+        )
+        command = [
+            "cargo",
+            "run",
+            "--quiet",
+            "--",
+            "preflight",
+            "--inventory",
+            str(inventory_path),
+        ]
+        if current_provider_snapshot is not None:
+            command.extend(["--current-provider-snapshot", current_provider_snapshot])
+        command.extend(["--format", "json", "."])
+        output = subprocess.check_output(command, text=True, env=environment)
+    report = json.loads(output)
+    if not isinstance(report, dict):
+        raise RuntimeError("product preflight did not return a JSON object")
+    return report
+
+
+def main() -> None:
+    repo = os.environ["GITHUB_REPOSITORY"]
+    current_number = int(os.environ["CURRENT_PR"])
+
+    inventory_started = time.monotonic()
+    inventory, metadata = base.build_inventory_and_metadata(repo, current_number)
+    inventory_seconds = time.monotonic() - inventory_started
+
+    relevant_edges, metadata_note, coordination_seconds = coordination_for_snapshot(
+        inventory, metadata, retain_note=True
+    )
+    if relevant_edges:
+        inventory["coordination_edges"] = relevant_edges
+
+    population_started = time.monotonic()
+    current_population = read_current_provider_snapshot(repo, current_number)
+    population_seconds = time.monotonic() - population_started
+
+    snapshots = [(inventory, relevant_edges)]
+    if current_population is not None:
+        snapshots.append(current_population)
+    identities = derive_provider_snapshot_identities(repo, snapshots)
+    required_provider_snapshot = identities[0]
+    current_provider_snapshot = identities[1] if current_population is not None else None
+    inventory["provider_snapshot_identity"] = required_provider_snapshot
+
+    # Preserve #333's independent terminal work-head read after the broader population read.
+    provider_current = base.read_current_provider_work(repo, current_number)
+
+    current = inventory.get("current")
+    active_work = inventory.get("active_work")
+    if not isinstance(current, dict) or not isinstance(active_work, list):
+        raise RuntimeError("active-work inventory has unexpected work fields")
+
+    current_head = provider_current.get("head_sha")
+    current_head_label = str(current_head) if current_head else "<unavailable>"
+    current_snapshot_label = current_provider_snapshot or "<unavailable>"
+    print(
+        f"inventory: {len(active_work)} open PR(s), current #{current_number}, "
+        f"{len(current['changed_paths'])} current path(s)"
+    )
+    print(
+        "provider-current work: "
+        f"{provider_current['repository']} {provider_current['work_id']} @ {current_head_label}"
+    )
+    print(f"provider snapshot required: {required_provider_snapshot}")
+    print(f"provider snapshot current:  {current_snapshot_label}")
+    if relevant_edges:
+        print(
+            "coordination metadata: "
+            f"{len(relevant_edges)} resolved edge(s) involving current work"
+        )
+
+    direct_overlap = base.potential_direct_overlap(inventory)
+    exact_current_work = base.provider_current_matches_inventory(
+        inventory, repo, provider_current
+    )
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if can_skip_product(
+        direct_overlap=direct_overlap,
+        relevant_edges=relevant_edges,
+        exact_current_work=exact_current_work,
+        required_provider_snapshot=required_provider_snapshot,
+        current_provider_snapshot=current_provider_snapshot,
+    ):
+        print(base.quiet_status_line(metadata_note))
+        print(
+            f"timing: inventory {inventory_seconds:.2f}s; "
+            f"coordination {coordination_seconds:.2f}s; "
+            f"population {population_seconds:.2f}s; product 0.00s"
+        )
+        if summary_path:
+            with Path(summary_path).open("a") as summary:
+                summary.write(base.quiet_summary(inventory, metadata_note))
+        return
+
+    product_started = time.monotonic()
+    report = run_product_preflight(
+        inventory,
+        repo,
+        provider_current,
+        current_provider_snapshot,
+    )
+    product_seconds = time.monotonic() - product_started
+    findings = report.get("findings")
+    finding_count = len(findings) if isinstance(findings, list) else 0
+    print(f"HEADS UP: {finding_count} product preflight finding(s)")
+    if isinstance(findings, list):
+        for finding in findings:
+            if isinstance(finding, dict):
+                print(
+                    f"  {finding.get('kind', 'finding')}: "
+                    f"{finding.get('title', '')}"
+                )
+    print(
+        f"timing: inventory {inventory_seconds:.2f}s; "
+        f"coordination {coordination_seconds:.2f}s; "
+        f"population {population_seconds:.2f}s; product {product_seconds:.2f}s"
+    )
+
+    if summary_path:
+        with Path(summary_path).open("a") as summary:
+            summary.write(base.render_product_summary(report, inventory, metadata_note))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/active_work_heads_up_snapshot_ci_test.py
+++ b/scripts/active_work_heads_up_snapshot_ci_test.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from active_work_heads_up_snapshot_ci import can_skip_product
+
+
+def main() -> None:
+    identity = "sha256:" + "a" * 64
+    moved = "sha256:" + "b" * 64
+
+    assert can_skip_product(
+        direct_overlap=False,
+        relevant_edges=[],
+        exact_current_work=True,
+        required_provider_snapshot=identity,
+        current_provider_snapshot=identity,
+    )
+
+    assert not can_skip_product(
+        direct_overlap=False,
+        relevant_edges=[],
+        exact_current_work=True,
+        required_provider_snapshot=identity,
+        current_provider_snapshot=moved,
+    )
+    assert not can_skip_product(
+        direct_overlap=False,
+        relevant_edges=[],
+        exact_current_work=True,
+        required_provider_snapshot=identity,
+        current_provider_snapshot=None,
+    )
+    assert not can_skip_product(
+        direct_overlap=False,
+        relevant_edges=[],
+        exact_current_work=False,
+        required_provider_snapshot=identity,
+        current_provider_snapshot=identity,
+    )
+    assert not can_skip_product(
+        direct_overlap=True,
+        relevant_edges=[],
+        exact_current_work=True,
+        required_provider_snapshot=identity,
+        current_provider_snapshot=identity,
+    )
+    assert not can_skip_product(
+        direct_overlap=False,
+        relevant_edges=[{"kind": "depends_on"}],
+        exact_current_work=True,
+        required_provider_snapshot=identity,
+        current_provider_snapshot=identity,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/github_provider_snapshot_ci.py
+++ b/scripts/github_provider_snapshot_ci.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Thin CI bridge from GitHub provider facts to the canonical Rust snapshot producer."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Callable
+
+PRODUCER_SCHEMA_VERSION = 1
+
+
+def _work_number(work_id: object) -> int:
+    value = str(work_id)
+    if not value.startswith("#"):
+        raise RuntimeError(f"GitHub work id `{value}` must use `#<number>` form")
+    digits = value[1:]
+    if not digits or digits.startswith("0") or not digits.isascii() or not digits.isdigit():
+        raise RuntimeError(f"GitHub work id `{value}` must use a positive canonical decimal number")
+    return int(digits)
+
+
+def _snapshot_input(
+    repo: str,
+    inventory: dict[str, object],
+    coordination_edges: list[dict[str, object]],
+) -> dict[str, object]:
+    active_work = inventory.get("active_work")
+    if not isinstance(active_work, list):
+        raise RuntimeError("active-work inventory must contain a work list")
+
+    work: list[dict[str, object]] = []
+    for item in active_work:
+        if not isinstance(item, dict):
+            raise RuntimeError("active-work item must be an object")
+        paths = item.get("changed_paths")
+        if not isinstance(paths, list):
+            raise RuntimeError("active-work item changed_paths must be a list")
+        work.append(
+            {
+                "number": _work_number(item.get("id")),
+                "head_sha": str(item.get("head_sha", "")),
+                "activity": str(item.get("activity", "confirmed_active")),
+                "changed_paths": [str(path) for path in paths],
+            }
+        )
+
+    edges: list[dict[str, object]] = []
+    for edge in coordination_edges:
+        if not isinstance(edge, dict):
+            raise RuntimeError("coordination edge must be an object")
+        edges.append(
+            {
+                "kind": str(edge.get("kind", "")),
+                "from_number": _work_number(edge.get("from")),
+                "to_number": _work_number(edge.get("to")),
+                "source": str(edge.get("source", "")),
+            }
+        )
+
+    return {
+        "provider_instance": "github.com",
+        "collection": repo,
+        "work": work,
+        "coordination_edges": edges,
+    }
+
+
+def derive_provider_snapshot_identities(
+    repo: str,
+    snapshots: list[tuple[dict[str, object], list[dict[str, object]]]],
+    runner: Callable[..., str] = subprocess.check_output,
+) -> list[str]:
+    request = {
+        "schema_version": PRODUCER_SCHEMA_VERSION,
+        "snapshots": [
+            _snapshot_input(repo, inventory, edges)
+            for inventory, edges in snapshots
+        ],
+    }
+    output = runner(
+        ["cargo", "run", "--quiet", "--example", "github_provider_snapshot"],
+        input=json.dumps(request),
+        text=True,
+    )
+    parsed = json.loads(output)
+    if not isinstance(parsed, dict) or parsed.get("schema_version") != 1:
+        raise RuntimeError("GitHub provider snapshot producer returned an unsupported envelope")
+    receipts = parsed.get("snapshots")
+    if not isinstance(receipts, list) or len(receipts) != len(snapshots):
+        raise RuntimeError("GitHub provider snapshot producer returned the wrong receipt count")
+
+    identities: list[str] = []
+    for receipt in receipts:
+        if not isinstance(receipt, dict):
+            raise RuntimeError("GitHub provider snapshot receipt must be an object")
+        identity = receipt.get("provider_snapshot_identity")
+        if not isinstance(identity, str) or not identity.startswith("sha256:"):
+            raise RuntimeError("GitHub provider snapshot producer returned a malformed identity")
+        identities.append(identity)
+    return identities

--- a/scripts/github_provider_snapshot_ci_test.py
+++ b/scripts/github_provider_snapshot_ci_test.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+
+from github_provider_snapshot_ci import derive_provider_snapshot_identities
+
+
+def inventory() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "source": "fixture",
+        "observed_at": "2026-08-23T00:00:00Z",
+        "current": {
+            "id": "#10",
+            "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "changed_paths": ["src/a.rs"],
+        },
+        "active_work": [
+            {
+                "id": "#10",
+                "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "activity": "confirmed_active",
+                "changed_paths": ["src/a.rs", "docs/a.md"],
+            },
+            {
+                "id": "#20",
+                "head_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "changed_paths": ["src/b.rs"],
+            },
+        ],
+    }
+
+
+def fake_runner(expected_snapshots: int):
+    def run(args: list[str], *, input: str, text: bool) -> str:
+        assert args == [
+            "cargo",
+            "run",
+            "--quiet",
+            "--example",
+            "github_provider_snapshot",
+        ]
+        assert text is True
+        request = json.loads(input)
+        assert request["schema_version"] == 1
+        assert len(request["snapshots"]) == expected_snapshots
+        snapshot = request["snapshots"][0]
+        assert snapshot["provider_instance"] == "github.com"
+        assert snapshot["collection"] == "teamleaderleo/cultist"
+        assert snapshot["work"][0]["number"] == 10
+        assert snapshot["work"][1]["activity"] == "confirmed_active"
+        return json.dumps(
+            {
+                "schema_version": 1,
+                "snapshots": [
+                    {"provider_snapshot_identity": f"sha256:{index:064x}"}
+                    for index in range(1, expected_snapshots + 1)
+                ],
+            }
+        )
+
+    return run
+
+
+def main() -> None:
+    first = inventory()
+    second = inventory()
+    second["active_work"] = list(second["active_work"]) + [
+        {
+            "id": "#30",
+            "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+            "activity": "confirmed_active",
+            "changed_paths": ["src/c.rs"],
+        }
+    ]
+    edges = [
+        {
+            "kind": "depends_on",
+            "from": "#10",
+            "to": "#20",
+            "source": "fixture",
+        }
+    ]
+
+    identities = derive_provider_snapshot_identities(
+        "teamleaderleo/cultist",
+        [(first, edges), (second, [])],
+        runner=fake_runner(2),
+    )
+    assert identities == [f"sha256:{1:064x}", f"sha256:{2:064x}"]
+
+    bad = inventory()
+    bad["active_work"] = [
+        {
+            "id": "pull/10",
+            "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "changed_paths": ["src/a.rs"],
+        }
+    ]
+    try:
+        derive_provider_snapshot_identities(
+            "teamleaderleo/cultist", [(bad, [])], runner=fake_runner(1)
+        )
+    except RuntimeError as error:
+        assert "#<number>" in str(error)
+    else:
+        raise AssertionError("noncanonical GitHub work id was accepted")
+
+    # Exercise the real Rust wire -> merged product producer path on hosted CI.
+    actual = derive_provider_snapshot_identities(
+        "teamleaderleo/cultist", [(inventory(), edges)]
+    )[0]
+    reordered = inventory()
+    reordered_work = list(reordered["active_work"])
+    reordered_work.reverse()
+    reordered_work[1]["changed_paths"] = list(reversed(reordered_work[1]["changed_paths"]))
+    reordered["active_work"] = reordered_work
+    same = derive_provider_snapshot_identities(
+        "TeamLeaderLeo/Cultist", [(reordered, edges)]
+    )[0]
+    assert actual == same
+
+    moved = derive_provider_snapshot_identities(
+        "teamleaderleo/cultist", [(second, edges)]
+    )[0]
+    assert actual != moved
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Progresses #292 by wiring the merged #329 provider-population gate into the live GitHub active-work advisory, on top of merged #333 work-head currentness and merged #337 canonical snapshot production.

## Producer boundary

#338 defines no canonical hash or identity grammar. The GitHub wire example maps already-fetched GitHub facts into the merged #337 typed producer:

- `github.com` + current `owner/repository`;
- open pull requests;
- drafts included;
- exhaustive traversal matching the live `first: 100` paging query;
- provider work numbers -> canonical product work ids;
- exact provider heads, declared activity, changed paths, and resolved semantic coordination edges.

Python performs no snapshot hashing or canonical JSON construction. Its bridge supplies raw provider facts to `cargo run --example github_provider_snapshot` and consumes only the resulting product `ProviderSnapshotIdentity`.

## Live adapter

The advisory now:

1. builds the frozen open-PR inventory and reviewed current-work coordination edges;
2. performs an independent second exhaustive provider-population read and derives its current snapshot through the same merged product producer;
3. preserves #333's independent terminal current-PR head reread;
4. binds the frozen inventory to `provider_snapshot_identity` and passes the independently derived current identity through `--current-provider-snapshot`;
5. keeps the cheap quiet prefilter only when both provider repository/work/head and provider-population snapshot match exactly.

If the current population read or its coordination extraction is unavailable, current snapshot identity is omitted and merged product returns provider-snapshot UNKNOWN. Known population movement reaches product as INVALID. A local producer/admission failure fails the advisory step instead of silently falling back to an unbound inventory.

## Controls

- the Python bridge only translates provider facts and validates the Rust receipt envelope;
- hosted controls run the real GitHub wire -> merged #337 producer path and prove work/path ordering canonicalization plus membership movement;
- provider-population mismatch or unavailable current identity disables the quiet prefilter even when work-head currentness still matches;
- existing #333 work-head controls continue to run unchanged.

## Boundary

Provider population identity, provider repository/work/head applicability, and per-item activity certainty remain separate. Unresolved coordination-endpoint metadata remains outside the snapshot identity under the existing reviewed contract. Mixed head/path reads inside provider pagination remain UNKNOWN; this change adds no timestamp TTL or repository-revision substitute. No ownership, scheduling, merge, or mutation authority.

All execution/validation is GitHub-hosted Actions only.