### PR TITLE
Bound C1A expansion before canonical decode

### DIFF
--- a/src/c1_local_alias.rs
+++ b/src/c1_local_alias.rs
@@ -2,6 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
 
+use crate::compact_ir::MAX_C1_BYTES;
+
 const ALIAS_HEADER: &str = "C1A";
 const CANONICAL_HEADER: &str = "C1";
 
@@ -179,6 +181,11 @@ pub fn expand_c1_aliases(input: &str) -> Result<String, AliasError> {
             "input must begin with `C1` or the research `C1A` header",
         ));
     }
+    if input.len() > MAX_C1_BYTES {
+        return Err(AliasError::new(format!(
+            "C1A input exceeds the {MAX_C1_BYTES}-byte transport limit"
+        )));
+    }
 
     let mut offset = "C1A\n".len();
     let mut aliases = BTreeMap::<usize, String>::new();
@@ -319,6 +326,23 @@ fn json_string_spans(input: &str) -> Result<Vec<(usize, usize)>, AliasError> {
     Ok(spans)
 }
 
+fn checked_expanded_len(current: usize, additional: usize) -> Result<usize, AliasError> {
+    current
+        .checked_add(additional)
+        .ok_or_else(|| AliasError::new("expanded canonical C1 byte count overflow"))
+}
+
+fn append_bounded(output: &mut String, value: &str) -> Result<(), AliasError> {
+    let next_len = checked_expanded_len(output.len(), value.len())?;
+    if next_len > MAX_C1_BYTES {
+        return Err(AliasError::new(format!(
+            "expanded canonical C1 exceeds the {MAX_C1_BYTES}-byte transport limit"
+        )));
+    }
+    output.push_str(value);
+    Ok(())
+}
+
 fn expand_body(body: &str, aliases: &BTreeMap<usize, String>) -> Result<String, AliasError> {
     if !body.starts_with("C1\n") {
         return Err(AliasError::new(
@@ -358,7 +382,7 @@ fn expand_body(body: &str, aliases: &BTreeMap<usize, String>) -> Result<String, 
             continue;
         }
 
-        output.push_str(&body[cursor..index]);
+        append_bounded(&mut output, &body[cursor..index])?;
         let token_start = index;
         index += 1;
         let digits_start = index;
@@ -377,7 +401,7 @@ fn expand_body(body: &str, aliases: &BTreeMap<usize, String>) -> Result<String, 
         let raw_literal = aliases
             .get(&id)
             .ok_or_else(|| AliasError::new(format!("unknown alias reference `@{id}`")))?;
-        output.push_str(raw_literal);
+        append_bounded(&mut output, raw_literal)?;
         cursor = index;
     }
 
@@ -385,6 +409,16 @@ fn expand_body(body: &str, aliases: &BTreeMap<usize, String>) -> Result<String, 
         return Err(AliasError::new("unterminated JSON string in alias body"));
     }
 
-    output.push_str(&body[cursor..]);
+    append_bounded(&mut output, &body[cursor..])?;
     Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expanded_length_arithmetic_fails_closed_on_overflow() {
+        assert!(checked_expanded_len(usize::MAX, 1).is_err());
+    }
 }

--- a/tests/c1_local_alias.rs
+++ b/tests/c1_local_alias.rs
@@ -164,3 +164,32 @@ fn alias_expansion_is_strict_and_only_resolves_tokens_outside_json_strings() {
     assert!(expand_c1_aliases("C1A\nA1 \"x\"\nC1\nR[1,@x,\"r\"]\n").is_err());
     assert!(expand_c1_aliases("C1A\nA1 nope\nC1\nR[1,@1,\"r\"]\n").is_err());
 }
