### PR TITLE
research: replay refinement candidate readiness on current main

### DIFF
--- a/examples/refinement_candidate_readiness.rs
+++ b/examples/refinement_candidate_readiness.rs
@@ -1,0 +1,48 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+#[allow(dead_code)]
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[allow(dead_code)]
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[allow(dead_code)]
+#[path = "../src/refinement_candidate_readiness.rs"]
+mod refinement_candidate_readiness;
+#[allow(dead_code)]
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+#[allow(dead_code)]
+#[path = "../src/refinement_observation_requirement.rs"]
+mod refinement_observation_requirement;
+
+use refinement_candidate_readiness::{
+    MAX_REFINEMENT_CANDIDATE_READINESS_REQUEST_BYTES, evaluate_refinement_candidate_readiness,
+    parse_refinement_candidate_readiness_request,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("refinement-candidate-readiness: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take((MAX_REFINEMENT_CANDIDATE_READINESS_REQUEST_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_REFINEMENT_CANDIDATE_READINESS_REQUEST_BYTES {
+        return Err(format!(
+            "refinement candidate readiness request exceeds the {MAX_REFINEMENT_CANDIDATE_READINESS_REQUEST_BYTES}-byte limit"
+        )
+        .into());
+    }
+
+    let request = parse_refinement_candidate_readiness_request(&bytes)?;
+    let evaluation = evaluate_refinement_candidate_readiness(&request)?;
+    println!("{}", serde_json::to_string_pretty(&evaluation)?);
+    Ok(())
+}

