### PR TITLE
#50: cache diff-time test-module baseline aggregates

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -10,9 +10,10 @@ use crate::git_stream::{
     self, MAX_DIFF_LINE_BYTES, UnquotedPath, drain_stderr, read_text_line_bounded, terminate_child,
 };
 use crate::performance;
+use crate::rust_facts::FactCache;
+use crate::test_module_aggregate::{ScopeCache, TestModulePrecedent, overlay_precedent_with};
 use crate::test_modules::{
-    TestModuleOccurrence, TestModuleReport, analyze_test_module_files,
-    analyze_test_modules_excluding,
+    TestModuleOccurrence, analyze_test_module_files, analyze_test_modules_excluding,
 };
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -99,6 +100,20 @@ pub fn build_diff_analysis_report(
     root: &Path,
     base: Option<&str>,
 ) -> Result<AnalysisReport, Box<dyn Error>> {
+    build_diff_analysis_report_with_caches(
+        root,
+        base,
+        FactCache::from_environment(),
+        ScopeCache::from_environment(),
+    )
+}
+
+pub(crate) fn build_diff_analysis_report_with_caches(
+    root: &Path,
+    base: Option<&str>,
+    fact_cache: Option<FactCache>,
+    scope_cache: Option<ScopeCache>,
+) -> Result<AnalysisReport, Box<dyn Error>> {
     let changed = git_diff_changed_lines(root, base)?;
 
     let mut analysis = AnalysisReport::new("diff-precedent", root.to_string_lossy().into_owned());
@@ -149,7 +164,17 @@ pub fn build_diff_analysis_report(
         return Ok(analysis);
     }
 
-    if changed_test_modules(root, &changed_report, &changed).is_empty() {
+    let relevant_changed_modules = changed_report
+        .occurrences
+        .iter()
+        .filter(|occurrence| {
+            occurrence
+                .path
+                .strip_prefix(root)
+                .is_ok_and(|path| changed.contains(path, occurrence.line))
+        })
+        .count();
+    if relevant_changed_modules == 0 {
         analysis.claims.push(Claim::new(
             ClaimKind::Observed,
             "No added or renamed test-gated module declarations were found in the diff.",
@@ -157,37 +182,88 @@ pub fn build_diff_analysis_report(
         return Ok(analysis);
     }
 
-    // A relevant declaration needs repository precedent. Reuse the changed
-    // files we already parsed and scan only the remaining Rust files.
-    let excluded_paths: BTreeSet<_> = changed_rust_paths.into_iter().collect();
+    // A relevant declaration needs repository precedent. Prefer combining
+    // the changed-file facts we already parsed with cached clean baseline
+    // aggregates, so a small diff never walks every remaining fact row. Any
+    // working state outside the overlay's exactness envelope — or any cache
+    // failure — falls back to the deterministic full scan below without
+    // altering findings.
+    let changed_paths: BTreeSet<_> = changed_rust_paths.iter().cloned().collect();
+    match overlay_precedent_with(
+        fact_cache.as_ref(),
+        scope_cache.as_ref(),
+        root,
+        &changed_paths,
+        &changed_report.occurrences,
+    ) {
+        Ok(Some(precedent)) => {
+            add_diff_findings(
+                root,
+                &changed_report.occurrences,
+                &changed,
+                &precedent,
+                &mut analysis,
+            );
+            return Ok(analysis);
+        }
+        // Dirty/staged/untracked/deleted states outside the changed set.
+        Ok(None) => {}
+        // Baseline aggregation is advisory; recompute from live facts.
+        Err(_) => {}
+    }
+
+    let excluded_paths = changed_paths;
     let mut report = analyze_test_modules_excluding(root, &excluded_paths)?;
     report.extend(changed_report);
 
-    add_diff_findings(root, &report, &changed, &mut analysis);
+    let precedent = TestModulePrecedent::from_occurrences(&report.occurrences);
+    add_diff_findings(
+        root,
+        &report.occurrences,
+        &changed,
+        &precedent,
+        &mut analysis,
+    );
     Ok(analysis)
 }
 
 fn add_diff_findings(
     root: &Path,
-    report: &TestModuleReport,
+    candidate_occurrences: &[TestModuleOccurrence],
     changed: &ChangedLines,
+    precedent: &TestModulePrecedent,
     analysis: &mut AnalysisReport,
 ) {
-    let changed_modules = changed_test_modules(root, report, changed);
+    let changed_modules: Vec<&TestModuleOccurrence> = candidate_occurrences
+        .iter()
+        .filter(|occurrence| {
+            occurrence
+                .path
+                .strip_prefix(root)
+                .is_ok_and(|path| changed.contains(path, occurrence.line))
+        })
+        .collect();
 
     for occurrence in changed_modules {
-        let local_names = same_file_names(report, occurrence);
+        let local_names: BTreeSet<String> = candidate_occurrences
+            .iter()
+            .filter(|other| {
+                other.path == occurrence.path
+                    && (other.line != occurrence.line || other.name != occurrence.name)
+            })
+            .map(|other| other.name.clone())
+            .collect();
         let different_local_names: Vec<_> = local_names
             .iter()
             .filter(|name| name.as_str() != occurrence.name)
             .cloned()
             .collect();
-        let precedent_counts = module_name_counts_excluding(report, occurrence);
+        let (precedent_counts, total_without_target) = precedent.excluding(&occurrence.name);
         let repository_count = precedent_counts
             .get(&occurrence.name)
             .copied()
             .unwrap_or_default();
-        let precedent_total = report.occurrences.len().saturating_sub(1);
+        let precedent_total = total_without_target;
         let one_off = repository_count == 0 && precedent_total > 0;
         let tension = precedent_tension(&precedent_counts, &local_names);
 
@@ -506,52 +582,6 @@ fn parse_diff_target(token: &str) -> io::Result<Option<PathBuf>> {
     }
 }
 
-fn changed_test_modules<'a>(
-    root: &Path,
-    report: &'a TestModuleReport,
-    changed: &ChangedLines,
-) -> Vec<&'a TestModuleOccurrence> {
-    report
-        .occurrences
-        .iter()
-        .filter(|occurrence| {
-            occurrence
-                .path
-                .strip_prefix(root)
-                .is_ok_and(|path| changed.contains(path, occurrence.line))
-        })
-        .collect()
-}
-
-fn module_name_counts_excluding(
-    report: &TestModuleReport,
-    target: &TestModuleOccurrence,
-) -> BTreeMap<String, usize> {
-    let mut counts = BTreeMap::new();
-    for occurrence in &report.occurrences {
-        if occurrence.path == target.path
-            && occurrence.line == target.line
-            && occurrence.name == target.name
-        {
-            continue;
-        }
-        *counts.entry(occurrence.name.clone()).or_default() += 1;
-    }
-    counts
-}
-
-fn same_file_names(report: &TestModuleReport, target: &TestModuleOccurrence) -> BTreeSet<String> {
-    report
-        .occurrences
-        .iter()
-        .filter(|occurrence| {
-            occurrence.path == target.path
-                && (occurrence.line != target.line || occurrence.name != target.name)
-        })
-        .map(|occurrence| occurrence.name.clone())
-        .collect()
-}
-
 fn repository_dominant_name(counts: &BTreeMap<String, usize>) -> Option<&str> {
     let dominant_count = counts.values().copied().max()?;
     let mut dominant = counts
@@ -639,6 +669,295 @@ mod tests {
         root
     }
 
+    // ---- diff-time baseline aggregate fixtures ---------------------------
+
+    struct IsolatedCaches {
+        fact_root: PathBuf,
+        scope_root: PathBuf,
+        base: PathBuf,
+    }
+
+    fn isolated_caches(name: &str) -> IsolatedCaches {
+        let base = unique_temp_dir(name);
+        let isolated = IsolatedCaches {
+            fact_root: base.join("facts"),
+            scope_root: base.join("scopes"),
+            base,
+        };
+        fs::create_dir_all(&isolated.fact_root).unwrap();
+        fs::create_dir_all(&isolated.scope_root).unwrap();
+        isolated
+    }
+
+    fn caches_for(isolated: &IsolatedCaches) -> (Option<FactCache>, Option<ScopeCache>) {
+        (
+            Some(FactCache {
+                root: isolated.fact_root.clone(),
+            }),
+            Some(ScopeCache {
+                root: isolated.scope_root.clone(),
+            }),
+        )
+    }
+
+    /// Seven-file repository with two directory scopes plus a root scope.
+    fn init_multi_scope_repo(name: &str) -> PathBuf {
+        let root = unique_temp_dir(name);
+        fs::create_dir_all(root.join("a")).unwrap();
+        fs::create_dir_all(root.join("b")).unwrap();
+        fs::write(root.join("README.md"), "baseline\n").unwrap();
+        fs::write(root.join("r.rs"), "#[cfg(test)]\nmod r_tests {}\n").unwrap();
+        for (dir, prefix, count) in [("a", "f", 3), ("b", "g", 3)] {
+            for index in 0..count {
+                let module = format!("{dir}_{prefix}{index}_tests");
+                fs::write(
+                    root.join(dir).join(format!("{prefix}{index}.rs")),
+                    format!("#[cfg(test)]\nmod {module} {{}}\n"),
+                )
+                .unwrap();
+            }
+        }
+        run_git(&root, &["init", "-q"]);
+        run_git(&root, &["config", "user.email", "cultist@example.invalid"]);
+        run_git(&root, &["config", "user.name", "Cargo Cultist Tests"]);
+        run_git(&root, &["add", "."]);
+        run_git(&root, &["commit", "-q", "-m", "baseline"]);
+        root
+    }
+
+    fn stage_append(root: &Path, relative: &str, addition: &str) {
+        let path = root.join(relative);
+        let mut current = fs::read_to_string(&path).unwrap();
+        current.push_str(addition);
+        fs::write(&path, current).unwrap();
+        run_git(root, &["add", relative]);
+    }
+
+    /// The deterministic pre-change behavior: scan everything except the
+    /// changed paths, then extend with the changed-file facts.
+    fn legacy_findings(root: &Path) -> Vec<Finding> {
+        let mut analysis =
+            AnalysisReport::new("diff-precedent", root.to_string_lossy().into_owned());
+        let changed = git_diff_changed_lines(root, None).unwrap();
+        let changed_rust_paths: Vec<_> = changed.rust_paths().map(|path| root.join(path)).collect();
+        assert!(
+            !changed_rust_paths.is_empty(),
+            "scenario must change Rust files"
+        );
+        let changed_report = analyze_test_module_files(&changed_rust_paths).unwrap();
+        assert!(changed_report.parse_failures.is_empty());
+        let excluded_paths: BTreeSet<_> = changed_rust_paths.into_iter().collect();
+        let mut report = analyze_test_modules_excluding(root, &excluded_paths).unwrap();
+        report.extend(changed_report);
+        let precedent = TestModulePrecedent::from_occurrences(&report.occurrences);
+        add_diff_findings(
+            root,
+            &report.occurrences,
+            &changed,
+            &precedent,
+            &mut analysis,
+        );
+        analysis.findings
+    }
+
+    fn findings_text(findings: &[Finding]) -> String {
+        findings
+            .iter()
+            .map(|finding| serde_json::to_string(finding).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn corrupt_scope_entries(scope_root: &Path) {
+        for entry in fs::read_dir(scope_root).unwrap().flatten() {
+            if entry.path().extension().and_then(|ext| ext.to_str()) == Some("json") {
+                fs::write(entry.path(), b"corrupted bytes").unwrap();
+            }
+        }
+    }
+
+    fn age_scope_entries(scope_root: &Path) {
+        for entry in fs::read_dir(scope_root).unwrap().flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let mut envelope: serde_json::Value =
+                serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+            envelope["schema_version"] = serde_json::Value::from(0);
+            fs::write(&path, serde_json::to_vec(&envelope).unwrap()).unwrap();
+        }
+    }
+
+    #[test]
+    fn warm_small_diff_matches_full_scan_and_scales_with_affected_scope() {
+        let root = init_multi_scope_repo("warm-small-diff");
+        let isolated = isolated_caches("warm-small-diff-caches");
+
+        stage_append(&root, "a/f0.rs", "\n#[cfg(test)]\nmod added_a_tests {}\n");
+        let (_, cold) = performance::capture(|| {
+            let (facts, scopes) = caches_for(&isolated);
+            build_diff_analysis_report_with_caches(&root, None, facts, scopes).unwrap()
+        });
+        // The staged edit makes `a/f0.rs` volatile, so it is parsed fresh as
+        // changed-file facts and never joins the clean scope tree: seven
+        // parses cover the changed file plus the six remaining clean rows.
+        assert_eq!(cold.rust_files_parsed, 7);
+        assert_eq!(cold.rust_cache_hits, 0);
+        assert_eq!(cold.baseline_scope_hits, 0);
+        assert_eq!(cold.baseline_scope_computed, 3);
+
+        stage_append(&root, "b/g1.rs", "\n#[cfg(test)]\nmod added_b_tests {}\n");
+        let (warm_analysis, warm) = performance::capture(|| {
+            let (facts, scopes) = caches_for(&isolated);
+            build_diff_analysis_report_with_caches(&root, None, facts, scopes).unwrap()
+        });
+
+        // Both staged files are reparsed as changed-file facts; everything
+        // else comes from caches: the sibling `a` scope is served whole and
+        // only the affected `b` scope plus the root fold recompute, so work
+        // scales with the affected scope instead of the repository rows.
+        assert_eq!(warm.rust_files_parsed, 2);
+        assert_eq!(warm.rust_cache_hits, 3);
+        assert_eq!(warm.baseline_scope_hits, 1);
+        assert_eq!(warm.baseline_scope_computed, 2);
+
+        let oracle = legacy_findings(&root);
+        assert_eq!(warm_analysis.findings.len(), 2);
+        assert_eq!(warm_analysis.findings, oracle);
+
+        let text = findings_text(&warm_analysis.findings);
+        assert!(text.contains("`added_b_tests` appears 0 time(s)"));
+        assert!(text.contains("`added_a_tests` appears 0 time(s)"));
+
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(isolated.base).unwrap();
+    }
+
+    #[test]
+    fn corrupt_baseline_cache_recomputes_without_altering_findings() {
+        let root = init_multi_scope_repo("corrupt-baseline");
+        let isolated = isolated_caches("corrupt-baseline-caches");
+
+        stage_append(&root, "a/f0.rs", "\n#[cfg(test)]\nmod added_a_tests {}\n");
+        let _ = performance::capture(|| {
+            let (facts, scopes) = caches_for(&isolated);
+            build_diff_analysis_report_with_caches(&root, None, facts, scopes)
+        });
+        corrupt_scope_entries(&isolated.scope_root);
+
+        let (analysis, counters) = performance::capture(|| {
+            let (facts, scopes) = caches_for(&isolated);
+            build_diff_analysis_report_with_caches(&root, None, facts, scopes).unwrap()
+        });
+
+        assert_eq!(counters.baseline_scope_hits, 0);
+        assert_eq!(counters.baseline_scope_computed, 3);
+        // Fact-layer reuse survives: corruption costs re-aggregation, not reparsing.
+        // The clean tree holds six rows (the staged file stays volatile).
+        assert_eq!(counters.rust_files_parsed, 1);
+        assert_eq!(counters.rust_cache_hits, 6);
+
+        assert_eq!(analysis.findings, legacy_findings(&root));
+
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(isolated.base).unwrap();
+    }
+
+    #[test]
+    fn version_old_baseline_cache_is_ignored_and_recomputed() {
+        let root = init_multi_scope_repo("stale-baseline-schema");
+        let isolated = isolated_caches("stale-baseline-caches");
+
+        stage_append(&root, "a/f0.rs", "\n#[cfg(test)]\nmod added_a_tests {}\n");
+        let _ = performance::capture(|| {
+            let (facts, scopes) = caches_for(&isolated);
+            build_diff_analysis_report_with_caches(&root, None, facts, scopes)
+        });
+        age_scope_entries(&isolated.scope_root);
+
+        let (analysis, counters) = performance::capture(|| {
+            let (facts, scopes) = caches_for(&isolated);
+            build_diff_analysis_report_with_caches(&root, None, facts, scopes).unwrap()
+        });
+
+        assert_eq!(counters.baseline_scope_hits, 0);
+        assert_eq!(counters.baseline_scope_computed, 3);
+        assert_eq!(analysis.findings, legacy_findings(&root));
+
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(isolated.base).unwrap();
+    }
+
+    #[test]
+    fn untracked_file_outside_diff_forces_exact_fallback() {
+        let root = init_multi_scope_repo("untracked-fallback");
+        let isolated = isolated_caches("untracked-fallback-caches");
+
+        stage_append(&root, "a/f0.rs", "\n#[cfg(test)]\nmod added_a_tests {}\n");
+        // Untracked files never appear in `git diff HEAD`, so this row sits
+        // outside the changed set and must invalidate the overlay instead of
+        // being dropped from the precedent counts.
+        fs::write(
+            root.join("scratch.rs"),
+            "#[cfg(test)]\nmod scratch_tests {}\n#[cfg(test)]\nmod added_a_tests {}\n",
+        )
+        .unwrap();
+
+        let (analysis, counters) = performance::capture(|| {
+            let (facts, scopes) = caches_for(&isolated);
+            build_diff_analysis_report_with_caches(&root, None, facts, scopes).unwrap()
+        });
+
+        assert_eq!(counters.baseline_scope_hits, 0);
+        assert_eq!(counters.baseline_scope_computed, 0);
+        assert_eq!(analysis.findings, legacy_findings(&root));
+
+        let text = findings_text(&analysis.findings);
+        assert!(
+            text.contains("`added_a_tests` appears 1 time(s)"),
+            "the untracked contribution must be counted exactly: {text}"
+        );
+
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(isolated.base).unwrap();
+    }
+
+    #[test]
+    fn deleted_file_updates_precedent_counts() {
+        let root = init_multi_scope_repo("deleted-scope");
+        let isolated = isolated_caches("deleted-scope-caches");
+        fs::create_dir_all(root.join("x")).unwrap();
+        fs::write(
+            root.join("x/only.rs"),
+            "#[cfg(test)]\nmod target_tests {}\n",
+        )
+        .unwrap();
+        run_git(&root, &["add", "x/only.rs"]);
+        run_git(&root, &["commit", "-q", "-m", "add target"]);
+
+        fs::remove_file(root.join("x/only.rs")).unwrap();
+        stage_append(&root, "a/f0.rs", "\n#[cfg(test)]\nmod target_tests {}\n");
+
+        let (analysis, counters) = performance::capture(|| {
+            let (facts, scopes) = caches_for(&isolated);
+            build_diff_analysis_report_with_caches(&root, None, facts, scopes).unwrap()
+        });
+
+        assert_eq!(counters.baseline_scope_hits, 0);
+        assert_eq!(counters.baseline_scope_computed, 3);
+        assert_eq!(analysis.findings, legacy_findings(&root));
+
+        let text = findings_text(&analysis.findings);
+        assert!(
+            text.contains("`target_tests` appears 0 time(s)"),
+            "the deleted file's declaration must leave the counts: {text}"
+        );
+
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(isolated.base).unwrap();
+    }
+
     #[test]
     fn detects_scope_tension_only_with_clear_precedent() {
         let counts = BTreeMap::from([("tests".to_string(), 33), ("unit_tests".to_string(), 88)]);
@@ -664,21 +983,42 @@ mod tests {
             path: root.join("src/lib.rs"),
             line: 40,
         };
-        let report = TestModuleReport {
-            occurrences: vec![
-                TestModuleOccurrence {
-                    name: "tests".to_string(),
-                    path: root.join("src/lib.rs"),
-                    line: 20,
-                },
-                changed.clone(),
-            ],
-            parse_failures: Vec::new(),
-        };
+        let occurrences = vec![
+            TestModuleOccurrence {
+                name: "tests".to_string(),
+                path: root.join("src/lib.rs"),
+                line: 20,
+            },
+            changed.clone(),
+        ];
 
-        let counts = module_name_counts_excluding(&report, &changed);
+        let precedent = TestModulePrecedent::from_occurrences(&occurrences);
+        let (counts, total) = precedent.excluding("unit_tests");
         assert_eq!(counts.get("tests"), Some(&1));
         assert_eq!(counts.get("unit_tests"), None);
+        assert_eq!(total, 1);
+    }
+
+    #[test]
+    fn precedent_excluding_keeps_same_name_occurrences_elsewhere() {
+        let root = Path::new("/repo");
+        let occurrences = vec![
+            TestModuleOccurrence {
+                name: "shared".to_string(),
+                path: root.join("src/a.rs"),
+                line: 10,
+            },
+            TestModuleOccurrence {
+                name: "shared".to_string(),
+                path: root.join("src/b.rs"),
+                line: 20,
+            },
+        ];
+        let precedent = TestModulePrecedent::from_occurrences(&occurrences);
+
+        let (counts, total) = precedent.excluding("shared");
+        assert_eq!(counts.get("shared"), Some(&1));
+        assert_eq!(total, 1);
     }
 
     #[test]
@@ -724,25 +1064,30 @@ mod tests {
     #[test]
     fn selects_test_modules_whose_declaration_line_was_added() {
         let root = Path::new("/repo");
-        let report = TestModuleReport {
-            occurrences: vec![
-                TestModuleOccurrence {
-                    name: "tests".to_string(),
-                    path: root.join("src/lib.rs"),
-                    line: 20,
-                },
-                TestModuleOccurrence {
-                    name: "special_tests".to_string(),
-                    path: root.join("src/lib.rs"),
-                    line: 40,
-                },
-            ],
-            parse_failures: Vec::new(),
-        };
+        let occurrences = [
+            TestModuleOccurrence {
+                name: "tests".to_string(),
+                path: root.join("src/lib.rs"),
+                line: 20,
+            },
+            TestModuleOccurrence {
+                name: "special_tests".to_string(),
+                path: root.join("src/lib.rs"),
+                line: 40,
+            },
+        ];
         let mut changed = ChangedLines::default();
         changed.insert(Path::new("src/lib.rs"), 40);
 
-        let selected = changed_test_modules(root, &report, &changed);
+        let selected: Vec<_> = occurrences
+            .iter()
+            .filter(|occurrence| {
+                occurrence
+                    .path
+                    .strip_prefix(root)
+                    .is_ok_and(|path| changed.contains(path, occurrence.line))
+            })
+            .collect();
         assert_eq!(selected.len(), 1);
         assert_eq!(selected[0].name, "special_tests");
     }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -789,6 +789,37 @@ mod tests {
         }
     }
 
+    /// Forges an aggregate payload that passes every pre-seal check: current
+    /// schema, matching fingerprint, and internally coherent count/total
+    /// arithmetic — while keeping the original integrity seal.
+    fn coherently_fabricate_scope_entries(scope_root: &Path) {
+        for entry in fs::read_dir(scope_root).unwrap().flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let mut envelope: serde_json::Value =
+                serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+            {
+                let counts = envelope
+                    .get_mut("name_counts")
+                    .and_then(|value| value.as_object_mut())
+                    .expect("aggregate entry must carry name_counts");
+                counts.insert(
+                    "fabricated_tests".to_string(),
+                    serde_json::Value::from(1_000),
+                );
+            }
+            let object = envelope.as_object_mut().unwrap();
+            let total = object
+                .get("total")
+                .and_then(|value| value.as_u64())
+                .unwrap_or_default();
+            object.insert("total".to_string(), serde_json::Value::from(total + 1_000));
+            fs::write(&path, serde_json::to_vec(&envelope).unwrap()).unwrap();
+        }
+    }
+
     #[test]
     fn warm_small_diff_matches_full_scan_and_scales_with_affected_scope() {
         let root = init_multi_scope_repo("warm-small-diff");
@@ -859,6 +890,49 @@ mod tests {
         assert_eq!(counters.rust_cache_hits, 6);
 
         assert_eq!(analysis.findings, legacy_findings(&root));
+
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(isolated.base).unwrap();
+    }
+
+    #[test]
+    fn coherently_fabricated_aggregates_miss_and_reproduce_full_scan_findings() {
+        let root = init_multi_scope_repo("fabricated-baseline");
+        let isolated = isolated_caches("fabricated-baseline-caches");
+
+        stage_append(&root, "a/f0.rs", "\n#[cfg(test)]\nmod added_a_tests {}\n");
+        let _ = performance::capture(|| {
+            let (facts, scopes) = caches_for(&isolated);
+            build_diff_analysis_report_with_caches(&root, None, facts, scopes)
+        });
+        coherently_fabricate_scope_entries(&isolated.scope_root);
+
+        // The forged entries carry the current schema, the correct
+        // fingerprint, and internally coherent arithmetic; only the stale
+        // integrity seal can reject them.
+        let (analysis, counters) = performance::capture(|| {
+            let (facts, scopes) = caches_for(&isolated);
+            build_diff_analysis_report_with_caches(&root, None, facts, scopes).unwrap()
+        });
+
+        assert_eq!(counters.baseline_scope_hits, 0);
+        assert_eq!(counters.baseline_scope_computed, 3);
+        let oracle = legacy_findings(&root);
+        assert_eq!(findings_text(&analysis.findings), findings_text(&oracle));
+
+        // Quarantine let the recompute repair every entry, so the warm path
+        // serves sealed aggregates again: one root-scope hit covers the whole
+        // tree, and findings stay identical.
+        let (repaired_analysis, repaired_counters) = performance::capture(|| {
+            let (facts, scopes) = caches_for(&isolated);
+            build_diff_analysis_report_with_caches(&root, None, facts, scopes).unwrap()
+        });
+        assert_eq!(repaired_counters.baseline_scope_hits, 1);
+        assert_eq!(repaired_counters.baseline_scope_computed, 0);
+        assert_eq!(
+            findings_text(&repaired_analysis.findings),
+            findings_text(&oracle)
+        );
 
         fs::remove_dir_all(root).unwrap();
         fs::remove_dir_all(isolated.base).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod provider_snapshot_applicability;
 mod render;
 mod report;
 mod rust_facts;
+mod test_module_aggregate;
 mod test_modules;
 
 use std::env;

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -21,6 +21,8 @@ pub struct PerfCounters {
     pub git_subprocesses: usize,
     pub rust_files_parsed: usize,
     pub rust_cache_hits: usize,
+    pub baseline_scope_hits: usize,
+    pub baseline_scope_computed: usize,
 }
 
 pub fn init_from_environment() {
@@ -48,6 +50,15 @@ pub fn record_rust_scan(parsed: usize, cache_hits: usize) {
         if let Some(state) = state.borrow_mut().as_mut() {
             state.counters.rust_files_parsed += parsed;
             state.counters.rust_cache_hits += cache_hits;
+        }
+    });
+}
+
+pub fn record_baseline_scopes(hits: usize, computed: usize) {
+    STATE.with(|state| {
+        if let Some(state) = state.borrow_mut().as_mut() {
+            state.counters.baseline_scope_hits += hits;
+            state.counters.baseline_scope_computed += computed;
         }
     });
 }

--- a/src/rust_facts.rs
+++ b/src/rust_facts.rs
@@ -16,8 +16,8 @@ use walkdir::{DirEntry, WalkDir};
 
 use crate::performance;
 
-const CACHE_SCHEMA_VERSION: u32 = 1;
-const CACHE_NAMESPACE: &str = "rust-syntax-v1";
+pub(crate) const CACHE_SCHEMA_VERSION: u32 = 1;
+pub(crate) const CACHE_NAMESPACE: &str = "rust-syntax-v1";
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct NamedRustFact {
@@ -47,20 +47,38 @@ pub struct RustFactScan {
 }
 
 #[derive(Debug, Clone)]
-struct RustInput {
-    path: PathBuf,
-    content_id: Option<String>,
+pub(crate) struct RustInput {
+    pub(crate) path: PathBuf,
+    pub(crate) content_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
-struct FactCache {
-    root: PathBuf,
+pub(crate) struct FactCache {
+    pub(crate) root: PathBuf,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct CacheEnvelope {
     schema_version: u32,
     facts: RustFileFacts,
+}
+
+/// Loads content-addressed facts for one clean input, deterministically
+/// extracting and storing them on a cache miss. The boolean result reports
+/// whether the facts came from the cache.
+pub(crate) fn cached_or_extracted_facts(
+    content_id: &str,
+    path: &Path,
+    cache: Option<&FactCache>,
+) -> Result<(RustFileFacts, bool), Box<dyn Error>> {
+    if let Some(facts) = cache.and_then(|cache| cache.load(content_id)) {
+        return Ok((facts, true));
+    }
+    let facts = extract_rust_file(path)?;
+    if let Some(cache) = cache {
+        cache.store(content_id, &facts);
+    }
+    Ok((facts, false))
 }
 
 pub fn scan_rust_repository(
@@ -143,7 +161,7 @@ fn extract_rust_source(source: &str) -> RustFileFacts {
     facts
 }
 
-fn rust_inputs(
+pub(crate) fn rust_inputs(
     root: &Path,
     excluded_paths: &BTreeSet<PathBuf>,
     skipped_dirs: &[&str],
@@ -347,7 +365,7 @@ fn path_has_skipped_dir(path: &Path, skipped_dirs: &[&str]) -> bool {
 }
 
 impl FactCache {
-    fn from_environment() -> Option<Self> {
+    pub(crate) fn from_environment() -> Option<Self> {
         if env::var_os("CARGO_CULTIST_CACHE").is_some_and(|value| value == "0") {
             return None;
         }
@@ -364,7 +382,7 @@ impl FactCache {
         })
     }
 
-    fn load(&self, content_id: &str) -> Option<RustFileFacts> {
+    pub(crate) fn load(&self, content_id: &str) -> Option<RustFileFacts> {
         let path = self.path_for(content_id)?;
         let bytes = fs::read(&path).ok()?;
         let envelope: CacheEnvelope = match serde_json::from_slice(&bytes) {
@@ -377,7 +395,7 @@ impl FactCache {
         (envelope.schema_version == CACHE_SCHEMA_VERSION).then_some(envelope.facts)
     }
 
-    fn store(&self, content_id: &str, facts: &RustFileFacts) {
+    pub(crate) fn store(&self, content_id: &str, facts: &RustFileFacts) {
         let Some(path) = self.path_for(content_id) else {
             return;
         };
@@ -406,24 +424,24 @@ impl FactCache {
 }
 
 #[cfg(target_os = "windows")]
-fn platform_cache_dir() -> Option<PathBuf> {
+pub(crate) fn platform_cache_dir() -> Option<PathBuf> {
     env::var_os("LOCALAPPDATA").map(PathBuf::from)
 }
 
 #[cfg(target_os = "macos")]
-fn platform_cache_dir() -> Option<PathBuf> {
+pub(crate) fn platform_cache_dir() -> Option<PathBuf> {
     env::var_os("HOME").map(|home| PathBuf::from(home).join("Library/Caches"))
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
-fn platform_cache_dir() -> Option<PathBuf> {
+pub(crate) fn platform_cache_dir() -> Option<PathBuf> {
     env::var_os("XDG_CACHE_HOME")
         .map(PathBuf::from)
         .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".cache")))
 }
 
 #[cfg(not(any(unix, target_os = "windows")))]
-fn platform_cache_dir() -> Option<PathBuf> {
+pub(crate) fn platform_cache_dir() -> Option<PathBuf> {
     None
 }
 

--- a/src/test_module_aggregate.rs
+++ b/src/test_module_aggregate.rs
@@ -20,6 +20,24 @@
 //! - missing, corrupt, or version-old cache entries recompute; cache failures
 //!   degrade to fallback and never alter findings.
 //!
+//! Integrity seal: every aggregate entry carries a SHA-256 content digest,
+//! computed with domain separation and length framing over its exact
+//! serialized semantic payload (schema version, scope fingerprint, the
+//! ordered name counts, and the total). Loads recompute and verify the digest
+//! before returning any counts, and independently check the invariant that
+//! the counted names sum to the stored total. A missing, malformed,
+//! mismatched, or old seal is treated as a cache miss; current-schema entries
+//! that fail verification are quarantined (deleted) so the deterministic
+//! recompute can repair them, exactly like structurally broken entries. This
+//! means well-formed but fabricated aggregates — including coherent
+//! count/total fabrications that keep the older schema checks passing — can
+//! no longer alter findings. Boundary: this is an unkeyed digest, not
+//! authentication. It detects accidental corruption and stale or partial
+//! writes; it does not defend a malicious same-user actor who deliberately
+//! recomputes the digest over forged contents, and no HMAC claim is made.
+//! The pre-existing per-file fact cache keeps its own trust model and is
+//! unchanged by this contract.
+//!
 //! Privacy: scope entries persist only aggregated test-module name counts and
 //! a total, plus fingerprint/schema metadata, in the user-local cache
 //! directory already used for per-file Rust facts. No paths, source text, or
@@ -40,9 +58,13 @@ use crate::rust_facts::{
 };
 use crate::test_modules::{SKIPPED_DIRS, TestModuleOccurrence};
 
-const AGGREGATE_SCHEMA_VERSION: u32 = 1;
-const SCOPE_CACHE_NAMESPACE: &str = "test-module-scopes-v1";
+/// Version 2 introduces the integrity seal; version 1 entries carried no
+/// digest and must never be trusted, so both the schema gate and the cache
+/// namespace moved, leaving old entries unreachable.
+const AGGREGATE_SCHEMA_VERSION: u32 = 2;
+const SCOPE_CACHE_NAMESPACE: &str = "test-module-scopes-v2";
 const SCOPE_FINGERPRINT_SCHEME: &[u8] = b"cultist-test-module-scope-v1";
+const SCOPE_SEAL_DOMAIN: &[u8] = b"cultist-test-module-scope-seal-v2";
 
 /// Exact repository-wide test-module precedent used to evaluate changed
 /// declarations. `name_counts` and `total` include the changed occurrences.
@@ -241,12 +263,7 @@ fn scope_fingerprint(node: &ScopeNode, root: &Path) -> String {
     hash_part(&mut hasher, AGGREGATE_SCHEMA_VERSION.to_string().as_bytes());
     hash_part(&mut hasher, &root_coordinate(root));
     hash_part(&mut hasher, &node.fingerprint_material(root));
-    let digest = hasher.finalize();
-    let mut hex = String::with_capacity(digest.len() * 2);
-    for byte in digest {
-        hex.push_str(&format!("{byte:02x}"));
-    }
-    hex
+    hex_digest(&hasher.finalize())
 }
 
 impl ScopeNode {
@@ -289,6 +306,36 @@ fn push_framed(material: &mut Vec<u8>, part: &[u8]) {
     material.extend_from_slice(part);
 }
 
+/// The integrity seal: a domain-separated, length-framed SHA-256 digest over
+/// the exact semantic payload of one aggregate entry. `BTreeMap` iteration is
+/// key-sorted, so the encoding is canonical for a given payload.
+fn scope_seal(
+    schema_version: u32,
+    scope_fingerprint: &str,
+    name_counts: &BTreeMap<String, usize>,
+    total: usize,
+) -> String {
+    let mut hasher = Sha256::new();
+    hash_part(&mut hasher, SCOPE_SEAL_DOMAIN);
+    hasher.update(schema_version.to_le_bytes());
+    hash_part(&mut hasher, scope_fingerprint.as_bytes());
+    hasher.update((name_counts.len() as u64).to_le_bytes());
+    for (name, count) in name_counts {
+        hash_part(&mut hasher, name.as_bytes());
+        hasher.update((*count as u64).to_le_bytes());
+    }
+    hasher.update((total as u64).to_le_bytes());
+    hex_digest(&hasher.finalize())
+}
+
+fn hex_digest(digest: &[u8]) -> String {
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+    hex
+}
+
 /// Content-addressed store for scope aggregates, mirroring the per-file fact
 /// cache controls (`CARGO_CULTIST_CACHE`, `CARGO_CULTIST_CACHE_DIR`).
 pub(crate) struct ScopeCache {
@@ -301,6 +348,30 @@ struct ScopeEnvelope {
     scope_fingerprint: String,
     name_counts: BTreeMap<String, usize>,
     total: usize,
+    /// Required integrity seal over the exact payload above; entries without
+    /// it fail deserialization and are treated as corrupt.
+    integrity_seal: String,
+}
+
+impl ScopeEnvelope {
+    /// The checked arithmetic invariant: counted names must sum exactly to
+    /// the stored total, with no overflow.
+    fn counts_sum_to_total(&self) -> bool {
+        self.name_counts
+            .values()
+            .try_fold(0usize, |sum, count| sum.checked_add(*count))
+            == Some(self.total)
+    }
+
+    fn seal_matches(&self) -> bool {
+        self.integrity_seal
+            == scope_seal(
+                self.schema_version,
+                &self.scope_fingerprint,
+                &self.name_counts,
+                self.total,
+            )
+    }
 }
 
 impl ScopeCache {
@@ -326,18 +397,28 @@ impl ScopeCache {
         let bytes = fs::read(&path).ok()?;
         let envelope: ScopeEnvelope = match serde_json::from_slice(&bytes) {
             Ok(envelope) => envelope,
+            // Structurally broken data (including a missing seal field) is
+            // quarantined so the next recompute can repair the entry.
             Err(_) => {
                 let _ = fs::remove_file(path);
                 return None;
             }
         };
-        let usable = envelope.schema_version == AGGREGATE_SCHEMA_VERSION
+        let current_schema = envelope.schema_version == AGGREGATE_SCHEMA_VERSION
             && envelope.scope_fingerprint == fingerprint;
-        if usable {
-            Some((envelope.name_counts, envelope.total))
-        } else {
-            None
+        if !current_schema {
+            // Old-schema or foreign-coordinate entries are simply ignored,
+            // matching the historical stale-entry behavior.
+            return None;
         }
+        // A well-formed entry that fails its own integrity verification is
+        // corrupt at the current contract: quarantine it like broken bytes so
+        // the deterministic recompute below can rewrite it.
+        if !envelope.seal_matches() || !envelope.counts_sum_to_total() {
+            let _ = fs::remove_file(path);
+            return None;
+        }
+        Some((envelope.name_counts, envelope.total))
     }
 
     fn store(&self, fingerprint: &str, name_counts: &BTreeMap<String, usize>, total: usize) {
@@ -345,12 +426,14 @@ impl ScopeCache {
         if path.exists() || fs::create_dir_all(&self.root).is_err() {
             return;
         }
-        let Ok(bytes) = serde_json::to_vec(&ScopeEnvelope {
+        let envelope = ScopeEnvelope {
             schema_version: AGGREGATE_SCHEMA_VERSION,
             scope_fingerprint: fingerprint.to_string(),
             name_counts: name_counts.clone(),
             total,
-        }) else {
+            integrity_seal: scope_seal(AGGREGATE_SCHEMA_VERSION, fingerprint, name_counts, total),
+        };
+        let Ok(bytes) = serde_json::to_vec(&envelope) else {
             return;
         };
 
@@ -442,11 +525,37 @@ mod tests {
         );
     }
 
+    fn sealed_envelope(
+        fingerprint: &str,
+        counts: &BTreeMap<String, usize>,
+        total: usize,
+    ) -> ScopeEnvelope {
+        ScopeEnvelope {
+            schema_version: AGGREGATE_SCHEMA_VERSION,
+            scope_fingerprint: fingerprint.to_string(),
+            name_counts: counts.clone(),
+            total,
+            integrity_seal: scope_seal(AGGREGATE_SCHEMA_VERSION, fingerprint, counts, total),
+        }
+    }
+
+    fn write_envelope(cache: &ScopeCache, fingerprint: &str, envelope: &ScopeEnvelope) {
+        fs::write(
+            cache.path_for(fingerprint),
+            serde_json::to_vec(envelope).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn sample_counts() -> BTreeMap<String, usize> {
+        BTreeMap::from([("tests".to_string(), 3)])
+    }
+
     #[test]
     fn scope_cache_roundtrip_rejects_corrupt_and_foreign_entries() {
         let root = unique_temp_dir("scope-cache");
         let cache = ScopeCache { root: root.clone() };
-        let counts = BTreeMap::from([("tests".to_string(), 3)]);
+        let counts = sample_counts();
         let fingerprint = scope_fingerprint(&scope(&[("lib.rs", "aaa")], &[]), Path::new("/repo"));
         cache.store(&fingerprint, &counts, 3);
         assert_eq!(cache.load(&fingerprint), Some((counts.clone(), 3)));
@@ -458,11 +567,14 @@ mod tests {
         let mut stale: ScopeEnvelope =
             serde_json::from_slice(&fs::read(cache.path_for(&fingerprint)).unwrap()).unwrap();
         stale.schema_version = AGGREGATE_SCHEMA_VERSION.wrapping_sub(1);
-        fs::write(
-            cache.path_for(&fingerprint),
-            serde_json::to_vec(&stale).unwrap(),
-        )
-        .unwrap();
+        // Re-seal so only the schema gate can reject this entry.
+        stale.integrity_seal = scope_seal(
+            stale.schema_version,
+            &stale.scope_fingerprint,
+            &stale.name_counts,
+            stale.total,
+        );
+        write_envelope(&cache, &fingerprint, &stale);
         assert_eq!(cache.load(&fingerprint), None);
 
         cache.store(&fingerprint, &counts, 3);
@@ -470,12 +582,190 @@ mod tests {
             serde_json::from_slice(&fs::read(cache.path_for(&fingerprint)).unwrap()).unwrap();
         foreign.scope_fingerprint =
             scope_fingerprint(&scope(&[("lib.rs", "zzz")], &[]), Path::new("/repo"));
-        fs::write(
-            cache.path_for(&fingerprint),
-            serde_json::to_vec(&foreign).unwrap(),
-        )
-        .unwrap();
+        // Re-seal so only the coordinate gate can reject this entry.
+        foreign.integrity_seal = scope_seal(
+            foreign.schema_version,
+            &foreign.scope_fingerprint,
+            &foreign.name_counts,
+            foreign.total,
+        );
+        write_envelope(&cache, &fingerprint, &foreign);
         assert_eq!(cache.load(&fingerprint), None);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn tampered_payloads_miss_and_are_quarantined_even_when_coherent() {
+        let root = unique_temp_dir("scope-tamper");
+        fs::create_dir_all(&root).unwrap();
+        let cache = ScopeCache { root: root.clone() };
+        let fingerprint = scope_fingerprint(&scope(&[("lib.rs", "aaa")], &[]), Path::new("/repo"));
+        let entry_path = cache.path_for(&fingerprint);
+
+        // Counts mutated under a valid-looking envelope with the old seal.
+        let fabricated_counts = BTreeMap::from([("tests".to_string(), 41)]);
+        let mut tampered = sealed_envelope(&fingerprint, &sample_counts(), 3);
+        tampered.name_counts = fabricated_counts.clone();
+        write_envelope(&cache, &fingerprint, &tampered);
+        assert_eq!(cache.load(&fingerprint), None);
+        assert!(!entry_path.exists(), "tampered entry must be quarantined");
+
+        // Total mutated alone, old seal intact.
+        let mut tampered = sealed_envelope(&fingerprint, &sample_counts(), 3);
+        tampered.total = 99;
+        write_envelope(&cache, &fingerprint, &tampered);
+        assert_eq!(cache.load(&fingerprint), None);
+        assert!(!entry_path.exists());
+
+        // Coherent fabrication: counts and total agree with each other but
+        // the payload was written by someone else; the stale seal must catch it.
+        let mut coherent = sealed_envelope(&fingerprint, &sample_counts(), 3);
+        coherent.name_counts = BTreeMap::from([
+            ("tests".to_string(), 40),
+            ("fabricated_tests".to_string(), 60),
+        ]);
+        coherent.total = 100;
+        write_envelope(&cache, &fingerprint, &coherent);
+        assert_eq!(cache.load(&fingerprint), None);
+        assert!(!entry_path.exists());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn missing_malformed_or_old_seals_never_trust_the_entry() {
+        let root = unique_temp_dir("scope-seal-shapes");
+        fs::create_dir_all(&root).unwrap();
+        let cache = ScopeCache { root: root.clone() };
+        let fingerprint = scope_fingerprint(&scope(&[("lib.rs", "aaa")], &[]), Path::new("/repo"));
+        let entry_path = cache.path_for(&fingerprint);
+        let counts = sample_counts();
+
+        // A version-1-shaped unsealed entry must not deserialize into the
+        // current contract, even if dropped into the new namespace.
+        let legacy = serde_json::json!({
+            "schema_version": 1,
+            "scope_fingerprint": fingerprint,
+            "name_counts": counts,
+            "total": 3,
+        });
+        fs::write(&entry_path, serde_json::to_vec(&legacy).unwrap()).unwrap();
+        assert_eq!(cache.load(&fingerprint), None);
+        assert!(!entry_path.exists(), "unsealed entry must be quarantined");
+
+        // A current-schema entry whose seal field is missing is malformed.
+        let mut unsealed = serde_json::to_value(sealed_envelope(&fingerprint, &counts, 3)).unwrap();
+        unsealed
+            .as_object_mut()
+            .unwrap()
+            .remove("integrity_seal")
+            .unwrap();
+        fs::write(&entry_path, serde_json::to_vec(&unsealed).unwrap()).unwrap();
+        assert_eq!(cache.load(&fingerprint), None);
+        assert!(!entry_path.exists());
+
+        // A garbled seal value is a mismatched digest, not a usable one.
+        let mut garbled = sealed_envelope(&fingerprint, &counts, 3);
+        garbled.integrity_seal = "0".repeat(63) + "z";
+        write_envelope(&cache, &fingerprint, &garbled);
+        assert_eq!(cache.load(&fingerprint), None);
+        assert!(!entry_path.exists());
+
+        // Truncated serialization never loads.
+        let valid = serde_json::to_vec(&sealed_envelope(&fingerprint, &counts, 3)).unwrap();
+        fs::write(&entry_path, &valid[..valid.len() / 2]).unwrap();
+        assert_eq!(cache.load(&fingerprint), None);
+        assert!(!entry_path.exists());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn invariant_violation_misses_even_with_an_honestly_computed_seal() {
+        let root = unique_temp_dir("scope-invariant");
+        fs::create_dir_all(&root).unwrap();
+        let cache = ScopeCache { root: root.clone() };
+        let fingerprint = scope_fingerprint(&scope(&[("lib.rs", "aaa")], &[]), Path::new("/repo"));
+        let counts = BTreeMap::from([("tests".to_string(), 1)]);
+
+        // The seal honestly covers this exact payload, so only the checked
+        // sum invariant can reject it.
+        let inconsistent = ScopeEnvelope {
+            integrity_seal: scope_seal(AGGREGATE_SCHEMA_VERSION, &fingerprint, &counts, 99),
+            schema_version: AGGREGATE_SCHEMA_VERSION,
+            scope_fingerprint: fingerprint.clone(),
+            name_counts: counts,
+            total: 99,
+        };
+        write_envelope(&cache, &fingerprint, &inconsistent);
+        assert_eq!(cache.load(&fingerprint), None);
+        assert!(!cache.path_for(&fingerprint).exists());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn quarantined_entries_are_repaired_by_deterministic_recompute() {
+        let root = unique_temp_dir("scope-repair");
+        fs::create_dir_all(&root).unwrap();
+        let cache = ScopeCache { root: root.clone() };
+        let fingerprint = scope_fingerprint(&scope(&[("lib.rs", "aaa")], &[]), Path::new("/repo"));
+        let counts = sample_counts();
+
+        let mut tampered = sealed_envelope(&fingerprint, &counts, 3);
+        tampered.total += 7;
+        write_envelope(&cache, &fingerprint, &tampered);
+        assert_eq!(cache.load(&fingerprint), None);
+
+        // The recompute path stores again once the corrupt entry is gone.
+        cache.store(&fingerprint, &counts, 3);
+        assert_eq!(
+            cache.load(&fingerprint),
+            Some((counts.clone(), 3)),
+            "the repaired entry must carry a fresh valid seal"
+        );
+
+        // Restoring byte-identical semantics is stable across repairs.
+        let repaired = fs::read(cache.path_for(&fingerprint)).unwrap();
+        let replay = serde_json::to_vec(&sealed_envelope(&fingerprint, &counts, 3)).unwrap();
+        assert_eq!(repaired, replay);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn concurrent_stores_stay_atomic_and_deterministic() {
+        let root = unique_temp_dir("scope-concurrent");
+        let cache = std::sync::Arc::new(ScopeCache { root: root.clone() });
+        let base_node = scope(&[("lib.rs", "aaa")], &[]);
+
+        let handles: Vec<_> = (0..8)
+            .map(|index| {
+                let cache = std::sync::Arc::clone(&cache);
+                let node = ScopeNode {
+                    relative: PathBuf::from(format!("scope-{index}")),
+                    files: base_node.files.clone(),
+                    children: BTreeMap::new(),
+                };
+                std::thread::spawn(move || {
+                    let fingerprint = scope_fingerprint(&node, Path::new("/repo"));
+                    let counts = BTreeMap::from([(format!("tests_{index}"), index + 1)]);
+                    cache.store(&fingerprint, &counts, index + 1);
+                    // Concurrent duplicate writes of one scope stay atomic.
+                    cache.store(&fingerprint, &counts, index + 1);
+                    fingerprint
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            let fingerprint = handle.join().unwrap();
+            let loaded = cache.load(&fingerprint).expect("entry must survive races");
+            let expected_total = loaded.1;
+            let sum: usize = loaded.0.values().sum();
+            assert_eq!(sum, expected_total, "racing writes must stay coherent");
+        }
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/src/test_module_aggregate.rs
+++ b/src/test_module_aggregate.rs
@@ -1,0 +1,592 @@
+//! Diff-time clean-baseline aggregates for test-module precedent (#50).
+//!
+//! A small relevant diff combines fresh changed-file facts with cached
+//! directory-scoped histograms over the clean (index-content-addressed)
+//! remainder of the repository, so a warm analysis never walks or reparses
+//! every repository fact row.
+//!
+//! Exactness contract:
+//!
+//! - scope aggregates cover only clean rows whose facts are identified by a
+//!   Git blob id, keyed by a Merkle fingerprint over those child identities,
+//!   the exact repository/scope coordinate, the extractor/schema generation,
+//!   and the file-selection configuration;
+//! - a row is clean only when Git status reports it untouched, so every
+//!   changed, staged, renamed, or untracked path is already absent from the
+//!   baseline and the overlay only ever adds fresh changed-file facts;
+//! - any dirty/staged/untracked row outside the changed set forces
+//!   deterministic fallback to the ordinary full scan, so overlays can never
+//!   silently drop a contribution;
+//! - missing, corrupt, or version-old cache entries recompute; cache failures
+//!   degrade to fallback and never alter findings.
+//!
+//! Privacy: scope entries persist only aggregated test-module name counts and
+//! a total, plus fingerprint/schema metadata, in the user-local cache
+//! directory already used for per-file Rust facts. No paths, source text, or
+//! line numbers are retained at this layer.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::performance;
+use crate::rust_facts::{
+    CACHE_NAMESPACE, CACHE_SCHEMA_VERSION, FactCache, RustInput, cached_or_extracted_facts,
+    platform_cache_dir, rust_inputs,
+};
+use crate::test_modules::{SKIPPED_DIRS, TestModuleOccurrence};
+
+const AGGREGATE_SCHEMA_VERSION: u32 = 1;
+const SCOPE_CACHE_NAMESPACE: &str = "test-module-scopes-v1";
+const SCOPE_FINGERPRINT_SCHEME: &[u8] = b"cultist-test-module-scope-v1";
+
+/// Exact repository-wide test-module precedent used to evaluate changed
+/// declarations. `name_counts` and `total` include the changed occurrences.
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub(crate) struct TestModulePrecedent {
+    pub(crate) name_counts: BTreeMap<String, usize>,
+    pub(crate) total: usize,
+}
+
+impl TestModulePrecedent {
+    pub(crate) fn from_occurrences(occurrences: &[TestModuleOccurrence]) -> Self {
+        let mut precedent = Self::default();
+        for occurrence in occurrences {
+            precedent.add(&occurrence.name);
+        }
+        precedent
+    }
+
+    fn add(&mut self, name: &str) {
+        *self.name_counts.entry(name.to_string()).or_default() += 1;
+        self.total += 1;
+    }
+
+    /// Precedent excluding exactly one occurrence, matching the legacy
+    /// per-target iteration semantics: other same-name occurrences stay counted.
+    pub(crate) fn excluding(&self, target_name: &str) -> (BTreeMap<String, usize>, usize) {
+        let mut counts = self.name_counts.clone();
+        if let Some(count) = counts.get_mut(target_name) {
+            *count -= 1;
+            if *count == 0 {
+                counts.remove(target_name);
+            }
+        }
+        (counts, self.total.saturating_sub(1))
+    }
+}
+
+/// Attempts the cached clean-baseline overlay path. `Ok(None)` means the
+/// current working state is outside the overlay's exactness envelope and the
+/// caller must fall back to the ordinary full repository scan. Callers supply
+/// their caches so product and test flows share one deterministic entry point.
+pub(crate) fn overlay_precedent_with(
+    fact_cache: Option<&FactCache>,
+    scope_cache: Option<&ScopeCache>,
+    root: &Path,
+    changed_paths: &BTreeSet<PathBuf>,
+    changed_occurrences: &[TestModuleOccurrence],
+) -> Result<Option<TestModulePrecedent>, Box<dyn Error>> {
+    let rows = rust_inputs(root, &BTreeSet::new(), SKIPPED_DIRS)?;
+
+    // Dirty/staged/untracked rows have no content identity, so their facts
+    // cannot come from the clean baseline. Any such row outside the changed
+    // set would be silently dropped from the overlay; fall back instead so
+    // counts stay exact.
+    for row in &rows {
+        if row.content_id.is_none() && !changed_paths.contains(&row.path) {
+            return Ok(None);
+        }
+    }
+
+    let row_paths: BTreeSet<_> = rows.iter().map(|row| row.path.clone()).collect();
+    for path in changed_paths {
+        if !row_paths.contains(path) {
+            return Ok(None);
+        }
+    }
+
+    let mut stats = ScopeStats::default();
+    let clean_tree = CleanScopeTree::build(root, &rows);
+    let mut precedent = resolve_scope(scope_cache, fact_cache, root, &clean_tree.root, &mut stats)?;
+
+    for occurrence in changed_occurrences {
+        precedent.add(&occurrence.name);
+    }
+
+    debug_assert_eq!(
+        precedent.total,
+        precedent.name_counts.values().sum::<usize>()
+    );
+    performance::record_baseline_scopes(stats.hits, stats.computed);
+    Ok(Some(precedent))
+}
+
+#[derive(Debug, Default)]
+struct ScopeStats {
+    hits: usize,
+    computed: usize,
+}
+
+/// Directories of clean rows arranged for hierarchical content addressing.
+struct CleanScopeTree {
+    root: ScopeNode,
+}
+
+struct ScopeNode {
+    /// Repository-relative directory path; empty for the root scope.
+    relative: PathBuf,
+    /// Clean Rust files directly in this directory, by file name.
+    files: BTreeMap<String, String>,
+    children: BTreeMap<String, ScopeNode>,
+}
+
+impl CleanScopeTree {
+    fn build(root: &Path, rows: &[RustInput]) -> Self {
+        let mut tree = Self {
+            root: ScopeNode {
+                relative: PathBuf::new(),
+                files: BTreeMap::new(),
+                children: BTreeMap::new(),
+            },
+        };
+        for row in rows {
+            let Some(content_id) = row.content_id.as_deref() else {
+                continue;
+            };
+            let Ok(relative) = row.path.strip_prefix(root) else {
+                continue;
+            };
+            let mut components = relative
+                .components()
+                .map(|component| component.as_os_str().to_string_lossy().into_owned());
+            let file_name = components.next_back().unwrap_or_default();
+            let mut node = &mut tree.root;
+            for component in components {
+                let child_relative = node.relative.join(&component);
+                node = node.children.entry(component).or_insert_with(|| ScopeNode {
+                    relative: child_relative,
+                    files: BTreeMap::new(),
+                    children: BTreeMap::new(),
+                });
+            }
+            node.files.insert(file_name, content_id.to_string());
+        }
+        tree
+    }
+}
+
+/// Resolves the exact aggregate for one scope, serving it from the
+/// content-addressed cache when the fingerprint matches and recomputing it
+/// deterministically from child identities otherwise.
+fn resolve_scope(
+    scope_cache: Option<&ScopeCache>,
+    fact_cache: Option<&FactCache>,
+    root: &Path,
+    node: &ScopeNode,
+    stats: &mut ScopeStats,
+) -> Result<TestModulePrecedent, Box<dyn Error>> {
+    let fingerprint = scope_fingerprint(node, root);
+
+    if let Some((name_counts, total)) = scope_cache.and_then(|cache| cache.load(&fingerprint)) {
+        stats.hits += 1;
+        return Ok(TestModulePrecedent { name_counts, total });
+    }
+
+    let mut precedent = TestModulePrecedent::default();
+    for (file_name, content_id) in &node.files {
+        let path = node_file_path(root, &node.relative, file_name);
+        let (facts, hit) = cached_or_extracted_facts(content_id, &path, fact_cache)?;
+        performance::record_rust_scan(usize::from(!hit), usize::from(hit));
+        for occurrence in &facts.test_modules {
+            precedent.add(&occurrence.name);
+        }
+    }
+
+    for child in node.children.values() {
+        let child_precedent = resolve_scope(scope_cache, fact_cache, root, child, stats)?;
+        for (name, count) in child_precedent.name_counts {
+            *precedent.name_counts.entry(name).or_default() += count;
+            precedent.total += count;
+        }
+    }
+
+    if let Some(cache) = scope_cache {
+        cache.store(&fingerprint, &precedent.name_counts, precedent.total);
+    }
+    stats.computed += 1;
+    Ok(precedent)
+}
+
+fn node_file_path(root: &Path, relative_dir: &Path, file_name: &str) -> PathBuf {
+    if relative_dir.as_os_str().is_empty() {
+        root.join(file_name)
+    } else {
+        root.join(relative_dir).join(file_name)
+    }
+}
+
+/// Binds the exact repository/scope coordinate, relevant child content
+/// identities, the analyzer/extractor/schema generation, and the
+/// file-selection configuration into one SHA-256 scope identity.
+fn scope_fingerprint(node: &ScopeNode, root: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hash_part(&mut hasher, SCOPE_FINGERPRINT_SCHEME);
+    hash_part(&mut hasher, CACHE_NAMESPACE.as_bytes());
+    hash_part(&mut hasher, CACHE_SCHEMA_VERSION.to_string().as_bytes());
+    hash_part(&mut hasher, AGGREGATE_SCHEMA_VERSION.to_string().as_bytes());
+    hash_part(&mut hasher, &root_coordinate(root));
+    hash_part(&mut hasher, &node.fingerprint_material(root));
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+    hex
+}
+
+impl ScopeNode {
+    /// Canonical byte material for this scope: its relative coordinate,
+    /// selection configuration, direct clean files, and child fingerprints.
+    fn fingerprint_material(&self, root: &Path) -> Vec<u8> {
+        let mut material = Vec::new();
+        push_framed(&mut material, &self.repository_coordinate_bytes());
+        push_framed(&mut material, SKIPPED_DIRS.join("\u{1f}").as_bytes());
+        for (file_name, content_id) in &self.files {
+            push_framed(&mut material, file_name.as_bytes());
+            push_framed(&mut material, content_id.as_bytes());
+        }
+        for (dir_name, child) in &self.children {
+            push_framed(&mut material, dir_name.as_bytes());
+            push_framed(&mut material, scope_fingerprint(child, root).as_bytes());
+        }
+        material
+    }
+
+    fn repository_coordinate_bytes(&self) -> Vec<u8> {
+        self.relative.to_string_lossy().as_bytes().to_vec()
+    }
+}
+
+/// The canonical repository path anchors every scope identity to its exact
+/// repository coordinate, so entries never leak across checkouts.
+fn root_coordinate(root: &Path) -> Vec<u8> {
+    let canonical = fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    canonical.to_string_lossy().as_bytes().to_vec()
+}
+
+fn hash_part(hasher: &mut Sha256, part: &[u8]) {
+    hasher.update((part.len() as u64).to_le_bytes());
+    hasher.update(part);
+}
+
+fn push_framed(material: &mut Vec<u8>, part: &[u8]) {
+    material.extend_from_slice(&(part.len() as u64).to_le_bytes());
+    material.extend_from_slice(part);
+}
+
+/// Content-addressed store for scope aggregates, mirroring the per-file fact
+/// cache controls (`CARGO_CULTIST_CACHE`, `CARGO_CULTIST_CACHE_DIR`).
+pub(crate) struct ScopeCache {
+    pub(crate) root: PathBuf,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ScopeEnvelope {
+    schema_version: u32,
+    scope_fingerprint: String,
+    name_counts: BTreeMap<String, usize>,
+    total: usize,
+}
+
+impl ScopeCache {
+    pub(crate) fn from_environment() -> Option<Self> {
+        if std::env::var_os("CARGO_CULTIST_CACHE").is_some_and(|value| value == "0") {
+            return None;
+        }
+
+        if let Some(path) = std::env::var_os("CARGO_CULTIST_CACHE_DIR") {
+            return Some(Self {
+                root: PathBuf::from(path).join(SCOPE_CACHE_NAMESPACE),
+            });
+        }
+
+        let base = platform_cache_dir()?;
+        Some(Self {
+            root: base.join("cargo-cultist").join(SCOPE_CACHE_NAMESPACE),
+        })
+    }
+
+    fn load(&self, fingerprint: &str) -> Option<(BTreeMap<String, usize>, usize)> {
+        let path = self.path_for(fingerprint);
+        let bytes = fs::read(&path).ok()?;
+        let envelope: ScopeEnvelope = match serde_json::from_slice(&bytes) {
+            Ok(envelope) => envelope,
+            Err(_) => {
+                let _ = fs::remove_file(path);
+                return None;
+            }
+        };
+        let usable = envelope.schema_version == AGGREGATE_SCHEMA_VERSION
+            && envelope.scope_fingerprint == fingerprint;
+        if usable {
+            Some((envelope.name_counts, envelope.total))
+        } else {
+            None
+        }
+    }
+
+    fn store(&self, fingerprint: &str, name_counts: &BTreeMap<String, usize>, total: usize) {
+        let path = self.path_for(fingerprint);
+        if path.exists() || fs::create_dir_all(&self.root).is_err() {
+            return;
+        }
+        let Ok(bytes) = serde_json::to_vec(&ScopeEnvelope {
+            schema_version: AGGREGATE_SCHEMA_VERSION,
+            scope_fingerprint: fingerprint.to_string(),
+            name_counts: name_counts.clone(),
+            total,
+        }) else {
+            return;
+        };
+
+        let temporary = self
+            .root
+            .join(format!(".{fingerprint}.{}.tmp", std::process::id()));
+        if fs::write(&temporary, bytes).is_ok() {
+            let _ = fs::rename(&temporary, &path);
+        }
+        let _ = fs::remove_file(temporary);
+    }
+
+    fn path_for(&self, fingerprint: &str) -> PathBuf {
+        self.root.join(format!("{fingerprint}.json"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "cargo-cultist-{name}-{}-{nanos}",
+            std::process::id()
+        ))
+    }
+
+    fn scope(files: &[(&str, &str)], children: &[(&str, &str)]) -> ScopeNode {
+        ScopeNode {
+            relative: PathBuf::new(),
+            files: files
+                .iter()
+                .map(|(name, oid)| ((*name).to_string(), (*oid).to_string()))
+                .collect(),
+            children: children
+                .iter()
+                .map(|(name, oid)| {
+                    (
+                        (*name).to_string(),
+                        ScopeNode {
+                            relative: PathBuf::from(*name),
+                            files: BTreeMap::from([("inner.rs".to_string(), (*oid).to_string())]),
+                            children: BTreeMap::new(),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn fingerprint_binds_child_identity_config_and_coordinate() {
+        let root_a = Path::new("/repo-a");
+        let root_b = Path::new("/repo-b");
+        let baseline = scope(&[("lib.rs", "aaa")], &[("sub", "bbb")]);
+        let changed_file_oid = scope(&[("lib.rs", "ccc")], &[("sub", "bbb")]);
+        let changed_child_oid = scope(&[("lib.rs", "aaa")], &[("sub", "ddd")]);
+
+        assert_eq!(
+            scope_fingerprint(&baseline, root_a),
+            scope_fingerprint(&baseline, root_a)
+        );
+        assert_ne!(
+            scope_fingerprint(&baseline, root_a),
+            scope_fingerprint(&changed_file_oid, root_a)
+        );
+        assert_ne!(
+            scope_fingerprint(&baseline, root_a),
+            scope_fingerprint(&changed_child_oid, root_a)
+        );
+        // The exact repository coordinate participates in the identity.
+        assert_ne!(
+            scope_fingerprint(&baseline, root_a),
+            scope_fingerprint(&baseline, root_b)
+        );
+
+        let mut relocated = scope(&[("lib.rs", "aaa")], &[("sub", "bbb")]);
+        relocated.relative = PathBuf::from("elsewhere");
+        assert_ne!(
+            scope_fingerprint(&baseline, root_a),
+            scope_fingerprint(&relocated, root_a)
+        );
+    }
+
+    #[test]
+    fn scope_cache_roundtrip_rejects_corrupt_and_foreign_entries() {
+        let root = unique_temp_dir("scope-cache");
+        let cache = ScopeCache { root: root.clone() };
+        let counts = BTreeMap::from([("tests".to_string(), 3)]);
+        let fingerprint = scope_fingerprint(&scope(&[("lib.rs", "aaa")], &[]), Path::new("/repo"));
+        cache.store(&fingerprint, &counts, 3);
+        assert_eq!(cache.load(&fingerprint), Some((counts.clone(), 3)));
+
+        fs::write(cache.path_for(&fingerprint), "broken json").unwrap();
+        assert_eq!(cache.load(&fingerprint), None);
+
+        cache.store(&fingerprint, &counts, 3);
+        let mut stale: ScopeEnvelope =
+            serde_json::from_slice(&fs::read(cache.path_for(&fingerprint)).unwrap()).unwrap();
+        stale.schema_version = AGGREGATE_SCHEMA_VERSION.wrapping_sub(1);
+        fs::write(
+            cache.path_for(&fingerprint),
+            serde_json::to_vec(&stale).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(cache.load(&fingerprint), None);
+
+        cache.store(&fingerprint, &counts, 3);
+        let mut foreign: ScopeEnvelope =
+            serde_json::from_slice(&fs::read(cache.path_for(&fingerprint)).unwrap()).unwrap();
+        foreign.scope_fingerprint =
+            scope_fingerprint(&scope(&[("lib.rs", "zzz")], &[]), Path::new("/repo"));
+        fs::write(
+            cache.path_for(&fingerprint),
+            serde_json::to_vec(&foreign).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(cache.load(&fingerprint), None);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn overlay_arithmetic_matches_direct_counting() {
+        let occurrences = vec![
+            TestModuleOccurrence {
+                name: "tests".to_string(),
+                path: PathBuf::from("/repo/src/a.rs"),
+                line: 1,
+            },
+            TestModuleOccurrence {
+                name: "tests".to_string(),
+                path: PathBuf::from("/repo/src/b.rs"),
+                line: 2,
+            },
+            TestModuleOccurrence {
+                name: "unit_tests".to_string(),
+                path: PathBuf::from("/repo/src/c.rs"),
+                line: 3,
+            },
+        ];
+        let precedent = TestModulePrecedent::from_occurrences(&occurrences);
+        assert_eq!(precedent.total, 3);
+
+        let (excluding_target, total) = precedent.excluding("tests");
+        assert_eq!(excluding_target.get("tests"), Some(&1));
+        assert_eq!(excluding_target.get("unit_tests"), Some(&1));
+        assert_eq!(total, 2);
+
+        let (absent, total) = precedent.excluding("missing");
+        assert!(!absent.contains_key("missing"));
+        assert_eq!(total, 2);
+    }
+
+    #[test]
+    fn clean_tree_groups_rows_by_directory_and_ignores_volatile_rows() {
+        let root = PathBuf::from("/repo");
+        let rows = vec![
+            RustInput {
+                path: root.join("root.rs"),
+                content_id: Some("aaaa".to_string()),
+            },
+            RustInput {
+                path: root.join("src/lib.rs"),
+                content_id: Some("bbbb".to_string()),
+            },
+            RustInput {
+                path: root.join("src/deep/util.rs"),
+                content_id: None,
+            },
+        ];
+
+        let tree = CleanScopeTree::build(&root, &rows);
+
+        assert_eq!(tree.root.files.keys().collect::<Vec<_>>(), ["root.rs"]);
+        let src = tree.root.children.get("src").unwrap();
+        assert_eq!(src.files.keys().collect::<Vec<_>>(), ["lib.rs"]);
+        // A directory holding only volatile rows never joins the tree.
+        assert!(!src.children.contains_key("deep"));
+        assert_eq!(src.relative, PathBuf::from("src"));
+    }
+
+    #[test]
+    fn resolve_scope_computes_from_disk_and_serves_followups_from_cache() {
+        let root = unique_temp_dir("resolve-scope");
+        fs::create_dir_all(root.join("sub")).unwrap();
+        fs::write(
+            root.join("lib.rs"),
+            "#[cfg(test)]\nmod lib_tests {}\n#[cfg(test)]\nmod shared {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("sub/inner.rs"),
+            "#[cfg(test)]\nmod inner_tests {}\n",
+        )
+        .unwrap();
+
+        let node = ScopeNode {
+            relative: PathBuf::new(),
+            files: BTreeMap::from([("lib.rs".to_string(), "deadbeef".to_string())]),
+            children: BTreeMap::from([(
+                "sub".to_string(),
+                ScopeNode {
+                    relative: PathBuf::from("sub"),
+                    files: BTreeMap::from([("inner.rs".to_string(), "feedface".to_string())]),
+                    children: BTreeMap::new(),
+                },
+            )]),
+        };
+
+        let cache_root = unique_temp_dir("resolve-scope-cache");
+        let scope_cache = ScopeCache {
+            root: cache_root.clone(),
+        };
+        let mut stats = ScopeStats::default();
+        let resolved = resolve_scope(Some(&scope_cache), None, &root, &node, &mut stats).unwrap();
+        assert_eq!(stats.computed, 2);
+        assert_eq!(stats.hits, 0);
+        assert_eq!(resolved.total, 3);
+        assert_eq!(resolved.name_counts.get("shared"), Some(&1));
+
+        let mut warm_stats = ScopeStats::default();
+        let warmed =
+            resolve_scope(Some(&scope_cache), None, &root, &node, &mut warm_stats).unwrap();
+        assert_eq!(resolved, warmed);
+        assert_eq!(warm_stats.hits, 1);
+        assert_eq!(warm_stats.computed, 0);
+
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(cache_root).unwrap();
+    }
+}

--- a/src/test_modules.rs
+++ b/src/test_modules.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use crate::performance;
 use crate::rust_facts::{RustFactScan, scan_rust_paths, scan_rust_repository};
 
-const SKIPPED_DIRS: &[&str] = &[".git", "target", "node_modules"];
+pub(crate) const SKIPPED_DIRS: &[&str] = &[".git", "target", "node_modules"];
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TestModuleOccurrence {


### PR DESCRIPTION
## Summary

Implements a bounded #50 slice for the current diff-time test-module precedent analyzer:

- caches exact directory-scoped clean-baseline histograms under a SHA-256 identity binding repository root, scope coordinate, relevant child blob identities, extractor/schema generation, and skipped-directory configuration;
- overlays freshly parsed changed-file facts on unaffected cached baselines;
- falls back to the deterministic full scan whenever Git reports a dirty/staged/untracked row outside the requested changed set, or when an entry is missing, corrupt, or version-old;
- records `baseline_scope_hits` / `baseline_scope_computed` so the warm path proves it avoided repository-wide fact-row aggregation;
- stores only aggregate names/counts and totals in the user-local cache, not source contents or findings.

## Integrity seal (repair after review finding)

Review deterministically proved that a syntactically valid envelope with matching schema/fingerprint but fabricated `name_counts`/`total` was trusted and changed findings, violating the #50 contract that a corrupt cache must fall back without altering results. Repair commit `fcde336`:

- every scope aggregate entry now carries a domain-separated, length-framed SHA-256 seal over its exact serialized semantic payload — schema version, scope fingerprint, ordered name counts, and total; loads recompute and verify the digest before returning any counts;
- loads independently check the invariant that counted names sum exactly to the stored total (checked arithmetic, no overflow);
- missing, malformed, mismatched, or old seals are cache misses that recompute deterministically; current-schema entries failing verification are quarantined so the recompute repairs them, matching the existing corrupt-entry behavior; old-schema entries stay ignored as before;
- the aggregate schema moved to v2 with namespace `test-module-scopes-v2`, so unsealed v1 entries can never be trusted accidentally. The pre-existing per-file fact cache keeps its own trust model and is unchanged.

Demonstrated sealed corruption: coherently forged aggregates (`name_counts` and `total` fabricated consistently while keeping schema, fingerprint, and the original seal) are rejected end-to-end — the overlay run shows 0 hits / 10 recomputed scopes and byte-identical findings against the no-cache oracle; the follow-up run hits the repaired root aggregate. Adversarial tests additionally cover counts-only, total-only, honestly-sealed invariant violations, garbled/missing seals, truncated data, old-schema entries, quarantine repair determinism, and concurrent atomic stores.

Trust boundary, stated precisely: the seal is an unkeyed content digest with domain separation. It detects accidental corruption and stale or partial writes; it does not authenticate anything. A malicious same-user actor who deliberately recomputes the digest over forged contents defeats it by construction, and no HMAC or adversary-boundary claim is made.

Advances #50.

## Exact receipt

- Base: `b1a0c1301bcb556b1134782508070d6c3a40e088`
- Head: `fcde336` (single repair commit on top of reviewed `259d07d84e00780def664541aba6f5a00c2be71b`)
- Repair shape: 2 files, +390/-26
- Recovery identity (unchanged from the transplanted implementation): stable patch-id `80133777e5d1b8dcd8aa5592889cf6b6c710ff99`

## Verification

- `cargo fmt --check`: clean
- `cargo clippy --all-targets -- -D warnings`: green
- focused `cargo-cultist` bin suite: 187 passed (181 prior + 6 adversarial)
- full suite: 77/78 test binaries pass; the sole failure (`rust_edit_class_source_current_main`) is the repository's pre-existing `init.defaultBranch` master/main environment assumption and was reproduced on the exact base head
- cold dogfood (disposable clone at the reviewed base): 199 parses, 10 baseline scopes computed, about 235 ms
- warm dogfood: 1 parse, 1 baseline scope hit, about 65 ms; report byte-identical to cold
- coherently fabricated caches (stale seals kept): 0 hits, 10 scopes recomputed, report byte-identical to cold
- post-repair run: 1 hit, 0 computed, report byte-identical to cold
- unsealed v1-shaped entry planted in the v2 namespace: ignored, report byte-identical
- `git diff --check`: clean

No hosted workflow was manually dispatched.

## Review request

The earlier ACCEPT of `259d07d` predates this correctness repair and is no longer sufficient on its own. Please run a fresh exact-head review at `fcde336`, including whether the unkeyed-digest boundary is acceptable for #50's threat model.

## Residual boundaries

This intentionally caches one proven aggregate family rather than introducing a generic aggregate framework. Dirty/staged/untracked rows outside the caller's changed set use the conservative full-scan fallback so exactness wins over partial reuse. The seal covers well-formed corruption only, per the boundary above.

— 🗃️ Cacheline · Ox portfolio pod
