### PR TITLE
active-work: bind provider work evidence to one response

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Cultist's own PR CI dogfoods a GitHub adapter for this contract. Common disjoint
 
 Current main now binds that provider-backed dogfood to an explicit provider snapshot identity instead of treating one fetched inventory as timeless truth. The consumer revalidates the observed frontier when it uses the snapshot, preserves `UNKNOWN` when coordination/provider evidence is unresolved, and refuses to manufacture complete file coverage from paginated or partial observations. Complete bounded file coverage is asserted only when one provider response actually proves the selected union. These are landed correctness rules in the active-change path, not future research notes.
 
+Every shipped provider producer binds work identity and changed paths to exactly one GraphQL response: any required pagination, pull-request or file continuation, fails closed as unavailable instead of combining coordinates across reads. Whether the provider's cursors pin separate requests to one immutable snapshot remains `UNKNOWN` — official documentation does not establish it, so populations beyond one response and file sets whose bounded union cannot prove completeness stay unavailable by design until a controlled replay proves otherwise.
+
 ### Historical companions
 
 `cargo cultist history FILE` explores which paths repeatedly changed with one current file in recent non-merge history.

--- a/scripts/active_work_heads_up_ci.py
+++ b/scripts/active_work_heads_up_ci.py
@@ -14,7 +14,7 @@ import time
 COORDINATION_PREFIX = "Do not merge while #"
 
 PR_PAGE_QUERY = r"""
-query($owner: String!, $name: String!, $after: String) {
+query($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     pullRequests(
       states: OPEN
@@ -37,19 +37,6 @@ query($owner: String!, $name: String!, $after: String) {
         }
       }
       pageInfo { hasNextPage endCursor }
-    }
-  }
-}
-"""
-
-PR_FILES_QUERY = r"""
-query($owner: String!, $name: String!, $number: Int!, $after: String) {
-  repository(owner: $owner, name: $name) {
-    pullRequest(number: $number) {
-      files(first: 100, after: $after) {
-        nodes { path }
-        pageInfo { hasNextPage endCursor }
-      }
     }
   }
 }
@@ -99,48 +86,22 @@ def file_paths_from_connection(connection: dict[str, object]) -> list[str]:
     return [str(node["path"]) for node in nodes if isinstance(node, dict)]
 
 
-def remaining_file_paths(
-    owner: str,
-    name: str,
-    number: int,
-    after: str | None,
-) -> list[str]:
-    paths: list[str] = []
-    cursor = after
-    while cursor is not None:
-        result = graphql(
-            PR_FILES_QUERY,
-            {"owner": owner, "name": name, "number": number, "after": cursor},
-        )
-        data = result.get("data")
-        repository = data.get("repository") if isinstance(data, dict) else None
-        pull_request = (
-            repository.get("pullRequest") if isinstance(repository, dict) else None
-        )
-        files = pull_request.get("files") if isinstance(pull_request, dict) else None
-        if not isinstance(files, dict):
-            raise RuntimeError(f"could not paginate files for PR #{number}")
-        paths.extend(file_paths_from_connection(files))
-        has_next, cursor = page_info(files)
-        if not has_next:
-            break
-    return paths
-
-
-def work_item(
-    owner: str,
-    name: str,
-    node: dict[str, object],
-) -> dict[str, object]:
+def work_item(node: dict[str, object]) -> dict[str, object]:
     number = int(node["number"])
     files = node.get("files")
     if not isinstance(files, dict):
         raise RuntimeError(f"PR #{number} has no readable files connection")
 
     paths = file_paths_from_connection(files)
-    has_next, cursor = page_info(files)
+    has_next, _cursor = page_info(files)
     if has_next:
-        paths.extend(remaining_file_paths(owner, name, number, cursor))
+        # Exact work identity binds head and changed paths to one provider
+        # response. Cross-request pagination cannot prove that the later
+        # pages belong to the observed head, so fail closed instead of
+        # mixing coordinates across reads.
+        raise RuntimeError(
+            f"PR #{number} requires file pagination; exact snapshot unavailable"
+        )
 
     return {
         "id": f"#{number}",
@@ -175,35 +136,37 @@ def build_inventory_and_metadata(
     owner, name = repo.split("/", 1)
     work: list[dict[str, object]] = []
     metadata_work: list[dict[str, object]] = []
-    cursor: str | None = None
 
-    while True:
-        result = graphql(
-            PR_PAGE_QUERY,
-            {"owner": owner, "name": name, "after": cursor},
+    result = graphql(
+        PR_PAGE_QUERY,
+        {"owner": owner, "name": name},
+    )
+    data = result.get("data")
+    repository = data.get("repository") if isinstance(data, dict) else None
+    pull_requests = (
+        repository.get("pullRequests") if isinstance(repository, dict) else None
+    )
+    if not isinstance(pull_requests, dict):
+        raise RuntimeError("could not retrieve open pull requests")
+    nodes = pull_requests.get("nodes")
+    if not isinstance(nodes, list):
+        raise RuntimeError("open pull-request connection is missing nodes")
+
+    has_next, _cursor = page_info(pull_requests)
+    if has_next:
+        # Exact provider population identity must come from one response.
+        # Following cursors across requests cannot prove the later pages
+        # belong to the same provider population snapshot.
+        raise RuntimeError(
+            "provider population requires pull-request pagination; "
+            "exact snapshot unavailable"
         )
-        data = result.get("data")
-        repository = data.get("repository") if isinstance(data, dict) else None
-        pull_requests = (
-            repository.get("pullRequests") if isinstance(repository, dict) else None
-        )
-        if not isinstance(pull_requests, dict):
-            raise RuntimeError("could not retrieve open pull requests")
-        nodes = pull_requests.get("nodes")
-        if not isinstance(nodes, list):
-            raise RuntimeError("open pull-request connection is missing nodes")
 
-        for node in nodes:
-            if not isinstance(node, dict):
-                continue
-            work.append(work_item(owner, name, node))
-            metadata_work.append(metadata_item(node))
-
-        has_next, cursor = page_info(pull_requests)
-        if not has_next:
-            break
-        if cursor is None:
-            raise RuntimeError("pull-request pagination promised another page without cursor")
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        work.append(work_item(node))
+        metadata_work.append(metadata_item(node))
 
     current = next((item for item in work if item["id"] == f"#{current_number}"), None)
     if current is None:

--- a/scripts/active_work_heads_up_ci.py
+++ b/scripts/active_work_heads_up_ci.py
@@ -19,7 +19,6 @@ query($owner: String!, $name: String!) {
     pullRequests(
       states: OPEN
       first: 100
-      after: $after
       orderBy: {field: UPDATED_AT, direction: DESC}
     ) {
       nodes {

--- a/scripts/active_work_heads_up_ci_test.py
+++ b/scripts/active_work_heads_up_ci_test.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
+import active_work_heads_up_ci as base
 from active_work_heads_up_ci import (
+    PR_PAGE_QUERY,
+    build_inventory_and_metadata,
     current_provider_work_from_response,
     provider_current_environment,
     provider_current_matches_inventory,
@@ -8,6 +13,7 @@ from active_work_heads_up_ci import (
     quiet_summary,
     unresolved_endpoint_note,
     unresolved_endpoint_receipts_involving_current,
+    work_item,
 )
 
 INVENTORY = {
@@ -31,6 +37,58 @@ def provider_response(number: int, head: str | None) -> dict[str, object]:
             }
         }
     }
+
+
+def pr_page_response(
+    *,
+    pull_requests_has_next: bool = False,
+    nodes: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    if nodes is None:
+        nodes = [pr_node(10, "a" * 40)]
+    return {
+        "data": {
+            "repository": {
+                "pullRequests": {
+                    "nodes": nodes,
+                    "pageInfo": {
+                        "hasNextPage": pull_requests_has_next,
+                        "endCursor": (
+                            "pulls-next" if pull_requests_has_next else None
+                        ),
+                    },
+                }
+            }
+        }
+    }
+
+
+def pr_node(number: int, head: str, *, file_count: int = 1) -> dict[str, object]:
+    return {
+        "number": number,
+        "title": f"work {number}",
+        "url": f"https://github.com/owner/repo/pull/{number}",
+        "body": "",
+        "headRefName": f"work-{number}",
+        "headRefOid": head,
+        "updatedAt": "2026-08-24T00:00:00Z",
+        "isDraft": False,
+        "files": {
+            "nodes": [
+                {"path": f"src/file_{index}.rs"} for index in range(file_count)
+            ],
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+        },
+    }
+
+
+def assert_runtime_error(callback, expected: str) -> None:
+    try:
+        callback()
+    except RuntimeError as error:
+        assert expected in str(error), error
+    else:
+        raise AssertionError(f"expected RuntimeError containing {expected!r}")
 
 
 def main() -> int:
@@ -151,6 +209,70 @@ def main() -> int:
     )
     assert "CULTIST_CURRENT_PROVIDER_HEAD" not in unknown_environment
     assert unknown_environment["CULTIST_CURRENT_PROVIDER_WORK"] == "#10"
+
+    # Exact work identity binds head and changed paths to one provider
+    # response. Any required pagination must fail closed instead of mixing
+    # coordinates across separate reads.
+    original_graphql = base.graphql
+    try:
+        continuation_calls: list[dict[str, object]] = []
+
+        def continuation_graphql(
+            query: str, variables: dict[str, object]
+        ) -> dict[str, object]:
+            assert query == PR_PAGE_QUERY
+            continuation_calls.append(variables)
+            return pr_page_response(pull_requests_has_next=True)
+
+        base.graphql = continuation_graphql
+
+        continued = pr_node(10, "a" * 40)
+        continued["files"] = {
+            "nodes": [{"path": "src/file_0.rs"}],
+            "pageInfo": {"hasNextPage": True, "endCursor": "files-next"},
+        }
+        assert_runtime_error(
+            lambda: work_item(continued),
+            "PR #10 requires file pagination; exact snapshot unavailable",
+        )
+
+        assert_runtime_error(
+            lambda: build_inventory_and_metadata("owner/repo", 10),
+            "provider population requires pull-request pagination",
+        )
+        assert len(continuation_calls) == 1, continuation_calls
+    finally:
+        base.graphql = original_graphql
+
+    observed = pr_page_response(
+        nodes=[
+            pr_node(10, "a" * 40, file_count=2),
+            pr_node(20, "b" * 40),
+        ]
+    )
+    calls: list[dict[str, object]] = []
+
+    def single_page_graphql(query: str, variables: dict[str, object]) -> dict[str, object]:
+        assert query == PR_PAGE_QUERY
+        assert "after" not in variables, variables
+        calls.append(variables)
+        return observed
+
+    base.graphql = single_page_graphql
+    try:
+        inventory, metadata = build_inventory_and_metadata("owner/repo", 10)
+    finally:
+        base.graphql = original_graphql
+    assert len(calls) == 1, calls
+    assert [item["id"] for item in inventory["active_work"]] == ["#10", "#20"]
+    current_item = inventory["current"]
+    assert current_item["head_sha"] == "a" * 40, current_item
+    assert current_item["changed_paths"] == [
+        "src/file_0.rs",
+        "src/file_1.rs",
+    ], current_item
+    assert metadata["work"][0]["head_sha"] == "a" * 40
+    assert inventory["source"] == "github_pull_requests_graphql"
 
     return 0
 

--- a/scripts/active_work_heads_up_ci_test.py
+++ b/scripts/active_work_heads_up_ci_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import active_work_heads_up_ci as base
 from active_work_heads_up_ci import (
     PR_PAGE_QUERY,
@@ -209,6 +211,16 @@ def main() -> int:
     )
     assert "CULTIST_CURRENT_PROVIDER_HEAD" not in unknown_environment
     assert unknown_environment["CULTIST_CURRENT_PROVIDER_WORK"] == "#10"
+
+    # A GraphQL document that uses an undeclared variable is rejected with
+    # variableNotDefined before any runtime fail-closed logic can run, so
+    # prove the pagination document declares every variable it uses.
+    header = re.search(r"query\s*\(([^)]*)\)", PR_PAGE_QUERY)
+    assert header is not None, PR_PAGE_QUERY
+    declared = set(re.findall(r"\$(\w+)\s*:", header.group(1)))
+    used = set(re.findall(r"\$(\w+)", PR_PAGE_QUERY[header.end():]))
+    undeclared = sorted(used - declared)
+    assert not undeclared, f"PR_PAGE_QUERY uses undeclared variables: {undeclared}"
 
     # Exact work identity binds head and changed paths to one provider
     # response. Any required pagination must fail closed instead of mixing

--- a/scripts/active_work_heads_up_snapshot_ci.py
+++ b/scripts/active_work_heads_up_snapshot_ci.py
@@ -122,7 +122,7 @@ def build_single_read_inventory_and_metadata(
             "nodes": [{"path": path} for path in paths],
             "pageInfo": {"hasNextPage": False, "endCursor": None},
         }
-        work.append(base.work_item(owner, name, normalized_node))
+        work.append(base.work_item(normalized_node))
         metadata_work.append(base.metadata_item(node))
 
     current = next((item for item in work if item["id"] == f"#{current_number}"), None)

--- a/scripts/active_work_heads_up_snapshot_ci_test.py
+++ b/scripts/active_work_heads_up_snapshot_ci_test.py
@@ -17,10 +17,14 @@ def provider_response(
     file_count: int = 1,
     first_total: int | None = None,
     last_total: int | None = None,
+    first_paths: list[str] | None = None,
+    last_paths: list[str] | None = None,
 ) -> dict[str, object]:
     paths = [f"src/file_{index:03d}.rs" for index in range(file_count)]
-    first_paths = paths[:100]
-    last_paths = paths[-100:] if paths else []
+    if first_paths is None:
+        first_paths = paths[:100]
+    if last_paths is None:
+        last_paths = paths[-100:] if paths else []
     return {
         "data": {
             "repository": {
@@ -129,6 +133,8 @@ def main() -> None:
         assert calls[0] == {"owner": "owner", "name": "repo"}, calls[0]
         assert inventory["source"] == "github_pull_requests_graphql_single_read"
         assert inventory["current"]["id"] == "#10"
+        assert inventory["current"]["head_sha"] == "a" * 40
+        assert metadata["work"][0]["head_sha"] == "a" * 40
         assert inventory["active_work"][0]["changed_paths"] == ["src/file_000.rs"]
         assert metadata["work"][0]["id"] == "#10"
         assert read_current_provider_snapshot("owner/repo", 10) is not None
@@ -140,6 +146,21 @@ def main() -> None:
         assert "src/file_000.rs" in changed_paths
         assert "src/file_101.rs" in changed_paths
         assert read_current_provider_snapshot("owner/repo", 10) is not None
+
+        # Duplicated entries within one slice collapse into the unique union;
+        # admission still requires the union to equal the provider count.
+        base.graphql = lambda _query, _variables: provider_response(
+            first_total=3,
+            last_total=3,
+            first_paths=["src/a.rs", "src/a.rs", "src/b.rs"],
+            last_paths=["src/b.rs", "src/c.rs"],
+        )
+        inventory, _metadata = build_single_read_inventory_and_metadata("owner/repo", 10)
+        assert inventory["current"]["changed_paths"] == [
+            "src/a.rs",
+            "src/b.rs",
+            "src/c.rs",
+        ], inventory["current"]["changed_paths"]
 
         base.graphql = lambda _query, _variables: provider_response(
             pull_requests_has_next=True
@@ -164,6 +185,21 @@ def main() -> None:
         assert_runtime_error(
             lambda: build_single_read_inventory_and_metadata("owner/repo", 10),
             "provider file counts disagree within one response: 102 != 103",
+        )
+        assert read_current_provider_snapshot("owner/repo", 10) is None
+
+        # Over-coverage is also inconsistent: a response whose bounded slices
+        # yield more unique paths than the provider count cannot prove exact
+        # membership and must fail closed instead of admitting a superset.
+        base.graphql = lambda _query, _variables: provider_response(
+            first_total=2,
+            last_total=2,
+            first_paths=["src/a.rs", "src/b.rs"],
+            last_paths=["src/b.rs", "src/c.rs"],
+        )
+        assert_runtime_error(
+            lambda: build_single_read_inventory_and_metadata("owner/repo", 10),
+            "one-response file coverage incomplete for PR #10: 3 of 2",
         )
         assert read_current_provider_snapshot("owner/repo", 10) is None
     finally:


### PR DESCRIPTION
## Summary

Implements the in-repository portion of #340 (Prove GitHub active-work pagination is snapshot-consistent): the smallest correct current-main step that closes its demonstrated code-level gap.

### PROVEN by deterministic fixtures at this exact SHA

- Both shipped active-work producers now bind work identity and changed paths to exactly one GraphQL response. Any required pull-request or file continuation fails closed (`... exact snapshot unavailable`) before any inventory can be emitted.
- Single-response admission refuses inconsistent over-coverage (unique union > provider `totalCount`) in addition to the existing under-coverage and disagreeing-count controls.
- Duplicate entries within one bounded slice collapse into the unique union; admission still requires union size == `totalCount`.
- Emitted work items carry `head_sha` from the same response node whose changed-path union was proven complete.

### Removed hazard

The legacy producer still combined a PR-page `headRefOid` observation with changed paths completed through separate per-PR files calls (`remaining_file_paths`), and no mechanism in that path could notice provider movement between reads — exactly the mixed-receipt pattern #340 describes. That protocol is now removed: continuation fails closed at the same choke point the live single-read producer already uses. The live CI dispatch path is unchanged in behavior; it always passed single-page nodes.

### UNKNOWN (retained, unchanged)

Whether the provider's cross-request cursors pin separate requests to one immutable snapshot remains `UNKNOWN`. Prior documentation review found no such guarantee, and settling it needs the controlled hosted replay described in #340, which stays out of scope here. Populations beyond one response (>100 open PRs) and file sets whose bounded union cannot prove completeness remain unavailable by design.

## Checks

- `python3 scripts/active_work_heads_up_ci_test.py` - PASS (new pagination fail-closed + head-binding controls)
- `python3 scripts/active_work_heads_up_snapshot_ci_test.py` - PASS (new over-coverage and duplicate-collapse controls)
- `python3 scripts/github_provider_snapshot_ci_test.py` - PASS
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, full `cargo test` (487 tests) - PASS

Refs #340

🐝 Sable
