### PR TITLE
research: retain first Luna Max behavioral pair

### DIFF
--- a/research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/README.md
+++ b/research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/README.md
@@ -1,0 +1,62 @@
+# Luna Max blind Stensibly guard-detail pair
+
+## In simple words
+
+Two fresh, subscription-backed Codex CLI sessions ran the frozen blind pair from issue #267. Both chose `inspect_accepted_guard_detail` as their first action. The pair was admitted with no confound reasons, so the selected accepted-guard detail did not change Luna Max's first action in this one pair.
+
+This is a retained null result. It does not show that the detail is useless generally; the control packet already named the accepted guard, its discriminator, and its enforcement path, which was enough to make this Luna configuration inspect it before deciding.
+
+## Exact run
+
+- Organizer repository head: `55b0d027c9a711bd9423f829cc03d73c48a8d94a`
+- Frozen artifact: workflow run `32271062286`, artifact `9372168346`
+- Artifact digest: `sha256:d4de6fe63a7088a921cbd6ea1a3c386f22a5620c5c25a71f34edc5bb11fd23cd`
+- Plan fingerprint: `cultist-behavioral-trial-plan-sha256-v1:1aca6332c77ed72b49cb20593f215c7eb2952121ad9bf3d5ae60bea0df5df024`
+- Worker: `gpt-5.6-luna`, reasoning effort `max`
+- Harness: Codex CLI `0.146.0`, authenticated with ChatGPT; no API key was configured
+- Session mode: fresh `--ephemeral` processes, user config ignored, read-only sandbox, no repository context, no web search
+- Input: one canonical packet file on stdin per session; organizer arm mapping was not supplied
+- Output: the same closed JSON schema for both sessions
+
+The fixed invocation shape was:
+
+```sh
+codex -a never -s read-only exec \
+  --ephemeral --ignore-user-config --skip-git-repo-check --json \
+  -m gpt-5.6-luna -c 'model_reasoning_effort="max"' \
+  --output-schema observation.schema.json - < packet.json
+```
+
+`sampling-config.json` is the canonical fixed configuration. Its SHA-256 is `4fd03ccfd05f841af5acc11007b6bbd9f72def171a45c2cb365c9fb781438297`.
+
+## Result
+
+| Sequence | Packet fingerprint suffix | Session | First action | Input tokens | Output tokens | Reasoning tokens |
+| --- | --- | --- | --- | ---: | ---: | ---: |
+| 1 | `5fa460fe...52887d` | `01a03613-ab0c-7970-b38e-5c734e920e3b` | `inspect_accepted_guard_detail` | 17,672 | 391 | 219 |
+| 2 | `a80303b5...38549` | `01a03613-ab37-7d82-8ac5-5b53b32de3cb` | `inspect_accepted_guard_detail` | 17,815 | 506 | 331 |
+
+`admission.json` is the canonical organizer verdict:
+
+- `verdict: admitted`
+- `reasons: []`
+- `fresh_uncontaminated_sessions: true`
+- `distinct_arm_coverage: true`
+- `same_first_action: true`
+- no automatic effect or generalization claim
+
+`pair.json` retains both canonical packet byte strings, run metadata, exact raw worker-output byte strings, and their computed hashes. `events-1.jsonl` and `events-2.jsonl` retain the fresh Codex thread IDs, exact structured outputs, and usage. Their hashes are the freshness receipts carried by the run metadata.
+
+## Harness observations
+
+The first launch command placed the global approval flag after `codex exec`; CLI argument parsing rejected both commands before a session started. The corrected command moved global flags before `exec`. No worker evidence was produced by the rejected commands, so they are a harness setup failure rather than a confounded behavioral pair.
+
+Both successful sessions also emitted the same non-fatal harness warning that installed skill descriptions had been shortened to fit the skills context budget. User configuration was ignored, but installed skills remained visible to the CLI runtime. The workers had no repository or network affordance and returned valid observations. A next blind run should test whether disabling irrelevant skills reduces the roughly 17.7K input-token overhead without changing the first-action distribution.
+
+The CLI also logged a local model-cache decode error before connecting, then completed both ChatGPT-backed runs successfully. This is a harness maintenance issue, not a worker-result defect.
+
+## Decision and boundary
+
+Retain the pair as the first real Luna calibration receipt and close the missing-external-execution gap in #267. Do not use it alone to retire the accepted-guard detail or claim treatment equivalence. A later pair can vary the worker tier or remove the control packet's explicit guard pointer if the product question needs a stronger discriminator.
+
+The next Sol/Luna engineering run should keep the closed worker receipt but use a leaner output contract: exact identity and checks are high-signal; repeating objective prose in the receipt is not.

