### PR TITLE
fix: bind edit-class source to current repository

### DIFF
--- a/examples/rust_edit_class_observation.rs
+++ b/examples/rust_edit_class_observation.rs
@@ -1,0 +1,63 @@
+use std::env;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+#[allow(dead_code)]
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[allow(dead_code)]
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[allow(dead_code)]
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[allow(dead_code)]
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[allow(dead_code)]
+#[path = "../src/justification.rs"]
+mod justification;
+#[allow(dead_code)]
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[allow(dead_code)]
+#[path = "../src/observation_probe_bridge.rs"]
+mod observation_probe_bridge;
+#[allow(dead_code)]
+#[path = "../src/rust_edit_class_source.rs"]
+mod rust_edit_class_source;
+
+use rust_edit_class_source::{RustEditClassSubject, collect_rust_edit_class_source};
+
+const USAGE: &str = "usage: rust_edit_class_observation REPO_ROOT CURRENT_REPOSITORY SUBJECT_REPOSITORY REVISION FILE";
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("rust-edit-class-observation: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut args = env::args().skip(1);
+    let root = PathBuf::from(args.next().ok_or(USAGE)?);
+    let current_repository = args.next().ok_or(USAGE)?;
+    let subject_repository = args.next().ok_or(USAGE)?;
+    let revision = args.next().ok_or(USAGE)?;
+    let path = args.next().ok_or(USAGE)?;
+    if args.next().is_some() {
+        return Err(USAGE.into());
+    }
+
+    let result = collect_rust_edit_class_source(
+        Path::new(&root),
+        &current_repository,
+        &RustEditClassSubject {
+            repository: subject_repository,
+            revision,
+            path,
+        },
+    )?;
+    println!("{}", serde_json::to_string_pretty(&result)?);
+    Ok(())
+}

