### PR TITLE
fix: prove bounded file coverage in one provider read

### DIFF
--- a/scripts/active_work_heads_up_snapshot_ci.py
+++ b/scripts/active_work_heads_up_snapshot_ci.py
@@ -15,6 +15,75 @@ import active_work_heads_up_ci as base
 from github_provider_snapshot_ci import derive_provider_snapshot_identities
 
 
+SINGLE_READ_PR_PAGE_QUERY = r"""
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(
+      states: OPEN
+      first: 100
+      orderBy: {field: UPDATED_AT, direction: DESC}
+    ) {
+      nodes {
+        number
+        title
+        url
+        body
+        headRefName
+        headRefOid
+        updatedAt
+        isDraft
+        filesFirst: files(first: 100) {
+          totalCount
+          nodes { path }
+        }
+        filesLast: files(last: 100) {
+          totalCount
+          nodes { path }
+        }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}
+"""
+
+
+def complete_changed_paths_from_single_response(node: dict[str, object]) -> list[str]:
+    """Return exact changed paths only when one response proves completeness."""
+    number = int(node["number"])
+    files_first = node.get("filesFirst")
+    files_last = node.get("filesLast")
+    if not isinstance(files_first, dict) or not isinstance(files_last, dict):
+        raise RuntimeError(f"PR #{number} has no readable bounded files connections")
+
+    first_total = files_first.get("totalCount")
+    last_total = files_last.get("totalCount")
+    if (
+        isinstance(first_total, bool)
+        or not isinstance(first_total, int)
+        or first_total < 0
+        or isinstance(last_total, bool)
+        or not isinstance(last_total, int)
+        or last_total < 0
+    ):
+        raise RuntimeError(f"PR #{number} has no readable provider file count")
+    if first_total != last_total:
+        raise RuntimeError(
+            f"PR #{number} provider file counts disagree within one response: "
+            f"{first_total} != {last_total}"
+        )
+
+    first_paths = base.file_paths_from_connection(files_first)
+    last_paths = base.file_paths_from_connection(files_last)
+    paths = sorted(set(first_paths + last_paths))
+    if len(paths) != first_total:
+        raise RuntimeError(
+            f"provider one-response file coverage incomplete for PR #{number}: "
+            f"{len(paths)} of {first_total} path(s); exact snapshot unavailable"
+        )
+    return paths
+
+
 def build_single_read_inventory_and_metadata(
     repo: str,
     current_number: int,
@@ -22,8 +91,8 @@ def build_single_read_inventory_and_metadata(
     """Build one provider population from exactly one GraphQL response."""
     owner, name = repo.split("/", 1)
     result = base.graphql(
-        base.PR_PAGE_QUERY,
-        {"owner": owner, "name": name, "after": None},
+        SINGLE_READ_PR_PAGE_QUERY,
+        {"owner": owner, "name": name},
     )
     data = result.get("data")
     repository = data.get("repository") if isinstance(data, dict) else None
@@ -47,17 +116,13 @@ def build_single_read_inventory_and_metadata(
     for node in nodes:
         if not isinstance(node, dict):
             continue
-        number = int(node["number"])
-        files = node.get("files")
-        if not isinstance(files, dict):
-            raise RuntimeError(f"PR #{number} has no readable files connection")
-        files_has_next, _files_cursor = base.page_info(files)
-        if files_has_next:
-            raise RuntimeError(
-                f"provider population requires file pagination for PR #{number}; "
-                "exact snapshot unavailable"
-            )
-        work.append(base.work_item(owner, name, node))
+        paths = complete_changed_paths_from_single_response(node)
+        normalized_node = dict(node)
+        normalized_node["files"] = {
+            "nodes": [{"path": path} for path in paths],
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+        }
+        work.append(base.work_item(owner, name, normalized_node))
         metadata_work.append(base.metadata_item(node))
 
     current = next((item for item in work if item["id"] == f"#{current_number}"), None)

--- a/scripts/active_work_heads_up_snapshot_ci_test.py
+++ b/scripts/active_work_heads_up_snapshot_ci_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import active_work_heads_up_ci as base
 from active_work_heads_up_snapshot_ci import (
+    SINGLE_READ_PR_PAGE_QUERY,
     build_single_read_inventory_and_metadata,
     can_skip_product,
     read_current_provider_snapshot,
@@ -13,8 +14,13 @@ from active_work_heads_up_snapshot_ci import (
 def provider_response(
     *,
     pull_requests_has_next: bool = False,
-    files_has_next: bool = False,
+    file_count: int = 1,
+    first_total: int | None = None,
+    last_total: int | None = None,
 ) -> dict[str, object]:
+    paths = [f"src/file_{index:03d}.rs" for index in range(file_count)]
+    first_paths = paths[:100]
+    last_paths = paths[-100:] if paths else []
     return {
         "data": {
             "repository": {
@@ -29,12 +35,13 @@ def provider_response(
                             "headRefOid": "a" * 40,
                             "updatedAt": "2026-08-24T00:00:00Z",
                             "isDraft": False,
-                            "files": {
-                                "nodes": [{"path": "src/lib.rs"}],
-                                "pageInfo": {
-                                    "hasNextPage": files_has_next,
-                                    "endCursor": "files-next" if files_has_next else None,
-                                },
+                            "filesFirst": {
+                                "totalCount": file_count if first_total is None else first_total,
+                                "nodes": [{"path": path} for path in first_paths],
+                            },
+                            "filesLast": {
+                                "totalCount": file_count if last_total is None else last_total,
+                                "nodes": [{"path": path} for path in last_paths],
                             },
                         }
                     ],
@@ -112,18 +119,26 @@ def main() -> None:
         calls: list[dict[str, object]] = []
 
         def exact_graphql(query: str, variables: dict[str, object]) -> dict[str, object]:
-            assert query == base.PR_PAGE_QUERY
+            assert query == SINGLE_READ_PR_PAGE_QUERY
             calls.append(variables)
             return provider_response()
 
         base.graphql = exact_graphql
         inventory, metadata = build_single_read_inventory_and_metadata("owner/repo", 10)
         assert len(calls) == 1, calls
-        assert calls[0]["after"] is None
+        assert calls[0] == {"owner": "owner", "name": "repo"}, calls[0]
         assert inventory["source"] == "github_pull_requests_graphql_single_read"
         assert inventory["current"]["id"] == "#10"
-        assert inventory["active_work"][0]["changed_paths"] == ["src/lib.rs"]
+        assert inventory["active_work"][0]["changed_paths"] == ["src/file_000.rs"]
         assert metadata["work"][0]["id"] == "#10"
+        assert read_current_provider_snapshot("owner/repo", 10) is not None
+
+        base.graphql = lambda _query, _variables: provider_response(file_count=102)
+        inventory, _metadata = build_single_read_inventory_and_metadata("owner/repo", 10)
+        changed_paths = inventory["current"]["changed_paths"]
+        assert len(changed_paths) == 102, changed_paths
+        assert "src/file_000.rs" in changed_paths
+        assert "src/file_101.rs" in changed_paths
         assert read_current_provider_snapshot("owner/repo", 10) is not None
 
         base.graphql = lambda _query, _variables: provider_response(
@@ -135,10 +150,20 @@ def main() -> None:
         )
         assert read_current_provider_snapshot("owner/repo", 10) is None
 
-        base.graphql = lambda _query, _variables: provider_response(files_has_next=True)
+        base.graphql = lambda _query, _variables: provider_response(file_count=201)
         assert_runtime_error(
             lambda: build_single_read_inventory_and_metadata("owner/repo", 10),
-            "file pagination for PR #10",
+            "one-response file coverage incomplete for PR #10: 200 of 201",
+        )
+        assert read_current_provider_snapshot("owner/repo", 10) is None
+
+        base.graphql = lambda _query, _variables: provider_response(
+            file_count=102,
+            last_total=103,
+        )
+        assert_runtime_error(
+            lambda: build_single_read_inventory_and_metadata("owner/repo", 10),
+            "provider file counts disagree within one response: 102 != 103",
         )
         assert read_current_provider_snapshot("owner/repo", 10) is None
     finally:


### PR DESCRIPTION
Refs #340. Follow-up to #342; does not revive cross-request pagination.

Current private Quarry dogfood #874 showed the landed exact-current producer correctly becomes unavailable when one open PR has >100 changed files. Quarry #729 currently has 102 files. Disposable capability probe #875 then proved that today's full 39-PR population can be covered in one GitHub GraphQL operation by requesting both bounded ends of each changed-file connection and checking their union against provider `totalCount`.

This patch admits that bounded case generically while preserving the #342 safety boundary:
- one GraphQL operation for the entire required/current population;
- top-level >100 open PRs still fails closed;
- each PR requests `files(first: 100)` and `files(last: 100)` in that same response;
- changed paths are admitted only when the unique union count exactly equals both provider `totalCount` values;
- count disagreement or incomplete union remains unavailable/UNKNOWN;
- no cursor follow-up requests are made by the exact snapshot path;
- #333 terminal current-work head reread and per-item activity semantics remain unchanged.

Controls added for 1-file exact coverage, 102-file overlapping-slice exact coverage, top-level PR pagination refusal, 201-file incomplete-union refusal, and first/last count disagreement refusal.

Provider capability receipt from Quarry #875: hosted run/job `32663136113 / 97252216527`, 39 open PRs, #729 102/102 unique paths, receipt SHA-256 `c96e31ccca92496cadd1f8b51716783e832892887f4b81d0f2401661d7b7941d`, artifact `9499264449`.

Base `81cb89864a01cc2254c7744e9bd6518425e64458`; head `f63ac0da19cbef573b17268169acae510c0a65f6`. Hosted CI required; author review does not count as independent review.