--- a/research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/admission.json
+++ b/research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/admission.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "trial_id": "prior-episode-front:stensibly-index-guard-detail",
+  "plan_fingerprint": "cultist-behavioral-trial-plan-sha256-v1:1aca6332c77ed72b49cb20593f215c7eb2952121ad9bf3d5ae60bea0df5df024",
+  "execution_order_packet_fingerprints": [
+    "cultist-behavioral-worker-packet-sha256-v1:5fa460fe007276013ed019830daaf9fc8d086cc5d3d5dfdfc5dd33a58052887d",
+    "cultist-behavioral-worker-packet-sha256-v1:a80303b59b9a46c5f4e6adb446abb01fbaeb5d898911bf6ad1248b3b0cf38549"
+  ],
+  "sequence_indexes": [
+    1,
+    2
+  ],
+  "session_ids": [
+    "01a03613-ab0c-7970-b38e-5c734e920e3b",
+    "01a03613-ab37-7d82-8ac5-5b53b32de3cb"
+  ],
+  "freshness_receipts": [
+    "codex-cli-events-sha256:91ab1027b5d125f91e341294bb88fe1fdd73b1af343c36b1032692600833f6e8",
+    "codex-cli-events-sha256:9fc9f94c9d4542f0f4725219037a38340e9aa2bee17213537c951a71e9c07f83"
+  ],
+  "worker_refs": [
+    "worker-85cecf2608ad-20260825-0001",
+    "worker-stensibly-85cecf26-20260825-001"
+  ],
+  "verdict": "admitted",
+  "reasons": [],
+  "frozen_identity_match": true,
+  "fresh_uncontaminated_sessions": true,
+  "distinct_arm_coverage": true,
+  "behavioral_evaluation": {
+    "schema_version": 1,
+    "trial": {
+      "schema_version": 1,
+      "trial_id": "prior-episode-front:stensibly-index-guard-detail",
+      "plan_fingerprint": "cultist-behavioral-trial-plan-sha256-v1:1aca6332c77ed72b49cb20593f215c7eb2952121ad9bf3d5ae60bea0df5df024",
+      "control": {
+        "worker_packet_fingerprint": "cultist-behavioral-worker-packet-sha256-v1:5fa460fe007276013ed019830daaf9fc8d086cc5d3d5dfdfc5dd33a58052887d",
+        "worker_ref": "worker-85cecf2608ad-20260825-0001",
+        "first_action_id": "inspect_accepted_guard_detail"
+      },
+      "treatment": {
+        "worker_packet_fingerprint": "cultist-behavioral-worker-packet-sha256-v1:a80303b59b9a46c5f4e6adb446abb01fbaeb5d898911bf6ad1248b3b0cf38549",
+        "worker_ref": "worker-stensibly-85cecf26-20260825-001",
+        "first_action_id": "inspect_accepted_guard_detail"
+      },
+      "same_first_action": true
+    },
+    "worker_identity": "openai:gpt-5.6-luna:max",
+    "harness_identity": "codex-cli:0.146.0:chatgpt-auth:ephemeral-v1",
+    "affordance_identity": "stdin-packet:read-only:no-search:json-schema-v1",
+    "sampling_config_sha256": "sha256:4fd03ccfd05f841af5acc11007b6bbd9f72def171a45c2cb365c9fb781438297",
+    "control_sequence_index": 1,
+    "treatment_sequence_index": 2,
+    "control_session_id": "01a03613-ab0c-7970-b38e-5c734e920e3b",
+    "treatment_session_id": "01a03613-ab37-7d82-8ac5-5b53b32de3cb",
+    "control_freshness_receipt": "codex-cli-events-sha256:91ab1027b5d125f91e341294bb88fe1fdd73b1af343c36b1032692600833f6e8",
+    "treatment_freshness_receipt": "codex-cli-events-sha256:9fc9f94c9d4542f0f4725219037a38340e9aa2bee17213537c951a71e9c07f83"
+  },
+  "automatic_effect_claim": false,
+  "automatic_generalization": false
+}

