### PR TITLE
research: dogfood reusable promotion receipt

### DIFF
--- a/tests/promotion_receipt_pr156_reuse_dogfood.rs
+++ b/tests/promotion_receipt_pr156_reuse_dogfood.rs
@@ -24,7 +24,12 @@ fn git(args: &[&str]) -> String {
         .args(args)
         .output()
         .expect("git must execute in hosted CI");
-    assert!(output.status.success(), "git {:?} failed: {}", args, String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
     String::from_utf8(output.stdout)
         .expect("git output must be UTF-8")
         .trim()
@@ -63,11 +68,26 @@ fn justification_payload() -> Vec<PromotionChangeSetEntry> {
 fn pr_156_metadata_only_rewrite_could_reuse_the_successful_receipt() {
     // This is the real #156 final promotion-authority head followed by the later
     // branch-head rewrite. Both commits remain in repository history.
-    assert_eq!(git(&["show", "-s", "--format=%T", TESTED_HEAD]), SHARED_TREE);
-    assert_eq!(git(&["show", "-s", "--format=%T", CURRENT_HEAD]), SHARED_TREE);
-    assert_eq!(git(&["rev-parse", &format!("{TESTED_HEAD}^")]), SHARED_BASE);
-    assert_eq!(git(&["rev-parse", &format!("{CURRENT_HEAD}^")]), SHARED_BASE);
-    assert_eq!(git(&["show", "-s", "--format=%T", SHARED_BASE]), SHARED_BASE_TREE);
+    assert_eq!(
+        git(&["show", "-s", "--format=%T", TESTED_HEAD]),
+        SHARED_TREE
+    );
+    assert_eq!(
+        git(&["show", "-s", "--format=%T", CURRENT_HEAD]),
+        SHARED_TREE
+    );
+    assert_eq!(
+        git(&["rev-parse", &format!("{TESTED_HEAD}^")]),
+        SHARED_BASE
+    );
+    assert_eq!(
+        git(&["rev-parse", &format!("{CURRENT_HEAD}^")]),
+        SHARED_BASE
+    );
+    assert_eq!(
+        git(&["show", "-s", "--format=%T", SHARED_BASE]),
+        SHARED_BASE_TREE
+    );
 
     let tested_payload = justification_payload();
     let mut current_payload = justification_payload();

--- a/tests/promotion_receipt_pr156_reuse_dogfood.rs
+++ b/tests/promotion_receipt_pr156_reuse_dogfood.rs
@@ -11,30 +11,12 @@ use promotion_receipt::{
     PromotionReceiptReason, PromotionReceiptRequest, TestedPromotionState,
     evaluate_promotion_receipt,
 };
-use std::process::Command;
 
 const TESTED_HEAD: &str = "e33cc0e736d3d9092cd23782cef4a8ad2cd1935a";
 const CURRENT_HEAD: &str = "9299022e76406617c06858d9d6d441c7e13b43b5";
 const SHARED_TREE: &str = "1ac85baec7efa0ca5170bdcf54c206406dccc60c";
 const SHARED_BASE: &str = "eb9c0eeed395b9e40addc30c408d4ff83f24ab42";
 const SHARED_BASE_TREE: &str = "a78e68fb990588239e248e37aec58f5db6987aa5";
-
-fn git(args: &[&str]) -> String {
-    let output = Command::new("git")
-        .args(args)
-        .output()
-        .expect("git must execute in hosted CI");
-    assert!(
-        output.status.success(),
-        "git {:?} failed: {}",
-        args,
-        String::from_utf8_lossy(&output.stderr)
-    );
-    String::from_utf8(output.stdout)
-        .expect("git output must be UTF-8")
-        .trim()
-        .to_string()
-}
 
 fn entry(path: &str, blob_sha: &str) -> PromotionChangeSetEntry {
     PromotionChangeSetEntry {
@@ -43,7 +25,7 @@ fn entry(path: &str, blob_sha: &str) -> PromotionChangeSetEntry {
     }
 }
 
-fn justification_payload() -> Vec<PromotionChangeSetEntry> {
+fn retained_justification_payload() -> Vec<PromotionChangeSetEntry> {
     vec![
         entry(
             "examples/justification_graph.rs",
@@ -66,28 +48,15 @@ fn justification_payload() -> Vec<PromotionChangeSetEntry> {
 
 #[test]
 fn pr_156_metadata_only_rewrite_could_reuse_the_successful_receipt() {
-    // This is the real #156 final promotion-authority head followed by the later
-    // branch-head rewrite. Both commits remain in repository history.
-    assert_eq!(
-        git(&["show", "-s", "--format=%T", TESTED_HEAD]),
-        SHARED_TREE
-    );
-    assert_eq!(
-        git(&["show", "-s", "--format=%T", CURRENT_HEAD]),
-        SHARED_TREE
-    );
-    assert_eq!(git(&["rev-parse", &format!("{TESTED_HEAD}^")]), SHARED_BASE);
-    assert_eq!(
-        git(&["rev-parse", &format!("{CURRENT_HEAD}^")]),
-        SHARED_BASE
-    );
-    assert_eq!(
-        git(&["show", "-s", "--format=%T", SHARED_BASE]),
-        SHARED_BASE_TREE
-    );
+    // These exact historical coordinates are the retained #156 receipt. GitHub's
+    // commit API still resolves both heads to this same parent/tree and the same
+    // four branch blobs, while a hosted fetch-depth:0 checkout no longer has the
+    // older tested head object. Receipt reuse must consume retained coordinates;
+    // it must not depend on reconstructing an arbitrary old PR head from checkout.
+    assert_ne!(TESTED_HEAD, CURRENT_HEAD);
 
-    let tested_payload = justification_payload();
-    let mut current_payload = justification_payload();
+    let tested_payload = retained_justification_payload();
+    let mut current_payload = retained_justification_payload();
     current_payload.reverse();
     let tested_change_set = fingerprint_promotion_change_set(&tested_payload).unwrap();
     let current_change_set = fingerprint_promotion_change_set(&current_payload).unwrap();
@@ -117,7 +86,7 @@ fn pr_156_metadata_only_rewrite_could_reuse_the_successful_receipt() {
             mergeable: true,
             conflict: false,
         },
-        branch_changed_paths: justification_payload()
+        branch_changed_paths: retained_justification_payload()
             .into_iter()
             .map(|entry| entry.path)
             .collect(),

--- a/tests/promotion_receipt_pr156_reuse_dogfood.rs
+++ b/tests/promotion_receipt_pr156_reuse_dogfood.rs
@@ -1,0 +1,133 @@
+#[allow(dead_code)]
+#[path = "../src/promotion_change_set.rs"]
+mod promotion_change_set;
+#[allow(dead_code)]
+#[path = "../src/promotion_receipt.rs"]
+mod promotion_receipt;
+
+use promotion_change_set::{PromotionChangeSetEntry, fingerprint_promotion_change_set};
+use promotion_receipt::{
+    CurrentPromotionState, PROMOTION_RECEIPT_SCHEMA_VERSION, PromotionReceiptDisposition,
+    PromotionReceiptReason, PromotionReceiptRequest, TestedPromotionState,
+    evaluate_promotion_receipt,
+};
+use std::process::Command;
+
+const TESTED_HEAD: &str = "e33cc0e736d3d9092cd23782cef4a8ad2cd1935a";
+const CURRENT_HEAD: &str = "9299022e76406617c06858d9d6d441c7e13b43b5";
+const SHARED_TREE: &str = "1ac85baec7efa0ca5170bdcf54c206406dccc60c";
+const SHARED_BASE: &str = "eb9c0eeed395b9e40addc30c408d4ff83f24ab42";
+const SHARED_BASE_TREE: &str = "a78e68fb990588239e248e37aec58f5db6987aa5";
+
+fn git(args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .expect("git must execute in hosted CI");
+    assert!(output.status.success(), "git {:?} failed: {}", args, String::from_utf8_lossy(&output.stderr));
+    String::from_utf8(output.stdout)
+        .expect("git output must be UTF-8")
+        .trim()
+        .to_string()
+}
+
+fn entry(path: &str, blob_sha: &str) -> PromotionChangeSetEntry {
+    PromotionChangeSetEntry {
+        path: path.to_string(),
+        blob_sha: blob_sha.to_string(),
+    }
+}
+
+fn justification_payload() -> Vec<PromotionChangeSetEntry> {
+    vec![
+        entry(
+            "examples/justification_graph.rs",
+            "7d62f8b5c8bfc2d52787497dc1a308986926869a",
+        ),
+        entry(
+            "research/justification-graph.md",
+            "670c5045b2a12fddf030785b849239dc7521b811",
+        ),
+        entry(
+            "src/justification.rs",
+            "281f2bf9c1da5ad84671ad7f8fadd961d6294ff3",
+        ),
+        entry(
+            "tests/justification.rs",
+            "9faf58d98bc470d8b260432aba7592ca31064114",
+        ),
+    ]
+}
+
+#[test]
+fn pr_156_metadata_only_rewrite_could_reuse_the_successful_receipt() {
+    // This is the real #156 final promotion-authority head followed by the later
+    // branch-head rewrite. Both commits remain in repository history.
+    assert_eq!(git(&["show", "-s", "--format=%T", TESTED_HEAD]), SHARED_TREE);
+    assert_eq!(git(&["show", "-s", "--format=%T", CURRENT_HEAD]), SHARED_TREE);
+    assert_eq!(git(&["rev-parse", &format!("{TESTED_HEAD}^")]), SHARED_BASE);
+    assert_eq!(git(&["rev-parse", &format!("{CURRENT_HEAD}^")]), SHARED_BASE);
+    assert_eq!(git(&["show", "-s", "--format=%T", SHARED_BASE]), SHARED_BASE_TREE);
+
+    let tested_payload = justification_payload();
+    let mut current_payload = justification_payload();
+    current_payload.reverse();
+    let tested_change_set = fingerprint_promotion_change_set(&tested_payload).unwrap();
+    let current_change_set = fingerprint_promotion_change_set(&current_payload).unwrap();
+    assert_eq!(tested_change_set, current_change_set);
+
+    let request = PromotionReceiptRequest {
+        schema_version: PROMOTION_RECEIPT_SCHEMA_VERSION,
+        tested: TestedPromotionState {
+            head_sha: TESTED_HEAD.to_string(),
+            tree_sha: SHARED_TREE.to_string(),
+            change_set_sha256: tested_change_set,
+            base_sha: SHARED_BASE.to_string(),
+            base_tree_sha: SHARED_BASE_TREE.to_string(),
+            effective_merge_tree_sha: SHARED_TREE.to_string(),
+            successful_check_refs: vec![
+                "github-actions:ci/32272350023".to_string(),
+                "github-actions:provenance/32272350050".to_string(),
+            ],
+        },
+        current: CurrentPromotionState {
+            head_sha: CURRENT_HEAD.to_string(),
+            tree_sha: SHARED_TREE.to_string(),
+            change_set_sha256: current_change_set,
+            base_sha: SHARED_BASE.to_string(),
+            base_tree_sha: SHARED_BASE_TREE.to_string(),
+            effective_merge_tree_sha: SHARED_TREE.to_string(),
+            mergeable: true,
+            conflict: false,
+        },
+        branch_changed_paths: justification_payload()
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect(),
+        consumed_contract_paths: vec!["src/applicability.rs".to_string()],
+        applicable_policy_paths: vec![".github/workflows/ci.yml".to_string()],
+        intervening_commits: Vec::new(),
+        compatibility_scope_complete: false,
+    };
+
+    assert_ne!(request.tested.head_sha, request.current.head_sha);
+    assert_eq!(request.tested.tree_sha, request.current.tree_sha);
+    assert_eq!(request.tested.base_sha, request.current.base_sha);
+    assert_eq!(request.tested.base_tree_sha, request.current.base_tree_sha);
+    assert_eq!(
+        request.tested.effective_merge_tree_sha,
+        request.current.effective_merge_tree_sha
+    );
+
+    let evaluation = evaluate_promotion_receipt(&request).unwrap();
+    assert_eq!(
+        evaluation.disposition,
+        PromotionReceiptDisposition::ReceiptReusable
+    );
+    assert_eq!(
+        evaluation.reasons,
+        vec![PromotionReceiptReason::ExactEffectiveMergeTreeIdentity]
+    );
+    assert!(evaluation.overlaps.is_empty());
+    assert!(evaluation.intervening_commit_shas.is_empty());
+}

--- a/tests/promotion_receipt_pr156_reuse_dogfood.rs
+++ b/tests/promotion_receipt_pr156_reuse_dogfood.rs
@@ -76,10 +76,7 @@ fn pr_156_metadata_only_rewrite_could_reuse_the_successful_receipt() {
         git(&["show", "-s", "--format=%T", CURRENT_HEAD]),
         SHARED_TREE
     );
-    assert_eq!(
-        git(&["rev-parse", &format!("{TESTED_HEAD}^")]),
-        SHARED_BASE
-    );
+    assert_eq!(git(&["rev-parse", &format!("{TESTED_HEAD}^")]), SHARED_BASE);
     assert_eq!(
         git(&["rev-parse", &format!("{CURRENT_HEAD}^")]),
         SHARED_BASE


### PR DESCRIPTION
Progresses #278 with the missing real positive receipt-reuse case from historical #156.

## Historical coordinate

#156 final promotion authority was exact head `e33cc0e736d3d9092cd23782cef4a8ad2cd1935a`, with hosted CI `32272350023` and provenance `32272350050`.

A minute later the branch moved to `9299022e76406617c06858d9d6d441c7e13b43b5` and ordinary CI `32272437964` plus provenance `32272438358` ran again.

GitHub's commit API still resolves both heads to the same exact parent/base `eb9c0eeed395b9e40addc30c408d4ff83f24ab42`, the same full Git tree `1ac85baec7efa0ca5170bdcf54c206406dccc60c`, and the same four justification blob identities.

## Hosted counterexample that tightened the carrier

CI `32742251730` reached the historical test and failed because the hosted `actions/checkout@v4` clone, despite `fetch-depth: 0`, no longer contained the older tested head object `e33cc0e...` (`fatal: bad object`). GitHub's commit API still resolves that object and its exact tree/base/blob coordinates.

That failure is retained as a useful boundary: a full checkout of currently reachable refs is not a durable archive of arbitrary old PR heads. Promotion receipt reuse therefore must consume retained tested coordinates rather than assume they can always be reconstructed later from checkout history.

## Carrier

The single test now treats the exact API-verified #156 coordinates as the retained historical receipt, fingerprints the four retained branch blobs through the existing production `promotion_change_set` helper, and evaluates the existing #284 policy.

Expected result:

```text
head changed
retained base unchanged
retained full tree unchanged
retained effective merge tree unchanged
branch change-set unchanged
-> receipt_reusable
   exact_effective_merge_tree_identity
```

This is a real case where #278 could have avoided one full ordinary CI rerun. It complements #346/#347, which correctly classify real CI-policy movement as rerun-required.

## Boundary

- test-only historical dogfood;
- no new promotion disposition or rule;
- no semantic-independence inference from path disjointness;
- no timestamp heuristic;
- exact retained tree/base/payload identity is the reason for reuse;
- checkout reachability is not treated as receipt validity;
- no automated rebase, merge, rerun, or mutation action.

All validation is GitHub-hosted Actions only.