--- a/examples/rust_syntax_cohort.rs
+++ b/examples/rust_syntax_cohort.rs
@@ -20,7 +20,7 @@ struct Commit {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum RustEditClass {
+pub(crate) enum RustEditClass {
     SyntaxChanged,
     CommentsOrWhitespaceOnly,
     Unclassified,
@@ -230,7 +230,7 @@ fn commit_metadata(root: &Path, sha: &str) -> Result<(String, BTreeSet<PathBuf>)
     Ok((subject.trim().to_string(), paths))
 }
 
-fn classify_rust_edit(root: &Path, sha: &str, anchor: &Path) -> RustEditClass {
+pub(crate) fn classify_rust_edit(root: &Path, sha: &str, anchor: &Path) -> RustEditClass {
     let after = source_at_revision(root, sha, anchor);
     let before = source_at_revision(root, &format!("{sha}^"), anchor);
     let (Some(before), Some(after)) = (before, after) else {

--- a/src/rust_edit_class_source.rs
+++ b/src/rust_edit_class_source.rs
@@ -1,0 +1,347 @@
+use std::error::Error;
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use crate::applicability::{
+    APPLICABILITY_SCHEMA_VERSION, ApplicabilityQuery, ApplicabilityStatus, EvaluationContext,
+    EvidenceRequirements, PathScope, PathScopeMode, evaluate_query,
+};
+use crate::discriminator_observation::{
+    DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation,
+    DiscriminatorObservationBatch, DiscriminatorValueState, ObservationApplicability,
+    ObservationApplicabilityStatus, validate_discriminator_observation_batch,
+};
+use crate::durable_obligation::DiscriminatorKey;
+use crate::evidence_planner::{EvidenceProbe, ProbeCost, ProbeEffect};
+use crate::observation_probe_bridge::ObservationProbeBridge;
+
+#[allow(dead_code)]
+#[path = "../examples/rust_syntax_cohort.rs"]
+mod rust_syntax_cohort;
+
+use rust_syntax_cohort::{RustEditClass, classify_rust_edit};
+
+pub const RUST_EDIT_CLASS_DISCRIMINATOR_ID: &str = "edit_class";
+pub const RUST_EDIT_CLASS_PROBE_KIND: &str = "rust_edit_class";
+const MAX_REPOSITORY_BYTES: usize = 256;
+const MAX_PATH_BYTES: usize = 2048;
+const SHA_BYTES: usize = 40;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustEditClassSubject {
+    pub repository: String,
+    pub revision: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustEditClassSourceResult {
+    pub subject: RustEditClassSubject,
+    pub current_head: String,
+    pub bridge: ObservationProbeBridge,
+    pub probe: EvidenceProbe,
+    pub observation: DiscriminatorObservation,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RustEditClassSourceError {
+    message: String,
+}
+
+impl RustEditClassSourceError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for RustEditClassSourceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for RustEditClassSourceError {}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum FocusAdmission {
+    Focused,
+    NotSingleParent,
+    AnchorUnchanged,
+}
+
+pub fn collect_rust_edit_class_source(
+    root: &Path,
+    current_repository: &str,
+    subject: &RustEditClassSubject,
+) -> Result<RustEditClassSourceResult, RustEditClassSourceError> {
+    validate_subject(subject)?;
+    validate_repository(current_repository, "current repository")?;
+    let root = root.canonicalize().map_err(|error| {
+        RustEditClassSourceError::new(format!("cannot canonicalize repository root: {error}"))
+    })?;
+    let current_head = git_head(&root)?;
+    let path = PathBuf::from(&subject.path);
+    let subject_ref = subject_ref(subject);
+    let requirements = exact_requirements(subject);
+    let context = EvaluationContext {
+        repository: Some(current_repository.to_string()),
+        revision: Some(current_head.clone()),
+        work: None,
+        path: Some(subject.path.clone()),
+    };
+    let applicability = evaluate_query(&ApplicabilityQuery {
+        schema_version: APPLICABILITY_SCHEMA_VERSION,
+        requirements: requirements.clone(),
+        context,
+    })
+    .map_err(|error| {
+        RustEditClassSourceError::new(format!("edit-class applicability failed: {error}"))
+    })?;
+
+    let value_state = match focus_admission(&root, &subject.revision, &path)? {
+        FocusAdmission::Focused => match classify_rust_edit(&root, &subject.revision, &path) {
+            RustEditClass::SyntaxChanged => DiscriminatorValueState::Known {
+                value_ref: "syntax_changed".to_string(),
+            },
+            RustEditClass::CommentsOrWhitespaceOnly => DiscriminatorValueState::Known {
+                value_ref: "comments_or_docs_only".to_string(),
+            },
+            RustEditClass::Unclassified => DiscriminatorValueState::Unknown {
+                reason_ref: format!("rust-edit-class:unclassified:{subject_ref}"),
+            },
+        },
+        FocusAdmission::NotSingleParent => DiscriminatorValueState::Unknown {
+            reason_ref: format!("rust-edit-class:not-single-parent:{subject_ref}"),
+        },
+        FocusAdmission::AnchorUnchanged => DiscriminatorValueState::Unknown {
+            reason_ref: format!("rust-edit-class:anchor-unchanged:{subject_ref}"),
+        },
+    };
+    let applicability_status = match applicability.status {
+        ApplicabilityStatus::Applies => ObservationApplicabilityStatus::Applies,
+        ApplicabilityStatus::Unknown => ObservationApplicabilityStatus::Unknown,
+        ApplicabilityStatus::Invalid => ObservationApplicabilityStatus::Invalid,
+    };
+    let applicability_ref = format!(
+        "rust-edit-class:applicability:{subject_ref}:current={current_repository}@{current_head}"
+    );
+    let source_receipt = format!("rust-syntax-cohort:{subject_ref}");
+    let observation = DiscriminatorObservation {
+        observation_id: format!("rust-edit-class:{subject_ref}"),
+        discriminator_id: RUST_EDIT_CLASS_DISCRIMINATOR_ID.to_string(),
+        subject_ref: subject_ref.clone(),
+        source_receipt,
+        value_state,
+        applicability: ObservationApplicability {
+            status: applicability_status,
+            receipt_ref: applicability_ref,
+        },
+    };
+    validate_discriminator_observation_batch(&DiscriminatorObservationBatch {
+        schema_version: DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+        observations: vec![observation.clone()],
+    })
+    .map_err(|error| {
+        RustEditClassSourceError::new(format!("produced observation failed validation: {error}"))
+    })?;
+
+    let probe_discriminator = DiscriminatorKey {
+        kind: RUST_EDIT_CLASS_PROBE_KIND.to_string(),
+        target: subject_ref.clone(),
+    };
+    let suffix = &subject.revision[..12];
+    let bridge = ObservationProbeBridge {
+        bridge_id: format!("rust-edit-class-{suffix}"),
+        observation_discriminator_id: RUST_EDIT_CLASS_DISCRIMINATOR_ID.to_string(),
+        observation_subject_ref: subject_ref.clone(),
+        probe_discriminator: probe_discriminator.clone(),
+        clearing_requirements: requirements.clone(),
+        source_receipt: format!("rust-edit-class-adapter:{subject_ref}"),
+    };
+    let probe = EvidenceProbe {
+        id: format!("rust-edit-class-{suffix}"),
+        produces: probe_discriminator,
+        requirements,
+        effect: ProbeEffect::ReadOnly,
+        cost: ProbeCost {
+            git_subprocesses: 5,
+            rust_files_parsed: 2,
+            ..ProbeCost::default()
+        },
+    };
+
+    Ok(RustEditClassSourceResult {
+        subject: subject.clone(),
+        current_head,
+        bridge,
+        probe,
+        observation,
+    })
+}
+
+pub fn subject_ref(subject: &RustEditClassSubject) -> String {
+    format!(
+        "{}@{}:{}",
+        subject.repository, subject.revision, subject.path
+    )
+}
+
+fn exact_requirements(subject: &RustEditClassSubject) -> EvidenceRequirements {
+    EvidenceRequirements {
+        repository: Some(subject.repository.clone()),
+        revision: Some(subject.revision.clone()),
+        work: None,
+        scope: Some(PathScope {
+            mode: PathScopeMode::Exact,
+            path: subject.path.clone(),
+        }),
+    }
+}
+
+fn git_head(root: &Path) -> Result<String, RustEditClassSourceError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .map_err(|error| {
+            RustEditClassSourceError::new(format!("cannot execute git rev-parse: {error}"))
+        })?;
+    if !output.status.success() {
+        return Err(RustEditClassSourceError::new(format!(
+            "git rev-parse HEAD failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    let head = String::from_utf8(output.stdout)
+        .map_err(|error| RustEditClassSourceError::new(format!("invalid git head UTF-8: {error}")))?
+        .trim()
+        .to_string();
+    validate_revision(&head, "current git head")?;
+    Ok(head)
+}
+
+fn focus_admission(
+    root: &Path,
+    revision: &str,
+    path: &Path,
+) -> Result<FocusAdmission, RustEditClassSourceError> {
+    let parents = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-list", "--parents", "-n", "1", revision])
+        .output()
+        .map_err(|error| {
+            RustEditClassSourceError::new(format!("cannot inspect edit-class parents: {error}"))
+        })?;
+    if !parents.status.success() {
+        return Err(RustEditClassSourceError::new(format!(
+            "git rev-list failed for {revision}: {}",
+            String::from_utf8_lossy(&parents.stderr)
+        )));
+    }
+    let parents = String::from_utf8(parents.stdout).map_err(|error| {
+        RustEditClassSourceError::new(format!("invalid parent-list UTF-8: {error}"))
+    })?;
+    if parents.split_whitespace().count() != 2 {
+        return Ok(FocusAdmission::NotSingleParent);
+    }
+
+    let changed = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args([
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "-r",
+            revision,
+            "--",
+        ])
+        .arg(path)
+        .output()
+        .map_err(|error| {
+            RustEditClassSourceError::new(format!("cannot inspect edit-class path change: {error}"))
+        })?;
+    if !changed.status.success() {
+        return Err(RustEditClassSourceError::new(format!(
+            "git diff-tree failed for {revision}: {}",
+            String::from_utf8_lossy(&changed.stderr)
+        )));
+    }
+    if String::from_utf8(changed.stdout)
+        .map_err(|error| {
+            RustEditClassSourceError::new(format!("invalid changed-path UTF-8: {error}"))
+        })?
+        .lines()
+        .all(|line| line.trim().is_empty())
+    {
+        return Ok(FocusAdmission::AnchorUnchanged);
+    }
+    Ok(FocusAdmission::Focused)
+}
+
+fn validate_subject(subject: &RustEditClassSubject) -> Result<(), RustEditClassSourceError> {
+    validate_repository(&subject.repository, "subject repository")?;
+    validate_revision(&subject.revision, "subject revision")?;
+    if subject.path.is_empty()
+        || subject.path.trim() != subject.path
+        || subject.path.len() > MAX_PATH_BYTES
+        || subject.path.contains(['\n', '\r', '\0', '\\'])
+    {
+        return Err(RustEditClassSourceError::new(
+            "path must be bounded canonical repository-relative text",
+        ));
+    }
+    let path = Path::new(&subject.path);
+    if path.is_absolute()
+        || path.extension().and_then(|extension| extension.to_str()) != Some("rs")
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(RustEditClassSourceError::new(
+            "path must be a normalized repository-relative Rust source path",
+        ));
+    }
+    let reference = subject_ref(subject);
+    if reference.len() > 480 {
+        return Err(RustEditClassSourceError::new(
+            "edit-class subject reference exceeds the admitted boundary",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_repository(value: &str, label: &str) -> Result<(), RustEditClassSourceError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_REPOSITORY_BYTES
+        || value.contains(['\n', '\r', '\0'])
+    {
+        return Err(RustEditClassSourceError::new(format!(
+            "{label} must be bounded canonical single-line text"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_revision(value: &str, label: &str) -> Result<(), RustEditClassSourceError> {
+    if value.len() != SHA_BYTES
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(RustEditClassSourceError::new(format!(
+            "{label} must be an exact lowercase 40-hex Git commit"
+        )));
+    }
+    Ok(())
+}

--- a/tests/rust_edit_class_source_current_main.rs
+++ b/tests/rust_edit_class_source_current_main.rs
@@ -1,0 +1,287 @@
+#![allow(dead_code)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[path = "../src/applicability.rs"]
+mod applicability;
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/durable_obligation.rs"]
+mod durable_obligation;
+#[path = "../src/evidence_planner.rs"]
+mod evidence_planner;
+#[path = "../src/justification.rs"]
+mod justification;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/observation_probe_bridge.rs"]
+mod observation_probe_bridge;
+#[path = "../src/rust_edit_class_source.rs"]
+mod rust_edit_class_source;
+
+use applicability::{ApplicabilityStatus, EvaluationContext};
+use discriminator_observation::{DiscriminatorValueState, ObservationApplicabilityStatus};
+use evidence_planner::{EvidencePlanStatus, ProbeSelectionPolicy};
+use observation_frontier::{
+    OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierRequest, ObservationFrontierStatus,
+    ObservationRequirement, evaluate_observation_frontiers,
+};
+use observation_probe_bridge::{
+    OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION, ObservationProbePlanRequest,
+    ObservationProbePlanStatus, plan_observation_probe,
+};
+use rust_edit_class_source::{
+    RustEditClassSourceResult, RustEditClassSubject, collect_rust_edit_class_source,
+};
+
+const CURRENT_REPOSITORY: &str = "owner/repo";
+
+struct TempRepo(PathBuf);
+
+impl TempRepo {
+    fn new() -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cultist-rust-edit-class-current-main-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(root.join("src")).unwrap();
+        git(&root, &["init", "-q"]);
+        git(&root, &["config", "user.email", "cultist@example.invalid"]);
+        git(&root, &["config", "user.name", "Cultist Test"]);
+        Self(root)
+    }
+
+    fn write(&self, source: &str) {
+        fs::write(self.0.join("src/lib.rs"), source).unwrap();
+    }
+
+    fn commit(&self, message: &str) -> String {
+        git(&self.0, &["add", "src/lib.rs"]);
+        git(&self.0, &["commit", "-q", "-m", message]);
+        git_text(&self.0, &["rev-parse", "HEAD"])
+    }
+
+    fn commit_unrelated(&self) -> String {
+        fs::write(self.0.join("README.md"), "unrelated\n").unwrap();
+        git(&self.0, &["add", "README.md"]);
+        git(&self.0, &["commit", "-q", "-m", "unrelated"]);
+        git_text(&self.0, &["rev-parse", "HEAD"])
+    }
+}
+
+impl Drop for TempRepo {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_text(root: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
+fn subject(revision: &str) -> RustEditClassSubject {
+    RustEditClassSubject {
+        repository: CURRENT_REPOSITORY.to_string(),
+        revision: revision.to_string(),
+        path: "src/lib.rs".to_string(),
+    }
+}
+
+fn collect(repo: &TempRepo, subject: &RustEditClassSubject) -> RustEditClassSourceResult {
+    collect_rust_edit_class_source(&repo.0, CURRENT_REPOSITORY, subject).unwrap()
+}
+
+fn seeded() -> (TempRepo, String, String, String) {
+    let repo = TempRepo::new();
+    repo.write("fn answer() -> usize { 41 }\n");
+    let root = repo.commit("root");
+    repo.write("fn answer() -> usize { 42 }\n");
+    let syntax = repo.commit("syntax");
+    repo.write("// comment\nfn answer() -> usize { 42 }\n");
+    let comments = repo.commit("comments");
+    (repo, root, syntax, comments)
+}
+
+#[test]
+fn focused_source_values_and_focus_admission_survive_current_main() {
+    let (repo, root, syntax, comments) = seeded();
+
+    git(&repo.0, &["checkout", "-q", &syntax]);
+    let syntax_result = collect(&repo, &subject(&syntax));
+    assert_eq!(
+        syntax_result.observation.value_state,
+        DiscriminatorValueState::Known {
+            value_ref: "syntax_changed".to_string()
+        }
+    );
+    assert_eq!(
+        syntax_result.observation.applicability.status,
+        ObservationApplicabilityStatus::Applies
+    );
+
+    git(&repo.0, &["checkout", "-q", &comments]);
+    let comments_result = collect(&repo, &subject(&comments));
+    assert_eq!(
+        comments_result.observation.value_state,
+        DiscriminatorValueState::Known {
+            value_ref: "comments_or_docs_only".to_string()
+        }
+    );
+
+    git(&repo.0, &["checkout", "-q", &root]);
+    let root_result = collect(&repo, &subject(&root));
+    assert!(matches!(
+        root_result.observation.value_state,
+        DiscriminatorValueState::Unknown { .. }
+    ));
+
+    git(&repo.0, &["checkout", "-q", "master"]);
+    let unrelated = repo.commit_unrelated();
+    let unrelated_result = collect(&repo, &subject(&unrelated));
+    assert!(matches!(
+        &unrelated_result.observation.value_state,
+        DiscriminatorValueState::Unknown { reason_ref } if reason_ref.contains("anchor-unchanged")
+    ));
+}
+
+#[test]
+fn source_bridge_uses_v2_consumption_applicability_and_closes_missing_frontier() {
+    let (repo, _root, _syntax, comments) = seeded();
+    let source = collect(&repo, &subject(&comments));
+    let required_subject = source.observation.subject_ref.clone();
+    let missing = observation_frontier::ObservationFrontierReceipt {
+        discriminator_id: "edit_class".to_string(),
+        subject_ref: required_subject.clone(),
+        status: ObservationFrontierStatus::Missing,
+        current: Vec::new(),
+        unknown: Vec::new(),
+        invalid: Vec::new(),
+        other_subject: Vec::new(),
+    };
+
+    let plan = plan_observation_probe(&ObservationProbePlanRequest {
+        schema_version: OBSERVATION_PROBE_BRIDGE_SCHEMA_VERSION,
+        frontier: missing,
+        frontier_requirements: source.bridge.clearing_requirements.clone(),
+        bridges: vec![source.bridge.clone()],
+        context: EvaluationContext {
+            repository: Some(CURRENT_REPOSITORY.to_string()),
+            revision: Some(comments.clone()),
+            work: None,
+            path: Some("src/lib.rs".to_string()),
+        },
+        probes: vec![source.probe.clone()],
+        allow_effectful: false,
+        policy: ProbeSelectionPolicy::Conservative,
+    })
+    .unwrap();
+
+    assert_eq!(plan.applicability_status, ApplicabilityStatus::Applies);
+    assert_eq!(plan.status, ObservationProbePlanStatus::Planned);
+    assert_eq!(
+        plan.evidence_plan.unwrap().status,
+        EvidencePlanStatus::Selected
+    );
+
+    let evaluation = evaluate_observation_frontiers(&ObservationFrontierRequest {
+        schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+        requirements: vec![ObservationRequirement {
+            discriminator_id: "edit_class".to_string(),
+            subject_ref: required_subject,
+        }],
+        observations: discriminator_observation::DiscriminatorObservationBatch {
+            schema_version: discriminator_observation::DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION,
+            observations: vec![source.observation],
+        },
+    })
+    .unwrap();
+
+    assert_eq!(
+        evaluation.frontiers[0].status,
+        ObservationFrontierStatus::Current
+    );
+    assert_eq!(
+        evaluation.frontiers[0].current[0].value_ref,
+        "comments_or_docs_only"
+    );
+}
+
+#[test]
+fn repository_and_head_movement_are_independent_applicability_axes() {
+    let (repo, _root, syntax, comments) = seeded();
+
+    let wrong_repository =
+        collect_rust_edit_class_source(&repo.0, "owner/other", &subject(&comments)).unwrap();
+    assert_eq!(
+        wrong_repository.observation.value_state,
+        DiscriminatorValueState::Known {
+            value_ref: "comments_or_docs_only".to_string()
+        }
+    );
+    assert_eq!(
+        wrong_repository.observation.applicability.status,
+        ObservationApplicabilityStatus::Invalid
+    );
+    assert!(
+        wrong_repository
+            .observation
+            .applicability
+            .receipt_ref
+            .contains("current=owner/other@")
+    );
+
+    let moved_head =
+        collect_rust_edit_class_source(&repo.0, CURRENT_REPOSITORY, &subject(&syntax)).unwrap();
+    assert_eq!(
+        moved_head.observation.applicability.status,
+        ObservationApplicabilityStatus::Invalid
+    );
+    assert_eq!(git_text(&repo.0, &["rev-parse", "HEAD"]), comments);
+}
+
+#[test]
+fn bad_source_and_subject_coordinates_fail_closed() {
+    let (repo, _root, _syntax, comments) = seeded();
+
+    assert!(collect_rust_edit_class_source(&repo.0, " owner/repo", &subject(&comments)).is_err());
+
+    let mut bad_path = subject(&comments);
+    bad_path.path = "../src/lib.rs".to_string();
+    assert!(collect_rust_edit_class_source(&repo.0, CURRENT_REPOSITORY, &bad_path).is_err());
+
+    let mut short_revision = subject(&comments);
+    short_revision.revision = "deadbeef".to_string();
+    assert!(collect_rust_edit_class_source(&repo.0, CURRENT_REPOSITORY, &short_revision).is_err());
+}


### PR DESCRIPTION
Progresses #220 as the current-main repair of the generic source applicability gap found in #221.

## Repair

The Rust edit-class source now receives the **current checkout repository identity** as an explicit input separate from the evidence subject repository.

Applicability is evaluated against:

```text
required repository = subject.repository
required revision   = subject.revision
required path       = subject.path

current repository  = caller-supplied source/check-out identity
current revision    = git rev-parse HEAD from REPO_ROOT
current path        = subject.path inside that checkout
```

The source no longer copies `subject.repository` into both sides of the applicability query.

The existing #54 classifier, single-parent/focused-path admission, value mapping, bridge, probe, and current-head behavior are retained.

## Controls

- syntax edit at matching repository/head/path -> KNOWN `syntax_changed` + APPLIES;
- comments/docs-only edit -> KNOWN `comments_or_docs_only` + APPLIES;
- root and unchanged-anchor cases remain UNKNOWN value states;
- exact head movement -> INVALID applicability while retaining the observed value;
- **wrong current repository at exact matching head/path -> INVALID applicability while retaining the observed value**;
- applicability receipt names the independently supplied current repository and checkout-observed head;
- malformed current repository, subject path, and revision fail closed;
- the existing MISSING -> source bridge -> read-only plan -> produced observation -> CURRENT loop remains intact.

## Public carrier contract

`rust_edit_class_observation` now takes both repository coordinates explicitly:

```text
REPO_ROOT CURRENT_REPOSITORY SUBJECT_REPOSITORY REVISION FILE
```

A hosted Oxc carrier can therefore bind `CURRENT_REPOSITORY` from the repository it intentionally checked out while preserving the selected subject coordinate separately.

## Boundary

- research/source adapter only;
- no second Rust syntax classifier;
- no remote-URL inference or GitHub-specific repository parser in the source core;
- current repository identity remains caller-supplied evidence and current Git head remains checkout-observed;
- no ownership, scheduling, merge, mutation, or action authority.

Supersedes the generic source API in #221 after hosted certification. #335 can compose on this repaired current-main source rather than the self-bound historical carrier.