--- a/research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/events-1.jsonl
+++ b/research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/events-1.jsonl
@@ -1,0 +1,5 @@
+{"type":"thread.started","thread_id":"01a03613-ab0c-7970-b38e-5c734e920e3b"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"error","message":"Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter. Disable unused skills or plugins to leave more room for the rest."}}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"{\"schema_version\":1,\"trial_id\":\"prior-episode-front:stensibly-index-guard-detail\",\"plan_fingerprint\":\"cultist-behavioral-trial-plan-sha256-v1:1aca6332c77ed72b49cb20593f215c7eb2952121ad9bf3d5ae60bea0df5df024\",\"worker_packet_fingerprint\":\"cultist-behavioral-worker-packet-sha256-v1:5fa460fe007276013ed019830daaf9fc8d086cc5d3d5dfdfc5dd33a58052887d\",\"worker_ref\":\"worker-85cecf2608ad-20260825-0001\",\"first_action_id\":\"inspect_accepted_guard_detail\"}"}}
+{"type":"turn.completed","usage":{"input_tokens":17672,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":391,"reasoning_output_tokens":219}}

--- a/research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/events-2.jsonl
+++ b/research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/events-2.jsonl
@@ -1,0 +1,5 @@
+{"type":"thread.started","thread_id":"01a03613-ab37-7d82-8ac5-5b53b32de3cb"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"error","message":"Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter. Disable unused skills or plugins to leave more room for the rest."}}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"{\"schema_version\":1,\"trial_id\":\"prior-episode-front:stensibly-index-guard-detail\",\"plan_fingerprint\":\"cultist-behavioral-trial-plan-sha256-v1:1aca6332c77ed72b49cb20593f215c7eb2952121ad9bf3d5ae60bea0df5df024\",\"worker_packet_fingerprint\":\"cultist-behavioral-worker-packet-sha256-v1:a80303b59b9a46c5f4e6adb446abb01fbaeb5d898911bf6ad1248b3b0cf38549\",\"worker_ref\":\"worker-stensibly-85cecf26-20260825-001\",\"first_action_id\":\"inspect_accepted_guard_detail\"}"}}
+{"type":"turn.completed","usage":{"input_tokens":17815,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":506,"reasoning_output_tokens":331}}

--- a/research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/observation.schema.json
+++ b/research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/observation.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "trial_id",
+    "plan_fingerprint",
+    "worker_packet_fingerprint",
+    "worker_ref",
+    "first_action_id"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer" },
+    "trial_id": { "type": "string" },
+    "plan_fingerprint": { "type": "string" },
+    "worker_packet_fingerprint": { "type": "string" },
+    "worker_ref": {
+      "type": "string",
+      "description": "A session-local, unique worker run reference chosen for this fresh execution."
+    },
+    "first_action_id": {
+      "type": "string",
+      "enum": [
+        "block_patch",
+        "inspect_accepted_guard_detail",
+        "approve_patch",
+        "inspect_more_repository_context"
+      ]
+    }
+  }
+}