--- a/research/refinement-candidate-readiness.md
+++ b/research/refinement-candidate-readiness.md
@@ -1,0 +1,248 @@
+# Refinement candidate evidence readiness
+
+Tracking: #240. Builds on #179 replay bookkeeping, #231 exact candidate observation requirements, #210 frontier currentness, and the complete selected-candidate acquisition replay in #235.
+
+## Question
+
+Can one descriptive view show both:
+
+```text
+replay verdict
+current exact evidence readiness
+```
+
+without letting either axis overwrite the other?
+
+The trigger is now concrete. #235 proved that the retained selected Oxc candidate can acquire a missing exact `edit_class` observation and move its exact frontier from MISSING to CURRENT. #179 simultaneously preserves competing Oxc candidates that were rejected by replay for different reasons.
+
+Current evidence availability therefore answers a different question from replay quality.
+
+## V0 receipt
+
+`src/refinement_candidate_readiness.rs` evaluates every retained candidate and emits:
+
+```text
+RefinementCandidateReadiness
+  episode_id
+  candidate_id
+  is_selected_transition
+  replay_status
+  replay_result
+  evidence_status
+    current
+    blocked
+  requirements[]
+  requirement_mappings[]
+  requirement_frontiers[]
+  missing_requirement_mappings[]
+```
+
+`evidence_status` is deliberately evidence-only. It says whether every exact mapped observation requirement is currently KNOWN+APPLIES. It grants no candidate selection, replay revision, promotion, policy, or execution authority.
+
+The full replay status/result from #179 remains present beside it.
+
+## Reuse boundary
+
+The readiness evaluator does not invent a second mapping validator. Before reading candidate mappings it constructs the existing #231 request and calls the existing selected-requirement evaluator, which validates:
+
+```text
+mapping schema
+mapping ID uniqueness
+(episode, candidate, discriminator) uniqueness
+existing episode/candidate references
+candidate discriminator membership
+```
+
+After that validation, readiness reads the same exact tuple:
+
+```text
+(episode_id, candidate_id, discriminator_id)
+-> subject_ref + source receipt
+```
+
+for each candidate.
+
+Every resolved requirement is passed unchanged to #210 `evaluate_observation_frontiers`. Current evidence means every required frontier is `CURRENT` and no requirement mapping is missing.
+
+## Retained Oxc asymmetric controls
+
+### Selected replay survivor + current evidence
+
+```text
+candidate  syntax-changing-current-cohort
+replay     weakened
+evidence   current
+selected   true
+```
+
+This uses the exact #221/#231 focused subject:
+
+```text
+edit_class @ oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:
+             crates/oxc_linter/src/rules.rs
+```
+
+### Replay survivor + missing exact evidence
+
+The test removes that exact observation and inserts a current `edit_class=syntax_changed` observation for the same revision but `other.rs`.
+
+Expected and executed:
+
+```text
+replay     weakened
+evidence   blocked
+frontier   missing
+other_subject = 1
+```
+
+The replay survivor remains a survivor. Current use is blocked by evidence identity/currentness.
+
+### Replay rejected + current evidence
+
+The test supplies explicit candidate-specific mappings and current observations for:
+
+```text
+reverse-edit-class-control
+  replay = rejected_no_improvement
+  evidence = current
+
+singleton-commit-partition
+  replay = rejected_overfit
+  evidence = current
+```
+
+These are intentionally synthetic readiness controls. The exact mapping/observation facts are supplied explicitly; no source claim is inferred from the candidate name.
+
+The executed result protects the key direction:
+
+> Perfect current evidence cannot rescue a candidate that deterministic replay already rejected.
+
+### Missing mapping
+
+Removing the selected Oxc candidate's #231 mapping yields:
+
+```text
+replay     weakened
+evidence   blocked
+requirements = []
+missing_requirement_mappings = [edit_class]
+```
+
+The evaluator does not search the observation corpus for a convenient subject.
+
+## Default retained corpus
+
+The retained #231 mapping corpus maps only selected transitions. As a result, the two rejected Oxc candidates are evidence-blocked by missing candidate-specific mappings in the unmodified retained request.
+
+That is descriptive: their replay rejection already explains why no acquisition path was needed. A caller can still supply an exact mapping/current observation for a rejected candidate when testing the independence of the two axes.
+
+## Reader
+
+```text
+cargo run --example refinement_candidate_readiness < request.json
+```
+
+The request carries:
+
+```text
+schema_version = 1
+refinements     #179 batch
+mappings        #231 batch
+observations    #185/#210 v2 batch
+```
+
+Input is bounded to 1 MiB before parsing. The underlying refinement, mapping, and observation validators remain authoritative for their own records.
+
+## Boundary
+
+- research only;
+- no automatic candidate selection;
+- no ranking or confidence score;
+- no promotion authority;
+- evidence currentness never changes `replay_status`;
+- replay status never fabricates evidence;
+- rejected candidates stay rejected with current evidence;
+- replay survivors may stay evidence-blocked;
+- wrong-subject observations stay `other_subject` through #210;
+- source acquisition remains #216/#221/#235 and is outside this view;
+- no product CLI/report-schema change.
+
+## Execution receipt
+
+The first three CI attempts exercised only carrier hygiene:
+
+```text
+#1689 run 32265386776
+  rustfmt only
+
+#1708 run 32265609939
+  rustfmt passed
+  Clippy found one unused test import
+
+#1720 run 32265840673
+  final import cleanup needed one rustfmt wrap
+```
+
+No semantic assertion ran before those issues were corrected.
+
+Formatted semantic head:
+
+```text
+9b37d4d54f895442b26947151331f2e7ac2de459
+```
+
+passed full ordinary CI:
+
+```text
+run:        32266090296
+run number: 1727
+result:     success
+```
+
+The branch was then compacted to one semantic commit on #235:
+
+```text
+7fe8e00dbe080e85b896442a2ce3dfec189c4dfb
+```
+
+That exact compacted head passed full ordinary CI again:
+
+```text
+run:        32266336188
+run number: 1741
+result:     success
+```
+
+Both green runs passed format, strict Clippy, active-work preflight, the full candidate-readiness test suite, and repository/history/CI-filter/diff dogfood.
+
+The executable result keeps both axes independent:
+
+```text
+selected syntax-changing-current-cohort
+  replay   weakened
+  evidence current
+
+same candidate, exact observation withheld + wrong-path current control
+  replay   weakened
+  evidence blocked
+  frontier missing
+
+reverse-edit-class-control with exact synthetic current evidence
+  replay   rejected_no_improvement
+  evidence current
+
+singleton-commit-partition with exact synthetic current evidence
+  replay   rejected_overfit
+  evidence current
+
+selected candidate with exact mapping removed
+  replay   weakened
+  evidence blocked
+  missing mapping edit_class
+```
+
+Evidence currentness therefore neither rescues a replay-rejected candidate nor supplies missing evidence to a replay-surviving candidate.
+
+North star:
+
+> Keep “did this refinement survive replay?” separate from “is the exact evidence it needs usable right now?”

