### PR TITLE
DO NOT MERGE: Mako provider-basis A/B preflight

### DIFF
--- a/tests/quarry_mako_provider_basis_preflight.rs
+++ b/tests/quarry_mako_provider_basis_preflight.rs
@@ -1,0 +1,113 @@
+use std::fs;
+use std::process::Command;
+
+use serde_json::Value;
+
+#[test]
+fn quarry_mako_provider_basis_is_path_quiet() {
+    let root = std::env::temp_dir().join(format!(
+        "cultist-quarry-mako-provider-basis-root-{}",
+        std::process::id()
+    ));
+    let inventory_path = std::env::temp_dir().join(format!(
+        "cultist-quarry-mako-provider-basis-inventory-{}.json",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).expect("create analysis root");
+    fs::write(root.join(".gitignore"), "\n").expect("write seed file");
+    for args in [
+        vec!["init", "-q"],
+        vec!["config", "user.email", "mako@example.invalid"],
+        vec!["config", "user.name", "Mako"],
+        vec!["add", ".gitignore"],
+        vec!["commit", "-q", "-m", "seed"],
+    ] {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(args)
+            .status()
+            .expect("run git setup command");
+        assert!(status.success(), "git setup command failed");
+    }
+
+    let inventory = r#"{
+  "schema_version": 1,
+  "source": "github:mako-provider-basis-preflight-2026-08-23",
+  "observed_at": "2026-08-23T19:00:00Z",
+  "current": {
+    "id": "mako/provider-basis-ab",
+    "kind": "planned_work",
+    "title": "Mako measure operation-owned provider basis",
+    "url": "https://github.com/teamleaderleo/quarry/issues/563",
+    "head_ref": "main",
+    "head_sha": "f2a4e65441e6e8886373f6d1fddaf915c22cc175",
+    "updated_at": "2026-08-23T19:00:00Z",
+    "draft": false,
+    "activity": "preparation",
+    "changed_paths": [
+      ".github/workflows/research-563-provider-basis-ab.yml",
+      "scripts/research_563_provider_basis_ab.py"
+    ]
+  },
+  "active_work": [
+    {
+      "id": "pull/862",
+      "kind": "pull_request",
+      "title": "research: add frozen #633 daily source-attempt core",
+      "url": "https://github.com/teamleaderleo/quarry/pull/862",
+      "head_ref": "research/633-daily-source-attempt-core",
+      "head_sha": "81f5c3c0de44567753c4df2d4a36a75423322ae1",
+      "updated_at": "2026-08-23T19:00:00Z",
+      "draft": false,
+      "activity": "confirmed_active",
+      "changed_paths": [
+        "src/quarry/data/btc_prospective_source_attempt.py",
+        "tests/test_btc_prospective_source_attempt.py"
+      ]
+    }
+  ],
+  "coordination_edges": []
+}"#;
+    fs::write(&inventory_path, inventory).expect("write bounded inventory");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-cultist"))
+        .args([
+            "preflight",
+            "--inventory",
+            inventory_path.to_str().expect("inventory path is utf-8"),
+            "--format",
+            "json",
+            root.to_str().expect("root path is utf-8"),
+        ])
+        .output()
+        .expect("run current Cultist preflight binary");
+    assert!(
+        output.status.success(),
+        "preflight failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("preflight output is utf-8");
+    let report: Value = serde_json::from_str(&stdout).expect("preflight output is json");
+    let findings = report["findings"].as_array().expect("findings array");
+    let overlaps = findings
+        .iter()
+        .filter(|finding| finding["kind"].as_str() == Some("preflight-inventory-path-overlap"))
+        .collect::<Vec<_>>();
+    assert!(
+        overlaps.is_empty(),
+        "provider-basis experiment unexpectedly overlaps active work: {stdout}"
+    );
+
+    let claims = report["claims"].as_array().expect("claims array");
+    assert!(claims.iter().any(|claim| {
+        claim["kind"].as_str() == Some("unknown")
+            && claim["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("semantically independent"))
+    }));
+
+    fs::remove_file(&inventory_path).ok();
+    fs::remove_dir_all(&root).ok();
+}


### PR DESCRIPTION
Disposable Mako 🦈 collision preflight before one Quarry #563/#566/#595 provider-basis A/B carrier. Closed unmerged after hosted receipt.

## Planned Quarry write paths
- `.github/workflows/research-563-provider-basis-ab.yml`
- `scripts/research_563_provider_basis_ab.py`

## Frozen experiment question
#705/#704 measured repeated strategy-provider construction around `0.32-0.34s` across the 54 strategy evaluations. The dominant timing-revalidation cost from the same evaluator family was subsequently solved by #710/#714/#719/#765. No retained carrier found in repository history tests provider-basis reuse.

Candidate: build exactly six operation-owned provider bases (2 treatments × 3 symbols), each containing only exact replay-owned rules, schedule decisions, retained bars, timing projections and fixed identities. Mint a fresh lightweight provider closure for every one of the 54 scenario evaluations. Never share the closure object, portfolio, queue, execution state or result state across scenario leaves.

The candidate dispatch is bounded: exact operation-owned receipt/schedule/fitted objects hit the six bases; copied, changed, or otherwise non-owned requests fall back to the existing public provider builder. No generic trust flag is introduced.

## Exact Cultist receipt
- parent: `26ff528e243808c8107d562aa55e8f6e0fe2d037`
- carrier head: `54daf382024a1fe083af57d18d97ffff52d14684`
- hosted CI run/job: `32659870373 / 97244276839`
- format, clippy, project/review/issue/external-reference/active-work controls, full Rust suite, and all dogfood stages: PASS

## Terminal provider/currentness reread
Quarry main advanced from declaration head `f2a4e65441e6e8886373f6d1fddaf915c22cc175` to `96e2eac4034138ac5752c83f969c131ea1471c23` through merged #861 only. The exact delta is three additive adaptive-router files:
- `research/experiments/855-adaptive-trend-router-v2-batch1.json`
- `src/quarry/adaptive_trend_router.py`
- `tests/test_adaptive_trend_router.py`

No provider, trend-replay, alpha-helper, timing, evaluator, or planned evidence path changed. Direct search still finds no open #563/#566/#595/#576 carrier and no provider-basis path claim. #862 remains path-disjoint. Semantic independence remains UNKNOWN.

## Consequence
Proceed with one disposable two-file provider-basis A/B directly on current Quarry main `96e2eac4034138ac5752c83f969c131ea1471c23`. Candidate must include six basis builds in measured cost, mint 54 fresh closures, hold direct timing fixed on both sides, preserve all 54 strategy result identities, and cold-check six basis closures against the public provider/evaluator contract outside timing.

Dogfood receipt: **surfaced; consulted; same action after provider-current verification; semantic independence remains UNKNOWN.**

GitHub-hosted Actions only. No Cultist product change.