--- a/research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/pair.json
+++ b/research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/pair.json
@@ -1,0 +1,94 @@
+{
+  "schema_version": 1,
+  "plan": {
+    "schema_version": 1,
+    "trial_id": "prior-episode-front:stensibly-index-guard-detail",
+    "task_instruction": "Choose exactly one first justified action for this proposed Stensibly patch before writing review feedback.",
+    "allowed_first_actions": [
+      {
+        "id": "block_patch",
+        "label": "Block the patch as currently proposed"
+      },
+      {
+        "id": "inspect_accepted_guard_detail",
+        "label": "Inspect the accepted guard detail before deciding merge eligibility"
+      },
+      {
+        "id": "approve_patch",
+        "label": "Approve the patch as merge-eligible"
+      },
+      {
+        "id": "inspect_more_repository_context",
+        "label": "Inspect more repository context before deciding"
+      }
+    ],
+    "control": {
+      "context_ref": "research/behavioral-trials/stensibly-index-guard-detail.json#front",
+      "context": "Repository: teamleaderleo/stensibly\nRevision: 85cecf2608ad9e734a67518577fa85b9a08a550c\nTarget: convex/schema.ts\nTarget blob: 7fdd51e2f9fba80d1c0a814cea708d601a7b9925\nReview prompt: Review this proposed patch for merge eligibility against the repository's existing conventions and production constraints. Identify any blocking issue and the smallest corrective action. Do not assume the patch is correct.\nPatch:\n@@ githubProjectContexts index chain @@\n   .index(\"by_project_issue_accepted\", [\"projectId\", \"issueExternalId\", \"acceptedAt\", \"externalId\"])\n+  .index(\"by_project_issue_revision_instruction_set_sha256_provider_updated_at\", [\"projectId\", \"issueExternalId\", \"sourceRevision\", \"instructionSetSha256\", \"providerUpdatedAt\"]),\n\nCultist prior-episode front:\nnext: use_accepted_guard\ncandidate discriminator: convex_production_failure_class\ncandidate value: index_identifier_limit\nguard: pull_request#1575\nenforcement path: test/convex-index-identifier-limit.test.ts\nscope: convex/**/*.ts\nsame-class repairs: pull_request#1571, pull_request#1573\nautomatic policy authority: false",
+      "context_digest": "cultist-behavioral-context-sha256-v1:5db3451306ec047f7a6487f235299f2725c169b8235b97fc3cfbc84705ddfe62"
+    },
+    "treatment": {
+      "context_ref": "research/behavioral-trials/stensibly-index-guard-detail.json#front-plus-selected-detail",
+      "context": "Repository: teamleaderleo/stensibly\nRevision: 85cecf2608ad9e734a67518577fa85b9a08a550c\nTarget: convex/schema.ts\nTarget blob: 7fdd51e2f9fba80d1c0a814cea708d601a7b9925\nReview prompt: Review this proposed patch for merge eligibility against the repository's existing conventions and production constraints. Identify any blocking issue and the smallest corrective action. Do not assume the patch is correct.\nPatch:\n@@ githubProjectContexts index chain @@\n   .index(\"by_project_issue_accepted\", [\"projectId\", \"issueExternalId\", \"acceptedAt\", \"externalId\"])\n+  .index(\"by_project_issue_revision_instruction_set_sha256_provider_updated_at\", [\"projectId\", \"issueExternalId\", \"sourceRevision\", \"instructionSetSha256\", \"providerUpdatedAt\"]),\n\nCultist prior-episode front:\nnext: use_accepted_guard\ncandidate discriminator: convex_production_failure_class\ncandidate value: index_identifier_limit\nguard: pull_request#1575\nenforcement path: test/convex-index-identifier-limit.test.ts\nscope: convex/**/*.ts\nsame-class repairs: pull_request#1571, pull_request#1573\nautomatic policy authority: false\n\nCultist selected accepted-guard detail:\noperational marker: 64-character identifier limit\nguard marker: two historical mail index names\nguard source evidence:\nPrevent the same class of production-only Convex failure from merging again. Ordinary CI previously accepted two `by_*` index identifiers over Convex's 64-character limit; protected production schema analysis caught them only after merge.\n\nAdd one Bun regression that scans retained `convex/**/*.ts` string literals matching `by_*` and fails when any exceed 64 characters. Generated Convex files are excluded. The test also reconstructs the two historical mail index names from fragments and proves both exceed the production limit.",
+      "context_digest": "cultist-behavioral-context-sha256-v1:63c1fe7ef786886a36af2ffc212b5102cc33ca706a968debc5904d58adf0e52c"
+    }
+  },
+  "runs": [
+    {
+      "schema_version": 1,
+      "metadata": {
+        "schema_version": 1,
+        "execution_origin": "external_harness",
+        "sequence_index": 1,
+        "worker_identity": "openai:gpt-5.6-luna:max",
+        "harness_identity": "codex-cli:0.146.0:chatgpt-auth:ephemeral-v1",
+        "affordance_identity": "stdin-packet:read-only:no-search:json-schema-v1",
+        "sampling_config_sha256": "sha256:4fd03ccfd05f841af5acc11007b6bbd9f72def171a45c2cb365c9fb781438297",
+        "session_id": "01a03613-ab0c-7970-b38e-5c734e920e3b",
+        "freshness_receipt": "codex-cli-events-sha256:91ab1027b5d125f91e341294bb88fe1fdd73b1af343c36b1032692600833f6e8",
+        "fresh_session": true,
+        "prior_condition_exposure": false
+      },
+      "worker_packet_sha256": "sha256:6a568aed1eb660141cd7e7759e47edeb10a5c759fe1402689699dd7b6837149e",
+      "raw_worker_packet": "{\n  \"schema_version\": 1,\n  \"trial_id\": \"prior-episode-front:stensibly-index-guard-detail\",\n  \"plan_fingerprint\": \"cultist-behavioral-trial-plan-sha256-v1:1aca6332c77ed72b49cb20593f215c7eb2952121ad9bf3d5ae60bea0df5df024\",\n  \"worker_packet_fingerprint\": \"cultist-behavioral-worker-packet-sha256-v1:5fa460fe007276013ed019830daaf9fc8d086cc5d3d5dfdfc5dd33a58052887d\",\n  \"task_instruction\": \"Choose exactly one first justified action for this proposed Stensibly patch before writing review feedback.\",\n  \"context\": \"Repository: teamleaderleo/stensibly\\nRevision: 85cecf2608ad9e734a67518577fa85b9a08a550c\\nTarget: convex/schema.ts\\nTarget blob: 7fdd51e2f9fba80d1c0a814cea708d601a7b9925\\nReview prompt: Review this proposed patch for merge eligibility against the repository's existing conventions and production constraints. Identify any blocking issue and the smallest corrective action. Do not assume the patch is correct.\\nPatch:\\n@@ githubProjectContexts index chain @@\\n   .index(\\\"by_project_issue_accepted\\\", [\\\"projectId\\\", \\\"issueExternalId\\\", \\\"acceptedAt\\\", \\\"externalId\\\"])\\n+  .index(\\\"by_project_issue_revision_instruction_set_sha256_provider_updated_at\\\", [\\\"projectId\\\", \\\"issueExternalId\\\", \\\"sourceRevision\\\", \\\"instructionSetSha256\\\", \\\"providerUpdatedAt\\\"]),\\n\\nCultist prior-episode front:\\nnext: use_accepted_guard\\ncandidate discriminator: convex_production_failure_class\\ncandidate value: index_identifier_limit\\nguard: pull_request#1575\\nenforcement path: test/convex-index-identifier-limit.test.ts\\nscope: convex/**/*.ts\\nsame-class repairs: pull_request#1571, pull_request#1573\\nautomatic policy authority: false\",\n  \"context_digest\": \"cultist-behavioral-context-sha256-v1:5db3451306ec047f7a6487f235299f2725c169b8235b97fc3cfbc84705ddfe62\",\n  \"allowed_first_actions\": [\n    {\n      \"id\": \"block_patch\",\n      \"label\": \"Block the patch as currently proposed\"\n    },\n    {\n      \"id\": \"inspect_accepted_guard_detail\",\n      \"label\": \"Inspect the accepted guard detail before deciding merge eligibility\"\n    },\n    {\n      \"id\": \"approve_patch\",\n      \"label\": \"Approve the patch as merge-eligible\"\n    },\n    {\n      \"id\": \"inspect_more_repository_context\",\n      \"label\": \"Inspect more repository context before deciding\"\n    }\n  ]\n}\n",
+      "raw_output_sha256": "sha256:bb50dd48634b501866d75a9cff4fe5e7a2d7d2ec3af160489babdffcb1e8a7c9",
+      "raw_output": "{\"schema_version\":1,\"trial_id\":\"prior-episode-front:stensibly-index-guard-detail\",\"plan_fingerprint\":\"cultist-behavioral-trial-plan-sha256-v1:1aca6332c77ed72b49cb20593f215c7eb2952121ad9bf3d5ae60bea0df5df024\",\"worker_packet_fingerprint\":\"cultist-behavioral-worker-packet-sha256-v1:5fa460fe007276013ed019830daaf9fc8d086cc5d3d5dfdfc5dd33a58052887d\",\"worker_ref\":\"worker-85cecf2608ad-20260825-0001\",\"first_action_id\":\"inspect_accepted_guard_detail\"}",
+      "observation": {
+        "schema_version": 1,
+        "trial_id": "prior-episode-front:stensibly-index-guard-detail",
+        "plan_fingerprint": "cultist-behavioral-trial-plan-sha256-v1:1aca6332c77ed72b49cb20593f215c7eb2952121ad9bf3d5ae60bea0df5df024",
+        "worker_packet_fingerprint": "cultist-behavioral-worker-packet-sha256-v1:5fa460fe007276013ed019830daaf9fc8d086cc5d3d5dfdfc5dd33a58052887d",
+        "worker_ref": "worker-85cecf2608ad-20260825-0001",
+        "first_action_id": "inspect_accepted_guard_detail"
+      }
+    },
+    {
+      "schema_version": 1,
+      "metadata": {
+        "schema_version": 1,
+        "execution_origin": "external_harness",
+        "sequence_index": 2,
+        "worker_identity": "openai:gpt-5.6-luna:max",
+        "harness_identity": "codex-cli:0.146.0:chatgpt-auth:ephemeral-v1",
+        "affordance_identity": "stdin-packet:read-only:no-search:json-schema-v1",
+        "sampling_config_sha256": "sha256:4fd03ccfd05f841af5acc11007b6bbd9f72def171a45c2cb365c9fb781438297",
+        "session_id": "01a03613-ab37-7d82-8ac5-5b53b32de3cb",
+        "freshness_receipt": "codex-cli-events-sha256:9fc9f94c9d4542f0f4725219037a38340e9aa2bee17213537c951a71e9c07f83",
+        "fresh_session": true,
+        "prior_condition_exposure": false
+      },
+      "worker_packet_sha256": "sha256:1063efc8ecdf0313b947923dad8216fb9fa43b2e8b8cafa7ab6b63d53eb65c7d",
+      "raw_worker_packet": "{\n  \"schema_version\": 1,\n  \"trial_id\": \"prior-episode-front:stensibly-index-guard-detail\",\n  \"plan_fingerprint\": \"cultist-behavioral-trial-plan-sha256-v1:1aca6332c77ed72b49cb20593f215c7eb2952121ad9bf3d5ae60bea0df5df024\",\n  \"worker_packet_fingerprint\": \"cultist-behavioral-worker-packet-sha256-v1:a80303b59b9a46c5f4e6adb446abb01fbaeb5d898911bf6ad1248b3b0cf38549\",\n  \"task_instruction\": \"Choose exactly one first justified action for this proposed Stensibly patch before writing review feedback.\",\n  \"context\": \"Repository: teamleaderleo/stensibly\\nRevision: 85cecf2608ad9e734a67518577fa85b9a08a550c\\nTarget: convex/schema.ts\\nTarget blob: 7fdd51e2f9fba80d1c0a814cea708d601a7b9925\\nReview prompt: Review this proposed patch for merge eligibility against the repository's existing conventions and production constraints. Identify any blocking issue and the smallest corrective action. Do not assume the patch is correct.\\nPatch:\\n@@ githubProjectContexts index chain @@\\n   .index(\\\"by_project_issue_accepted\\\", [\\\"projectId\\\", \\\"issueExternalId\\\", \\\"acceptedAt\\\", \\\"externalId\\\"])\\n+  .index(\\\"by_project_issue_revision_instruction_set_sha256_provider_updated_at\\\", [\\\"projectId\\\", \\\"issueExternalId\\\", \\\"sourceRevision\\\", \\\"instructionSetSha256\\\", \\\"providerUpdatedAt\\\"]),\\n\\nCultist prior-episode front:\\nnext: use_accepted_guard\\ncandidate discriminator: convex_production_failure_class\\ncandidate value: index_identifier_limit\\nguard: pull_request#1575\\nenforcement path: test/convex-index-identifier-limit.test.ts\\nscope: convex/**/*.ts\\nsame-class repairs: pull_request#1571, pull_request#1573\\nautomatic policy authority: false\\n\\nCultist selected accepted-guard detail:\\noperational marker: 64-character identifier limit\\nguard marker: two historical mail index names\\nguard source evidence:\\nPrevent the same class of production-only Convex failure from merging again. Ordinary CI previously accepted two `by_*` index identifiers over Convex's 64-character limit; protected production schema analysis caught them only after merge.\\n\\nAdd one Bun regression that scans retained `convex/**/*.ts` string literals matching `by_*` and fails when any exceed 64 characters. Generated Convex files are excluded. The test also reconstructs the two historical mail index names from fragments and proves both exceed the production limit.\",\n  \"context_digest\": \"cultist-behavioral-context-sha256-v1:63c1fe7ef786886a36af2ffc212b5102cc33ca706a968debc5904d58adf0e52c\",\n  \"allowed_first_actions\": [\n    {\n      \"id\": \"block_patch\",\n      \"label\": \"Block the patch as currently proposed\"\n    },\n    {\n      \"id\": \"inspect_accepted_guard_detail\",\n      \"label\": \"Inspect the accepted guard detail before deciding merge eligibility\"\n    },\n    {\n      \"id\": \"approve_patch\",\n      \"label\": \"Approve the patch as merge-eligible\"\n    },\n    {\n      \"id\": \"inspect_more_repository_context\",\n      \"label\": \"Inspect more repository context before deciding\"\n    }\n  ]\n}\n",
+      "raw_output_sha256": "sha256:f3b62ce84e4f4843a8917e6581ca92c0cd18c3cbf6382f0593679c3235c94495",
+      "raw_output": "{\"schema_version\":1,\"trial_id\":\"prior-episode-front:stensibly-index-guard-detail\",\"plan_fingerprint\":\"cultist-behavioral-trial-plan-sha256-v1:1aca6332c77ed72b49cb20593f215c7eb2952121ad9bf3d5ae60bea0df5df024\",\"worker_packet_fingerprint\":\"cultist-behavioral-worker-packet-sha256-v1:a80303b59b9a46c5f4e6adb446abb01fbaeb5d898911bf6ad1248b3b0cf38549\",\"worker_ref\":\"worker-stensibly-85cecf26-20260825-001\",\"first_action_id\":\"inspect_accepted_guard_detail\"}",
+      "observation": {
+        "schema_version": 1,
+        "trial_id": "prior-episode-front:stensibly-index-guard-detail",
+        "plan_fingerprint": "cultist-behavioral-trial-plan-sha256-v1:1aca6332c77ed72b49cb20593f215c7eb2952121ad9bf3d5ae60bea0df5df024",
+        "worker_packet_fingerprint": "cultist-behavioral-worker-packet-sha256-v1:a80303b59b9a46c5f4e6adb446abb01fbaeb5d898911bf6ad1248b3b0cf38549",
+        "worker_ref": "worker-stensibly-85cecf26-20260825-001",
+        "first_action_id": "inspect_accepted_guard_detail"
+      }
+    }
+  ]
+}

