### PR TITLE
Research reversible local aliases over canonical C1

### DIFF
--- a/research/c1-local-aliases.md
+++ b/research/c1-local-aliases.md
@@ -1,0 +1,29 @@
+# C1 local alias research
+
+Issue: #155
+
+This experiment keeps canonical C1 as the semantic source and applies a reversible report-local string table only after ordinary C1 encoding.
+
+The retained external input is the raw `AnalysisReport` captured from the historical SmolRunner replay used by closed evidence carrier #143. Its old byte measurements are historical receipts only. This branch re-encodes that raw report with current `main` before measuring alias savings.
+
+Candidate rule:
+
+```text
+repeated canonical JSON string literal
++ replacement bytes saved > alias declaration bytes
+-> eligible local alias
+```
+
+Alias numbers are packet-local and carry no durable identity. Expansion must reproduce canonical C1 byte-for-byte before the existing C1 decoder runs. Inputs that do not earn positive total savings remain ordinary C1.
+
+The executable controls live in `tests/c1_local_alias.rs` and cover:
+
+- fresh current-C1 measurement over the retained external report;
+- byte-identical expansion and ordinary C1 decode;
+- deterministic alias selection;
+- a representative current report;
+- a tiny no-repetition report that stays plain C1;
+- rejection of a frequent low-value one-character literal;
+- malformed definitions, duplicate values, unknown references, and references inside JSON strings.
+
+Exact current byte results are recorded on the PR after hosted CI executes the branch.