+
+#[test]
+fn alias_expansion_enforces_encoded_and_canonical_byte_limits() {
+    const RAW_LITERAL: &str = "\"0123456789\"";
+
+    let available = compact_ir::MAX_C1_BYTES - "C1\n".len();
+    let repeats = available / RAW_LITERAL.len();
+    let remainder = available % RAW_LITERAL.len();
+    let body = format!(
+        "C1\n{}{}",
+        "@1".repeat(repeats),
+        "x".repeat(remainder)
+    );
+    let packet = format!("C1A\nA1 {RAW_LITERAL}\n{body}");
+    assert!(packet.len() < compact_ir::MAX_C1_BYTES);
+
+    let expanded = expand_c1_aliases(&packet).unwrap();
+    assert_eq!(expanded.len(), compact_ir::MAX_C1_BYTES);
+
+    let oversized_body = format!("{body}@1");
+    let oversized_packet = format!("C1A\nA1 {RAW_LITERAL}\n{oversized_body}");
+    assert!(oversized_packet.len() < compact_ir::MAX_C1_BYTES);
+    let error = expand_c1_aliases(&oversized_packet).unwrap_err().to_string();
+    assert!(error.contains("expanded canonical C1 exceeds"));
+
+    let oversized_input = format!("C1A\n{}", "x".repeat(compact_ir::MAX_C1_BYTES));
+    let error = expand_c1_aliases(&oversized_input).unwrap_err().to_string();
+    assert!(error.contains("C1A input exceeds"));
+}

--- a/tests/c1_local_alias.rs
+++ b/tests/c1_local_alias.rs
@@ -172,11 +172,7 @@ fn alias_expansion_enforces_encoded_and_canonical_byte_limits() {
     let available = compact_ir::MAX_C1_BYTES - "C1\n".len();
     let repeats = available / RAW_LITERAL.len();
     let remainder = available % RAW_LITERAL.len();
-    let body = format!(
-        "C1\n{}{}",
-        "@1".repeat(repeats),
-        "x".repeat(remainder)
-    );
+    let body = format!("C1\n{}{}", "@1".repeat(repeats), "x".repeat(remainder));
     let packet = format!("C1A\nA1 {RAW_LITERAL}\n{body}");
     assert!(packet.len() < compact_ir::MAX_C1_BYTES);
 
@@ -186,7 +182,9 @@ fn alias_expansion_enforces_encoded_and_canonical_byte_limits() {
     let oversized_body = format!("{body}@1");
     let oversized_packet = format!("C1A\nA1 {RAW_LITERAL}\n{oversized_body}");
     assert!(oversized_packet.len() < compact_ir::MAX_C1_BYTES);
-    let error = expand_c1_aliases(&oversized_packet).unwrap_err().to_string();
+    let error = expand_c1_aliases(&oversized_packet)
+        .unwrap_err()
+        .to_string();
     assert!(error.contains("expanded canonical C1 exceeds"));
 
     let oversized_input = format!("C1A\n{}", "x".repeat(compact_ir::MAX_C1_BYTES));


### PR DESCRIPTION
Closes #368

## Fix

Keep the research C1A wrapper inside the canonical C1 resource envelope before it can ever become a transport candidate.

- reject C1A input larger than the existing canonical `MAX_C1_BYTES` ceiling before parsing alias definitions;
- route every expanded body append through checked length accounting;
- reject arithmetic overflow explicitly;
- reject an alias substitution before it would grow the canonical output past `MAX_C1_BYTES`;
- keep ordinary C1 passthrough behavior unchanged;
- reuse the existing canonical limit instead of creating a second transport-size policy.

## Controls

- the retained #155 corpus still round-trips exactly with its 25.1% saving;
- a compressed C1A packet that expands to exactly the canonical byte ceiling succeeds;
- adding one more alias reference to that same bounded packet fails before oversized output is constructed;
- an over-limit C1A input fails before alias parsing;
- checked expanded-length arithmetic fails closed on overflow;
- malformed/unknown/duplicate/reference-inside-string controls remain unchanged.

## Boundary

Research-only. This does not promote C1A, change canonical C1 grammar, or add a public command. It closes the resource-bound promotion discriminator found while reviewing #366.

Base: `70a6e052126abaab9f8099369d53cf717e2afd98`