### PR TITLE
fix: keep paginated provider snapshots unknown

### DIFF
--- a/scripts/active_work_heads_up_snapshot_ci.py
+++ b/scripts/active_work_heads_up_snapshot_ci.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import datetime
 import json
 import os
 from pathlib import Path
@@ -12,6 +13,75 @@ import time
 
 import active_work_heads_up_ci as base
 from github_provider_snapshot_ci import derive_provider_snapshot_identities
+
+
+def build_single_read_inventory_and_metadata(
+    repo: str,
+    current_number: int,
+) -> tuple[dict[str, object], dict[str, object]]:
+    """Build one provider population from exactly one GraphQL response."""
+    owner, name = repo.split("/", 1)
+    result = base.graphql(
+        base.PR_PAGE_QUERY,
+        {"owner": owner, "name": name, "after": None},
+    )
+    data = result.get("data")
+    repository = data.get("repository") if isinstance(data, dict) else None
+    pull_requests = (
+        repository.get("pullRequests") if isinstance(repository, dict) else None
+    )
+    if not isinstance(pull_requests, dict):
+        raise RuntimeError("could not retrieve open pull requests")
+
+    nodes = pull_requests.get("nodes")
+    if not isinstance(nodes, list):
+        raise RuntimeError("open pull-request connection is missing nodes")
+    has_next, _cursor = base.page_info(pull_requests)
+    if has_next:
+        raise RuntimeError(
+            "provider population requires pull-request pagination; exact snapshot unavailable"
+        )
+
+    work: list[dict[str, object]] = []
+    metadata_work: list[dict[str, object]] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        number = int(node["number"])
+        files = node.get("files")
+        if not isinstance(files, dict):
+            raise RuntimeError(f"PR #{number} has no readable files connection")
+        files_has_next, _files_cursor = base.page_info(files)
+        if files_has_next:
+            raise RuntimeError(
+                f"provider population requires file pagination for PR #{number}; "
+                "exact snapshot unavailable"
+            )
+        work.append(base.work_item(owner, name, node))
+        metadata_work.append(base.metadata_item(node))
+
+    current = next((item for item in work if item["id"] == f"#{current_number}"), None)
+    if current is None:
+        raise RuntimeError(f"current PR #{current_number} was absent from open inventory")
+
+    observed_at = (
+        datetime.datetime.now(datetime.timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    inventory = {
+        "schema_version": 1,
+        "source": "github_pull_requests_graphql_single_read",
+        "observed_at": observed_at,
+        "current": current,
+        "active_work": work,
+    }
+    metadata = {
+        "schema_version": 1,
+        "source": "github_pull_requests_graphql_single_read",
+        "work": metadata_work,
+    }
+    return inventory, metadata
 
 
 def coordination_for_snapshot(
@@ -59,7 +129,9 @@ def read_current_provider_snapshot(
     current_number: int,
 ) -> tuple[dict[str, object], list[dict[str, object]]] | None:
     try:
-        inventory, metadata = base.build_inventory_and_metadata(repo, current_number)
+        inventory, metadata = build_single_read_inventory_and_metadata(
+            repo, current_number
+        )
         edges, _note, _seconds = coordination_for_snapshot(
             inventory, metadata, retain_note=False
         )
@@ -128,7 +200,7 @@ def main() -> None:
     current_number = int(os.environ["CURRENT_PR"])
 
     inventory_started = time.monotonic()
-    inventory, metadata = base.build_inventory_and_metadata(repo, current_number)
+    inventory, metadata = build_single_read_inventory_and_metadata(repo, current_number)
     inventory_seconds = time.monotonic() - inventory_started
 
     relevant_edges, metadata_note, coordination_seconds = coordination_for_snapshot(

--- a/scripts/active_work_heads_up_snapshot_ci_test.py
+++ b/scripts/active_work_heads_up_snapshot_ci_test.py
@@ -2,7 +2,61 @@
 
 from __future__ import annotations
 
-from active_work_heads_up_snapshot_ci import can_skip_product
+import active_work_heads_up_ci as base
+from active_work_heads_up_snapshot_ci import (
+    build_single_read_inventory_and_metadata,
+    can_skip_product,
+    read_current_provider_snapshot,
+)
+
+
+def provider_response(
+    *,
+    pull_requests_has_next: bool = False,
+    files_has_next: bool = False,
+) -> dict[str, object]:
+    return {
+        "data": {
+            "repository": {
+                "pullRequests": {
+                    "nodes": [
+                        {
+                            "number": 10,
+                            "title": "current work",
+                            "url": "https://github.com/owner/repo/pull/10",
+                            "body": "",
+                            "headRefName": "current",
+                            "headRefOid": "a" * 40,
+                            "updatedAt": "2026-08-24T00:00:00Z",
+                            "isDraft": False,
+                            "files": {
+                                "nodes": [{"path": "src/lib.rs"}],
+                                "pageInfo": {
+                                    "hasNextPage": files_has_next,
+                                    "endCursor": "files-next" if files_has_next else None,
+                                },
+                            },
+                        }
+                    ],
+                    "pageInfo": {
+                        "hasNextPage": pull_requests_has_next,
+                        "endCursor": (
+                            "pulls-next" if pull_requests_has_next else None
+                        ),
+                    },
+                }
+            }
+        }
+    }
+
+
+def assert_runtime_error(callback, expected: str) -> None:
+    try:
+        callback()
+    except RuntimeError as error:
+        assert expected in str(error), error
+    else:
+        raise AssertionError(f"expected RuntimeError containing {expected!r}")
 
 
 def main() -> None:
@@ -52,6 +106,43 @@ def main() -> None:
         required_provider_snapshot=identity,
         current_provider_snapshot=identity,
     )
+
+    original_graphql = base.graphql
+    try:
+        calls: list[dict[str, object]] = []
+
+        def exact_graphql(query: str, variables: dict[str, object]) -> dict[str, object]:
+            assert query == base.PR_PAGE_QUERY
+            calls.append(variables)
+            return provider_response()
+
+        base.graphql = exact_graphql
+        inventory, metadata = build_single_read_inventory_and_metadata("owner/repo", 10)
+        assert len(calls) == 1, calls
+        assert calls[0]["after"] is None
+        assert inventory["source"] == "github_pull_requests_graphql_single_read"
+        assert inventory["current"]["id"] == "#10"
+        assert inventory["active_work"][0]["changed_paths"] == ["src/lib.rs"]
+        assert metadata["work"][0]["id"] == "#10"
+        assert read_current_provider_snapshot("owner/repo", 10) is not None
+
+        base.graphql = lambda _query, _variables: provider_response(
+            pull_requests_has_next=True
+        )
+        assert_runtime_error(
+            lambda: build_single_read_inventory_and_metadata("owner/repo", 10),
+            "pull-request pagination",
+        )
+        assert read_current_provider_snapshot("owner/repo", 10) is None
+
+        base.graphql = lambda _query, _variables: provider_response(files_has_next=True)
+        assert_runtime_error(
+            lambda: build_single_read_inventory_and_metadata("owner/repo", 10),
+            "file pagination for PR #10",
+        )
+        assert read_current_provider_snapshot("owner/repo", 10) is None
+    finally:
+        base.graphql = original_graphql
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Completes the reopened #292 boundary left after merged #338.

## Trigger

Merged #338 correctly routes GitHub provider facts through the shared #337 snapshot producer, but its final `read_current_provider_snapshot()` still hashes any successful `build_inventory_and_metadata()` result. That base reader may span multiple open-PR pages and additional per-PR file pages, so membership/head/path movement between those provider reads can create a mixed population that is still supplied as an exact current snapshot identity.

## Repair

Snapshot-bound active-work reads now use one strict provider acquisition function:

```text
one GitHub GraphQL response
  + pullRequests.hasNextPage == false
  + every PR files.hasNextPage == false
  -> exact population facts may be hashed

any required pagination
  -> exact provider snapshot unavailable
```

The rule applies to both axes:

- the frozen/required provider population used to bind the inventory;
- the independent current population reread used for `--current-provider-snapshot`.

If the **current** reread requires pagination, it is returned as unavailable, so #329 preserves provider-snapshot UNKNOWN. If the **required/frozen** read requires pagination, the advisory fails closed before minting a required identity from mixed reads.

The existing #333 terminal current-work reread remains separate and unchanged.

## Controls

The Python adapter controls now prove:

- an unpaginated population is built from exactly one GraphQL call;
- its source receipt explicitly names the single-read contract;
- top-level open-PR pagination rejects exact snapshot construction;
- per-PR file pagination rejects exact snapshot construction;
- the current-population wrapper converts either pagination case into unavailable/UNKNOWN;
- existing exact/moved/unavailable work-head and snapshot-equality quiet-prefilter controls remain intact.

## Boundary

This is deliberately conservative. It does not claim provider-wide transactional snapshot semantics across multiple calls. Repositories that exceed one `first: 100` PR page or one `files(first: 100)` page per PR lose exact population identity until a separately proven multi-read consistency protocol exists.

No hash changes, Rust applicability changes, TTL, checkout-HEAD inference, ownership, scheduling, merge, or mutation authority.