--- a/src/c1_local_alias.rs
+++ b/src/c1_local_alias.rs
@@ -1,0 +1,390 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+
+const ALIAS_HEADER: &str = "C1A";
+const CANONICAL_HEADER: &str = "C1";
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct AliasError {
+    message: String,
+}
+
+impl AliasError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for AliasError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "C1 local aliases: {}", self.message)
+    }
+}
+
+impl Error for AliasError {}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct AliasEntry {
+    pub id: usize,
+    pub value: String,
+    pub occurrences: usize,
+    pub net_bytes_saved: usize,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct AliasTransform {
+    pub encoded: String,
+    pub aliases: Vec<AliasEntry>,
+    pub canonical_bytes: usize,
+    pub encoded_bytes: usize,
+}
+
+impl AliasTransform {
+    pub fn used_aliases(&self) -> bool {
+        !self.aliases.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct Candidate {
+    raw_literal: String,
+    occurrences: usize,
+    preliminary_savings: usize,
+}
+
+pub fn alias_canonical_c1(input: &str) -> Result<AliasTransform, AliasError> {
+    if !input.starts_with("C1\n") {
+        return Err(AliasError::new(
+            "input must begin with the canonical `C1` header",
+        ));
+    }
+
+    let spans = json_string_spans(input)?;
+    let mut counts = BTreeMap::<String, usize>::new();
+    for (start, end) in &spans {
+        *counts.entry(input[*start..*end].to_string()).or_default() += 1;
+    }
+
+    let mut candidates = counts
+        .into_iter()
+        .filter_map(|(raw_literal, occurrences)| {
+            if occurrences < 2 {
+                return None;
+            }
+            let preliminary_savings = alias_net_savings(raw_literal.len(), occurrences, 1)?;
+            Some(Candidate {
+                raw_literal,
+                occurrences,
+                preliminary_savings,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    candidates.sort_by(|left, right| {
+        right
+            .preliminary_savings
+            .cmp(&left.preliminary_savings)
+            .then_with(|| left.raw_literal.cmp(&right.raw_literal))
+    });
+
+    let mut selected = Vec::<(String, usize, usize)>::new();
+    for candidate in candidates {
+        let id = selected.len() + 1;
+        let Some(net_bytes_saved) =
+            alias_net_savings(candidate.raw_literal.len(), candidate.occurrences, id)
+        else {
+            continue;
+        };
+        selected.push((
+            candidate.raw_literal,
+            candidate.occurrences,
+            net_bytes_saved,
+        ));
+    }
+
+    if selected.is_empty() {
+        return Ok(plain_transform(input));
+    }
+
+    let lookup = selected
+        .iter()
+        .enumerate()
+        .map(|(index, (raw_literal, _, _))| (raw_literal.as_str(), index + 1))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut body = String::with_capacity(input.len());
+    let mut cursor = 0usize;
+    for (start, end) in spans {
+        body.push_str(&input[cursor..start]);
+        let raw_literal = &input[start..end];
+        if let Some(id) = lookup.get(raw_literal) {
+            body.push('@');
+            body.push_str(&id.to_string());
+        } else {
+            body.push_str(raw_literal);
+        }
+        cursor = end;
+    }
+    body.push_str(&input[cursor..]);
+
+    let mut encoded = String::new();
+    encoded.push_str(ALIAS_HEADER);
+    encoded.push('\n');
+    for (index, (raw_literal, _, _)) in selected.iter().enumerate() {
+        encoded.push('A');
+        encoded.push_str(&(index + 1).to_string());
+        encoded.push(' ');
+        encoded.push_str(raw_literal);
+        encoded.push('\n');
+    }
+    encoded.push_str(&body);
+
+    if encoded.len() >= input.len() {
+        return Ok(plain_transform(input));
+    }
+
+    let aliases = selected
+        .into_iter()
+        .enumerate()
+        .map(|(index, (raw_literal, occurrences, net_bytes_saved))| {
+            let value = serde_json::from_str::<String>(&raw_literal).map_err(|error| {
+                AliasError::new(format!("invalid canonical C1 string literal: {error}"))
+            })?;
+            Ok(AliasEntry {
+                id: index + 1,
+                value,
+                occurrences,
+                net_bytes_saved,
+            })
+        })
+        .collect::<Result<Vec<_>, AliasError>>()?;
+
+    Ok(AliasTransform {
+        canonical_bytes: input.len(),
+        encoded_bytes: encoded.len(),
+        encoded,
+        aliases,
+    })
+}
+
+pub fn expand_c1_aliases(input: &str) -> Result<String, AliasError> {
+    if input.starts_with("C1\n") {
+        return Ok(input.to_string());
+    }
+    if !input.starts_with("C1A\n") {
+        return Err(AliasError::new(
+            "input must begin with `C1` or the research `C1A` header",
+        ));
+    }
+
+    let mut offset = "C1A\n".len();
+    let mut aliases = BTreeMap::<usize, String>::new();
+    let mut values = BTreeSet::<String>::new();
+    let body_offset = loop {
+        let remainder = &input[offset..];
+        let Some(relative_end) = remainder.find('\n') else {
+            return Err(AliasError::new("alias packet is missing canonical C1 body"));
+        };
+        let line_end = offset + relative_end;
+        let line = &input[offset..line_end];
+        let next_offset = line_end + 1;
+
+        if line == CANONICAL_HEADER {
+            break offset;
+        }
+
+        let (id, raw_literal) = parse_alias_definition(line)?;
+        let expected_id = aliases.len() + 1;
+        if id != expected_id {
+            return Err(AliasError::new(format!(
+                "alias A{id} is out of sequence; expected A{expected_id}"
+            )));
+        }
+        if aliases.insert(id, raw_literal.clone()).is_some() {
+            return Err(AliasError::new(format!("duplicate alias id A{id}")));
+        }
+        if !values.insert(raw_literal) {
+            return Err(AliasError::new("duplicate alias literal"));
+        }
+        offset = next_offset;
+    };
+
+    if aliases.is_empty() {
+        return Err(AliasError::new(
+            "C1A packet must declare at least one alias",
+        ));
+    }
+
+    expand_body(&input[body_offset..], &aliases)
+}
+
+fn plain_transform(input: &str) -> AliasTransform {
+    AliasTransform {
+        encoded: input.to_string(),
+        aliases: Vec::new(),
+        canonical_bytes: input.len(),
+        encoded_bytes: input.len(),
+    }
+}
+
+fn alias_net_savings(literal_bytes: usize, occurrences: usize, id: usize) -> Option<usize> {
+    let digits = id.to_string().len();
+    let token_bytes = 1 + digits;
+    if literal_bytes <= token_bytes {
+        return None;
+    }
+    let replacement_savings = occurrences.checked_mul(literal_bytes - token_bytes)?;
+    let declaration_bytes = literal_bytes.checked_add(digits + 3)?;
+    let net = replacement_savings.checked_sub(declaration_bytes)?;
+    (net > 0).then_some(net)
+}
+
+fn parse_alias_definition(line: &str) -> Result<(usize, String), AliasError> {
+    let Some(rest) = line.strip_prefix('A') else {
+        return Err(AliasError::new(format!(
+            "malformed alias definition `{line}`"
+        )));
+    };
+    let Some((id_text, raw_literal)) = rest.split_once(' ') else {
+        return Err(AliasError::new(format!(
+            "malformed alias definition `{line}`"
+        )));
+    };
+    if id_text.is_empty() || !id_text.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(AliasError::new(format!("invalid alias id `{id_text}`")));
+    }
+    let id = id_text
+        .parse::<usize>()
+        .map_err(|_| AliasError::new(format!("invalid alias id `{id_text}`")))?;
+    if id == 0 {
+        return Err(AliasError::new("alias ids start at A1"));
+    }
+
+    let value = serde_json::from_str::<String>(raw_literal)
+        .map_err(|error| AliasError::new(format!("invalid alias JSON string: {error}")))?;
+    let canonical = serde_json::to_string(&value).map_err(|error| {
+        AliasError::new(format!("could not canonicalize alias string: {error}"))
+    })?;
+    if canonical != raw_literal {
+        return Err(AliasError::new(
+            "alias literal must use canonical JSON encoding",
+        ));
+    }
+
+    Ok((id, raw_literal.to_string()))
+}
+
+fn json_string_spans(input: &str) -> Result<Vec<(usize, usize)>, AliasError> {
+    let bytes = input.as_bytes();
+    let mut spans = Vec::new();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        if bytes[index] != b'"' {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        index += 1;
+        let mut escaped = false;
+        let mut closed = false;
+        while index < bytes.len() {
+            let byte = bytes[index];
+            if escaped {
+                escaped = false;
+                index += 1;
+                continue;
+            }
+            if byte == b'\\' {
+                escaped = true;
+                index += 1;
+                continue;
+            }
+            if byte == b'"' {
+                index += 1;
+                spans.push((start, index));
+                closed = true;
+                break;
+            }
+            index += 1;
+        }
+        if !closed {
+            return Err(AliasError::new("unterminated JSON string in canonical C1"));
+        }
+    }
+
+    Ok(spans)
+}
+
+fn expand_body(body: &str, aliases: &BTreeMap<usize, String>) -> Result<String, AliasError> {
+    if !body.starts_with("C1\n") {
+        return Err(AliasError::new(
+            "alias body must begin with canonical `C1` header",
+        ));
+    }
+
+    let bytes = body.as_bytes();
+    let mut output = String::with_capacity(body.len());
+    let mut cursor = 0usize;
+    let mut index = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if byte == b'"' {
+            in_string = true;
+            index += 1;
+            continue;
+        }
+
+        if byte != b'@' {
+            index += 1;
+            continue;
+        }
+
+        output.push_str(&body[cursor..index]);
+        let token_start = index;
+        index += 1;
+        let digits_start = index;
+        while index < bytes.len() && bytes[index].is_ascii_digit() {
+            index += 1;
+        }
+        if digits_start == index {
+            return Err(AliasError::new(format!(
+                "malformed alias reference at byte {token_start}"
+            )));
+        }
+        let id_text = &body[digits_start..index];
+        let id = id_text
+            .parse::<usize>()
+            .map_err(|_| AliasError::new(format!("invalid alias reference `@{id_text}`")))?;
+        let raw_literal = aliases
+            .get(&id)
+            .ok_or_else(|| AliasError::new(format!("unknown alias reference `@{id}`")))?;
+        output.push_str(raw_literal);
+        cursor = index;
+    }
+
+    if in_string {
+        return Err(AliasError::new("unterminated JSON string in alias body"));
+    }
+
+    output.push_str(&body[cursor..]);
+    Ok(output)
+}

--- a/tests/c1_local_alias.rs
+++ b/tests/c1_local_alias.rs
@@ -1,0 +1,166 @@
+#[allow(dead_code)]
+#[path = "../src/c1_local_alias.rs"]
+mod c1_local_alias;
+#[allow(dead_code)]
+#[path = "../src/compact_ir.rs"]
+mod compact_ir;
+#[allow(dead_code)]
+#[path = "../src/finding.rs"]
+mod finding;
+
+use c1_local_alias::{alias_canonical_c1, expand_c1_aliases};
+use finding::{AnalysisReport, Claim, ClaimKind, Evidence, Finding, Location};
+
+fn representative_report() -> AnalysisReport {
+    AnalysisReport {
+        schema_version: 1,
+        analysis: "projection-compression-research".to_string(),
+        repository: "/repo".to_string(),
+        claims: vec![
+            Claim::new(
+                ClaimKind::Derived,
+                "Current work and active work were compared at the admitted coordinates.",
+            )
+            .with_evidence(Evidence::new(
+                "Current work is #121 at exact head abcdef1234567890.",
+            ))
+            .with_evidence(Evidence::new(
+                "Other work is #124 at exact head fedcba0987654321.",
+            )),
+        ],
+        findings: vec![
+            Finding::new("preflight-explicit-coordination", "Explicit coordination edge")
+                .at(Location::new("src/auth.rs", Some(42)))
+                .with_claim(
+                    Claim::new(
+                        ClaimKind::Observed,
+                        "The admitted inventory records `hold_merge_while` from `#121` to `#124`.",
+                    )
+                    .with_evidence(Evidence::new(
+                        "Coordination source reference: github:pull/121.",
+                    ))
+                    .with_evidence(Evidence::new(
+                        "Related active work #124 is at exact head fedcba0987654321.",
+                    )),
+                )
+                .with_claim(Claim::new(
+                    ClaimKind::Unknown,
+                    "The inventory does not establish the operational consequence beyond the declared relation.",
+                ))
+                .with_question(
+                    "Should merge order be coordinated before either change advances the evidence baseline?",
+                ),
+        ],
+    }
+}
+
+#[test]
+fn retained_historical_scan_gets_material_alias_savings_and_exact_round_trip() {
+    let report: AnalysisReport =
+        serde_json::from_str(include_str!("fixtures/smolrunner_scan_ed3b70e.json")).unwrap();
+    let canonical = compact_ir::encode_report(&report).unwrap();
+    let transformed = alias_canonical_c1(&canonical).unwrap();
+
+    assert!(transformed.used_aliases());
+    assert_eq!(transformed.canonical_bytes, canonical.len());
+    assert_eq!(transformed.encoded_bytes, transformed.encoded.len());
+    assert!(transformed.encoded_bytes < transformed.canonical_bytes);
+
+    let bytes_saved = transformed.canonical_bytes - transformed.encoded_bytes;
+    assert!(
+        bytes_saved * 100 >= transformed.canonical_bytes * 20,
+        "expected at least 20% savings; canonical={} aliased={} saved={}",
+        transformed.canonical_bytes,
+        transformed.encoded_bytes,
+        bytes_saved
+    );
+
+    let values = transformed
+        .aliases
+        .iter()
+        .map(|alias| alias.value.as_str())
+        .collect::<Vec<_>>();
+    assert!(values.contains(&"src/unix_personal_worker_store.rs"));
+    assert!(values.contains(&"test-module-one-off"));
+    assert!(values.contains(&"One-off test-module name"));
+    assert!(values.contains(
+        &"Is this one-off name intentionally scoped, or an accidental deviation from local precedent?"
+    ));
+    assert!(
+        !values.contains(&"O"),
+        "the frequent one-character claim code must lose to declaration overhead"
+    );
+    assert!(
+        transformed
+            .aliases
+            .iter()
+            .all(|alias| alias.net_bytes_saved > 0)
+    );
+
+    let second = alias_canonical_c1(&canonical).unwrap();
+    assert_eq!(
+        second, transformed,
+        "same C1 input must alias deterministically"
+    );
+
+    let expanded = expand_c1_aliases(&transformed.encoded).unwrap();
+    assert_eq!(expanded.as_bytes(), canonical.as_bytes());
+    assert_eq!(compact_ir::decode_report(&expanded).unwrap(), report);
+}
+
+#[test]
+fn representative_c1_report_remains_exact_after_optional_aliasing() {
+    let report = representative_report();
+    let canonical = compact_ir::encode_report(&report).unwrap();
+    let transformed = alias_canonical_c1(&canonical).unwrap();
+    let expanded = expand_c1_aliases(&transformed.encoded).unwrap();
+
+    assert_eq!(expanded, canonical);
+    assert_eq!(compact_ir::decode_report(&expanded).unwrap(), report);
+    assert!(transformed.encoded_bytes <= transformed.canonical_bytes);
+}
+
+#[test]
+fn tiny_no_repetition_report_stays_plain_c1() {
+    let report = AnalysisReport {
+        schema_version: 1,
+        analysis: "a".to_string(),
+        repository: "r".to_string(),
+        claims: vec![Claim::new(ClaimKind::Observed, "m")],
+        findings: Vec::new(),
+    };
+    let canonical = compact_ir::encode_report(&report).unwrap();
+    let transformed = alias_canonical_c1(&canonical).unwrap();
+
+    assert!(!transformed.used_aliases());
+    assert_eq!(transformed.encoded, canonical);
+    assert_eq!(transformed.encoded_bytes, transformed.canonical_bytes);
+    assert_eq!(expand_c1_aliases(&transformed.encoded).unwrap(), canonical);
+}
+
+#[test]
+fn alias_expansion_is_strict_and_only_resolves_tokens_outside_json_strings() {
+    let packet = concat!(
+        "C1A\n",
+        "A1 \"replacement\"\n",
+        "C1\n",
+        "R[1,\"literal @1 stays literal\",\"repo\"]\n",
+        "C[\"O\",@1]\n",
+    );
+    let expanded = expand_c1_aliases(packet).unwrap();
+    assert_eq!(
+        expanded,
+        concat!(
+            "C1\n",
+            "R[1,\"literal @1 stays literal\",\"repo\"]\n",
+            "C[\"O\",\"replacement\"]\n",
+        )
+    );
+
+    assert!(expand_c1_aliases("C1A\nC1\nR[1,\"a\",\"r\"]\n").is_err());
+    assert!(expand_c1_aliases("C1A\nA2 \"x\"\nC1\nR[1,@2,\"r\"]\n").is_err());
+    assert!(expand_c1_aliases("C1A\nA1 \"x\"\nA2 \"x\"\nC1\nR[1,@1,@2]\n").is_err());
+    assert!(expand_c1_aliases("C1A\nA1 \"x\"\nC1\nR[1,@2,\"r\"]\n").is_err());
+    assert!(expand_c1_aliases("C1A\nA1 \"x\"\nC1\nR[1,@x,\"r\"]\n").is_err());
+    assert!(expand_c1_aliases("C1A\nA1 nope\nC1\nR[1,@1,\"r\"]\n").is_err());
+}

--- a/tests/fixtures/smolrunner_scan_ed3b70e.json
+++ b/tests/fixtures/smolrunner_scan_ed3b70e.json
@@ -1,0 +1,131 @@
+{
+  "schema_version": 1,
+  "analysis": "test-module-conventions",
+  "repository": "/home/runner/work/cultist/cultist/target",
+  "claims": [
+    {
+      "kind": "observed",
+      "message": "Found 130 test-gated modules across 4 distinct names.",
+      "evidence": [
+        {
+          "message": "Repository counts: `tests`=127, `clone_identity_tests`=1, `publication_fault`=1, `publication_fault_tests`=1."
+        }
+      ]
+    },
+    {
+      "kind": "observed",
+      "message": "`tests` is the most frequent test-module name (127 of 130)."
+    }
+  ],
+  "findings": [
+    {
+      "kind": "test-module-local-mix",
+      "title": "File-local test-module naming mix",
+      "location": {
+        "path": "src/unix_personal_worker_store.rs"
+      },
+      "claims": [
+        {
+          "kind": "observed",
+          "message": "This file uses 3 different names for test-gated modules: `publication_fault`, `publication_fault_tests`, `tests`.",
+          "evidence": [
+            {
+              "message": "`mod publication_fault` is test-gated here.",
+              "location": {
+                "path": "src/unix_personal_worker_store.rs",
+                "line": 35
+              }
+            },
+            {
+              "message": "`mod publication_fault_tests` is test-gated here.",
+              "location": {
+                "path": "src/unix_personal_worker_store.rs",
+                "line": 37
+              }
+            },
+            {
+              "message": "`mod tests` is test-gated here.",
+              "location": {
+                "path": "src/unix_personal_worker_store.rs",
+                "line": 1326
+              }
+            }
+          ]
+        }
+      ],
+      "question": "Is the local mix deliberate, or would one name make the file easier to read?"
+    },
+    {
+      "kind": "test-module-one-off",
+      "title": "One-off test-module name",
+      "location": {
+        "path": "src/disposable_attempt_catalog.rs",
+        "line": 1092
+      },
+      "claims": [
+        {
+          "kind": "observed",
+          "message": "`clone_identity_tests` appears once across 130 test-gated modules.",
+          "evidence": [
+            {
+              "message": "`mod clone_identity_tests` is declared here.",
+              "location": {
+                "path": "src/disposable_attempt_catalog.rs",
+                "line": 1092
+              }
+            }
+          ]
+        }
+      ],
+      "question": "Is this one-off name intentionally scoped, or an accidental deviation from local precedent?"
+    },
+    {
+      "kind": "test-module-one-off",
+      "title": "One-off test-module name",
+      "location": {
+        "path": "src/unix_personal_worker_store.rs",
+        "line": 35
+      },
+      "claims": [
+        {
+          "kind": "observed",
+          "message": "`publication_fault` appears once across 130 test-gated modules.",
+          "evidence": [
+            {
+              "message": "`mod publication_fault` is declared here.",
+              "location": {
+                "path": "src/unix_personal_worker_store.rs",
+                "line": 35
+              }
+            }
+          ]
+        }
+      ],
+      "question": "Is this one-off name intentionally scoped, or an accidental deviation from local precedent?"
+    },
+    {
+      "kind": "test-module-one-off",
+      "title": "One-off test-module name",
+      "location": {
+        "path": "src/unix_personal_worker_store.rs",
+        "line": 37
+      },
+      "claims": [
+        {
+          "kind": "observed",
+          "message": "`publication_fault_tests` appears once across 130 test-gated modules.",
+          "evidence": [
+            {
+              "message": "`mod publication_fault_tests` is declared here.",
+              "location": {
+                "path": "src/unix_personal_worker_store.rs",
+                "line": 37
+              }
+            }
+          ]
+        }
+      ],
+      "question": "Is this one-off name intentionally scoped, or an accidental deviation from local precedent?"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #155

## Experiment

Add a research-only reversible transform over canonical C1 text:

`AnalysisReport -> existing C1 -> local aliases -> exact C1 expansion -> existing C1 decoder`.

The alias layer:
- scans canonical JSON string literals only;
- selects repeated literals only when each alias has strictly positive measured net savings after declaration cost;
- uses packet-local `@N` references outside JSON strings;
- expands back to byte-identical canonical C1 before normal decoding;
- rejects malformed, out-of-sequence, duplicate-literal, and unknown alias references;
- returns ordinary C1 unchanged when the wrapper would fail to save bytes.

## Corpus and current measurement

The raw `smolrunner_scan_ed3b70e.json` report is retained from evidence-only #143. #143's older renderer-size measurements remain historical; this PR re-encodes the raw report with current `main` before measuring aliases.

Exact current result on final head:

```text
canonical C1   1981 bytes
C1A aliases    1483 bytes
saved           498 bytes (25.1%)
profitable aliases 5
```

The five selected literals are the repeated path/kind/title/question strings that pay for their declarations. The frequently repeated one-character `O` claim code remains literal because its declaration has no positive net saving.

The acceptance suite also reuses the representative report from merged #132 plus a tiny no-repetition negative.

## Verification

Final compact carrier:

```text
base  d0a44ad60bacd813e2473965d7f76d19aabe88bd
head  6b8ab1bc4fd04f06439e52ad3427c9a0cc27d581
commits 1
files   4
tree    63ff8ec98f1157d6bc9adbe4e76f27a90adf8a31
```

- `CI` run `32904663050`: success — rustfmt, strict Clippy, full tests, project/review/closure/reference guards, active-work checks, and repository/history/CI-filter/PR-diff dogfood all passed.
- generated-provenance review dogfood `32904663023`: success.
- exact C1 expansion is byte-identical before the ordinary decoder runs; round-trip returns the exact `AnalysisReport`.
- malformed/out-of-sequence/duplicate definitions and unknown references fail; `@N` inside JSON strings stays literal.
- tiny/no-repetition input stays ordinary C1.
- same canonical C1 input selects aliases deterministically.
- PR discussion currently has no review comments.

The compacted final tree is byte-identical to exploratory green head `7f953343e30c95899f570a269f1e1dee2afdd5e6` (CI `32904301296`). An earlier compact commit used a stale pre-rustfmt test blob and failed only the format gate; it was superseded before this final certification.

Research-only; no canonical C1 format, public CLI, or durable alias identity change.