### PR TITLE
DO NOT MERGE: Mako provider-basis macro preflight

### DIFF
--- a/tests/quarry_mako_provider_basis_macro_preflight.rs
+++ b/tests/quarry_mako_provider_basis_macro_preflight.rs
@@ -1,0 +1,113 @@
+use std::fs;
+use std::process::Command;
+
+use serde_json::Value;
+
+#[test]
+fn quarry_mako_provider_basis_macro_is_path_quiet() {
+    let root = std::env::temp_dir().join(format!(
+        "cultist-quarry-mako-provider-basis-macro-root-{}",
+        std::process::id()
+    ));
+    let inventory_path = std::env::temp_dir().join(format!(
+        "cultist-quarry-mako-provider-basis-macro-inventory-{}.json",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).expect("create analysis root");
+    fs::write(root.join(".gitignore"), "\n").expect("write seed file");
+    for args in [
+        vec!["init", "-q"],
+        vec!["config", "user.email", "mako@example.invalid"],
+        vec!["config", "user.name", "Mako"],
+        vec!["add", ".gitignore"],
+        vec!["commit", "-q", "-m", "seed"],
+    ] {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(args)
+            .status()
+            .expect("run git setup command");
+        assert!(status.success(), "git setup command failed");
+    }
+
+    let inventory = r#"{
+  "schema_version": 1,
+  "source": "github:mako-provider-basis-macro-preflight-2026-08-23",
+  "observed_at": "2026-08-23T19:11:00Z",
+  "current": {
+    "id": "mako/provider-basis-macro",
+    "kind": "planned_work",
+    "title": "Mako compose provider basis into strongest alpha harness",
+    "url": "https://github.com/teamleaderleo/quarry/issues/563",
+    "head_ref": "main",
+    "head_sha": "96e2eac4034138ac5752c83f969c131ea1471c23",
+    "updated_at": "2026-08-23T19:11:00Z",
+    "draft": false,
+    "activity": "preparation",
+    "changed_paths": [
+      ".github/workflows/research-563-combined-alpha-provider-basis.yml",
+      "scripts/research_563_combined_alpha_composition.py",
+      "scripts/research_563_combined_alpha_owned_source.py",
+      "scripts/research_563_combined_alpha_timing_parent.py",
+      "scripts/research_563_combined_alpha_direct_timing.py",
+      "scripts/research_563_combined_alpha_source_admission.py",
+      "scripts/research_563_combined_alpha_provider_basis.py",
+      "src/quarry/_exact_regime_attribution_receipts.py"
+    ]
+  },
+  "active_work": [
+    {
+      "id": "pull/862",
+      "kind": "pull_request",
+      "title": "research: add frozen #633 daily source-attempt core",
+      "url": "https://github.com/teamleaderleo/quarry/pull/862",
+      "head_ref": "research/633-daily-source-attempt-core",
+      "head_sha": "81f5c3c0de44567753c4df2d4a36a75423322ae1",
+      "updated_at": "2026-08-23T19:11:00Z",
+      "draft": false,
+      "activity": "confirmed_active",
+      "changed_paths": [
+        "src/quarry/data/btc_prospective_source_attempt.py",
+        "tests/test_btc_prospective_source_attempt.py"
+      ]
+    }
+  ],
+  "coordination_edges": []
+}"#;
+    fs::write(&inventory_path, inventory).expect("write bounded inventory");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-cultist"))
+        .args([
+            "preflight",
+            "--inventory",
+            inventory_path.to_str().expect("inventory path is utf-8"),
+            "--format",
+            "json",
+            root.to_str().expect("root path is utf-8"),
+        ])
+        .output()
+        .expect("run current Cultist preflight binary");
+    assert!(
+        output.status.success(),
+        "preflight failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("preflight output is utf-8");
+    let report: Value = serde_json::from_str(&stdout).expect("preflight output is json");
+    let findings = report["findings"].as_array().expect("findings array");
+    assert!(
+        findings.iter().all(|finding| finding["kind"].as_str() != Some("preflight-inventory-path-overlap")),
+        "provider-basis macro unexpectedly overlaps active work: {stdout}"
+    );
+    let claims = report["claims"].as_array().expect("claims array");
+    assert!(claims.iter().any(|claim| {
+        claim["kind"].as_str() == Some("unknown")
+            && claim["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("semantically independent"))
+    }));
+
+    fs::remove_file(&inventory_path).ok();
+    fs::remove_dir_all(&root).ok();
+}

--- a/tests/quarry_mako_provider_basis_macro_preflight.rs
+++ b/tests/quarry_mako_provider_basis_macro_preflight.rs
@@ -97,7 +97,9 @@ fn quarry_mako_provider_basis_macro_is_path_quiet() {
     let report: Value = serde_json::from_str(&stdout).expect("preflight output is json");
     let findings = report["findings"].as_array().expect("findings array");
     assert!(
-        findings.iter().all(|finding| finding["kind"].as_str() != Some("preflight-inventory-path-overlap")),
+        findings
+            .iter()
+            .all(|finding| finding["kind"].as_str() != Some("preflight-inventory-path-overlap")),
         "provider-basis macro unexpectedly overlaps active work: {stdout}"
     );
     let claims = report["claims"].as_array().expect("claims array");


### PR DESCRIPTION
Disposable Mako 🦈 collision preflight before one Quarry #563/#566/#595 same-host macro composition of #866 provider-basis reuse into #773 source-schema + direct-timing alpha carrier. Closed unmerged after hosted receipt.

## Planned Quarry write paths
- `.github/workflows/research-563-combined-alpha-provider-basis.yml`
- `scripts/research_563_combined_alpha_composition.py`
- `scripts/research_563_combined_alpha_owned_source.py`
- `scripts/research_563_combined_alpha_timing_parent.py`
- `scripts/research_563_combined_alpha_direct_timing.py`
- `scripts/research_563_combined_alpha_source_admission.py`
- `scripts/research_563_combined_alpha_provider_basis.py`
- `src/quarry/_exact_regime_attribution_receipts.py`

## Question
#866 reduced the direct-timing 54-strategy family `0.913748879s -> 0.614042226s` (`1.488088×`) while preserving all 54 result IDs, fresh closure/evaluator state, public fallback rejection, and six cold public provider/evaluator oracles per repeat. Does that component materially improve #773's strongest retained full alpha composition?

The reference is byte-exact #773 source-schema + direct-timing research machinery. The candidate adds provider-basis reuse only during candidate construction: exactly six operation-owned bases, 54 fresh provider closures and 270 provider invocations. The complete public current-alpha oracle inside each process remains untouched.

## Exact Cultist receipt
- branch head after formatter correction: `1f0a6ff15c090bf0350448a7850d489a1346110c`
- hosted CI run/job: `32660686551 / 97246277912`
- runtime PR base used by hosted merge test: `7e41bb116c67552d43253f8bd85253dc391c8119`
- format, clippy, project/review/issue/external-reference/active-work controls, full Rust suite and all dogfood stages: PASS

Initial run `32660520709 / 97245875062` stopped at rustfmt only; the exact hosted formatter diff was applied with no semantic change and is superseded by the green run above.

Cultist main subsequently advanced to `c84e151714d3d9a53a0723dbbf384e0df7e12242` through one commit adding only:
- `.github/workflows/selected-refinement-observation-loop-current-main.yml`
- `research/selected-refinement-observation-loop.md`
- `tests/selected_refinement_observation_loop.rs`

No preflight engine/adapter code changed.

## Terminal Quarry currentness / ownership
Quarry main remains exactly `96e2eac4034138ac5752c83f969c131ea1471c23`. #773's consumed alpha/provider/timing/helper files remain byte-compatible across the 27 commits since its original parent; intervening changes are additive research/data work plus #815's separately landed supergraph repair, which the composition harness does not import.

Newest bounded active candidate remains #862 `81f5c3c0de44567753c4df2d4a36a75423322ae1`, two #633 source-attempt files, disjoint from all eight planned macro paths. No competing #563/#566/#595 macro carrier is open.

## Consequence
Proceed with one disposable eight-file same-host macro A/B directly on current Quarry main `96e2eac4034138ac5752c83f969c131ea1471c23`. Candidate runs first; byte-exact #773 source-schema + direct-timing reference runs second. Exact scorecard/grid/seam/oracle equality and material full-candidate saving are mandatory before advancement.

Dogfood receipt: **surfaced; consulted; same action after provider-current verification; semantic independence remains UNKNOWN.**

No Cultist product change.