--- a/src/refinement_candidate_readiness.rs
+++ b/src/refinement_candidate_readiness.rs
@@ -1,0 +1,224 @@
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::discriminator_observation::{
+    DiscriminatorObservationBatch, validate_discriminator_observation_batch,
+};
+use crate::observation_frontier::{
+    OBSERVATION_FRONTIER_SCHEMA_VERSION, ObservationFrontierReceipt, ObservationFrontierRequest,
+    ObservationFrontierStatus, ObservationRequirement, evaluate_observation_frontiers,
+};
+use crate::refinement_episode::{
+    RefinementEpisodeBatch, RefinementStatus, ReplayResult, validate_refinement_episode_batch,
+};
+use crate::refinement_observation_requirement::{
+    REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION, RefinementObservationRequirementBatch,
+    RefinementObservationRequirementMapping, RefinementObservationRequirementRequest,
+    evaluate_selected_observation_requirements,
+};
+
+pub const REFINEMENT_CANDIDATE_READINESS_SCHEMA_VERSION: u32 = 1;
+pub const MAX_REFINEMENT_CANDIDATE_READINESS_REQUEST_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementCandidateReadinessRequest {
+    pub schema_version: u32,
+    pub refinements: RefinementEpisodeBatch,
+    pub mappings: RefinementObservationRequirementBatch,
+    pub observations: DiscriminatorObservationBatch,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CandidateEvidenceStatus {
+    Current,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementCandidateReadiness {
+    pub episode_id: String,
+    pub candidate_id: String,
+    pub is_selected_transition: bool,
+    pub replay_status: RefinementStatus,
+    pub replay_result: ReplayResult,
+    pub evidence_status: CandidateEvidenceStatus,
+    pub requirements: Vec<ObservationRequirement>,
+    pub requirement_mappings: Vec<RefinementObservationRequirementMapping>,
+    pub requirement_frontiers: Vec<ObservationFrontierReceipt>,
+    pub missing_requirement_mappings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefinementCandidateReadinessEvaluation {
+    pub schema_version: u32,
+    pub candidates: Vec<RefinementCandidateReadiness>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RefinementCandidateReadinessError {
+    message: String,
+}
+
+impl RefinementCandidateReadinessError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for RefinementCandidateReadinessError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for RefinementCandidateReadinessError {}
+
+pub fn parse_refinement_candidate_readiness_request(
+    bytes: &[u8],
+) -> Result<RefinementCandidateReadinessRequest, RefinementCandidateReadinessError> {
+    if bytes.len() > MAX_REFINEMENT_CANDIDATE_READINESS_REQUEST_BYTES {
+        return Err(RefinementCandidateReadinessError::new(format!(
+            "refinement candidate readiness request exceeds the {MAX_REFINEMENT_CANDIDATE_READINESS_REQUEST_BYTES}-byte limit"
+        )));
+    }
+    let request: RefinementCandidateReadinessRequest =
+        serde_json::from_slice(bytes).map_err(|error| {
+            RefinementCandidateReadinessError::new(format!(
+                "invalid refinement candidate readiness JSON: {error}"
+            ))
+        })?;
+    validate_request(&request)?;
+    Ok(request)
+}
+
+pub fn evaluate_refinement_candidate_readiness(
+    request: &RefinementCandidateReadinessRequest,
+) -> Result<RefinementCandidateReadinessEvaluation, RefinementCandidateReadinessError> {
+    validate_request(request)?;
+
+    let mut candidates = Vec::new();
+    for episode in &request.refinements.episodes {
+        for candidate in &episode.candidate_refinements {
+            let mut requirements = Vec::new();
+            let mut requirement_mappings = Vec::new();
+            let mut missing_requirement_mappings = Vec::new();
+
+            for discriminator_id in &candidate.discriminator_refs {
+                if let Some(mapping) = request.mappings.mappings.iter().find(|mapping| {
+                    mapping.episode_id == episode.id
+                        && mapping.candidate_id == candidate.id
+                        && mapping.discriminator_id == *discriminator_id
+                }) {
+                    requirements.push(ObservationRequirement {
+                        discriminator_id: discriminator_id.clone(),
+                        subject_ref: mapping.subject_ref.clone(),
+                    });
+                    requirement_mappings.push(mapping.clone());
+                } else {
+                    missing_requirement_mappings.push(discriminator_id.clone());
+                }
+            }
+
+            requirements.sort();
+            requirement_mappings.sort_by(|left, right| left.id.cmp(&right.id));
+            missing_requirement_mappings.sort();
+
+            let requirement_frontiers = if requirements.is_empty() {
+                Vec::new()
+            } else {
+                evaluate_observation_frontiers(&ObservationFrontierRequest {
+                    schema_version: OBSERVATION_FRONTIER_SCHEMA_VERSION,
+                    requirements: requirements.clone(),
+                    observations: request.observations.clone(),
+                })
+                .map_err(|error| {
+                    RefinementCandidateReadinessError::new(format!(
+                        "candidate {} frontier evaluation failed: {error}",
+                        candidate.id
+                    ))
+                })?
+                .frontiers
+            };
+
+            let evidence_status = if missing_requirement_mappings.is_empty()
+                && !requirement_frontiers.is_empty()
+                && requirement_frontiers
+                    .iter()
+                    .all(|frontier| frontier.status == ObservationFrontierStatus::Current)
+            {
+                CandidateEvidenceStatus::Current
+            } else {
+                CandidateEvidenceStatus::Blocked
+            };
+
+            candidates.push(RefinementCandidateReadiness {
+                episode_id: episode.id.clone(),
+                candidate_id: candidate.id.clone(),
+                is_selected_transition: episode.selected_transition.as_deref()
+                    == Some(candidate.id.as_str()),
+                replay_status: candidate.status,
+                replay_result: candidate.replay_result,
+                evidence_status,
+                requirements,
+                requirement_mappings,
+                requirement_frontiers,
+                missing_requirement_mappings,
+            });
+        }
+    }
+
+    candidates.sort_by(|left, right| {
+        left.episode_id
+            .cmp(&right.episode_id)
+            .then_with(|| left.candidate_id.cmp(&right.candidate_id))
+    });
+
+    Ok(RefinementCandidateReadinessEvaluation {
+        schema_version: REFINEMENT_CANDIDATE_READINESS_SCHEMA_VERSION,
+        candidates,
+    })
+}
+
+fn validate_request(
+    request: &RefinementCandidateReadinessRequest,
+) -> Result<(), RefinementCandidateReadinessError> {
+    if request.schema_version != REFINEMENT_CANDIDATE_READINESS_SCHEMA_VERSION {
+        return Err(RefinementCandidateReadinessError::new(format!(
+            "unsupported refinement candidate readiness schema {}; expected {REFINEMENT_CANDIDATE_READINESS_SCHEMA_VERSION}",
+            request.schema_version
+        )));
+    }
+
+    validate_refinement_episode_batch(&request.refinements).map_err(|error| {
+        RefinementCandidateReadinessError::new(format!("invalid refinement episode batch: {error}"))
+    })?;
+
+    // Reuse #231 as the owning validator for mapping identity, uniqueness, and
+    // candidate/discriminator membership before this composition reads mappings.
+    let mapping_request = RefinementObservationRequirementRequest {
+        schema_version: REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION,
+        refinements: request.refinements.clone(),
+        mappings: request.mappings.clone(),
+    };
+    evaluate_selected_observation_requirements(&mapping_request).map_err(|error| {
+        RefinementCandidateReadinessError::new(format!(
+            "invalid refinement observation requirement mappings: {error}"
+        ))
+    })?;
+
+    validate_discriminator_observation_batch(&request.observations).map_err(|error| {
+        RefinementCandidateReadinessError::new(format!(
+            "invalid discriminator observation batch: {error}"
+        ))
+    })?;
+
+    Ok(())
+}

--- a/tests/refinement_candidate_readiness.rs
+++ b/tests/refinement_candidate_readiness.rs
@@ -1,0 +1,352 @@
+#![allow(dead_code)]
+
+#[path = "../src/discriminator_observation.rs"]
+mod discriminator_observation;
+#[path = "../src/observation_frontier.rs"]
+mod observation_frontier;
+#[path = "../src/refinement_candidate_readiness.rs"]
+mod refinement_candidate_readiness;
+#[path = "../src/refinement_episode.rs"]
+mod refinement_episode;
+#[path = "../src/refinement_observation_requirement.rs"]
+mod refinement_observation_requirement;
+
+use discriminator_observation::{
+    DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION, DiscriminatorObservation, DiscriminatorValueState,
+    ObservationApplicability, ObservationApplicabilityStatus,
+    parse_discriminator_observation_batch,
+};
+use observation_frontier::ObservationFrontierStatus;
+use refinement_candidate_readiness::{
+    CandidateEvidenceStatus, MAX_REFINEMENT_CANDIDATE_READINESS_REQUEST_BYTES,
+    REFINEMENT_CANDIDATE_READINESS_SCHEMA_VERSION, RefinementCandidateReadinessRequest,
+    evaluate_refinement_candidate_readiness, parse_refinement_candidate_readiness_request,
+};
+use refinement_episode::{RefinementStatus, parse_refinement_episode_batch};
+use refinement_observation_requirement::{
+    REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION, RefinementObservationRequirementBatch,
+    RefinementObservationRequirementMapping,
+};
+
+const OBSERVATIONS: &[u8] =
+    include_bytes!("../research/discriminator-observations/cultist-v1.json");
+const FOCUSED_OXC_OBSERVATION: &[u8] = include_bytes!(
+    "../research/refinement-observation-requirements/oxc-focused-edit-class-v1.json"
+);
+const REFINEMENTS: &[u8] = include_bytes!("../research/refinement-episodes/cultist-v1.json");
+const MAPPINGS: &[u8] =
+    include_bytes!("../research/refinement-observation-requirements/cultist-v1.json");
+
+fn observations_with_focused_oxc() -> discriminator_observation::DiscriminatorObservationBatch {
+    let mut observations = parse_discriminator_observation_batch(OBSERVATIONS).unwrap();
+    observations
+        .observations
+        .retain(|observation| observation.discriminator_id != "edit_class");
+    let focused = parse_discriminator_observation_batch(FOCUSED_OXC_OBSERVATION).unwrap();
+    assert_eq!(focused.observations.len(), 1);
+    observations.observations.extend(focused.observations);
+    observations
+}
+
+fn request() -> RefinementCandidateReadinessRequest {
+    RefinementCandidateReadinessRequest {
+        schema_version: REFINEMENT_CANDIDATE_READINESS_SCHEMA_VERSION,
+        refinements: parse_refinement_episode_batch(REFINEMENTS).unwrap(),
+        mappings: serde_json::from_slice(MAPPINGS).unwrap(),
+        observations: observations_with_focused_oxc(),
+    }
+}
+
+fn current_observation(
+    observation_id: &str,
+    discriminator_id: &str,
+    subject_ref: &str,
+    value_ref: &str,
+) -> DiscriminatorObservation {
+    DiscriminatorObservation {
+        observation_id: observation_id.to_string(),
+        discriminator_id: discriminator_id.to_string(),
+        subject_ref: subject_ref.to_string(),
+        source_receipt: format!("research:candidate-readiness:{observation_id}"),
+        value_state: DiscriminatorValueState::Known {
+            value_ref: value_ref.to_string(),
+        },
+        applicability: ObservationApplicability {
+            status: ObservationApplicabilityStatus::Applies,
+            receipt_ref: format!("research:candidate-readiness:{observation_id}:applies"),
+        },
+    }
+}
+
+fn add_rejected_oxc_candidate_evidence(request: &mut RefinementCandidateReadinessRequest) {
+    let reverse_subject = "refinement:history/oxc-edit-class-v1/reverse-edit-class-control";
+    request
+        .mappings
+        .mappings
+        .push(RefinementObservationRequirementMapping {
+            id: "history/oxc-edit-class-v1:reverse-edit-class-control:edit-class".to_string(),
+            episode_id: "history/oxc-edit-class-v1".to_string(),
+            candidate_id: "reverse-edit-class-control".to_string(),
+            discriminator_id: "edit_class".to_string(),
+            subject_ref: reverse_subject.to_string(),
+            source_receipt: "research:candidate-readiness:reverse-subject-control".to_string(),
+        });
+    request.observations.observations.push(current_observation(
+        "candidate-readiness:reverse-edit-class",
+        "edit_class",
+        reverse_subject,
+        "syntax_changed",
+    ));
+
+    let singleton_subject = "refinement:history/oxc-edit-class-v1/singleton-commit-partition";
+    request
+        .mappings
+        .mappings
+        .push(RefinementObservationRequirementMapping {
+            id: "history/oxc-edit-class-v1:singleton-commit-partition:commit-identity".to_string(),
+            episode_id: "history/oxc-edit-class-v1".to_string(),
+            candidate_id: "singleton-commit-partition".to_string(),
+            discriminator_id: "commit_identity".to_string(),
+            subject_ref: singleton_subject.to_string(),
+            source_receipt: "research:candidate-readiness:singleton-subject-control".to_string(),
+        });
+    request.observations.observations.push(current_observation(
+        "candidate-readiness:singleton-commit-identity",
+        "commit_identity",
+        singleton_subject,
+        "228e8e0f85c0e7aeded02c5e27fd810004d3b41a",
+    ));
+}
+
+#[test]
+fn current_evidence_does_not_rescue_replay_rejected_oxc_candidates() {
+    let mut request = request();
+    add_rejected_oxc_candidate_evidence(&mut request);
+    let evaluation = evaluate_refinement_candidate_readiness(&request).unwrap();
+    let oxc = evaluation
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.episode_id == "history/oxc-edit-class-v1")
+        .collect::<Vec<_>>();
+    assert_eq!(oxc.len(), 3);
+
+    let selected = oxc
+        .iter()
+        .copied()
+        .find(|candidate| candidate.candidate_id == "syntax-changing-current-cohort")
+        .unwrap();
+    assert_eq!(selected.replay_status, RefinementStatus::Weakened);
+    assert_eq!(selected.evidence_status, CandidateEvidenceStatus::Current);
+    assert!(selected.is_selected_transition);
+
+    let reverse = oxc
+        .iter()
+        .copied()
+        .find(|candidate| candidate.candidate_id == "reverse-edit-class-control")
+        .unwrap();
+    assert_eq!(
+        reverse.replay_status,
+        RefinementStatus::RejectedNoImprovement
+    );
+    assert_eq!(reverse.evidence_status, CandidateEvidenceStatus::Current);
+    assert!(!reverse.is_selected_transition);
+    assert_eq!(reverse.requirement_frontiers.len(), 1);
+    assert_eq!(
+        reverse.requirement_frontiers[0].status,
+        ObservationFrontierStatus::Current
+    );
+
+    let singleton = oxc
+        .iter()
+        .copied()
+        .find(|candidate| candidate.candidate_id == "singleton-commit-partition")
+        .unwrap();
+    assert_eq!(singleton.replay_status, RefinementStatus::RejectedOverfit);
+    assert_eq!(singleton.evidence_status, CandidateEvidenceStatus::Current);
+    assert!(!singleton.is_selected_transition);
+    assert_eq!(singleton.requirement_frontiers.len(), 1);
+    assert_eq!(
+        singleton.requirement_frontiers[0].status,
+        ObservationFrontierStatus::Current
+    );
+}
+
+#[test]
+fn replay_survivor_stays_evidence_blocked_when_exact_observation_is_missing() {
+    let mut request = request();
+    let exact = request
+        .observations
+        .observations
+        .iter()
+        .find(|observation| {
+            observation.discriminator_id == "edit_class"
+                && observation.subject_ref
+                    == "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/rules.rs"
+        })
+        .unwrap()
+        .clone();
+    request
+        .observations
+        .observations
+        .retain(|observation| observation.observation_id != exact.observation_id);
+    request.observations.observations.push(current_observation(
+        "candidate-readiness:wrong-subject-edit-class",
+        "edit_class",
+        "oxc-project/oxc@228e8e0f85c0e7aeded02c5e27fd810004d3b41a:crates/oxc_linter/src/other.rs",
+        "syntax_changed",
+    ));
+
+    let evaluation = evaluate_refinement_candidate_readiness(&request).unwrap();
+    let selected = evaluation
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.episode_id == "history/oxc-edit-class-v1"
+                && candidate.candidate_id == "syntax-changing-current-cohort"
+        })
+        .unwrap();
+    assert_eq!(selected.replay_status, RefinementStatus::Weakened);
+    assert_eq!(selected.evidence_status, CandidateEvidenceStatus::Blocked);
+    assert!(selected.is_selected_transition);
+    assert!(selected.missing_requirement_mappings.is_empty());
+    assert_eq!(selected.requirement_frontiers.len(), 1);
+    assert_eq!(
+        selected.requirement_frontiers[0].status,
+        ObservationFrontierStatus::Missing
+    );
+    assert_eq!(selected.requirement_frontiers[0].other_subject.len(), 1);
+}
+
+#[test]
+fn missing_exact_subject_mapping_blocks_without_changing_replay_status() {
+    let mut request = request();
+    request.mappings.mappings.retain(|mapping| {
+        !(mapping.episode_id == "history/oxc-edit-class-v1"
+            && mapping.candidate_id == "syntax-changing-current-cohort"
+            && mapping.discriminator_id == "edit_class")
+    });
+
+    let evaluation = evaluate_refinement_candidate_readiness(&request).unwrap();
+    let selected = evaluation
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.episode_id == "history/oxc-edit-class-v1"
+                && candidate.candidate_id == "syntax-changing-current-cohort"
+        })
+        .unwrap();
+    assert_eq!(selected.replay_status, RefinementStatus::Weakened);
+    assert_eq!(selected.evidence_status, CandidateEvidenceStatus::Blocked);
+    assert!(selected.requirements.is_empty());
+    assert!(selected.requirement_frontiers.is_empty());
+    assert_eq!(selected.missing_requirement_mappings, vec!["edit_class"]);
+}
+
+#[test]
+fn retained_unmapped_rejected_candidates_are_explicitly_blocked() {
+    let evaluation = evaluate_refinement_candidate_readiness(&request()).unwrap();
+    let reverse = evaluation
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.episode_id == "history/oxc-edit-class-v1"
+                && candidate.candidate_id == "reverse-edit-class-control"
+        })
+        .unwrap();
+    assert_eq!(
+        reverse.replay_status,
+        RefinementStatus::RejectedNoImprovement
+    );
+    assert_eq!(reverse.evidence_status, CandidateEvidenceStatus::Blocked);
+    assert_eq!(reverse.missing_requirement_mappings, vec!["edit_class"]);
+
+    let singleton = evaluation
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.episode_id == "history/oxc-edit-class-v1"
+                && candidate.candidate_id == "singleton-commit-partition"
+        })
+        .unwrap();
+    assert_eq!(singleton.replay_status, RefinementStatus::RejectedOverfit);
+    assert_eq!(singleton.evidence_status, CandidateEvidenceStatus::Blocked);
+    assert_eq!(
+        singleton.missing_requirement_mappings,
+        vec!["commit_identity"]
+    );
+}
+
+#[test]
+fn all_retained_candidates_keep_their_replay_receipts() {
+    let evaluation = evaluate_refinement_candidate_readiness(&request()).unwrap();
+    let source_candidates = parse_refinement_episode_batch(REFINEMENTS)
+        .unwrap()
+        .episodes
+        .into_iter()
+        .flat_map(|episode| {
+            let episode_id = episode.id;
+            episode
+                .candidate_refinements
+                .into_iter()
+                .map(move |candidate| (episode_id.clone(), candidate))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(evaluation.candidates.len(), source_candidates.len());
+    for readiness in &evaluation.candidates {
+        let (_, source) = source_candidates
+            .iter()
+            .find(|(episode_id, candidate)| {
+                episode_id == &readiness.episode_id && candidate.id == readiness.candidate_id
+            })
+            .unwrap();
+        assert_eq!(readiness.replay_status, source.status);
+        assert_eq!(readiness.replay_result, source.replay_result);
+    }
+}
+
+#[test]
+fn request_round_trip_and_byte_bound_are_explicit() {
+    let request = request();
+    let encoded = serde_json::to_vec(&request).unwrap();
+    let decoded = parse_refinement_candidate_readiness_request(&encoded).unwrap();
+    assert_eq!(decoded, request);
+
+    let oversized = vec![b' '; MAX_REFINEMENT_CANDIDATE_READINESS_REQUEST_BYTES + 1];
+    let error = parse_refinement_candidate_readiness_request(&oversized).unwrap_err();
+    assert!(error.to_string().contains("exceeds"));
+}
+
+#[test]
+fn malformed_mapping_is_rejected_by_the_existing_requirement_validator() {
+    let mut request = request();
+    request.mappings = RefinementObservationRequirementBatch {
+        schema_version: REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION,
+        mappings: request.mappings.mappings,
+    };
+    request
+        .mappings
+        .mappings
+        .push(RefinementObservationRequirementMapping {
+            id: "candidate-readiness:bad-mapping".to_string(),
+            episode_id: "history/oxc-edit-class-v1".to_string(),
+            candidate_id: "syntax-changing-current-cohort".to_string(),
+            discriminator_id: "commit_identity".to_string(),
+            subject_ref: "research:bad-subject".to_string(),
+            source_receipt: "research:bad-mapping".to_string(),
+        });
+    let error = evaluate_refinement_candidate_readiness(&request).unwrap_err();
+    assert!(error.to_string().contains("is not required by candidate"));
+}
+
+#[test]
+fn observation_schema_is_still_v2() {
+    let request = request();
+    assert_eq!(
+        request.observations.schema_version,
+        DISCRIMINATOR_OBSERVATION_SCHEMA_VERSION
+    );
+    assert_eq!(
+        request.mappings.schema_version,
+        REFINEMENT_OBSERVATION_REQUIREMENT_SCHEMA_VERSION
+    );
+}


### PR DESCRIPTION
Progresses #240 as the current-main successor to historical #243, now on the merged #335 selected-observation loop.

## Retained contract

The candidate-readiness evaluator preserves two independent axes for every retained refinement candidate:

```text
replay_status / replay_result
current exact evidence readiness
```

`evidence_status = current` only when every discriminator has an exact mapping and every mapped frontier is CURRENT. Replay status remains unchanged.

## Current-main fixture repair

Current main deliberately keeps the focused Oxc edit-class receipt in the dedicated fixture:

`research/refinement-observation-requirements/oxc-focused-edit-class-v1.json`

rather than the broad discriminator corpus. This replay composes that focused receipt into the request exactly as merged #287/#335 do, while keeping the #243 evaluator semantics unchanged.

Controls preserve the asymmetric cases:

- selected `syntax-changing-current-cohort`: `weakened + current`;
- remove the exact focused receipt and add a wrong-path edit-class observation: replay remains `weakened`, evidence becomes blocked with an exact MISSING frontier;
- remove the selected candidate's D@S mapping: replay remains `weakened`, evidence stays blocked with `missing_requirement_mappings=[edit_class]`;
- provide explicit current evidence for `reverse-edit-class-control`: replay remains `rejected_no_improvement` while evidence is current;
- provide explicit current evidence for `singleton-commit-partition`: replay remains `rejected_overfit` while evidence is current;
- retained rejected candidates without mappings remain explicitly evidence-blocked;
- every candidate preserves its exact replay receipt.

## Boundary

Descriptive research layer only. No candidate promotion, automatic selection, ranking score, source acquisition, ownership, scheduling, merge, effect, or mutation authority. Exact subject/currentness semantics remain owned by the merged requirement/frontier layers.

Supersedes #243 after hosted certification. Refs #148 #179 #185 #210 #216 #220 #227 #231 #234 #240 #243 #335.