### PR TITLE
Rename current SmolRunner dogfood labels to Glaeda

### DIFF
--- a/.github/workflows/jei-change-scope-pilot.yml
+++ b/.github/workflows/jei-change-scope-pilot.yml
@@ -89,7 +89,7 @@ jobs:
           }
           PY
 
-      - name: Checkout SmolRunner #540 base
+      - name: Checkout Glaeda historical #540 base
         uses: actions/checkout@v4
         with:
           repository: teamleaderleo/smolrunner
@@ -98,7 +98,7 @@ jobs:
           persist-credentials: false
           path: target-smolrunner
 
-      - name: Verify SmolRunner single-path evidence
+      - name: Verify Glaeda historical single-path evidence
         run: |
           set -euo pipefail
           test "$(git -C target-smolrunner rev-parse HEAD)" = "c8cb347eb1c85200793fd22693294f5f6a13f5f8"
@@ -113,7 +113,7 @@ jobs:
             exit 1
           fi
 
-      - name: Replay SmolRunner single-path control
+      - name: Replay Glaeda historical single-path control
         run: |
           set -euo pipefail
           python cultist/scripts/jei_change_scope_pilot.py \
@@ -141,7 +141,7 @@ jobs:
 
           cases = [
               ("Stensibly #1573 multi-path", Path("artifacts/stensibly-1573-change-scope.json")),
-              ("SmolRunner #540 single-path", Path("artifacts/smolrunner-540-change-scope.json")),
+              ("Glaeda historical corpus (SmolRunner #540) · single-path", Path("artifacts/smolrunner-540-change-scope.json")),
           ]
           with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as out:
               out.write("## Change-set-driven scope pilot\n\n")

--- a/.github/workflows/jei-history-pilot.yml
+++ b/.github/workflows/jei-history-pilot.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  smolrunner-same-target-positive:
+  glaeda-historical-same-target-positive:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Cultist
@@ -38,7 +38,7 @@ jobs:
       - name: Build agent context packet research example
         run: cargo build --release --example agent_context_packet --manifest-path cultist/Cargo.toml
 
-      - name: Checkout pinned SmolRunner state
+      - name: Checkout pinned Glaeda historical corpus
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.target.outputs.repository }}
@@ -197,7 +197,7 @@ jobs:
   summarize:
     if: always()
     needs:
-      - smolrunner-same-target-positive
+      - glaeda-historical-same-target-positive
       - stensibly-cross-file-negative
     runs-on: ubuntu-latest
     steps:
@@ -221,7 +221,7 @@ jobs:
           from pathlib import Path
 
           paths = [
-              ("Positive · SmolRunner same-target history", Path("receipts/positive/smolrunner-same-target-positive.json")),
+              ("Positive · Glaeda historical corpus · same-target history", Path("receipts/positive/smolrunner-same-target-positive.json")),
               ("Negative · Stensibly cross-file history", Path("receipts/negative/stensibly-cross-file-negative.json")),
           ]
           overall = True

--- a/.github/workflows/jei-parent-scope-pilot.yml
+++ b/.github/workflows/jei-parent-scope-pilot.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           path: cultist
 
-      - name: Resolve SmolRunner control
+      - name: Resolve Glaeda historical control
         id: smol
         run: |
           python cultist/scripts/external_dogfood_case.py \
@@ -49,7 +49,7 @@ jobs:
           cargo build --release --example agent_context_packet --manifest-path cultist/Cargo.toml
           cargo build --release --example scoped_agent_context_packet --manifest-path cultist/Cargo.toml
 
-      - name: Checkout pinned SmolRunner state
+      - name: Checkout pinned Glaeda historical corpus
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.smol.outputs.repository }}
@@ -58,7 +58,7 @@ jobs:
           persist-credentials: false
           path: target-smolrunner
 
