### PR TITLE
Prefilter byte-proven irrelevant Rust repository files

### DIFF
--- a/src/ci_test_filters.rs
+++ b/src/ci_test_filters.rs
@@ -183,6 +183,7 @@ fn collect_explicit_tests(
 ) -> Result<(), Box<dyn Error>> {
     let scan = scan_rust_repository(root, &BTreeSet::new(), SKIPPED_RUST_DIRS)?;
     performance::record_rust_scan(scan.parsed_files, scan.cache_hits);
+    performance::record_rust_prefiltered(scan.prefiltered_files);
 
     for file in scan.files {
         if let Some(error) = file.facts.parse_error {
@@ -478,6 +479,30 @@ mod tests {
         assert!(report.commands.is_empty());
         assert!(report.tests.is_empty());
         assert!(report.parse_failures.is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn supported_workflow_records_prefiltered_rust_work() {
+        let root = unique_temp_dir("ci-tests-prefilter");
+        fs::create_dir_all(root.join(".github/workflows")).unwrap();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(
+            root.join(".github/workflows/ci.yml"),
+            "steps:\n  - run: cargo test --lib existing_test\n",
+        )
+        .unwrap();
+        fs::write(root.join("src/lib.rs"), "#[test]\nfn existing_test() {}\n").unwrap();
+        fs::write(root.join("src/value.rs"), "pub const VALUE: usize = 42;\n").unwrap();
+
+        let (report, counters) = performance::capture(|| analyze_ci_test_filters(&root).unwrap());
+
+        assert_eq!(report.commands.len(), 1);
+        assert_eq!(report.tests.len(), 1);
+        assert!(report.parse_failures.is_empty());
+        assert_eq!(counters.rust_files_parsed, 1);
+        assert_eq!(counters.rust_files_prefiltered, 1);
+
         fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -20,6 +20,7 @@ pub struct PerfCounters {
     pub wall_time_us: u64,
     pub git_subprocesses: usize,
     pub rust_files_parsed: usize,
+    pub rust_files_prefiltered: usize,
     pub rust_cache_hits: usize,
     pub baseline_scope_hits: usize,
     pub baseline_scope_computed: usize,
@@ -50,6 +51,14 @@ pub fn record_rust_scan(parsed: usize, cache_hits: usize) {
         if let Some(state) = state.borrow_mut().as_mut() {
             state.counters.rust_files_parsed += parsed;
             state.counters.rust_cache_hits += cache_hits;
+        }
+    });
+}
+
+pub fn record_rust_prefiltered(prefiltered: usize) {
+    STATE.with(|state| {
+        if let Some(state) = state.borrow_mut().as_mut() {
+            state.counters.rust_files_prefiltered += prefiltered;
         }
     });
 }
@@ -110,6 +119,7 @@ mod tests {
     fn disabled_counters_are_inert() {
         record_git_subprocess();
         record_rust_scan(3, 4);
+        record_rust_prefiltered(5);
         assert_eq!(finish(), None);
     }
 
@@ -119,9 +129,11 @@ mod tests {
             record_git_subprocess();
             record_git_subprocess();
             record_rust_scan(3, 7);
+            record_rust_prefiltered(5);
         });
         assert_eq!(counters.git_subprocesses, 2);
         assert_eq!(counters.rust_files_parsed, 3);
+        assert_eq!(counters.rust_files_prefiltered, 5);
         assert_eq!(counters.rust_cache_hits, 7);
     }
 }

--- a/src/rust_facts.rs
+++ b/src/rust_facts.rs
@@ -44,6 +44,7 @@ pub struct RustFactScan {
     pub files: Vec<RustFactFile>,
     pub cache_hits: usize,
     pub parsed_files: usize,
+    pub prefiltered_files: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -88,7 +89,7 @@ pub fn scan_rust_repository(
 ) -> Result<RustFactScan, Box<dyn Error>> {
     let inputs = rust_inputs(root, excluded_paths, skipped_dirs)?;
     let cache = FactCache::from_environment();
-    scan_inputs(&inputs, cache.as_ref())
+    scan_repository_inputs(&inputs, cache.as_ref())
 }
 
 pub fn scan_rust_paths(paths: &[PathBuf]) -> Result<RustFactScan, Box<dyn Error>> {
@@ -105,9 +106,24 @@ pub fn scan_rust_paths(paths: &[PathBuf]) -> Result<RustFactScan, Box<dyn Error>
     scan_inputs(&inputs, None)
 }
 
+fn scan_repository_inputs(
+    inputs: &[RustInput],
+    cache: Option<&FactCache>,
+) -> Result<RustFactScan, Box<dyn Error>> {
+    scan_inputs_inner(inputs, cache, true)
+}
+
 fn scan_inputs(
     inputs: &[RustInput],
     cache: Option<&FactCache>,
+) -> Result<RustFactScan, Box<dyn Error>> {
+    scan_inputs_inner(inputs, cache, false)
+}
+
+fn scan_inputs_inner(
+    inputs: &[RustInput],
+    cache: Option<&FactCache>,
+    prefilter_repository_inputs: bool,
 ) -> Result<RustFactScan, Box<dyn Error>> {
     let mut scan = RustFactScan::default();
 
@@ -118,8 +134,39 @@ fn scan_inputs(
             .and_then(|content_id| cache.and_then(|cache| cache.load(content_id)));
 
         let facts = if let Some(facts) = cached {
-            scan.cache_hits += 1;
-            facts
+            if prefilter_repository_inputs && facts.parse_error.is_some() {
+                let source = fs::read_to_string(&input.path)?;
+                if source_might_contain_shared_facts(&source) {
+                    scan.cache_hits += 1;
+                    facts
+                } else {
+                    // Old v1 cache entries may contain parse errors for files
+                    // whose bytes prove they cannot contribute the current
+                    // shared fact families. Ignore that history-dependent
+                    // receipt so warm and cold repository scans agree.
+                    scan.prefiltered_files += 1;
+                    RustFileFacts::default()
+                }
+            } else {
+                scan.cache_hits += 1;
+                facts
+            }
+        } else if prefilter_repository_inputs {
+            let source = fs::read_to_string(&input.path)?;
+            if source_might_contain_shared_facts(&source) {
+                scan.parsed_files += 1;
+                let facts = extract_rust_source(&source);
+                if let (Some(cache), Some(content_id)) = (cache, input.content_id.as_deref()) {
+                    cache.store(content_id, &facts);
+                }
+                facts
+            } else {
+                // Keep prefiltered negatives out of the shared syntax cache.
+                // That cache remains an exact receipt of full extraction and
+                // can continue serving consumers that explicitly request it.
+                scan.prefiltered_files += 1;
+                RustFileFacts::default()
+            }
         } else {
             scan.parsed_files += 1;
             let facts = extract_rust_file(&input.path)?;
@@ -142,6 +189,15 @@ fn scan_inputs(
 fn extract_rust_file(path: &Path) -> Result<RustFileFacts, Box<dyn Error>> {
     let source = fs::read_to_string(path)?;
     Ok(extract_rust_source(&source))
+}
+
+fn source_might_contain_shared_facts(source: &str) -> bool {
+    // Raw substring checks intentionally favor false positives. Every module
+    // fact requires the Rust `mod` keyword. Every explicit #[test] function
+    // requires both `test` and `fn`. Comments, strings, longer identifiers,
+    // and nested cfg syntax may therefore trigger a full parse; they never
+    // cause a candidate source to be skipped.
+    source.contains("mod") || (source.contains("test") && source.contains("fn"))
 }
 
 fn extract_rust_source(source: &str) -> RustFileFacts {
@@ -572,6 +628,91 @@ mod tests {
         assert!(facts.module_names.contains(&"support".to_string()));
         assert!(facts.module_names.contains(&"tests".to_string()));
         assert_eq!(facts.parse_error, None);
+    }
+
+    #[test]
+    fn raw_prefilter_favors_false_positives_for_current_fact_families() {
+        assert!(!source_might_contain_shared_facts(
+            "pub const VALUE: usize = 42;"
+        ));
+        assert!(source_might_contain_shared_facts(
+            "#[cfg(all(unix, test))] mod unix_tests {}"
+        ));
+        assert!(source_might_contain_shared_facts(
+            "const EXAMPLE: &str = \"mod fake {}\";"
+        ));
+        assert!(source_might_contain_shared_facts(
+            "const EXAMPLE: &str = \"#[test] fn fake_test() {}\";"
+        ));
+    }
+
+    #[test]
+    fn repository_prefilter_skips_only_byte_proven_irrelevant_sources() {
+        let root = init_repo("rust-fact-prefilter");
+        fs::write(
+            root.join("src/relevant.rs"),
+            "#[cfg(all(unix, test))]\nmod unix_tests {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("src/comment_candidate.rs"),
+            "// mod fake {}\npub const EXAMPLE: &str = \"fn fake_test() {}\";\n",
+        )
+        .unwrap();
+        fs::write(root.join("src/value.rs"), "pub const VALUE: usize = 42;\n").unwrap();
+
+        let inputs = rust_inputs(&root, &BTreeSet::new(), &[".git", "target"]).unwrap();
+        let scan = scan_repository_inputs(&inputs, None).unwrap();
+
+        assert_eq!(scan.parsed_files, 2);
+        assert_eq!(scan.prefiltered_files, 1);
+        assert_eq!(scan.cache_hits, 0);
+        assert_eq!(scan.files.len(), 3);
+        let relevant = scan
+            .files
+            .iter()
+            .find(|file| file.path.ends_with("src/relevant.rs"))
+            .unwrap();
+        assert_eq!(relevant.facts.test_modules[0].name, "unix_tests");
+        let comment_candidate = scan
+            .files
+            .iter()
+            .find(|file| file.path.ends_with("src/comment_candidate.rs"))
+            .unwrap();
+        assert!(comment_candidate.facts.test_modules.is_empty());
+        assert!(comment_candidate.facts.explicit_tests.is_empty());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn repository_prefilter_ignores_old_irrelevant_parse_error_cache_receipt() {
+        let root = init_repo("rust-fact-prefilter-cache");
+        let cache = FactCache {
+            root: root.join("cache"),
+        };
+        let source = root.join("src/lib.rs");
+        fs::write(&source, "this is deliberately invalid Rust {{{\n").unwrap();
+        run_git(&root, &["add", "."]);
+        run_git(&root, &["commit", "-q", "-m", "baseline"]);
+
+        let inputs = rust_inputs(&root, &BTreeSet::new(), &[".git", "target"]).unwrap();
+        let content_id = inputs[0].content_id.as_deref().unwrap();
+        cache.store(
+            content_id,
+            &RustFileFacts {
+                parse_error: Some("historical parse error".to_string()),
+                ..RustFileFacts::default()
+            },
+        );
+
+        let scan = scan_repository_inputs(&inputs, Some(&cache)).unwrap();
+        assert_eq!(scan.cache_hits, 0);
+        assert_eq!(scan.parsed_files, 0);
+        assert_eq!(scan.prefiltered_files, 1);
+        assert_eq!(scan.files[0].facts, RustFileFacts::default());
+
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/test_modules.rs
+++ b/src/test_modules.rs
@@ -46,6 +46,7 @@ pub fn analyze_test_module_files(paths: &[PathBuf]) -> Result<TestModuleReport, 
 
 fn test_module_report(scan: RustFactScan) -> TestModuleReport {
     performance::record_rust_scan(scan.parsed_files, scan.cache_hits);
+    performance::record_rust_prefiltered(scan.prefiltered_files);
     let mut report = TestModuleReport::default();
 
     for file in scan.files {
@@ -158,17 +159,38 @@ mod tests {
     }
 
     #[test]
-    fn repository_scan_budget_counts_git_and_parsed_files() {
+    fn targeted_malformed_file_still_surfaces_parse_failure() {
+        let root = unique_temp_dir("targeted-malformed");
+        fs::create_dir_all(&root).unwrap();
+        let malformed = root.join("malformed.rs");
+        fs::write(&malformed, "this is deliberately invalid Rust {{{").unwrap();
+
+        let (report, counters) = performance::capture(|| {
+            analyze_test_module_files(std::slice::from_ref(&malformed)).unwrap()
+        });
+
+        assert_eq!(report.parse_failures.len(), 1);
+        assert_eq!(report.parse_failures[0].0, malformed);
+        assert_eq!(counters.rust_files_parsed, 1);
+        assert_eq!(counters.rust_files_prefiltered, 0);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn repository_scan_budget_counts_git_parsed_and_prefiltered_files() {
         let root = unique_temp_dir("repository-scan-budget");
         fs::create_dir_all(root.join("src")).unwrap();
         run_git(&root, &["init", "-q"]);
         fs::write(root.join("src/lib.rs"), "#[cfg(test)]\nmod tests {}\n").unwrap();
+        fs::write(root.join("src/value.rs"), "pub const VALUE: usize = 42;\n").unwrap();
 
         let (report, counters) = performance::capture(|| analyze_test_modules(&root).unwrap());
 
         assert_eq!(report.occurrences.len(), 1);
         assert_eq!(counters.git_subprocesses, 4);
         assert_eq!(counters.rust_files_parsed, 1);
+        assert_eq!(counters.rust_files_prefiltered, 1);
         assert_eq!(counters.rust_cache_hits, 0);
 
         fs::remove_dir_all(root).unwrap();


### PR DESCRIPTION
Progresses #45

## Bounded slice

Add the first conservative repository-scan prefilter in the existing shared Rust fact path.

For repository scans only, a cache miss reads the source bytes and skips full `syn` parsing when the bytes rule out both current shared fact families:

```text
module facts        -> require raw `mod`
explicit #[test] fn -> require raw `test` + `fn`
```

The gate deliberately favors false positives. Candidate text inside comments/strings, longer identifiers, and nested cfg forms still pays for a full parse. Targeted `scan_rust_paths` keeps full parsing, preserving changed-file parse-error evidence.

## Cache boundary

Prefiltered negatives stay out of the existing `rust-syntax-v1` cache. A compatibility control handles an old cached parse-error receipt for a byte-proven irrelevant file, so warm and cold repository scans yield the same current facts without changing cache namespace or content identity.

## Work receipt

`CULTIST_PERF` gains additive `rust_files_prefiltered`. Both repository-scan consumers (`test_modules` and `ci_test_filters`) record it while existing `rust_files_parsed` and `rust_cache_hits` semantics remain intact.

Focused controls prove:
- nested `cfg(... test ...)` module still parses and is found;
- `mod` / `#[test] fn` candidates inside comments or strings conservatively parse;
- ordinary byte-proven irrelevant Rust skips `syn`;
- old irrelevant parse-error cache receipt cannot make warm output differ from cold output;
- targeted malformed Rust still parses, surfaces its parse failure, and records `1 parsed / 0 prefiltered`;
- repository test-module scan records `1 parsed / 1 prefiltered` with the same Git-process budget;
- CI-test inventory records `1 parsed / 1 prefiltered` on its mixed fixture.

## Final receipt

```text
base    d0a44ad60bacd813e2473965d7f76d19aabe88bd
head    620895cfcef752905b2636d47cae4a6066eb67d3
commits 1
files   4
tree    89aae1a4c98efc8c9a6f08a0bf58152fcb9b7730
```

- exploratory green head `0d274876c1b5f5966db2a7d2dc82bc274ac26bff` had the exact same tree `89aae1a4c98efc8c9a6f08a0bf58152fcb9b7730`;
- final `CI` run `32906014981`: success — rustfmt, strict Clippy, full tests, project/review/closure/reference guards, active-work checks, and all repository/history/CI-filter/PR-diff dogfood passed;
- generated-provenance review dogfood `32906014975`: success;
- PR discussion currently has no review comments.

The first exploratory run failed only rustfmt on one new test assignment; the formatted tree then passed completely and was compacted byte-for-byte into the final one-commit head.

No report vocabulary, finding semantics, provider/CI behavior, parser dependency, public command surface, or generic extractor framework changes in this slice. #45 remains open for deeper tiered/shared extraction, bounded parallelism, and broader benchmark work.