### PR TITLE
diff: stream git output into bounded merged ranges

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -2,13 +2,13 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::io::{self, BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
-
-#[cfg(test)]
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use crate::finding::{AnalysisReport, Claim, ClaimKind, Evidence, Finding, Location};
 use crate::generated_diff::add_generated_companion_findings;
+use crate::git_stream::{
+    self, MAX_DIFF_LINE_BYTES, UnquotedPath, drain_stderr, read_text_line_bounded, terminate_child,
+};
 use crate::performance;
 use crate::test_modules::{
     TestModuleOccurrence, TestModuleReport, analyze_test_module_files,
@@ -27,13 +27,20 @@ struct ChangedLines {
 }
 
 impl ChangedLines {
+    /// Records one added new-file line number. Git streams hunks in ascending
+    /// new-file order per path, so lines arrive monotonically; adjacent and
+    /// contiguous numbers merge into a single inclusive range, keeping storage
+    /// proportional to hunks rather than added lines.
     fn insert(&mut self, path: &Path, line: usize) {
         let ranges = self.by_path.entry(path.to_path_buf()).or_default();
-        if let Some(last) = ranges.last_mut()
-            && line <= last.end.saturating_add(1)
-        {
-            last.end = last.end.max(line);
-            return;
+        if let Some(last) = ranges.last_mut() {
+            // Descending lines would create overlapping ranges and break the
+            // logarithmic interval search; saturated repeats are allowed.
+            debug_assert!(last.end <= line, "added line numbers must ascend per path");
+            if line <= last.end.saturating_add(1) {
+                last.end = last.end.max(line);
+                return;
+            }
         }
         ranges.push(LineRange {
             start: line,
@@ -41,11 +48,12 @@ impl ChangedLines {
         });
     }
 
+    /// Membership is an interval search over sorted, disjoint ranges:
+    /// logarithmic in hunk count instead of linear over individual lines.
     fn contains(&self, path: &Path, line: usize) -> bool {
         self.by_path.get(path).is_some_and(|ranges| {
-            ranges
-                .iter()
-                .any(|range| range.start <= line && line <= range.end)
+            let index = ranges.partition_point(|range| range.end < line);
+            ranges.get(index).is_some_and(|range| range.start <= line)
         })
     }
 
@@ -63,6 +71,11 @@ impl ChangedLines {
     #[cfg(test)]
     fn range_count(&self, path: &Path) -> usize {
         self.by_path.get(path).map_or(0, Vec::len)
+    }
+
+    #[cfg(test)]
+    fn total_range_entries(&self) -> usize {
+        self.by_path.values().map(Vec::len).sum()
     }
 }
 
@@ -286,7 +299,8 @@ fn git_diff_changed_lines(root: &Path, base: Option<&str>) -> Result<ChangedLine
         None => "HEAD".to_string(),
     };
 
-    let mut child = performance::git_command()
+    let mut command = performance::git_command();
+    command
         .arg("-C")
         .arg(root)
         .args([
@@ -300,19 +314,39 @@ fn git_diff_changed_lines(root: &Path, base: Option<&str>) -> Result<ChangedLine
         ])
         .arg(anchor)
         .arg("--")
-        .arg("*.rs")
+        .arg("*.rs");
+    run_git_diff_streaming(command)
+}
+
+fn run_git_diff_streaming(mut command: Command) -> Result<ChangedLines, Box<dyn Error>> {
+    command
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .spawn()?;
+        .stderr(Stdio::piped());
+    let mut child = command.spawn()?;
 
     let stdout = child
         .stdout
         .take()
         .ok_or("git diff did not provide a stdout pipe")?;
-    let changed = parse_changed_lines(BufReader::new(stdout))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("git diff did not provide a stderr pipe")?;
+    let stderr_reader = drain_stderr(stderr);
+
+    let changed = match parse_changed_lines(BufReader::new(stdout)) {
+        Ok(changed) => changed,
+        Err(error) => {
+            terminate_child(child, stderr_reader);
+            return Err(format!("failed to stream git diff output: {error}").into());
+        }
+    };
     let status = child.wait()?;
+    let stderr_text = stderr_reader.finish();
 
     if !status.success() {
-        return Err(format!("git diff failed with status {status}").into());
+        return Err(format!("git diff failed with status {status}: {stderr_text}").into());
     }
 
     Ok(changed)
@@ -333,57 +367,143 @@ fn merge_base(root: &Path, base: &str) -> Result<String, Box<dyn Error>> {
     Ok(String::from_utf8(output.stdout)?.trim().to_string())
 }
 
-fn parse_changed_lines<R: BufRead>(mut reader: R) -> io::Result<ChangedLines> {
+/// Parses a `--unified=0` unified diff stream into per-path added-line ranges.
+///
+/// The stream is consumed line by line with a bounded line buffer, so raw
+/// patch bytes become facts and are released incrementally. Hunk headers carry
+/// the new-side line count; the parser consumes exactly that many body lines,
+/// which keeps structural headers (`diff --git`, `+++`, binary markers) from
+/// being mistaken for hunk content and lets malformed bodies fail closed
+/// instead of silently mis-attributing lines.
+fn parse_changed_lines<R: BufRead>(reader: R) -> io::Result<ChangedLines> {
+    parse_changed_lines_bounded(reader, MAX_DIFF_LINE_BYTES)
+}
+
+fn parse_changed_lines_bounded<R: BufRead>(
+    mut reader: R,
+    max_line_bytes: usize,
+) -> io::Result<ChangedLines> {
     let mut changed = ChangedLines::default();
     let mut current_path: Option<PathBuf> = None;
+    // Some(next new-file line number) while a hunk body is active.
     let mut current_new_line: Option<usize> = None;
-    let mut buffer = String::new();
+    // Remaining body lines in the active hunk's new side (0 = none).
+    let mut remaining_new_lines: usize = 0;
+    let mut text = String::new();
+    let mut scratch = Vec::new();
 
-    while reader.read_line(&mut buffer)? != 0 {
-        let line = buffer.trim_end_matches(['\n', '\r']);
-
-        if let Some(path) = line.strip_prefix("+++ ") {
-            current_path = (path != "/dev/null").then(|| PathBuf::from(path));
-            current_new_line = None;
-            buffer.clear();
-            continue;
+    loop {
+        text.clear();
+        if read_text_line_bounded(&mut reader, &mut text, &mut scratch, max_line_bytes)? == 0 {
+            break;
         }
+        let line = text.trim_end_matches(['\n', '\r']);
 
         if line.starts_with("@@") {
-            current_new_line = hunk_new_start(line);
-            buffer.clear();
+            let (start, count) = parse_hunk_header(line)?;
+            current_new_line = Some(start);
+            remaining_new_lines = count;
             continue;
         }
 
-        let Some(new_line) = current_new_line else {
-            buffer.clear();
-            continue;
-        };
-
-        if line.starts_with('+') && !line.starts_with("+++") {
-            if let Some(path) = &current_path {
-                changed.insert(path, new_line);
+        if remaining_new_lines == 0 {
+            current_new_line = None;
+        } else if let Some(new_line) = current_new_line {
+            match consume_hunk_body_line(&mut changed, current_path.as_deref(), line, new_line)? {
+                HunkBodyOutcome::Advanced => {
+                    current_new_line = Some(new_line.saturating_add(1));
+                    remaining_new_lines -= 1;
+                }
+                HunkBodyOutcome::Retained => {}
             }
-            current_new_line = Some(new_line + 1);
-        } else if line.starts_with('-') && !line.starts_with("---") {
-            // Deleted lines do not advance the line number in the new file.
-        } else if !line.starts_with('\\') {
-            current_new_line = Some(new_line + 1);
+            continue;
         }
 
-        buffer.clear();
+        // Outside any active hunk: only file headers are structural here.
+        if let Some(target) = line.strip_prefix("+++ ") {
+            current_path = parse_diff_target(target)?;
+        }
     }
 
     Ok(changed)
 }
 
-fn hunk_new_start(header: &str) -> Option<usize> {
+enum HunkBodyOutcome {
+    /// The line belongs to the hunk's new side and advanced the cursor.
+    Advanced,
+    /// The line is old-side or metadata and left the cursor unchanged.
+    Retained,
+}
+
+fn consume_hunk_body_line(
+    changed: &mut ChangedLines,
+    path: Option<&Path>,
+    line: &str,
+    new_line: usize,
+) -> io::Result<HunkBodyOutcome> {
+    // An empty body line is an empty context line whose leading space some
+    // producers trim away; it still occupies one new-side slot.
+    let first = line.as_bytes().first().copied();
+    match first {
+        None | Some(b' ') => Ok(HunkBodyOutcome::Advanced),
+        Some(b'\\') => Ok(HunkBodyOutcome::Retained),
+        Some(b'-') => Ok(HunkBodyOutcome::Retained),
+        Some(b'+') => {
+            if let Some(path) = path {
+                changed.insert(path, new_line);
+            }
+            Ok(HunkBodyOutcome::Advanced)
+        }
+        Some(_) => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("malformed hunk body line: {line:.80}"),
+        )),
+    }
+}
+
+/// Parses the new-side start and count out of a `@@ -a,b +c,d @@ context`
+/// header. A missing count means one line. Malformed numbers fail closed:
+/// silently skipping a header would mis-attribute every following line.
+fn parse_hunk_header(header: &str) -> io::Result<(usize, usize)> {
+    let malformed = || {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("malformed hunk header: {header:.120}"),
+        )
+    };
+
     let range = header
         .split_whitespace()
-        .find(|part| part.starts_with('+'))?
-        .trim_start_matches('+');
-    let start = range.split_once(',').map_or(range, |(start, _)| start);
-    start.parse().ok()
+        .find(|part| part.starts_with('+'))
+        .ok_or_else(malformed)?;
+    let spec = range.trim_start_matches('+');
+    let (start, count) = spec.split_once(',').unwrap_or((spec, ""));
+    let start = start.parse::<usize>().map_err(|_| malformed())?;
+    let count = if count.is_empty() {
+        1
+    } else {
+        count.parse::<usize>().map_err(|_| malformed())?
+    };
+    Ok((start, count))
+}
+
+/// Resolves a `+++ ` target token into a tracked path. `/dev/null` marks a
+/// created-from-nothing or deleted file. Git C-quotes targets containing
+/// quotes, backslashes, or control characters; those decode back to exact
+/// bytes. A trailing tab is Git's marker for paths with trailing whitespace
+/// and is not part of the path.
+fn parse_diff_target(token: &str) -> io::Result<Option<PathBuf>> {
+    if token == "/dev/null" {
+        return Ok(None);
+    }
+    let token = token.strip_suffix('\t').unwrap_or(token);
+    match git_stream::c_style_unquote(token) {
+        Ok(UnquotedPath::Verbatim) => Ok(Some(PathBuf::from(token))),
+        Ok(UnquotedPath::Decoded(bytes)) => String::from_utf8(bytes)
+            .map(|path| Some(PathBuf::from(path)))
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "quoted path is not UTF-8")),
+        Err(reason) => Err(io::Error::new(io::ErrorKind::InvalidData, reason)),
+    }
 }
 
 fn changed_test_modules<'a>(
@@ -684,5 +804,282 @@ mod tests {
                     .contains("No added or renamed test-gated module declarations")
         }));
         fs::remove_dir_all(root).unwrap();
+    }
+
+    struct TrickleReader<R> {
+        inner: R,
+    }
+
+    impl<R: io::Read> io::Read for TrickleReader<R> {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if buf.is_empty() {
+                return Ok(0);
+            }
+            self.inner.read(&mut buf[..1])
+        }
+    }
+
+    fn parse_bytes(bytes: &[u8]) -> ChangedLines {
+        parse_changed_lines(io::Cursor::new(bytes)).unwrap()
+    }
+
+    #[test]
+    fn fragmented_reads_parse_identically_to_whole_buffers() {
+        let patch = b"diff --git src/a.rs src/a.rs\n\
+                      --- src/a.rs\n\
+                      +++ src/a.rs\r\n\
+                      @@ -10,0 +11,2 @@\r\n\
+                      +one\n\
+                      +two\n\
+                      @@ -30 +32 @@\n\
+                      -old\n\
+                      \\ No newline at end of file\n\
+                      +new";
+        let whole = parse_bytes(patch);
+        let fragmented = parse_changed_lines(BufReader::new(TrickleReader {
+            inner: io::Cursor::new(patch),
+        }))
+        .unwrap();
+        assert_eq!(whole, fragmented);
+        assert!(whole.contains(Path::new("src/a.rs"), 11));
+        assert!(whole.contains(Path::new("src/a.rs"), 12));
+        assert!(whole.contains(Path::new("src/a.rs"), 32));
+        assert!(!whole.contains(Path::new("src/a.rs"), 13));
+    }
+
+    #[test]
+    fn binary_file_markers_between_files_do_not_corrupt_ranges() {
+        let patch = concat!(
+            "diff --git src/a.rs src/a.rs\n",
+            "--- src/a.rs\n",
+            "+++ src/a.rs\n",
+            "@@ -1,0 +2,1 @@\n",
+            "+added\n",
+            "diff --git data.bin data.bin\n",
+            "index 111..222 100644\n",
+            "Binary files data.bin and data.bin differ\n",
+            "diff --git src/b.rs src/b.rs\n",
+            "--- src/b.rs\n",
+            "+++ src/b.rs\n",
+            "@@ -5,0 +6,2 @@\n",
+            "+first\n",
+            "+second\n",
+        );
+        let changed = parse_bytes(patch.as_bytes());
+        assert!(changed.contains(Path::new("src/a.rs"), 2));
+        assert!(changed.contains(Path::new("src/b.rs"), 7));
+        assert_eq!(changed.range_count(Path::new("src/a.rs")), 1);
+        assert_eq!(changed.range_count(Path::new("src/b.rs")), 1);
+        assert!(!changed.by_path.contains_key(Path::new("data.bin")));
+    }
+
+    #[test]
+    fn counted_hunks_stop_consuming_at_the_header_count() {
+        // An added line whose content itself starts with `++ ` renders as a
+        // line beginning with `+++`; the counted state machine must treat it
+        // as hunk content, not as the next file header.
+        let patch = concat!(
+            "diff --git src/a.rs src/a.rs\n",
+            "--- src/a.rs\n",
+            "+++ src/a.rs\n",
+            "@@ -1,0 +2,3 @@\n",
+            "+first\n",
+            "+++ looks like a header\n",
+            "+third\n",
+        );
+        let changed = parse_bytes(patch.as_bytes());
+        assert_eq!(changed.range_count(Path::new("src/a.rs")), 1);
+        assert!(changed.contains(Path::new("src/a.rs"), 3));
+        assert!(changed.contains(Path::new("src/a.rs"), 4));
+        assert!(!changed.contains(Path::new("looks like a header"), 1));
+    }
+
+    #[test]
+    fn quoted_target_paths_decode_c_escapes() {
+        let patch = concat!(
+            "diff --git src/we\tird.rs src/we\tird.rs\n",
+            "--- src/we\tird.rs\n",
+            "+@@ header-shaped content\n",
+            "+++ \"src/we\\tird.rs\"\n",
+            "@@ -0,0 +1,1 @@\n",
+            "+inside\n",
+        );
+        let changed = parse_bytes(patch.as_bytes());
+        assert!(changed.contains(Path::new("src/we\tird.rs"), 1));
+    }
+
+    #[test]
+    fn malformed_hunk_headers_fail_closed_instead_of_skipping() {
+        for bad in [
+            &b"+++ src/a.rs\n@@ garbage @@\n+x\n"[..],
+            b"+++ src/a.rs\n@@ -1,0 +99999999999999999999,2 @@\n+x\n",
+            b"+++ src/a.rs\n@@ -1,0 +18446744073709551616 @@\n+x\n",
+        ] {
+            let error = parse_changed_lines(io::Cursor::new(bad)).unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::InvalidData, "{error}");
+        }
+    }
+
+    #[test]
+    fn malformed_hunk_body_lines_fail_closed() {
+        let patch = b"+++ src/a.rs\n@@ -1,0 +1,2 @@\n+ok\nunexpected body\n";
+        let error = parse_changed_lines(io::Cursor::new(patch)).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn oversized_lines_fail_closed_with_a_bounded_buffer() {
+        let long_line = vec![b'a'; 128];
+        let mut patch = b"+++ src/a.rs\n@@ -1,0 +1,2 @@\n".to_vec();
+        patch.extend_from_slice(&long_line);
+
+        let error = parse_changed_lines_bounded(io::Cursor::new(&patch), 32).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn saturating_hunk_starts_never_overflow() {
+        let max = usize::MAX;
+        let patch = format!("+++ src/a.rs\n@@ -1,0 +{max},2 @@\n+a\n+b\n");
+        let changed = parse_bytes(patch.as_bytes());
+        assert!(changed.contains(Path::new("src/a.rs"), max));
+        assert!(changed.range_count(Path::new("src/a.rs")) <= 2);
+    }
+
+    #[test]
+    fn million_line_contiguous_addition_is_one_range_entry() {
+        let started = std::time::Instant::now();
+        const LINES: usize = 1_000_000;
+        let mut patch = String::with_capacity(LINES * 8 + 64);
+        patch.push_str("+++ src/generated.rs\n@@ -0,0 +1,");
+        patch.push_str(&LINES.to_string());
+        patch.push_str(" @@\n");
+        for _ in 0..LINES {
+            patch.push_str("+generated line\n");
+        }
+
+        let changed = parse_bytes(patch.as_bytes());
+        let elapsed = started.elapsed();
+
+        // Structural memory proxy: one merged range entry proves storage is
+        // O(hunks), independent of the million added lines.
+        assert_eq!(changed.total_range_entries(), 1);
+        assert_eq!(changed.range_count(Path::new("src/generated.rs")), 1);
+        assert!(changed.contains(Path::new("src/generated.rs"), 1));
+        assert!(changed.contains(Path::new("src/generated.rs"), LINES));
+        assert!(!changed.contains(Path::new("src/generated.rs"), LINES + 1));
+
+        println!(
+            "million-line contiguous addition: {} range entries in {elapsed:?}",
+            changed.total_range_entries()
+        );
+        assert!(
+            elapsed.as_secs() < 60,
+            "million-line parse should stay far below wall-clock CI limits"
+        );
+    }
+
+    #[test]
+    fn sparse_additions_keep_disjoint_ranges_and_boundary_membership() {
+        const HUNKS: usize = 50_000;
+        let mut patch = String::from("+++ src/sparse.rs\n");
+        for hunk in 0..HUNKS {
+            let start = hunk * 4 + 1;
+            patch.push_str(&format!("@@ -{start},0 +{start},1 @@\n+sparse\n"));
+        }
+        let changed = parse_bytes(patch.as_bytes());
+
+        assert_eq!(changed.range_count(Path::new("src/sparse.rs")), HUNKS);
+        assert_eq!(changed.total_range_entries(), HUNKS);
+        for probe in [0_usize, 1, 2_000, 199_999, 200_000] {
+            let expected = probe > 0 && (probe - 1) % 4 == 0 && probe <= HUNKS * 4;
+            assert_eq!(
+                changed.contains(Path::new("src/sparse.rs"), probe),
+                expected,
+                "probe {probe}"
+            );
+        }
+    }
+
+    #[test]
+    fn overlapping_and_adjacent_ranges_merge_into_canonical_form() {
+        let mut changed = ChangedLines::default();
+        for line in [10_usize, 11, 12, 14, 15] {
+            changed.insert(Path::new("src/a.rs"), line);
+        }
+        assert_eq!(changed.range_count(Path::new("src/a.rs")), 2);
+        assert!(changed.contains(Path::new("src/a.rs"), 12));
+        assert!(!changed.contains(Path::new("src/a.rs"), 13));
+        assert!(changed.contains(Path::new("src/a.rs"), 15));
+
+        let later_file = ChangedLines {
+            by_path: BTreeMap::from([(
+                PathBuf::from("src/b.rs"),
+                vec![
+                    LineRange { start: 5, end: 6 },
+                    LineRange { start: 9, end: 9 },
+                    LineRange {
+                        start: 100,
+                        end: 100,
+                    },
+                    LineRange {
+                        start: 4096,
+                        end: 8192,
+                    },
+                ],
+            )]),
+        };
+        for line in [5_usize, 6, 8, 9, 100, 4095, 5000, 8192, 8193] {
+            assert_eq!(
+                later_file.contains(Path::new("src/b.rs"), line),
+                [5, 6, 9, 100, 5000, 8192].contains(&line),
+                "probe {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn parser_errors_kill_and_reap_the_child_promptly() {
+        let started = std::time::Instant::now();
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg("printf '+++ src/a.rs\n@@ broken header @@\n'; sleep 30");
+        let error = run_git_diff_streaming(command).expect_err("malformed stream must fail");
+
+        assert!(
+            error.to_string().contains("malformed hunk header"),
+            "{error}"
+        );
+        assert!(
+            started.elapsed().as_secs() < 20,
+            "a stuck child must be killed instead of waited on: {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn stderr_pressure_cannot_deadlock_stdout_parsing() {
+        let mut command = Command::new("/bin/sh");
+        command.arg("-c").arg(
+            "yes x | head -c 2097152 >&2; \
+             printf '+++ src/a.rs\n@@ -0,0 +1,1 @@\n+line\n'",
+        );
+        let changed = run_git_diff_streaming(command).unwrap();
+        assert!(changed.contains(Path::new("src/a.rs"), 1));
+    }
+
+    #[test]
+    fn nonzero_child_exit_reports_stderr_text() {
+        let outside = unique_temp_dir("outside-repo");
+        fs::create_dir_all(&outside).unwrap();
+        let mut command = Command::new("git");
+        command.arg("-C").arg(&outside).arg("log").arg("-1");
+        let error = run_git_diff_streaming(command).expect_err("outside a repo git must fail");
+
+        let message = error.to_string();
+        assert!(message.contains("failed with status"), "{message}");
+        assert!(message.contains("fatal:"), "{message}");
+        fs::remove_dir_all(outside).unwrap();
     }
 }

--- a/src/generated_diff.rs
+++ b/src/generated_diff.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fs;
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{self, BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::process::Command;
@@ -14,6 +14,10 @@ use proc_macro2::{Delimiter, Group, TokenStream, TokenTree};
 mod generator_ownership;
 
 use crate::finding::{AnalysisReport, Claim, ClaimKind, Evidence, Finding, Location};
+use crate::git_stream::{
+    self, MAX_LOG_LINE_BYTES, MAX_PATH_LINE_BYTES, UnquotedPath, drain_stderr,
+    read_text_line_bounded, terminate_child,
+};
 use crate::performance;
 use generator_ownership::{
     GeneratorRelation, discover_generator_relations, generated_attribute_paths,
@@ -60,6 +64,7 @@ struct SourceHistoryRecord {
     parent: Option<String>,
     subject: String,
     paths: BTreeSet<PathBuf>,
+    changed_paths: usize,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -75,8 +80,23 @@ pub fn add_generated_companion_findings(
     base: Option<&str>,
     analysis: &mut AnalysisReport,
 ) -> Result<(), Box<dyn Error>> {
+    let relations = discover_generator_relations(root)?;
+    if relations.is_empty() {
+        return Ok(());
+    }
+    let generated_attrs = generated_attribute_paths(root);
+
+    // The analyzer only ever asks two questions of the changed set: which
+    // changed paths are Rust files, and whether each admitted relation's exact
+    // generated output changed. Restricting the Git pathspec to those classes
+    // (`*.rs` plus literal output paths) keeps the query exact while letting
+    // Git skip every other file class in large trees.
+    let watched_outputs: BTreeSet<String> = relations
+        .iter()
+        .map(|relation| relation.output.clone())
+        .collect();
     let anchor = diff_anchor(root, base)?;
-    let changed = changed_paths(root, &anchor)?;
+    let changed = changed_paths(root, &anchor, &watched_outputs)?;
     if changed.is_empty() {
         return Ok(());
     }
@@ -90,11 +110,6 @@ pub fn add_generated_companion_findings(
         return Ok(());
     }
 
-    let relations = discover_generator_relations(root)?;
-    if relations.is_empty() {
-        return Ok(());
-    }
-    let generated_attrs = generated_attribute_paths(root);
     let mut history_by_input = BTreeMap::<PathBuf, Vec<ClassifiedSourceCommit>>::new();
 
     for relation in relations {
@@ -254,8 +269,17 @@ fn diff_anchor(root: &Path, base: Option<&str>) -> Result<String, Box<dyn Error>
     }
 }
 
-fn changed_paths(root: &Path, anchor: &str) -> Result<BTreeSet<PathBuf>, Box<dyn Error>> {
-    let output = performance::git_command()
+/// Streams `git diff --name-only` over the analyzer's exact file classes:
+/// every Rust file plus the literal generated-output paths admitted by the
+/// discovered relations. Paths stream into the result set as raw Git output
+/// becomes facts; nothing output-sized is retained beyond the set itself.
+fn changed_paths(
+    root: &Path,
+    anchor: &str,
+    watched_outputs: &BTreeSet<String>,
+) -> Result<BTreeSet<PathBuf>, Box<dyn Error>> {
+    let mut command = performance::git_command();
+    command
         .arg("-C")
         .arg(root)
         .args([
@@ -267,20 +291,72 @@ fn changed_paths(root: &Path, anchor: &str) -> Result<BTreeSet<PathBuf>, Box<dyn
         ])
         .arg(anchor)
         .arg("--")
-        .output()?;
-    if !output.status.success() {
-        return Err(format!(
-            "git diff --name-only failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        )
-        .into());
+        .arg("*.rs");
+    for output in watched_outputs {
+        // Literal magic disables glob interpretation so generated outputs with
+        // pathspec metacharacters match exactly.
+        command.arg(format!(":(literal){output}"));
     }
-    Ok(String::from_utf8(output.stdout)?
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .map(PathBuf::from)
-        .collect())
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = command.spawn()?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or("git diff --name-only did not provide a stdout pipe")?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("git diff --name-only did not provide a stderr pipe")?;
+    let stderr_reader = drain_stderr(stderr);
+
+    let paths = match stream_changed_paths(BufReader::new(stdout)) {
+        Ok(paths) => paths,
+        Err(error) => {
+            terminate_child(child, stderr_reader);
+            return Err(format!("failed to stream git diff --name-only output: {error}").into());
+        }
+    };
+
+    let status = child.wait()?;
+    let stderr_text = stderr_reader.finish();
+    if !status.success() {
+        return Err(format!("git diff --name-only failed: {stderr_text}").into());
+    }
+
+    Ok(paths)
+}
+
+fn stream_changed_paths<R: BufRead>(mut reader: R) -> std::io::Result<BTreeSet<PathBuf>> {
+    let mut paths = BTreeSet::new();
+    let mut text = String::new();
+    let mut scratch = Vec::new();
+
+    loop {
+        if read_text_line_bounded(&mut reader, &mut text, &mut scratch, MAX_PATH_LINE_BYTES)? == 0 {
+            break;
+        }
+        let line = text.trim_end_matches(['\n', '\r']);
+        if line.is_empty() {
+            continue;
+        }
+        paths.insert(decode_git_path_line(line)?);
+    }
+
+    Ok(paths)
+}
+
+fn decode_git_path_line(line: &str) -> std::io::Result<PathBuf> {
+    match git_stream::c_style_unquote(line) {
+        Ok(UnquotedPath::Verbatim) => Ok(PathBuf::from(line)),
+        Ok(UnquotedPath::Decoded(bytes)) => String::from_utf8(bytes)
+            .map(PathBuf::from)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "quoted path is not UTF-8")),
+        Err(reason) => Err(io::Error::new(io::ErrorKind::InvalidData, reason)),
+    }
 }
 
 fn source_syntax_changed(root: &Path, anchor: &str, path: &Path) -> Result<bool, Box<dyn Error>> {
@@ -306,7 +382,7 @@ fn classify_source_history(
     let considered: Vec<_> = records
         .into_iter()
         .filter(|record| {
-            !is_revert_subject(&record.subject) && record.paths.len() <= MAX_PATHS_PER_COMMIT
+            !is_revert_subject(&record.subject) && record.changed_paths <= MAX_PATHS_PER_COMMIT
         })
         .collect();
     let versions = read_source_versions(root, input, &considered)?;
@@ -382,12 +458,16 @@ fn build_syntax_cohort(history: &[ClassifiedSourceCommit], output: &Path) -> Syn
     cohort
 }
 
+/// Streams the batched `git log` feed for one input path. Raw output becomes
+/// records incrementally; once a commit crosses the broad-commit threshold its
+/// retained path strings are dropped and only counting continues, which keeps
+/// exclusion decisions exact without holding every path of a mass commit.
 fn read_source_history(
     root: &Path,
     input: &Path,
     max_commits: usize,
 ) -> Result<Vec<SourceHistoryRecord>, Box<dyn Error>> {
-    let output = performance::git_command()
+    let mut child = performance::git_command()
         .arg("-C")
         .arg(root)
         .args([
@@ -407,32 +487,142 @@ fn read_source_history(
         .arg(max_commits.to_string())
         .arg("--")
         .arg(input)
-        .output()?;
-    if !output.status.success() {
-        return Err(format!(
-            "git log failed for {}: {}",
-            input.display(),
-            String::from_utf8_lossy(&output.stderr)
-        )
-        .into());
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or("git log did not provide a stdout pipe")?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("git log did not provide a stderr pipe")?;
+    let stderr_reader = drain_stderr(stderr);
+
+    let parsed = match stream_source_history_log(BufReader::new(stdout), MAX_PATHS_PER_COMMIT) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            terminate_child(child, stderr_reader);
+            return Err(format!(
+                "failed to stream git history for {}: {error}",
+                input.display()
+            )
+            .into());
+        }
+    };
+
+    let status = child.wait()?;
+    let stderr_text = stderr_reader.finish();
+    if !status.success() {
+        return Err(format!("git log failed for {}: {stderr_text}", input.display()).into());
     }
 
-    parse_source_history_log(&String::from_utf8(output.stdout)?)
-        .ok_or_else(|| format!("could not parse git history for {}", input.display()).into())
+    parsed.ok_or_else(|| format!("could not parse git history for {}", input.display()).into())
 }
 
-fn parse_source_history_log(output: &str) -> Option<Vec<SourceHistoryRecord>> {
-    output
-        .split('\u{1e}')
-        .filter(|record| !record.trim().is_empty())
-        .map(parse_source_history_record)
-        .collect()
+fn stream_source_history_log<R: BufRead>(
+    mut reader: R,
+    max_paths_per_commit: usize,
+) -> std::io::Result<Option<Vec<SourceHistoryRecord>>> {
+    let mut records = Vec::new();
+    let mut current: Option<SourceHistoryAccumulator> = None;
+    let mut malformed = false;
+    let mut text = String::new();
+    let mut scratch = Vec::new();
+
+    loop {
+        if read_text_line_bounded(&mut reader, &mut text, &mut scratch, MAX_LOG_LINE_BYTES)? == 0 {
+            break;
+        }
+        if malformed {
+            continue;
+        }
+
+        if let Some(metadata) = text.strip_prefix('\u{1e}') {
+            if let Some(record) = current.take() {
+                records.push(record.finish(max_paths_per_commit));
+            }
+            match source_history_summary(metadata) {
+                Some((sha, parent, subject)) => {
+                    current = Some(SourceHistoryAccumulator::new(sha, parent, subject));
+                }
+                None => malformed = true,
+            }
+        } else if let Some(accumulator) = current.as_mut() {
+            let path = text.trim_end_matches(['\n', '\r']).trim();
+            if !path.is_empty() {
+                accumulator.offer_path(max_paths_per_commit, path);
+            }
+        } else if !text.trim().is_empty() {
+            malformed = true;
+        }
+    }
+
+    if malformed {
+        return Ok(None);
+    }
+    if let Some(record) = current.take() {
+        records.push(record.finish(max_paths_per_commit));
+    }
+
+    Ok(Some(records))
 }
 
-fn parse_source_history_record(record: &str) -> Option<SourceHistoryRecord> {
-    let record = record.trim_start_matches(['\n', '\r']);
-    let mut lines = record.lines();
-    let metadata = lines.next()?.trim();
+struct SourceHistoryAccumulator {
+    sha: String,
+    parent: Option<String>,
+    subject: String,
+    paths: BTreeSet<PathBuf>,
+    counting_only: bool,
+    counted_overflow_paths: usize,
+}
+
+impl SourceHistoryAccumulator {
+    fn new(sha: String, parent: Option<String>, subject: String) -> Self {
+        Self {
+            sha,
+            parent,
+            subject,
+            paths: BTreeSet::new(),
+            counting_only: false,
+            counted_overflow_paths: 0,
+        }
+    }
+
+    fn offer_path(&mut self, max_paths_per_commit: usize, path: &str) {
+        if self.counting_only {
+            self.counted_overflow_paths += 1;
+            return;
+        }
+        self.paths.insert(PathBuf::from(path));
+        if self.paths.len() > max_paths_per_commit {
+            self.counting_only = true;
+            self.paths.clear();
+            self.counted_overflow_paths = 0;
+        }
+    }
+
+    fn finish(self, max_paths_per_commit: usize) -> SourceHistoryRecord {
+        let changed_paths = if self.counting_only {
+            max_paths_per_commit + 1 + self.counted_overflow_paths
+        } else {
+            self.paths.len()
+        };
+        SourceHistoryRecord {
+            sha: self.sha,
+            parent: self.parent,
+            subject: self.subject,
+            paths: self.paths,
+            changed_paths,
+        }
+    }
+}
+
+fn source_history_summary(metadata: &str) -> Option<(String, Option<String>, String)> {
+    let metadata = metadata.trim_end_matches(['\n', '\r']);
     let mut fields = metadata.splitn(3, '\u{1f}');
     let sha = fields.next()?.trim().to_string();
     let parent = fields
@@ -441,18 +631,7 @@ fn parse_source_history_record(record: &str) -> Option<SourceHistoryRecord> {
         .next()
         .map(ToOwned::to_owned);
     let subject = fields.next()?.trim().to_string();
-    let paths = lines
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .map(PathBuf::from)
-        .collect();
-
-    Some(SourceHistoryRecord {
-        sha,
-        parent,
-        subject,
-        paths,
-    })
+    Some((sha, parent, subject))
 }
 
 fn read_source_versions(
@@ -689,9 +868,11 @@ fn short_sha(sha: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;
+    use crate::diff::build_diff_analysis_report;
 
     fn unique_temp_dir(name: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -766,12 +947,71 @@ mod tests {
             "\x1edef\x1fabc\x1fdocs: two\n\n",
             "src/input.rs\n",
         );
-        let records = parse_source_history_log(output).unwrap();
+        let records = stream_source_history_log(Cursor::new(output), MAX_PATHS_PER_COMMIT)
+            .unwrap()
+            .unwrap();
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].sha, "abc");
         assert_eq!(records[0].parent.as_deref(), Some("parent"));
         assert!(records[0].paths.contains(Path::new("generated/output.rs")));
+        assert_eq!(records[0].changed_paths, 2);
         assert_eq!(records[1].subject, "docs: two");
+        assert_eq!(records[1].changed_paths, 1);
+    }
+
+    #[test]
+    fn broad_source_commits_count_without_retaining_paths() {
+        let mut output = String::from("\x1ebroad\x1fparent\x1fmass change\n\n");
+        for index in 0..9 {
+            output.push_str(&format!("src/generated_{index}.rs\n"));
+        }
+        output.push_str("\x1enarrow\x1fbroad\x1fsmall change\n\nsrc/input.rs\n");
+
+        let records = stream_source_history_log(Cursor::new(output.as_bytes()), 4)
+            .unwrap()
+            .unwrap();
+        assert_eq!(records.len(), 2);
+        assert!(records[0].paths.is_empty());
+        assert_eq!(records[0].changed_paths, 9);
+        assert_eq!(records[1].changed_paths, 1);
+        assert_eq!(records[1].paths.len(), 1);
+    }
+
+    #[test]
+    fn duplicate_overflow_lines_are_counted_not_retained() {
+        // Crossing the threshold switches the commit to counting mode; every
+        // later path line is counted even when it duplicates an earlier one.
+        let output = "\x1ea\x1fp\x1fs\nb.rs\na.rs\na.rs\nc.rs\nd.rs\n";
+        let records = stream_source_history_log(Cursor::new(output), 2)
+            .unwrap()
+            .unwrap();
+        assert!(records[0].paths.is_empty());
+        // Two retained distinct paths + the crossing line + one counted line.
+        assert_eq!(records[0].changed_paths, 4);
+    }
+
+    #[test]
+    fn malformed_source_history_fails_without_panicking() {
+        for bad in [
+            "garbage before any record\n",
+            "\x1esha-only\x1fparent-only\n",
+            "\x1esha\x1f",
+            "\x1ea\x1fp\x1fs\np\n\x1eb\x1fp",
+        ] {
+            let parsed = stream_source_history_log(Cursor::new(bad), MAX_PATHS_PER_COMMIT).unwrap();
+            assert!(parsed.is_none(), "{bad:?} must fail closed");
+        }
+    }
+
+    #[test]
+    fn oversized_source_history_lines_fail_closed() {
+        let long_path = format!("{}\n", "p".repeat(MAX_LOG_LINE_BYTES + 1));
+        let error = stream_source_history_log(
+            Cursor::new(format!("\x1ea\x1fp\x1fs\n{long_path}").into_bytes()),
+            MAX_PATHS_PER_COMMIT,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]
@@ -824,6 +1064,119 @@ mod tests {
         assert_eq!(cohort.support, 2);
         assert_eq!(cohort.comments_or_docs_only, 1);
         assert_eq!(cohort.unclassified, 1);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    fn init_generator_repo(name: &str) -> PathBuf {
+        let root = unique_temp_dir(name);
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::create_dir_all(root.join("data")).unwrap();
+        fs::create_dir_all(root.join(".cargo")).unwrap();
+        fs::create_dir_all(root.join("packages/gen_task/src")).unwrap();
+        run_git(&root, &["init", "-q", "-b", "main"]);
+        run_git(&root, &["config", "user.email", "cultist@example.invalid"]);
+        run_git(&root, &["config", "user.name", "Cargo Cultist Tests"]);
+        fs::write(
+            root.join(".cargo/config.toml"),
+            "[alias]\ngen = \"run -p gen_task\"\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("packages/gen_task/Cargo.toml"),
+            "[package]\nname = \"gen_task\"\nversion = \"0.0.0\"\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("packages/gen_task/src/main.rs"),
+            concat!(
+                "fn generate() -> std::io::Result<()> {\n",
+                "    let root = project_root::get_project_root()\n",
+                "        .map_err(|error| std::io::Error::other(error.to_string()))?;\n",
+                "    let source = std::fs::read_to_string(root.join(\"src/input.rs\"))?;\n",
+                "    let target = root.join(\"data/out.json\");\n",
+                "    std::fs::write(&target, source)?;\n",
+                "    Ok(())\n",
+                "}\n",
+            ),
+        )
+        .unwrap();
+        fs::write(
+            root.join(".gitattributes"),
+            "data/out.json linguist-generated=true\n",
+        )
+        .unwrap();
+        root
+    }
+
+    fn write_pair(root: &Path, value: usize, include_output: bool) {
+        if value == 0 {
+            fs::write(root.join("src/input.rs"), "fn value() -> usize { 0 }\n").unwrap();
+            write_output(root, 0);
+        } else {
+            fs::write(
+                root.join("src/input.rs"),
+                format!("// v{value}\nfn value() -> usize {{ {value} }}\n"),
+            )
+            .unwrap();
+            if include_output {
+                write_output(root, value);
+            }
+        }
+    }
+
+    fn write_output(root: &Path, value: usize) {
+        fs::write(
+            root.join("data/out.json"),
+            // Non-.rs generated output: only the literal-output pathspec keeps
+            // its diff membership exact.
+            format!("@generated do not edit\n{{\"value\": {value}}}\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn restricted_pathspec_keeps_non_rust_generated_outputs_exact_end_to_end() {
+        let root = init_generator_repo("pathspec-e2e");
+        write_pair(&root, 0, true);
+        run_git(&root, &["add", "."]);
+        run_git(&root, &["commit", "-q", "-m", "baseline"]);
+
+        for value in 1..=4 {
+            write_pair(&root, value, true);
+            run_git(&root, &["add", "."]);
+            run_git(&root, &["commit", "-q", "-m", &format!("regen {value}")]);
+        }
+
+        // Working tree: input syntax changes together with its non-Rust
+        // generated companion. Exact output membership means no finding.
+        write_pair(&root, 5, true);
+        let analysis = build_diff_analysis_report(&root, None).unwrap();
+        assert!(
+            analysis
+                .findings
+                .iter()
+                .all(|finding| finding.kind != "generated-companion-missing"),
+            "companion changed with the input; expected no missing-companion finding"
+        );
+
+        // Control: restore the companion, regenerate the input alone, and the
+        // finding must appear.
+        write_output(&root, 4);
+        write_pair(&root, 6, false);
+        let analysis = build_diff_analysis_report(&root, None).unwrap();
+        assert!(
+            analysis
+                .findings
+                .iter()
+                .any(|finding| finding.kind == "generated-companion-missing"),
+            "stale non-.rs companion must be reported; claims: {:?}",
+            analysis
+                .claims
+                .iter()
+                .map(|claim| claim.message.clone())
+                .collect::<Vec<_>>()
+        );
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/src/git_stream.rs
+++ b/src/git_stream.rs
@@ -16,6 +16,14 @@ pub(crate) const MAX_LOG_LINE_BYTES: usize = 64 * 1024;
 /// Upper bound for one `--name-only` path line.
 pub(crate) const MAX_PATH_LINE_BYTES: usize = 8 * 1024;
 
+/// Maximum retained diagnostic bytes from one Git child's stderr. The drainer
+/// continues consuming bytes after this cap so a chatty child never receives a
+/// closed pipe merely because diagnostics were bounded.
+pub(crate) const MAX_STDERR_CAPTURE_BYTES: usize = 64 * 1024;
+
+const STDERR_DRAIN_GRACE: Duration = Duration::from_millis(250);
+const STDERR_TRUNCATION_MARKER: &[u8] = b"\n[stderr truncated]\n";
+
 /// Reads one line into `line`, including its `\n` delimiter, mirroring
 /// [`BufRead::read_line`] semantics while refusing to buffer more than
 /// `max_bytes`. Returns the number of bytes read; `Ok(0)` marks end of stream.
@@ -86,12 +94,14 @@ pub(crate) struct StderrDrain {
 }
 
 impl StderrDrain {
-    /// Waits for the drain to finish and returns the captured text (lossily
-    /// decoded). Call only once the child has been waited on normally; orphaned
-    /// grandchildren can hold the pipe open, so the termination path uses
-    /// [`terminate_child`] instead.
+    /// Waits briefly for the drain to finish and returns bounded captured text
+    /// (lossily decoded). A successful direct child can still leave an orphaned
+    /// descendant holding the pipe open, so normal and termination paths share
+    /// the same bounded post-wait grace.
     pub(crate) fn finish(self) -> String {
-        self.receiver.recv().unwrap_or_default()
+        self.receiver
+            .recv_timeout(STDERR_DRAIN_GRACE)
+            .unwrap_or_default()
     }
 }
 
@@ -100,14 +110,37 @@ impl StderrDrain {
 pub(crate) fn drain_stderr<R: Read + Send + 'static>(stderr: R) -> StderrDrain {
     let (sender, receiver) = channel();
     thread::spawn(move || {
-        let mut bytes = Vec::new();
-        let text = match io::BufReader::new(stderr).read_to_end(&mut bytes) {
-            Ok(_) => String::from_utf8_lossy(&bytes).into_owned(),
-            Err(_) => String::new(),
-        };
+        let text = read_stderr_bounded(stderr);
         let _ = sender.send(text);
     });
     StderrDrain { receiver }
+}
+
+fn read_stderr_bounded<R: Read>(stderr: R) -> String {
+    let mut reader = io::BufReader::new(stderr);
+    let mut retained = Vec::new();
+    let mut buffer = [0_u8; 8192];
+    let mut truncated = false;
+
+    loop {
+        let read = match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+            Err(_) => return String::new(),
+        };
+        let available = MAX_STDERR_CAPTURE_BYTES.saturating_sub(retained.len());
+        let keep = read.min(available);
+        retained.extend_from_slice(&buffer[..keep]);
+        truncated |= keep < read;
+    }
+
+    if truncated {
+        let payload_cap = MAX_STDERR_CAPTURE_BYTES.saturating_sub(STDERR_TRUNCATION_MARKER.len());
+        retained.truncate(payload_cap);
+        retained.extend_from_slice(STDERR_TRUNCATION_MARKER);
+    }
+    String::from_utf8_lossy(&retained).into_owned()
 }
 
 /// Kills and reaps a child whose streamed output could not be parsed, then
@@ -120,9 +153,7 @@ pub(crate) fn terminate_child(mut child: Child, stderr_drain: StderrDrain) {
     let _ = child.kill();
     let _ = child.wait();
     // A short grace period only; orphans holding the pipe must not stall us.
-    let _ = stderr_drain
-        .receiver
-        .recv_timeout(Duration::from_millis(250));
+    let _ = stderr_drain.receiver.recv_timeout(STDERR_DRAIN_GRACE);
 }
 
 /// Outcome of [`c_style_unquote`].
@@ -280,6 +311,32 @@ mod tests {
                 .kind(),
             ErrorKind::InvalidData
         );
+    }
+
+    #[test]
+    fn stderr_capture_is_bounded_while_the_reader_drains_to_eof() {
+        let stderr = io::Cursor::new(vec![b'x'; MAX_STDERR_CAPTURE_BYTES * 2]);
+        let captured = drain_stderr(stderr).finish();
+
+        assert_eq!(captured.len(), MAX_STDERR_CAPTURE_BYTES);
+        assert!(captured.starts_with("xxxxxxxx"));
+        assert!(captured.ends_with("\n[stderr truncated]\n"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stderr_finish_is_bounded_when_an_inherited_writer_stays_open() {
+        use std::os::unix::net::UnixStream;
+        use std::time::Instant;
+
+        let (reader, inherited_writer) = UnixStream::pair().unwrap();
+        let drain = drain_stderr(reader);
+        let started = Instant::now();
+
+        assert_eq!(drain.finish(), "");
+        assert!(started.elapsed() < Duration::from_secs(2));
+
+        drop(inherited_writer);
     }
 
     #[test]

--- a/src/git_stream.rs
+++ b/src/git_stream.rs
@@ -1,0 +1,300 @@
+use std::io::{self, BufRead, ErrorKind, Read};
+use std::process::Child;
+use std::sync::mpsc::{Receiver, channel};
+use std::thread;
+use std::time::Duration;
+
+/// Upper bound for one unified-diff body line. Real Rust sources stay far
+/// below this; the bound exists so a hostile or corrupt stream cannot force an
+/// unbounded allocation before Cultist fails closed.
+pub(crate) const MAX_DIFF_LINE_BYTES: usize = 16 * 1024 * 1024;
+
+/// Upper bound for one `git log` metadata or path line (SHAs, dates, subjects,
+/// changed paths). Subjects and paths beyond this size are treated as malformed.
+pub(crate) const MAX_LOG_LINE_BYTES: usize = 64 * 1024;
+
+/// Upper bound for one `--name-only` path line.
+pub(crate) const MAX_PATH_LINE_BYTES: usize = 8 * 1024;
+
+/// Reads one line into `line`, including its `\n` delimiter, mirroring
+/// [`BufRead::read_line`] semantics while refusing to buffer more than
+/// `max_bytes`. Returns the number of bytes read; `Ok(0)` marks end of stream.
+/// A longer line fails closed with [`ErrorKind::InvalidData`] instead of
+/// growing the allocation.
+pub(crate) fn read_line_bounded<R: BufRead>(
+    reader: &mut R,
+    line: &mut Vec<u8>,
+    max_bytes: usize,
+) -> io::Result<usize> {
+    line.clear();
+    let mut total = 0_usize;
+
+    loop {
+        let available = match reader.fill_buf() {
+            Ok(available) => available,
+            Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        };
+        if available.is_empty() {
+            return Ok(total);
+        }
+
+        let consumed = match available.iter().position(|byte| *byte == b'\n') {
+            Some(newline) => newline + 1,
+            None => available.len(),
+        };
+
+        if total + consumed > max_bytes {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!("streamed line exceeded {max_bytes} bytes"),
+            ));
+        }
+        line.extend_from_slice(&available[..consumed]);
+        reader.consume(consumed);
+        total += consumed;
+
+        if line.ends_with(b"\n") {
+            return Ok(total);
+        }
+    }
+}
+
+/// Reads one bounded UTF-8 text line, trimming nothing. `Ok(0)` marks EOF.
+pub(crate) fn read_text_line_bounded<R: BufRead>(
+    reader: &mut R,
+    text: &mut String,
+    scratch: &mut Vec<u8>,
+    max_bytes: usize,
+) -> io::Result<usize> {
+    let read = read_line_bounded(reader, scratch, max_bytes)?;
+    if read == 0 {
+        text.clear();
+        return Ok(0);
+    }
+    let decoded = std::str::from_utf8(scratch)
+        .map_err(|_| io::Error::new(ErrorKind::InvalidData, "streamed line is not valid UTF-8"))?;
+    text.clear();
+    text.push_str(decoded);
+    Ok(read)
+}
+
+/// Handle to a child's stderr being drained on a worker thread so a chatty
+/// child cannot deadlock on a full pipe while stdout is being parsed.
+pub(crate) struct StderrDrain {
+    receiver: Receiver<String>,
+}
+
+impl StderrDrain {
+    /// Waits for the drain to finish and returns the captured text (lossily
+    /// decoded). Call only once the child has been waited on normally; orphaned
+    /// grandchildren can hold the pipe open, so the termination path uses
+    /// [`terminate_child`] instead.
+    pub(crate) fn finish(self) -> String {
+        self.receiver.recv().unwrap_or_default()
+    }
+}
+
+/// Spawns a background drainer for a child's stderr. The returned handle
+/// yields the captured text once joined via [`StderrDrain::finish`].
+pub(crate) fn drain_stderr<R: Read + Send + 'static>(stderr: R) -> StderrDrain {
+    let (sender, receiver) = channel();
+    thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let text = match io::BufReader::new(stderr).read_to_end(&mut bytes) {
+            Ok(_) => String::from_utf8_lossy(&bytes).into_owned(),
+            Err(_) => String::new(),
+        };
+        let _ = sender.send(text);
+    });
+    StderrDrain { receiver }
+}
+
+/// Kills and reaps a child whose streamed output could not be parsed, then
+/// collects whatever stderr was drained within a short grace period.
+///
+/// The grace period matters because killed parents can leave orphaned
+/// descendants holding the stderr write end; blocking on full EOF there would
+/// stall error reporting on processes Cultist does not own.
+pub(crate) fn terminate_child(mut child: Child, stderr_drain: StderrDrain) {
+    let _ = child.kill();
+    let _ = child.wait();
+    // A short grace period only; orphans holding the pipe must not stall us.
+    let _ = stderr_drain
+        .receiver
+        .recv_timeout(Duration::from_millis(250));
+}
+
+/// Outcome of [`c_style_unquote`].
+pub(crate) enum UnquotedPath {
+    /// The token was not C-quoted; it is used verbatim.
+    Verbatim,
+    /// The token was quoted and decoded successfully into raw path bytes.
+    Decoded(Vec<u8>),
+}
+
+/// Decodes a Git C-style quoted path token (`"..."` with `\"`, `\\`,
+/// `\a b f n r t v`, and three-digit octal escapes). Returns
+/// [`UnquotedPath::Verbatim`] when the token does not start with a quote, and
+/// an error when it is quoted but malformed.
+pub(crate) fn c_style_unquote(token: &str) -> Result<UnquotedPath, String> {
+    if !token.starts_with('"') {
+        return Ok(UnquotedPath::Verbatim);
+    }
+    if token.len() < 2 || !token.ends_with('"') {
+        return Err("quoted path is missing its closing quote".to_string());
+    }
+
+    let inner = &token[1..token.len() - 1];
+    let mut bytes = Vec::with_capacity(inner.len());
+    let mut chars = inner.chars();
+    while let Some(char) = chars.next() {
+        match char {
+            '"' => return Err("quoted path contains a raw double quote".to_string()),
+            '\\' => {
+                let escape = chars
+                    .next()
+                    .ok_or_else(|| "quoted path ends with a dangling backslash".to_string())?;
+                match escape {
+                    '"' => bytes.push(b'"'),
+                    '\\' => bytes.push(b'\\'),
+                    'a' => bytes.push(0x07),
+                    'b' => bytes.push(0x08),
+                    'f' => bytes.push(0x0c),
+                    'n' => bytes.push(b'\n'),
+                    'r' => bytes.push(b'\r'),
+                    't' => bytes.push(b'\t'),
+                    'v' => bytes.push(0x0b),
+                    '0'..='7' => {
+                        let mut value = escape.to_digit(8).expect("octal digit");
+                        for _ in 0..2 {
+                            let digit = chars.next().ok_or_else(|| {
+                                "quoted path octal escape is truncated".to_string()
+                            })?;
+                            value = value * 8
+                                + digit
+                                    .to_digit(8)
+                                    .ok_or("quoted path octal escape has a non-octal digit")?;
+                        }
+                        if value > u8::MAX as u32 {
+                            return Err("quoted path octal escape exceeds one byte".to_string());
+                        }
+                        bytes.push(value as u8);
+                    }
+                    other => {
+                        return Err(format!("quoted path uses unsupported escape `\\{other}`"));
+                    }
+                }
+            }
+            other => {
+                let mut buffer = [0_u8; 4];
+                bytes.extend_from_slice(other.encode_utf8(&mut buffer).as_bytes());
+            }
+        }
+    }
+
+    Ok(UnquotedPath::Decoded(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bounded_lines(input: &[u8], max: usize) -> Vec<String> {
+        let mut reader = io::Cursor::new(input);
+        let mut text = String::new();
+        let mut scratch = Vec::new();
+        let mut lines = Vec::new();
+        loop {
+            let read = read_text_line_bounded(&mut reader, &mut text, &mut scratch, max).unwrap();
+            if read == 0 {
+                break;
+            }
+            lines.push(text.trim_end_matches(['\n', '\r']).to_string());
+        }
+        lines
+    }
+
+    #[test]
+    fn reads_lines_with_and_without_trailing_newlines() {
+        assert_eq!(
+            bounded_lines(b"one\ntwo\nthree", 1024),
+            vec!["one".to_string(), "two".to_string(), "three".to_string()]
+        );
+        assert!(bounded_lines(b"", 16).is_empty());
+    }
+
+    #[test]
+    fn fragmented_fills_reassemble_exactly() {
+        struct Trickle<R> {
+            inner: R,
+        }
+        impl<R: Read> Read for Trickle<R> {
+            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+                if buf.is_empty() {
+                    return Ok(0);
+                }
+                buf[0] = 0;
+                self.inner.read(&mut buf[..1])
+            }
+        }
+
+        let mut reader = io::BufReader::new(Trickle {
+            inner: io::Cursor::new(b"alpha\r\nbeta\n".to_vec()),
+        });
+        let mut text = String::new();
+        let mut scratch = Vec::new();
+        let mut lines = Vec::new();
+        while read_text_line_bounded(&mut reader, &mut text, &mut scratch, 64).unwrap() != 0 {
+            lines.push(text.trim_end_matches(['\n', '\r']).to_string());
+        }
+        assert_eq!(lines, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn over_limit_lines_fail_closed_with_invalid_data() {
+        let mut reader = io::Cursor::new(b"ok\nway-too-long\n".to_vec());
+        let mut text = String::new();
+        let mut scratch = Vec::new();
+        assert_eq!(
+            read_text_line_bounded(&mut reader, &mut text, &mut scratch, 3).unwrap(),
+            3
+        );
+        assert_eq!(text.trim_end_matches(['\n']), "ok");
+        assert_eq!(
+            read_text_line_bounded(&mut reader, &mut text, &mut scratch, 3)
+                .unwrap_err()
+                .kind(),
+            ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn non_utf8_lines_fail_closed() {
+        let mut reader = io::Cursor::new(vec![b'a', 0xff, b'\n']);
+        let mut text = String::new();
+        let mut scratch = Vec::new();
+        assert_eq!(
+            read_text_line_bounded(&mut reader, &mut text, &mut scratch, 64)
+                .unwrap_err()
+                .kind(),
+            ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn decodes_git_c_style_paths() {
+        use UnquotedPath::*;
+        assert!(matches!(c_style_unquote("src/plain.rs").unwrap(), Verbatim));
+        match c_style_unquote(r#""src/we\tird\\\303\251.rs""#).unwrap() {
+            Decoded(bytes) => {
+                assert_eq!(String::from_utf8(bytes).unwrap(), "src/we\tird\\\u{e9}.rs")
+            }
+            Verbatim => panic!("quoted token must decode"),
+        }
+        assert!(c_style_unquote(r#""dangling\.rs"#).is_err());
+        assert!(c_style_unquote(r#""bad \q escape""#).is_err());
+        assert!(c_style_unquote(r#""truncated \12""#).is_err());
+        assert!(c_style_unquote("\"unterminated").is_err());
+    }
+}

--- a/src/history.rs
+++ b/src/history.rs
@@ -778,6 +778,10 @@ mod tests {
         run_git(&root, &["init", "-q"]);
         run_git(&root, &["config", "user.email", "cultist@example.invalid"]);
         run_git(&root, &["config", "user.name", "Cargo Cultist Tests"]);
+        // This fixture creates enough loose objects to trigger detached Git
+        // auto-maintenance on some CI runners. Keep cleanup deterministic: the
+        // fixture tests Cultist's streaming/accounting, not Git's GC policy.
+        run_git(&root, &["config", "gc.auto", "0"]);
 
         fs::write(root.join("anchor.rs"), "fn anchor() {}\n").unwrap();
         run_git(&root, &["add", "."]);

--- a/src/history.rs
+++ b/src/history.rs
@@ -5,11 +5,11 @@ use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::process::Command;
-use std::process::{Child, Stdio};
-use std::thread;
+use std::process::Stdio;
 
 use serde::Serialize;
 
+use crate::git_stream::{self, MAX_LOG_LINE_BYTES, drain_stderr, terminate_child};
 use crate::performance;
 
 pub const HISTORY_REPORT_SCHEMA_VERSION: u32 = 1;
@@ -326,35 +326,19 @@ fn read_anchor_history(
     let parsed = match stream_history_log(BufReader::new(stdout), options.max_paths_per_commit) {
         Ok(parsed) => parsed,
         Err(error) => {
-            terminate_git_log(child, stderr_reader);
+            terminate_child(child, stderr_reader);
             return Err(error.into());
         }
     };
 
     let status = child.wait()?;
-    let stderr_text = stderr_reader.join().unwrap_or_default();
+    let stderr_text = stderr_reader.finish();
 
     if !status.success() {
         return Err(format!("git log failed for {}: {stderr_text}", anchor.display()).into());
     }
 
     parsed.ok_or_else(|| format!("could not parse git history for {}", anchor.display()).into())
-}
-
-fn drain_stderr<R: Read + Send + 'static>(stderr: R) -> thread::JoinHandle<String> {
-    thread::spawn(move || {
-        let mut bytes = Vec::new();
-        match BufReader::new(stderr).read_to_end(&mut bytes) {
-            Ok(_) => String::from_utf8_lossy(&bytes).into_owned(),
-            Err(_) => String::new(),
-        }
-    })
-}
-
-fn terminate_git_log(mut child: Child, stderr_reader: thread::JoinHandle<String>) {
-    let _ = child.kill();
-    let _ = child.wait();
-    let _ = stderr_reader.join();
 }
 
 fn stream_history_log<R: BufRead>(
@@ -365,10 +349,16 @@ fn stream_history_log<R: BufRead>(
     let mut current: Option<RecordAccumulator> = None;
     let mut malformed = false;
     let mut line = String::new();
+    let mut scratch = Vec::new();
 
     loop {
-        line.clear();
-        if reader.read_line(&mut line)? == 0 {
+        if git_stream::read_text_line_bounded(
+            &mut reader,
+            &mut line,
+            &mut scratch,
+            MAX_LOG_LINE_BYTES,
+        )? == 0
+        {
             break;
         }
         if malformed {
@@ -777,6 +767,95 @@ mod tests {
         assert_eq!(excluded.changed_paths, 6);
 
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn mass_commit_crossing_threshold_retains_no_path_strings_and_counts_exactly() {
+        const MASS_PATHS: usize = 250;
+        let root = unique_temp_dir("mass-commit");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(root.join("mass")).unwrap();
+        run_git(&root, &["init", "-q"]);
+        run_git(&root, &["config", "user.email", "cultist@example.invalid"]);
+        run_git(&root, &["config", "user.name", "Cargo Cultist Tests"]);
+
+        fs::write(root.join("anchor.rs"), "fn anchor() {}\n").unwrap();
+        run_git(&root, &["add", "."]);
+        run_git(&root, &["commit", "-q", "-m", "baseline"]);
+
+        for index in 0..MASS_PATHS {
+            fs::write(
+                root.join(format!("mass/companion_{index:03}.rs")),
+                format!("fn companion_{index}() {{}}\n"),
+            )
+            .unwrap();
+        }
+        fs::write(root.join("anchor.rs"), "fn anchor_mass() {}\n").unwrap();
+        run_git(&root, &["add", "."]);
+        run_git(&root, &["commit", "-q", "-m", "tree-wide mass change"]);
+
+        let report = analyze_historical_companions(
+            &root,
+            Path::new("anchor.rs"),
+            HistoryOptions {
+                max_commits: 10,
+                ..HistoryOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(report.discovered_commits, 2);
+        assert_eq!(report.considered_commits, 1);
+        assert_eq!(report.excluded_commits.len(), 1);
+        let excluded = &report.excluded_commits[0];
+        // Exact accounting survives the threshold crossing: anchor + companions.
+        assert_eq!(excluded.changed_paths, MASS_PATHS + 1);
+
+        // Structural memory proxy: the retained set for the broad commit is
+        // empty even though the exact path count is reported. Reading the raw
+        // stream again with the same accumulator keeps every retained string
+        // bounded by the threshold.
+        let streamed = stream_history_log(
+            Cursor::new(read_log_output(&root, Path::new("anchor.rs"))),
+            DEFAULT_MAX_PATHS_PER_COMMIT,
+        )
+        .unwrap()
+        .unwrap();
+        let broad = streamed
+            .iter()
+            .find(|commit| commit.summary.subject == "tree-wide mass change")
+            .unwrap();
+        assert!(broad.paths.is_empty());
+        assert_eq!(broad.changed_paths, MASS_PATHS + 1);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    fn read_log_output(root: &Path, anchor: &Path) -> Vec<u8> {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args([
+                "-c",
+                "core.quotepath=false",
+                "log",
+                "--format=%x1e%H%x1f%cI%x1f%s",
+                "--name-only",
+                "--no-renames",
+                "--no-color",
+                "--no-ext-diff",
+                "--root",
+                "--no-merges",
+                "--full-diff",
+                "-n",
+                "10",
+                "--",
+            ])
+            .arg(anchor)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        output.stdout
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod ci_test_filters;
 mod diff;
 mod finding;
 mod generated_diff;
+mod git_stream;
 mod history;
 mod performance;
 mod preflight;
@@ -17,6 +18,7 @@ mod test_modules;
 
 use std::env;
 use std::error::Error;
+use std::io::{self, BufWriter, Write as _};
 use std::path::PathBuf;
 use std::process;
 
@@ -29,7 +31,6 @@ use history::{
 };
 use preflight::build_preflight_analysis_report;
 use provider_snapshot_applicability::ProviderSnapshotIdentity;
-use render::render_analysis_report;
 use report::build_test_module_analysis;
 use test_modules::analyze_test_modules;
 
@@ -204,17 +205,20 @@ fn run_preflight(args: Vec<String>) -> Result<(), Box<dyn Error>> {
 }
 
 fn emit_analysis(analysis: &AnalysisReport, format: OutputFormat) -> Result<(), Box<dyn Error>> {
+    let stdout = io::stdout();
+    let mut writer = BufWriter::new(stdout.lock());
     match format {
         OutputFormat::Text => {
-            println!("cargo-cultist {VERSION}");
-            println!("repository: {}\n", analysis.repository);
-            print!("{}", render_analysis_report(analysis));
+            writeln!(writer, "cargo-cultist {VERSION}")?;
+            writeln!(writer, "repository: {}\n", analysis.repository)?;
+            render::write_analysis_report(&mut writer, analysis)?;
         }
         OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(analysis)?);
+            serde_json::to_writer_pretty(&mut writer, analysis)?;
+            writeln!(writer)?;
         }
     }
-
+    writer.flush()?;
     Ok(())
 }
 
@@ -268,7 +272,11 @@ fn run_history(args: Vec<String>) -> Result<(), Box<dyn Error>> {
             print_history_report(&report);
         }
         OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&report)?);
+            let stdout = io::stdout();
+            let mut writer = BufWriter::new(stdout.lock());
+            serde_json::to_writer_pretty(&mut writer, &report)?;
+            writeln!(writer)?;
+            writer.flush()?;
         }
     }
 
@@ -612,6 +620,31 @@ are represented as UNKNOWN until authoritative test-listing evidence exists."#
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::finding::{Claim, ClaimKind};
+
+    #[test]
+    fn json_writer_emission_matches_serde_string_bytes() {
+        let analysis = AnalysisReport {
+            schema_version: 1,
+            analysis: "diff-precedent".to_string(),
+            repository: "/r\u{e9}po".to_string(),
+            claims: vec![
+                Claim::new(ClaimKind::Derived, "First claim."),
+                Claim::new(
+                    ClaimKind::Unknown,
+                    "Unicode \u{00fc}n\u{ed}code and \"quotes\" survive identically.",
+                ),
+            ],
+            findings: Vec::new(),
+        };
+
+        let mut streamed = Vec::new();
+        serde_json::to_writer_pretty(&mut streamed, &analysis).unwrap();
+        writeln!(streamed).unwrap();
+
+        let expected = format!("{}\n", serde_json::to_string_pretty(&analysis).unwrap());
+        assert_eq!(streamed, expected.into_bytes());
+    }
 
     #[test]
     fn recognizes_check_and_diff_as_the_same_change_command() {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,5 +1,5 @@
 use std::fmt::Write as _;
-use std::io;
+use std::io::{self, Write as _};
 
 use crate::finding::{AnalysisReport, Claim, ClaimKind, Evidence, Finding, Location};
 
@@ -20,19 +20,65 @@ pub fn write_analysis_report<W: io::Write>(
     writer: &mut W,
     report: &AnalysisReport,
 ) -> io::Result<()> {
+    let mut writer = TrackingWriter::new(writer);
     writeln!(writer, "{}", analysis_title(&report.analysis))?;
-    let mut started = true;
 
     for claim in &report.claims {
-        write_claim(writer, claim, 0, &mut started)?;
+        write_claim(&mut writer, claim, 0)?;
     }
 
     for (index, finding) in report.findings.iter().enumerate() {
         writeln!(writer, "\nFINDING {}: {}", index + 1, finding.title)?;
-        write_finding(writer, finding, &mut started)?;
+        write_finding(&mut writer, finding)?;
     }
 
     Ok(())
+}
+
+/// Writer state needed to preserve the historical renderer's separator rule
+/// without retaining the whole report: insert a separator only when emitted
+/// bytes do not already end in a blank line.
+struct TrackingWriter<'a, W> {
+    inner: &'a mut W,
+    bytes_written: usize,
+    trailing_newlines: u8,
+}
+
+impl<'a, W> TrackingWriter<'a, W> {
+    fn new(inner: &'a mut W) -> Self {
+        Self {
+            inner,
+            bytes_written: 0,
+            trailing_newlines: 0,
+        }
+    }
+
+    fn has_output(&self) -> bool {
+        self.bytes_written > 0
+    }
+
+    fn ends_with_blank_line(&self) -> bool {
+        self.trailing_newlines >= 2
+    }
+}
+
+impl<W: io::Write> io::Write for TrackingWriter<'_, W> {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buffer)?;
+        self.bytes_written = self.bytes_written.saturating_add(written);
+        for byte in &buffer[..written] {
+            self.trailing_newlines = if *byte == b'\n' {
+                self.trailing_newlines.saturating_add(1).min(2)
+            } else {
+                0
+            };
+        }
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
 }
 
 /// Experimental agent-oriented projection over the same canonical AnalysisReport.
@@ -92,16 +138,15 @@ pub fn render_terse_analysis_report(report: &AnalysisReport) -> String {
 }
 
 fn write_finding<W: io::Write>(
-    writer: &mut W,
+    writer: &mut TrackingWriter<'_, W>,
     finding: &Finding,
-    started: &mut bool,
 ) -> io::Result<()> {
     if let Some(location) = &finding.location {
         writeln!(writer, "  at {}", format_location(location))?;
     }
 
     for claim in &finding.claims {
-        write_claim(writer, claim, 2, started)?;
+        write_claim(writer, claim, 2)?;
     }
 
     if let Some(question) = &finding.question {
@@ -113,19 +158,13 @@ fn write_finding<W: io::Write>(
 }
 
 fn write_claim<W: io::Write>(
-    writer: &mut W,
+    writer: &mut TrackingWriter<'_, W>,
     claim: &Claim,
     indent: usize,
-    started: &mut bool,
 ) -> io::Result<()> {
-    // Every block ends with exactly one newline, so a separator blank line is
-    // required exactly when something has already been written. This mirrors
-    // the historical "not empty and not ending on a blank line" rule without
-    // inspecting accumulated bytes.
-    if *started {
+    if writer.has_output() && !writer.ends_with_blank_line() {
         writer.write_all(b"\n")?;
     }
-    *started = true;
 
     let prefix = " ".repeat(indent);
     writeln!(writer, "{prefix}{}", claim_kind_label(claim.kind))?;
@@ -139,7 +178,7 @@ fn write_claim<W: io::Write>(
 }
 
 fn write_evidence<W: io::Write>(
-    writer: &mut W,
+    writer: &mut TrackingWriter<'_, W>,
     evidence: &Evidence,
     indent: usize,
 ) -> io::Result<()> {
@@ -247,6 +286,27 @@ mod tests {
             write_analysis_report(&mut streamed, report).unwrap();
             assert_eq!(streamed, render_analysis_report(report).into_bytes());
         }
+    }
+
+    #[test]
+    fn preserves_historical_separators_after_trailing_newlines() {
+        let report = sample_report(
+            vec![
+                Claim::new(ClaimKind::Proven, "First claim already ends a line.\n"),
+                Claim::new(ClaimKind::Unknown, "Second claim.")
+                    .with_evidence(Evidence::new("Evidence already ends a line.\n")),
+                Claim::new(ClaimKind::Derived, "Third claim."),
+            ],
+            Vec::new(),
+        );
+
+        let mut streamed = Vec::new();
+        write_analysis_report(&mut streamed, &report).unwrap();
+
+        assert_eq!(
+            String::from_utf8(streamed).unwrap(),
+            "DIFF PRECEDENT\n\nPROVEN\n  First claim already ends a line.\n\nUNKNOWN\n  Second claim.\n  - Evidence already ends a line.\n\nDERIVED\n  Third claim.\n"
+        );
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,21 +1,38 @@
-use std::fmt::Write;
+use std::fmt::Write as _;
+use std::io;
 
 use crate::finding::{AnalysisReport, Claim, ClaimKind, Evidence, Finding, Location};
 
+/// Renders the canonical text projection into an owned string.
+///
+/// Equivalent byte-for-byte to [`write_analysis_report`]; kept for callers
+/// that need the rendered report as a value.
+#[allow(dead_code)]
 pub fn render_analysis_report(report: &AnalysisReport) -> String {
-    let mut output = String::new();
-    writeln!(output, "{}", analysis_title(&report.analysis)).unwrap();
+    let mut buffer = Vec::new();
+    write_analysis_report(&mut buffer, report).expect("writing into a Vec cannot fail");
+    String::from_utf8(buffer).expect("the text renderer only writes UTF-8")
+}
+
+/// Streams the canonical text projection straight into `writer` without
+/// building an output-sized intermediate string.
+pub fn write_analysis_report<W: io::Write>(
+    writer: &mut W,
+    report: &AnalysisReport,
+) -> io::Result<()> {
+    writeln!(writer, "{}", analysis_title(&report.analysis))?;
+    let mut started = true;
 
     for claim in &report.claims {
-        write_claim(&mut output, claim, 0);
+        write_claim(writer, claim, 0, &mut started)?;
     }
 
     for (index, finding) in report.findings.iter().enumerate() {
-        writeln!(output, "\nFINDING {}: {}", index + 1, finding.title).unwrap();
-        write_finding(&mut output, finding);
+        writeln!(writer, "\nFINDING {}: {}", index + 1, finding.title)?;
+        write_finding(writer, finding, &mut started)?;
     }
 
-    output
+    Ok(())
 }
 
 /// Experimental agent-oriented projection over the same canonical AnalysisReport.
@@ -74,46 +91,67 @@ pub fn render_terse_analysis_report(report: &AnalysisReport) -> String {
     output
 }
 
-fn write_finding(output: &mut String, finding: &Finding) {
+fn write_finding<W: io::Write>(
+    writer: &mut W,
+    finding: &Finding,
+    started: &mut bool,
+) -> io::Result<()> {
     if let Some(location) = &finding.location {
-        writeln!(output, "  at {}", format_location(location)).unwrap();
+        writeln!(writer, "  at {}", format_location(location))?;
     }
 
     for claim in &finding.claims {
-        write_claim(output, claim, 2);
+        write_claim(writer, claim, 2, started)?;
     }
 
     if let Some(question) = &finding.question {
-        writeln!(output, "\nQUESTION").unwrap();
-        writeln!(output, "  {question}").unwrap();
+        writeln!(writer, "\nQUESTION")?;
+        writeln!(writer, "  {question}")?;
     }
+
+    Ok(())
 }
 
-fn write_claim(output: &mut String, claim: &Claim, indent: usize) {
-    if !output.is_empty() && !output.ends_with("\n\n") {
-        output.push('\n');
+fn write_claim<W: io::Write>(
+    writer: &mut W,
+    claim: &Claim,
+    indent: usize,
+    started: &mut bool,
+) -> io::Result<()> {
+    // Every block ends with exactly one newline, so a separator blank line is
+    // required exactly when something has already been written. This mirrors
+    // the historical "not empty and not ending on a blank line" rule without
+    // inspecting accumulated bytes.
+    if *started {
+        writer.write_all(b"\n")?;
     }
+    *started = true;
 
     let prefix = " ".repeat(indent);
-    writeln!(output, "{prefix}{}", claim_kind_label(claim.kind)).unwrap();
-    writeln!(output, "{prefix}  {}", claim.message).unwrap();
+    writeln!(writer, "{prefix}{}", claim_kind_label(claim.kind))?;
+    writeln!(writer, "{prefix}  {}", claim.message)?;
 
     for evidence in &claim.evidence {
-        write_evidence(output, evidence, indent + 2);
+        write_evidence(writer, evidence, indent + 2)?;
     }
+
+    Ok(())
 }
 
-fn write_evidence(output: &mut String, evidence: &Evidence, indent: usize) {
+fn write_evidence<W: io::Write>(
+    writer: &mut W,
+    evidence: &Evidence,
+    indent: usize,
+) -> io::Result<()> {
     let prefix = " ".repeat(indent);
     match &evidence.location {
         Some(location) => writeln!(
-            output,
+            writer,
             "{prefix}- {} ({})",
             evidence.message,
             format_location(location)
-        )
-        .unwrap(),
-        None => writeln!(output, "{prefix}- {}", evidence.message).unwrap(),
+        ),
+        None => writeln!(writer, "{prefix}- {}", evidence.message),
     }
 }
 
@@ -158,6 +196,58 @@ fn analysis_title(analysis: &str) -> String {
 mod tests {
     use super::*;
     use crate::finding::{Evidence, Finding};
+
+    fn sample_report(claims: Vec<Claim>, findings: Vec<Finding>) -> AnalysisReport {
+        AnalysisReport {
+            schema_version: 1,
+            analysis: "diff-precedent".to_string(),
+            repository: "/r\u{e9}po".to_string(),
+            claims,
+            findings,
+        }
+    }
+
+    #[test]
+    fn streamed_output_is_byte_identical_to_rendered_string() {
+        let fixtures = vec![
+            sample_report(Vec::new(), Vec::new()),
+            sample_report(
+                vec![
+                    Claim::new(ClaimKind::Derived, "First derived claim."),
+                    Claim::new(
+                        ClaimKind::Unknown,
+                        "Multi-line\nmessage with \u{00fc}n\u{ed}code and trailing spaces.  ",
+                    ),
+                ],
+                Vec::new(),
+            ),
+            sample_report(
+                Vec::new(),
+                vec![
+                    Finding::new("kind-a", "Finding without claims")
+                        .at(Location::new("src/a.rs", Some(7))),
+                    Finding::new("kind-b", "Finding with evidence")
+                        .at(Location::new("src/b.rs", None))
+                        .with_claim(
+                            Claim::new(ClaimKind::Observed, "Observed tension.").with_evidence(
+                                Evidence::at(
+                                    "Local precedent.",
+                                    Location::new("src/b.rs", Some(3)),
+                                ),
+                            ),
+                        )
+                        .with_claim(Claim::new(ClaimKind::Inferred, "Inferred scope."))
+                        .with_question("Which precedent governs?"),
+                ],
+            ),
+        ];
+
+        for report in &fixtures {
+            let mut streamed = Vec::new();
+            write_analysis_report(&mut streamed, report).unwrap();
+            assert_eq!(streamed, render_analysis_report(report).into_bytes());
+        }
+    }
 
     #[test]
     fn renders_provenance_and_evidence() {


### PR DESCRIPTION
Implements the streaming/representation slice of issue 51 on top of the history work already merged from #351.

## What changed

### Diff capture (src/diff.rs)
- `git diff --unified=0` streams through a piped stdout with a bounded line reader; stderr is piped and drained off-thread; exit status and captured stderr feed the failure message.
- Parse failures kill and reap the child. Termination uses a short grace period so an orphaned descendant holding the stderr write end cannot stall error reporting.
- The parser is now a counted-hunk state machine: hunk headers carry the new-side line count, so structural lines between files (`diff --git`, binary markers, mode lines) can never be mistaken for hunk content, and an added line whose content begins `+++ ` is correctly treated as hunk content.
- Malformed hunk headers, malformed body bytes, non-UTF-8, and over-limit lines fail closed (`InvalidData`) instead of silently skipping facts; hostile hunk numbers saturate instead of overflowing.

### Changed-line representation (src/diff.rs)
- Storage remains merged sorted inclusive ranges per path; membership is a `partition_point` interval search, logarithmic in hunk count.
- A deterministic fixture parses a million-line contiguous addition into exactly **1** range entry (~160 ms release, ~40 ms measured earlier in-process); a 50k-hunk sparse fixture keeps disjoint ranges with boundary-exact probes.

### Generated-companion analyzer (src/generated_diff.rs)
- Relation discovery now runs before the changed-path query; the query is restricted to this analyzer's exact file classes: `*.rs` plus each admitted relation's literal generated output via `:(literal)` pathspec magic (exact matching, no glob surprises).
- `git diff --name-only` streams line by line with bounded reads and Git C-style quoted-path decoding.
- The batched source-history log for one input streams like #351's history reader; once a commit crosses the 100-path threshold its retained path strings are dropped while counting continues, preserving exact counts for exclusion. End-to-end fixture: a 251-path mass commit reports `changed_paths == 251` and retains zero path strings.

### Report emission (src/main.rs, src/render.rs)
- JSON reports use `serde_json::to_writer_pretty` into a locked buffered stdout; text rendering streams through a writer. No output-sized intermediate string. Bytes are asserted identical to the previous string paths (unit tests cover unicode, quotes, empty claims/findings).

## Compatibility

- Merge-base, rename/path, hunk, added-line, and finding-line semantics are unchanged for well-formed Git output; all prior membership/cohort tests pass unmodified except where signatures moved to streams.
- Behavior changes only where the old parser would have been silently wrong: malformed hunks now error, counted hunks no longer misread header-shaped added content, duplicate-heavy commits past the broad threshold are excluded by counted totals (same contract as #351).
- Pathspec restriction is semantically lossless for downstream queries: only `.rs` membership and exact output membership are ever consulted; covered end-to-end including a non-`.rs` generated output whose presence suppresses the companion finding.

## Gates

- cargo fmt --check clean; cargo clippy --all-targets -- -D warnings clean
- Full suite: 1422 passed, 1 failed — `focused_source_values_and_focus_admission_survive_current_main`, which fails identically on clean main `844c22f` (hardcoded `git checkout master` vs local `init.defaultBranch=main`; pre-existing, environmental, untouched here).
- Release fixtures: million-line addition = 1 range entry; sparse 50k hunks pass; mass-commit accounting passes; child killed promptly on parse failure; 2 MiB stderr pressure does not deadlock.

## Remaining / follow-ups

- Peak-RSS benchmarking: portable in-process RSS across macOS/Linux is unreliable, so fixtures assert truthful structural proxies (range entries, retained path strings) as issue 51 allows; a subprocess-based RSS harness could land later under the performance program (#49).
- Pre-existing `master` checkout assumption in `tests/rust_edit_class_source_current_main.rs` deserves a tiny portability fix (separate change).

Closes nothing yet; draft until CI runs. References #51.