-      - name: Measure SmolRunner parent scope
+      - name: Measure Glaeda historical parent scope
         env:
           TARGET_FILE: ${{ steps.smol.outputs.history_file }}
           TARGET_REPOSITORY: ${{ steps.smol.outputs.repository }}
@@ -121,7 +121,7 @@ jobs:
           from pathlib import Path
 
           cases = [
-              ("SmolRunner · file-local already sufficient", Path("artifacts/smolrunner-parent-scope.json")),
+              ("Glaeda historical corpus · file-local already sufficient", Path("artifacts/smolrunner-parent-scope.json")),
               ("Stensibly · parent adds missing lessons", Path("artifacts/stensibly-parent-scope.json")),
           ]
           with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as out:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -276,7 +276,7 @@ Work should be proportional to the evidence actually needed. Cheap irrelevant pa
 - #16 — dogfood/evaluation corpus
 - #41 — Stensibly agentic organizational-history corpus
 - #137 — behavioral A/B and interruption outcomes
-- SmolRunner replay research
+- Glaeda replay research over the pinned SmolRunner-era corpus
 
 Evaluation should include positive controls, quiet negatives, false assumptions, failed proofs, duplicate lanes, second-order regressions, and whether surfaced evidence actually changed behavior.
 

--- a/research/external-repository-dogfood.md
+++ b/research/external-repository-dogfood.md
@@ -110,9 +110,11 @@ Registered replay cases use exact 40-hex revisions. PR and issue numbers remain 
 
 The registry is intentionally small metadata. Adding fifty historical questions should add roughly fifty descriptors, not fifty default CI jobs or fifty repository clones.
 
-## First external carrier: SmolRunner
+## First external carrier: Glaeda historical corpus
 
-Issue #62 already established a useful pinned SmolRunner history replay at:
+Glaeda is the current product name. This section keeps SmolRunner where the pinned repository/corpus identity belongs to the historical evidence.
+
+Issue #62 already established a useful pinned history replay from Glaeda's SmolRunner-era corpus at:
 
 ```text
 teamleaderleo/smolrunner@ed3b70e375a57eabce26f2311f798f75b33bdeb0
@@ -123,7 +125,7 @@ That target is a good first carrier because it has known earned-history discrimi
 
 ### Executed receipt
 
-PR #129 ran the temporary carrier against that exact SmolRunner coordinate:
+PR #129 ran the temporary carrier against that exact SmolRunner-era coordinate:
 
 ```text
 workflow run: 32240366281
@@ -297,7 +299,7 @@ The useful Fieldwork corpus spans issues, investigations, notes, bug-species syn
 
 The current registry starts with:
 
-- SmolRunner for earned local history and agent-context work;
+- Glaeda, using the pinned SmolRunner-era corpus for earned local history and agent-context work;
 - Cloud Hypervisor for repository-vs-file precedent tension;
 - Stensibly for longitudinal agentic churn and handoff/recovery questions;
 - Linux Fieldwork for bug-species and research-memory controls.


### PR DESCRIPTION
Closes #356

## What changed

- use Glaeda in current JEI workflow job/step/summary labels;
- describe the live external-dogfood lane as Glaeda while identifying retained SmolRunner-era corpus evidence explicitly;
- update the current roadmap to name Glaeda replay research;
- preserve pinned `teamleaderleo/smolrunner` coordinates, exact revisions, historical case IDs/source labels, and existing receipt/artifact filenames.

## Boundary

This is naming maintenance only. Historical corpus identity and reproducible evidence coordinates remain unchanged.

## Verification

- self-reviewed the complete `main...rename/356-glaeda-consumer` diff;
- `CI` — success, including format, clippy, tests, reference guards, repository dogfood, history, CI-filter, and PR-diff checks;
- `JEI historical budget pilot` — success, including exact pinned-coordinate verification and both positive/negative controls;
- `JEI change-set scope pilot` — success;
- `JEI parent-scope inference pilot` — success;
- generated-provenance review dogfood — success.