--- a/research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/sampling-config.json
+++ b/research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/sampling-config.json
@@ -1,0 +1,12 @@
+{
+  "approval_policy": "never",
+  "codex_cli_version": "0.146.0",
+  "ephemeral": true,
+  "ignore_user_config": true,
+  "live_web_search": false,
+  "model": "gpt-5.6-luna",
+  "output_schema_sha256": "a9c4b713ec776cf9a24b7754dd609ead1c72bc3501720abc5aeab794f8bcfa2a",
+  "reasoning_effort": "max",
+  "repository_context": false,
+  "sandbox": "read-only"
+}


### PR DESCRIPTION
## In simple words

Runs the external-execution step owned by #267 with two fresh ChatGPT-authenticated Codex CLI sessions using gpt-5.6-luna at max reasoning, then retains the exact packets, outputs, session evidence, usage, pair receipt, and organizer verdict.

## Result

The pair is admitted with no confound reasons. Both arms chose inspect_accepted_guard_detail, so the selected accepted-guard detail did not change the first action in this one pair. This is a retained null result and carries no automatic effect or generalization claim.

## Proof

- exact branch head: 7345fc9
- replay: cargo run --quiet --example behavioral_trial_pair_admission < research/behavioral-trial-runs/2026-08-25-luna-max-stensibly-index-guard-detail/pair.json
- git diff --check
- byte comparison against downloaded artifact packets and generated organizer outputs

## Next

Review the retained evidence, merge if the exact receipt is sound, and close the missing real-worker observation in #267. Any later retirement or stronger causal claim needs another discriminator or additional pairs.