### PR TITLE
research: measure current Codex prompt surface

### DIFF
--- a/research/context-efficiency/2026-08-31-codex-current-prompt-surface/README.md
+++ b/research/context-efficiency/2026-08-31-codex-current-prompt-surface/README.md
@@ -1,0 +1,66 @@
+# Current Codex prompt-surface ablation
+
+This lane moved from the historical 17.7K Luna run to the current model-visible
+Codex surface. The historical pair remains provenance; it is not relabelled as a
+current baseline.
+
+## Result
+
+On Big Red with Codex CLI 0.151.0, a ten-character closed prompt carried 4,152
+`o200k_base` text tokens before protocol overhead. The two largest eager segments
+were the skills catalogue (1,655) and recommended-plugin list (1,389).
+
+The current client produced these deterministic prompt projections:
+
+| profile | text tokens | delta | reduction |
+| --- | ---: | ---: | ---: |
+| default | 4,152 | 0 | 0.0% |
+| skills catalogue muted | 2,497 | -1,655 | 39.9% |
+| plugins off | 1,598 | -2,554 | 61.5% |
+| apps off | 2,617 | -1,535 | 37.0% |
+| skills + plugins off | 899 | -3,253 | 78.3% |
+| skills + apps off | 962 | -3,190 | 76.8% |
+| multi-agent feature off | 4,152 | 0 | 0.0% |
+| skills + plugins + apps off | 753 | -3,399 | 81.9% |
+
+`features.plugins=false` and `features.apps=false` are capability changes, not pure
+context retirement. They belong in an explicitly selected closed-task runner
+profile, never an inferred or global default.
+
+`features.multi_agent=false` did not remove the host-injected team-orchestration
+or multi-agent-mode segments. That zero-saving control is retained; the CLI feature
+flag is not the owner of those prompt bytes.
+
+A live provider replay on a capability-free current task reduced reported input from
+19,471 to 10,712 tokens (-8,759; 45.0%). Both arms returned the same exact `OK`
+output. The run used the Codex client's built-in default model under
+`--ignore-user-config`; the event stream did not identify that model, so the result
+does not invent a model name. This microtask validates the real request-envelope
+saving, not broad engineering capability preservation.
+
+Three fresh behavioral replays with only the skills catalogue muted preserved the
+same first justified action. Provider input-token savings were -698, -698, and -490,
+so the useful conclusion is a non-zero saving with a retained first-action null—not
+an exact-token constant or a general capability claim.
+
+## Deterministic output
+
+- `codex_prompt_input_probe.py` proves effective model-visible catalogue removal.
+- `codex_prompt_token_report.py` counts each prompt segment with the OpenAI tokenizer
+  without emitting segment text.
+- `codex_prompt_surface_matrix.py` compares exact current client profiles and keeps
+  raw prompt projections private.
+- `codex_context_ablation_run.py` and its aggregator retain fresh usage evidence and
+  quiet/null behavior.
+
+Stensibly consumes the finding through a typed prompt-surface profile compiler. The
+compiler requires an explicit profile choice and receipts both context and capability
+retirements; task text is never used to guess missing capabilities.
+
+## Limits
+
+Tokenizer counts cover model-visible text segments, not provider protocol framing,
+tool schemas, or other server-side overhead. A debug renderer probe using a literal
+`$lazy-commander` did not expose the skill body after catalogue suppression. That is
+a retained negative result for the probe method, not evidence that real runtime
+explicit-skill invocation works or fails.

--- a/research/context-efficiency/2026-08-31-codex-current-prompt-surface/result.json
+++ b/research/context-efficiency/2026-08-31-codex-current-prompt-surface/result.json
@@ -1,0 +1,74 @@
+{
+  "schema": "cultist-codex-current-prompt-surface-result/v1",
+  "recorded_at": "2026-08-31",
+  "codex_version": "codex-cli 0.151.0",
+  "machine_class": "big-red-linux-x86_64",
+  "tokenizer": {
+    "implementation": "tiktoken 0.14.0",
+    "encoding": "o200k_base",
+    "counts_text_segments_only": true,
+    "counts_protocol_overhead": false
+  },
+  "current_prompt_surface": {
+    "prompt_sha256": "b4447319393924de48e7ee762507a4701409c060961acaeeb3902db46c6c7acf",
+    "default_text_tokens": 4152,
+    "segments": [
+      { "label": "skills-catalogue", "tokens": 1655, "characters": 7025 },
+      { "label": "permissions", "tokens": 68, "characters": 362 },
+      { "label": "apps-instructions", "tokens": 146, "characters": 646 },
+      { "label": "plugins-instructions", "tokens": 209, "characters": 1014 },
+      { "label": "team-orchestration", "tokens": 498, "characters": 2264 },
+      { "label": "multi-agent-mode", "tokens": 52, "characters": 271 },
+      { "label": "recommended-plugins", "tokens": 1389, "characters": 3387 },
+      { "label": "environment-context", "tokens": 132, "characters": 455 },
+      { "label": "user-prompt", "tokens": 3, "characters": 10 }
+    ]
+  },
+  "profiles": [
+    { "name": "default", "text_tokens": 4152, "delta": 0, "reduction_percent": 0.0 },
+    { "name": "skills-muted", "text_tokens": 2497, "delta": -1655, "reduction_percent": 39.86 },
+    { "name": "plugins-off", "text_tokens": 1598, "delta": -2554, "reduction_percent": 61.513 },
+    { "name": "apps-off", "text_tokens": 2617, "delta": -1535, "reduction_percent": 36.97 },
+    { "name": "skills-plugins-off", "text_tokens": 899, "delta": -3253, "reduction_percent": 78.348 },
+    { "name": "skills-apps-off", "text_tokens": 962, "delta": -3190, "reduction_percent": 76.83 },
+    { "name": "multi-agent-off", "text_tokens": 4152, "delta": 0, "reduction_percent": 0.0 },
+    { "name": "all-off", "text_tokens": 753, "delta": -3399, "reduction_percent": 81.864 }
+  ],
+  "behavioral_replay": {
+    "pair_count": 3,
+    "same_first_action_count": 3,
+    "quiet_null_count": 3,
+    "input_token_deltas": [-698, -698, -490],
+    "mean_input_token_delta": -628.6666666666666,
+    "exact_delta_stable": false
+  },
+  "current_closed_task_provider_replay": {
+    "model": "client-default-unresolved",
+    "reasoning_effort": "low",
+    "control_input_tokens": 19471,
+    "treatment_input_tokens": 10712,
+    "input_token_delta": -8759,
+    "input_token_reduction_percent": 44.985,
+    "same_exact_output": true,
+    "output": "OK"
+  },
+  "quiet_results": [
+    "The behavioral action did not change in any of three current pairs.",
+    "The provider input-token delta varied; an exact 698-token claim is rejected.",
+    "features.multi_agent=false did not remove the host-injected team-orchestration or multi-agent-mode prompt segments.",
+    "A literal $lazy-commander prompt under catalogue suppression did not make debug prompt-input expose the skill body; this renderer probe does not prove or disprove runtime explicit-skill capability."
+  ],
+  "authority": {
+    "broad_profiles_retire_capabilities": true,
+    "authorizes_global_default_change": false,
+    "authorizes_capability_retirement": false,
+    "authorizes_production_promotion": false
+  },
+  "private_evidence_sha256": {
+    "surface_matrix": "2297fee23eee2056c4292bcc32b74ead3af8982c23978076e80206c48cbf88e1",
+    "behavioral_aggregate": "86c0c8b6345f8c596aef10d683378f31dbe94cfdaedda059c8faf548f042490e",
+    "baseline_packet_token_report": "ecf19c15ea5900e22fed8816b0417d2eeb0f472a958e8fb9d7ca671bcdbfd3c7",
+    "current_closed_task_provider_receipt": "1f2bd6581f10eabd7cefa8d4772b179dfec8ce7b29a02c0ffe34b6c4848fd23e"
+  },
+  "raw_content_emitted": false
+}

--- a/scripts/codex_context_ablation_aggregate.py
+++ b/scripts/codex_context_ablation_aggregate.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Aggregate matched Codex context-ablation pairs without dropping nulls."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import statistics
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class AggregateError(RuntimeError):
+    pass
+
+
+def canonical(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def private_write(path: Path, value: bytes) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "wb") as sink:
+        sink.write(value)
+        sink.flush()
+        os.fsync(sink.fileno())
+
+
+def aggregate(results: list[dict[str, Any]]) -> dict[str, Any]:
+    if len(results) < 2:
+        raise AggregateError("at least two matched pairs are required")
+    identity_keys = (
+        "codexVersion", "model", "reasoningEffort", "packetSha256",
+        "outputSchemaSha256", "treatmentOverride",
+    )
+    identity = {key: results[0].get(key) for key in identity_keys}
+    for result in results:
+        if result.get("schema") != "cultist-codex-context-ablation-pair/v1":
+            raise AggregateError("pair schema is unsupported")
+        if any(result.get(key) != value for key, value in identity.items()):
+            raise AggregateError("pair identity drifted")
+    orders = [result.get("executionOrder") or "unrecorded" for result in results]
+    thread_ids = [
+        result[arm]["threadId"]
+        for result in results
+        for arm in ("control", "treatment")
+    ]
+    if len(thread_ids) != len(set(thread_ids)):
+        raise AggregateError("a fresh thread identity was reused")
+    rows = []
+    for index, result in enumerate(results, start=1):
+        control = result["control"]["usage"]["input_tokens"]
+        treatment = result["treatment"]["usage"]["input_tokens"]
+        rows.append({
+            "pair": index,
+            "order": orders[index - 1],
+            "controlInputTokens": control,
+            "treatmentInputTokens": treatment,
+            "inputTokenDelta": treatment - control,
+            "inputTokenReductionPercent": result["inputTokenReductionPercent"],
+            "sameFirstAction": result["sameFirstAction"],
+            "quietNullFirstActionResult": result["quietNullFirstActionResult"],
+        })
+    deltas = [row["inputTokenDelta"] for row in rows]
+    reductions = [row["inputTokenReductionPercent"] for row in rows]
+    return {
+        "schema": "cultist-codex-context-ablation-aggregate/v1",
+        "recordedAt": datetime.now(timezone.utc).isoformat(),
+        **identity,
+        "pairCount": len(rows),
+        "executionOrders": orders,
+        "pairs": rows,
+        "allFirstActionsPreserved": all(row["sameFirstAction"] for row in rows),
+        "quietNullFirstActionResults": sum(row["quietNullFirstActionResult"] for row in rows),
+        "meanInputTokenDelta": statistics.mean(deltas),
+        "medianInputTokenDelta": statistics.median(deltas),
+        "exactDeltaStableAcrossPairs": len(set(deltas)) == 1,
+        "meanInputTokenReductionPercent": round(statistics.mean(reductions), 3),
+        "medianInputTokenReductionPercent": round(statistics.median(reductions), 3),
+        "rawContentEmitted": False,
+        "authorizesGeneralization": False,
+        "authorizesCapabilityRetirement": False,
+        "authorizesProductionPromotion": False,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("result", nargs="+", type=Path)
+    args = parser.parse_args()
+    try:
+        results = [json.loads(path.read_text(encoding="utf-8")) for path in args.result]
+        aggregate_result = aggregate(results)
+        result_bytes = canonical(aggregate_result) + b"\n"
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        private_write(args.output, result_bytes)
+    except (OSError, json.JSONDecodeError, AggregateError) as error:
+        raise SystemExit(str(error)) from error
+    print(json.dumps({
+        "schema": "cultist-codex-context-ablation-aggregate-receipt/v1",
+        "resultSha256": digest(result_bytes),
+        "pairCount": aggregate_result["pairCount"],
+        "allFirstActionsPreserved": aggregate_result["allFirstActionsPreserved"],
+        "meanInputTokenDelta": aggregate_result["meanInputTokenDelta"],
+        "meanInputTokenReductionPercent": aggregate_result["meanInputTokenReductionPercent"],
+        "exactDeltaStableAcrossPairs": aggregate_result["exactDeltaStableAcrossPairs"],
+        "rawContentEmitted": False,
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/codex_context_ablation_aggregate_test.py
+++ b/scripts/codex_context_ablation_aggregate_test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import copy
+import unittest
+
+import codex_context_ablation_aggregate as aggregate
+
+
+def pair(order: str, suffix: str):
+    return {
+        "schema": "cultist-codex-context-ablation-pair/v1",
+        "codexVersion": "codex-cli test",
+        "model": "model",
+        "reasoningEffort": "max",
+        "packetSha256": "a" * 64,
+        "outputSchemaSha256": "b" * 64,
+        "treatmentOverride": "skills.include_instructions=false",
+        "executionOrder": order,
+        "control": {"threadId": f"control-{suffix}", "usage": {"input_tokens": 1000}},
+        "treatment": {"threadId": f"treatment-{suffix}", "usage": {"input_tokens": 900}},
+        "inputTokenReductionPercent": 10.0,
+        "sameFirstAction": True,
+        "quietNullFirstActionResult": True,
+    }
+
+
+class ContextAblationAggregateTests(unittest.TestCase):
+    def test_nulls_and_unrecorded_order_are_retained(self):
+        first = pair("control-treatment", "a")
+        first.pop("executionOrder")
+        result = aggregate.aggregate([
+            first, pair("treatment-control", "b")
+        ])
+        self.assertEqual(result["quietNullFirstActionResults"], 2)
+        self.assertTrue(result["exactDeltaStableAcrossPairs"])
+        self.assertEqual(result["meanInputTokenDelta"], -100)
+        self.assertEqual(result["executionOrders"], ["unrecorded", "treatment-control"])
+
+    def test_identity_drift_is_refused(self):
+        changed = pair("treatment-control", "b")
+        changed["model"] = "other"
+        with self.assertRaises(aggregate.AggregateError):
+            aggregate.aggregate([pair("control-treatment", "a"), changed])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/codex_context_ablation_run.py
+++ b/scripts/codex_context_ablation_run.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Run one fresh control/treatment Codex context-retirement pair."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class AblationError(RuntimeError):
+    pass
+
+
+def canonical(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def private_write(path: Path, value: bytes) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "wb") as sink:
+        sink.write(value)
+        sink.flush()
+        os.fsync(sink.fileno())
+
+
+def load_packet(pair_path: Path, run_index: int) -> tuple[str, str]:
+    pair = json.loads(pair_path.read_text(encoding="utf-8"))
+    runs = pair.get("runs") if isinstance(pair, dict) else None
+    if not isinstance(runs, list) or not 0 <= run_index < len(runs):
+        raise AblationError("pair run index is unavailable")
+    run = runs[run_index]
+    packet = run.get("raw_worker_packet")
+    claimed = run.get("worker_packet_sha256")
+    if not isinstance(packet, str) or not isinstance(claimed, str):
+        raise AblationError("pair run lacks exact packet evidence")
+    packet_sha = digest(packet.encode("utf-8"))
+    if claimed != f"sha256:{packet_sha}":
+        raise AblationError("packet digest mismatch")
+    return packet, packet_sha
+
+
+def parse_events(text: str) -> dict[str, Any]:
+    events = []
+    for line in text.splitlines():
+        if line.strip():
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError as error:
+                raise AblationError("Codex event stream contains invalid JSON") from error
+    thread_ids = [event.get("thread_id") for event in events if event.get("type") == "thread.started"]
+    completions = [event.get("usage") for event in events if event.get("type") == "turn.completed"]
+    messages = [
+        event.get("item", {}).get("text")
+        for event in events
+        if event.get("type") == "item.completed"
+        and event.get("item", {}).get("type") == "agent_message"
+    ]
+    errors = [
+        event.get("item", {}).get("message", "")
+        for event in events
+        if event.get("type") == "item.completed"
+        and event.get("item", {}).get("type") == "error"
+    ]
+    if len(thread_ids) != 1 or len(completions) != 1 or len(messages) != 1:
+        raise AblationError("Codex event stream lacks one complete fresh observation")
+    try:
+        observation = json.loads(messages[0])
+    except json.JSONDecodeError as error:
+        raise AblationError("Codex agent message is not the required JSON observation") from error
+    first_action = observation.get("first_action_id")
+    if not isinstance(first_action, str) or not first_action:
+        raise AblationError("observation lacks first_action_id")
+    usage = completions[0]
+    required_usage = {
+        "input_tokens", "cached_input_tokens", "output_tokens", "reasoning_output_tokens"
+    }
+    if not isinstance(usage, dict) or not required_usage <= set(usage):
+        raise AblationError("Codex completion lacks usage counters")
+    return {
+        "threadId": thread_ids[0],
+        "usage": {key: usage[key] for key in sorted(required_usage)},
+        "firstActionId": first_action,
+        "observationSha256": digest(canonical(observation)),
+        "skillBudgetWarning": any("skills context budget" in value for value in errors),
+        "errorItemCount": len(errors),
+        "eventCount": len(events),
+    }
+
+
+def invocation(
+    codex: Path,
+    session_root: Path,
+    schema: Path,
+    model: str,
+    reasoning: str,
+    override: str | None,
+) -> list[str]:
+    argv = [
+        str(codex), "-a", "never", "exec", "--ephemeral", "--ignore-user-config",
+        "--skip-git-repo-check", "--json", "-C", str(session_root), "-s", "read-only",
+        "-m", model, "-c", f'model_reasoning_effort="{reasoning}"',
+    ]
+    if override is not None:
+        argv.extend(["-c", override])
+    argv.extend(["--output-schema", str(schema), "-"])
+    return argv
+
+
+def run_arm(name: str, argv: list[str], packet: str, output: Path) -> dict[str, Any]:
+    process = subprocess.run(
+        argv, input=packet, check=False, capture_output=True, text=True
+    )
+    stdout = process.stdout.encode("utf-8")
+    stderr = process.stderr.encode("utf-8")
+    private_write(output / f"{name}.events.jsonl", stdout)
+    private_write(output / f"{name}.stderr.txt", stderr)
+    if process.returncode != 0:
+        raise AblationError(f"{name} Codex execution failed with exit {process.returncode}")
+    parsed = parse_events(process.stdout)
+    parsed.update({
+        "stdoutSha256": digest(stdout),
+        "stderrSha256": digest(stderr),
+        "stderrBytes": len(stderr),
+        "invocationSha256": digest(canonical(argv)),
+    })
+    return parsed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pair", type=Path, required=True)
+    parser.add_argument("--run-index", type=int, default=0)
+    parser.add_argument("--schema", type=Path, required=True)
+    parser.add_argument("--prompt-probe-result", type=Path, required=True)
+    parser.add_argument("--codex", type=Path, required=True)
+    parser.add_argument("--session-root", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--model", default="gpt-5.6-luna")
+    parser.add_argument("--reasoning", default="max")
+    parser.add_argument("--treatment-override", default="skills.include_instructions=false")
+    parser.add_argument(
+        "--order", choices=("control-treatment", "treatment-control"),
+        default="control-treatment",
+    )
+    args = parser.parse_args()
+    output = args.output_dir.expanduser().resolve()
+    if output.exists():
+        raise SystemExit("refusing to overwrite context ablation pair")
+    output.mkdir(parents=True, mode=0o700)
+    os.chmod(output, 0o700)
+    packet, packet_sha = load_packet(args.pair, args.run_index)
+    prompt_probe = json.loads(args.prompt_probe_result.read_text(encoding="utf-8"))
+    if prompt_probe.get("packetSha256") != packet_sha:
+        raise AblationError("prompt-input proof does not bind the selected packet")
+    if prompt_probe.get("treatmentOverride") != args.treatment_override:
+        raise AblationError("prompt-input proof does not bind the treatment override")
+    if prompt_probe.get("comparison", {}).get("effectiveCatalogueSuppression") is not True:
+        raise AblationError("prompt-input proof did not establish effective suppression")
+    schema = args.schema.resolve()
+    session_root = args.session_root.resolve()
+    session_root.mkdir(parents=True, exist_ok=True)
+    control_argv = invocation(
+        args.codex, session_root, schema, args.model, args.reasoning, None
+    )
+    treatment_argv = invocation(
+        args.codex, session_root, schema, args.model, args.reasoning,
+        args.treatment_override,
+    )
+    if args.order == "control-treatment":
+        control = run_arm("control", control_argv, packet, output)
+        treatment = run_arm("treatment", treatment_argv, packet, output)
+    else:
+        treatment = run_arm("treatment", treatment_argv, packet, output)
+        control = run_arm("control", control_argv, packet, output)
+    if control["threadId"] == treatment["threadId"]:
+        raise AblationError("fresh arms reused one thread identity")
+    control_input = control["usage"]["input_tokens"]
+    treatment_input = treatment["usage"]["input_tokens"]
+    result = {
+        "schema": "cultist-codex-context-ablation-pair/v1",
+        "recordedAt": datetime.now(timezone.utc).isoformat(),
+        "codexVersion": subprocess.run(
+            [str(args.codex), "--version"], check=True, capture_output=True, text=True
+        ).stdout.strip(),
+        "machine": {
+            "node": platform.node(),
+            "system": platform.system(),
+            "machine": platform.machine(),
+        },
+        "model": args.model,
+        "reasoningEffort": args.reasoning,
+        "packetSha256": packet_sha,
+        "packetCharacters": len(packet),
+        "outputSchemaSha256": digest(schema.read_bytes()),
+        "promptInputProofSha256": digest(args.prompt_probe_result.read_bytes()),
+        "treatmentOverride": args.treatment_override,
+        "executionOrder": args.order,
+        "control": control,
+        "treatment": treatment,
+        "sameFirstAction": control["firstActionId"] == treatment["firstActionId"],
+        "inputTokenDelta": treatment_input - control_input,
+        "inputTokenReductionPercent": round(
+            (control_input - treatment_input) * 100 / control_input, 3
+        ) if control_input else 0.0,
+        "quietNullFirstActionResult": control["firstActionId"] == treatment["firstActionId"],
+        "rawContentEmitted": False,
+        "authorizesGeneralization": False,
+        "authorizesCapabilityRetirement": False,
+        "authorizesProductionPromotion": False,
+    }
+    result_bytes = canonical(result) + b"\n"
+    private_write(output / "result.json", result_bytes)
+    receipt = {
+        "schema": "cultist-codex-context-ablation-pair-receipt/v1",
+        "resultSha256": digest(result_bytes),
+        "sameFirstAction": result["sameFirstAction"],
+        "controlInputTokens": control_input,
+        "treatmentInputTokens": treatment_input,
+        "inputTokenReductionPercent": result["inputTokenReductionPercent"],
+        "effectiveCatalogueSuppression": True,
+        "quietNullFirstActionResult": result["quietNullFirstActionResult"],
+        "rawContentEmitted": False,
+    }
+    private_write(output / "receipt.json", canonical(receipt) + b"\n")
+    print(json.dumps(receipt, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, json.JSONDecodeError, AblationError, subprocess.SubprocessError) as error:
+        raise SystemExit(str(error)) from error

--- a/scripts/codex_context_ablation_run_test.py
+++ b/scripts/codex_context_ablation_run_test.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import json
+import unittest
+
+import codex_context_ablation_run as ablation
+
+
+class ContextAblationRunTests(unittest.TestCase):
+    def test_event_projection_retains_usage_warning_and_first_action(self):
+        lines = [
+            {"type": "thread.started", "thread_id": "thread-one"},
+            {"type": "item.completed", "item": {"type": "error", "message": "skills context budget"}},
+            {"type": "item.completed", "item": {"type": "agent_message", "text": json.dumps({"first_action_id": "inspect"})}},
+            {"type": "turn.completed", "usage": {"input_tokens": 100, "cached_input_tokens": 0, "output_tokens": 5, "reasoning_output_tokens": 2}},
+        ]
+        parsed = ablation.parse_events("\n".join(json.dumps(item) for item in lines))
+        self.assertEqual(parsed["firstActionId"], "inspect")
+        self.assertEqual(parsed["usage"]["input_tokens"], 100)
+        self.assertTrue(parsed["skillBudgetWarning"])
+
+    def test_incomplete_stream_is_refused(self):
+        with self.assertRaises(ablation.AblationError):
+            ablation.parse_events(json.dumps({"type": "thread.started", "thread_id": "only"}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/codex_prompt_input_probe.py
+++ b/scripts/codex_prompt_input_probe.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Measure a one-variable Codex model-visible prompt-input ablation."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+SKILL_MARKERS = ("<skills_instructions>", "## Skills", "Available skills", "skills/config/write")
+VOLATILE_KEYS = {"id", "internal_chat_message_metadata_passthrough"}
+
+
+class ProbeError(RuntimeError):
+    pass
+
+
+def canonical(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def private_write(path: Path, value: bytes) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "wb") as sink:
+        sink.write(value)
+        sink.flush()
+        os.fsync(sink.fileno())
+
+
+def strings(value: Any):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, list):
+        for item in value:
+            yield from strings(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from strings(item)
+
+
+def normalized(value: Any) -> Any:
+    if isinstance(value, list):
+        return [normalized(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: normalized(item)
+            for key, item in value.items()
+            if key not in VOLATILE_KEYS
+        }
+    return value
+
+
+def item_shape(item: Any, index: int) -> dict[str, Any]:
+    encoded = canonical(item)
+    semantic = canonical(normalized(item))
+    text = "\n".join(strings(item))
+    return {
+        "index": index,
+        "type": item.get("type") if isinstance(item, dict) else type(item).__name__,
+        "role": item.get("role") if isinstance(item, dict) else None,
+        "keys": sorted(item) if isinstance(item, dict) else [],
+        "serializedBytes": len(encoded),
+        "textCharacters": len(text),
+        "rawSha256": digest(encoded),
+        "sha256": digest(semantic),
+        "skillMarkerPresent": any(marker in text for marker in SKILL_MARKERS),
+    }
+
+
+def shape(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, list):
+        raise ProbeError("prompt-input output must be a JSON list")
+    items = [item_shape(item, index) for index, item in enumerate(raw)]
+    encoded = canonical(raw)
+    return {
+        "items": items,
+        "itemCount": len(items),
+        "serializedBytes": len(encoded),
+        "textCharacters": sum(item["textCharacters"] for item in items),
+        "skillMarkerItems": sum(1 for item in items if item["skillMarkerPresent"]),
+        "sha256": digest(encoded),
+    }
+
+
+def extract_packet(pair_path: Path, run_index: int) -> tuple[str, str]:
+    pair = json.loads(pair_path.read_text(encoding="utf-8"))
+    runs = pair.get("runs") if isinstance(pair, dict) else None
+    if not isinstance(runs, list) or not 0 <= run_index < len(runs):
+        raise ProbeError("pair run index is unavailable")
+    run = runs[run_index]
+    packet = run.get("raw_worker_packet")
+    claimed = run.get("worker_packet_sha256")
+    if not isinstance(packet, str) or not isinstance(claimed, str) or not claimed.startswith("sha256:"):
+        raise ProbeError("pair run lacks an exact worker packet")
+    calculated = digest(packet.encode("utf-8"))
+    if claimed != f"sha256:{calculated}":
+        raise ProbeError("worker packet digest does not match exact bytes")
+    return packet, calculated
+
+
+def run_prompt_input(codex: Path, cwd: Path, prompt: str, override: str | None) -> tuple[Any, dict[str, Any]]:
+    argv = [str(codex), "debug", "prompt-input"]
+    if override is not None:
+        argv.extend(["-c", override])
+    argv.append(prompt)
+    process = subprocess.run(argv, cwd=cwd, check=False, capture_output=True, text=True)
+    if process.returncode != 0:
+        raise ProbeError(f"prompt-input failed with exit {process.returncode}: {process.stderr[:240]}")
+    if process.stderr:
+        raise ProbeError("prompt-input emitted stderr; preserve it outside an admitted pair")
+    try:
+        raw = json.loads(process.stdout)
+    except json.JSONDecodeError as error:
+        raise ProbeError("prompt-input returned invalid JSON") from error
+    return raw, shape(raw)
+
+
+def compare(control: dict[str, Any], treatment: dict[str, Any]) -> dict[str, Any]:
+    control_hashes = {item["sha256"] for item in control["items"]}
+    treatment_hashes = {item["sha256"] for item in treatment["items"]}
+    removed = [item for item in control["items"] if item["sha256"] not in treatment_hashes]
+    added = [item for item in treatment["items"] if item["sha256"] not in control_hashes]
+    return {
+        "serializedByteDelta": treatment["serializedBytes"] - control["serializedBytes"],
+        "serializedByteReductionPercent": round(
+            (control["serializedBytes"] - treatment["serializedBytes"]) * 100 / control["serializedBytes"], 3
+        ) if control["serializedBytes"] else 0.0,
+        "textCharacterDelta": treatment["textCharacters"] - control["textCharacters"],
+        "removedItems": removed,
+        "addedItems": added,
+        "unchangedItems": len(control_hashes & treatment_hashes),
+        "removedSkillMarkerItems": sum(1 for item in removed if item["skillMarkerPresent"]),
+        "treatmentSkillMarkerItems": treatment["skillMarkerItems"],
+        "effectiveCatalogueSuppression": (
+            control["skillMarkerItems"] > 0 and treatment["skillMarkerItems"] == 0
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pair", type=Path, required=True)
+    parser.add_argument("--run-index", type=int, default=0)
+    parser.add_argument("--codex", type=Path, required=True)
+    parser.add_argument("--cwd", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--treatment-override", default="skills.include_instructions=false")
+    args = parser.parse_args()
+    output = args.output_dir.expanduser().resolve()
+    if output.exists():
+        raise SystemExit("refusing to overwrite prompt-input probe")
+    output.mkdir(parents=True, mode=0o700)
+    os.chmod(output, 0o700)
+    packet, packet_sha = extract_packet(args.pair, args.run_index)
+    control_raw, control = run_prompt_input(args.codex, args.cwd, packet, None)
+    treatment_raw, treatment = run_prompt_input(
+        args.codex, args.cwd, packet, args.treatment_override
+    )
+    private_write(output / "control.raw.json", canonical(control_raw) + b"\n")
+    private_write(output / "treatment.raw.json", canonical(treatment_raw) + b"\n")
+    result = {
+        "schema": "cultist-codex-prompt-input-ablation/v1",
+        "recordedAt": datetime.now(timezone.utc).isoformat(),
+        "codexVersion": subprocess.run(
+            [str(args.codex), "--version"], check=True, capture_output=True, text=True
+        ).stdout.strip(),
+        "packetSha256": packet_sha,
+        "packetCharacters": len(packet),
+        "runIndex": args.run_index,
+        "treatmentOverride": args.treatment_override,
+        "control": control,
+        "treatment": treatment,
+        "comparison": compare(control, treatment),
+        "rawContentEmitted": False,
+        "authorizesCapabilityRetirement": False,
+        "authorizesProductionPromotion": False,
+    }
+    result_bytes = canonical(result) + b"\n"
+    private_write(output / "result.json", result_bytes)
+    receipt = {
+        "schema": "cultist-codex-prompt-input-ablation-receipt/v1",
+        "resultSha256": digest(result_bytes),
+        "controlPromptInputSha256": control["sha256"],
+        "treatmentPromptInputSha256": treatment["sha256"],
+        "serializedByteReductionPercent": result["comparison"]["serializedByteReductionPercent"],
+        "effectiveCatalogueSuppression": result["comparison"]["effectiveCatalogueSuppression"],
+        "rawContentEmitted": False,
+    }
+    private_write(output / "receipt.json", canonical(receipt) + b"\n")
+    print(json.dumps(receipt, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, json.JSONDecodeError, ProbeError, subprocess.SubprocessError) as error:
+        raise SystemExit(str(error)) from error

--- a/scripts/codex_prompt_input_probe_test.py
+++ b/scripts/codex_prompt_input_probe_test.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import codex_prompt_input_probe as probe
+
+
+class PromptInputProbeTests(unittest.TestCase):
+    def test_shape_and_comparison_detect_exact_skill_catalogue_retirement(self):
+        skill = {"role": "developer", "content": "<skills_instructions>Available skills</skills_instructions>"}
+        task = {"role": "user", "content": "bounded task"}
+        control = probe.shape([skill, task])
+        treatment = probe.shape([task])
+        comparison = probe.compare(control, treatment)
+        self.assertTrue(comparison["effectiveCatalogueSuppression"])
+        self.assertEqual(comparison["removedSkillMarkerItems"], 1)
+        self.assertLess(comparison["serializedByteDelta"], 0)
+
+    def test_quiet_null_change_is_retained(self):
+        task = {"role": "user", "content": "bounded task"}
+        control = probe.shape([task])
+        comparison = probe.compare(control, probe.shape([task]))
+        self.assertFalse(comparison["effectiveCatalogueSuppression"])
+        self.assertEqual(comparison["removedItems"], [])
+        self.assertEqual(comparison["serializedByteDelta"], 0)
+
+    def test_volatile_message_ids_do_not_create_false_semantic_changes(self):
+        control = probe.shape([{"id": "one", "role": "user", "content": "same"}])
+        treatment = probe.shape([{"id": "two", "role": "user", "content": "same"}])
+        comparison = probe.compare(control, treatment)
+        self.assertEqual(comparison["unchangedItems"], 1)
+        self.assertEqual(comparison["removedItems"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/codex_prompt_surface_matrix.py
+++ b/scripts/codex_prompt_surface_matrix.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Measure current Codex prompt surfaces under task-scoped capability profiles."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from codex_prompt_token_report import arm, canonical, digest
+
+
+PROFILES = {
+    "default": [],
+    "skills-muted": ["skills.include_instructions=false"],
+    "plugins-off": ["features.plugins=false"],
+    "apps-off": ["features.apps=false"],
+    "skills-plugins-off": ["skills.include_instructions=false", "features.plugins=false"],
+    "skills-apps-off": ["skills.include_instructions=false", "features.apps=false"],
+    "multi-agent-off": ["features.multi_agent=false"],
+    "all-off": [
+        "skills.include_instructions=false",
+        "features.plugins=false",
+        "features.apps=false",
+    ],
+}
+
+
+def private_write(path: Path, value: bytes) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "wb") as sink:
+        sink.write(value)
+        sink.flush()
+        os.fsync(sink.fileno())
+
+
+def component_presence(summary: dict[str, Any]) -> dict[str, bool]:
+    labels = {row["label"] for row in summary["segments"]}
+    return {
+        "skillsCatalogue": "skills-catalogue" in labels,
+        "recommendedPlugins": "recommended-plugins" in labels,
+        "appsInstructions": "apps-instructions" in labels,
+        "pluginsInstructions": "plugins-instructions" in labels,
+    }
+
+
+def comparison(default_tokens: int, current_tokens: int) -> dict[str, Any]:
+    delta = current_tokens - default_tokens
+    return {
+        "textTokenDeltaFromDefault": delta,
+        "textTokenReductionPercentFromDefault": round(
+            -delta * 100 / default_tokens, 3
+        ) if default_tokens else 0.0,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--codex", type=Path, required=True)
+    parser.add_argument("--cwd", type=Path, required=True)
+    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--encoding", default="o200k_base")
+    args = parser.parse_args()
+    try:
+        import tiktoken
+    except ImportError as error:
+        raise SystemExit("tiktoken is required for an OpenAI-tokenizer report") from error
+    output = args.output_dir.expanduser().resolve()
+    if output.exists():
+        raise SystemExit("refusing to overwrite prompt-surface matrix")
+    output.mkdir(parents=True, mode=0o700)
+    os.chmod(output, 0o700)
+    encoder = tiktoken.get_encoding(args.encoding)
+    rows: list[dict[str, Any]] = []
+    for name, overrides in PROFILES.items():
+        argv = [str(args.codex), "debug", "prompt-input"]
+        for override in overrides:
+            argv.extend(["-c", override])
+        argv.append(args.prompt)
+        process = subprocess.run(
+            argv, cwd=args.cwd, check=False, capture_output=True, text=True
+        )
+        if process.returncode != 0 or process.stderr:
+            raise SystemExit(f"prompt-input profile {name} failed clean execution")
+        raw = process.stdout.encode("utf-8")
+        private_write(output / f"{name}.raw.json", raw)
+        summary = arm(json.loads(process.stdout), encoder)
+        rows.append({
+            "profile": name,
+            "overrides": overrides,
+            "promptInputSha256": hashlib.sha256(raw).hexdigest(),
+            "summary": summary,
+            "components": component_presence(summary),
+        })
+    default_tokens = rows[0]["summary"]["textTokens"]
+    for row in rows:
+        row["comparison"] = comparison(default_tokens, row["summary"]["textTokens"])
+    result = {
+        "schema": "cultist-codex-prompt-surface-matrix/v1",
+        "recordedAt": datetime.now(timezone.utc).isoformat(),
+        "codexVersion": subprocess.run(
+            [str(args.codex), "--version"], check=True, capture_output=True, text=True
+        ).stdout.strip(),
+        "encoding": args.encoding,
+        "promptSha256": digest(args.prompt.encode("utf-8")),
+        "profiles": rows,
+        "countsTextSegmentsOnly": True,
+        "countsProtocolOverhead": False,
+        "broadProfilesRetireCapabilities": True,
+        "rawContentEmitted": False,
+        "authorizesGlobalDefaultChange": False,
+        "authorizesProductionPromotion": False,
+    }
+    payload = canonical(result) + b"\n"
+    private_write(output / "result.json", payload)
+    print(json.dumps({
+        "schema": "cultist-codex-prompt-surface-matrix-receipt/v1",
+        "resultSha256": digest(payload),
+        "profileCount": len(rows),
+        "defaultTextTokens": default_tokens,
+        "allOffTextTokens": rows[-1]["summary"]["textTokens"],
+        "allOffReductionPercent": rows[-1]["comparison"]["textTokenReductionPercentFromDefault"],
+        "broadProfilesRetireCapabilities": True,
+        "rawContentEmitted": False,
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/codex_prompt_surface_matrix_test.py
+++ b/scripts/codex_prompt_surface_matrix_test.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import codex_prompt_surface_matrix as matrix
+
+
+class PromptSurfaceMatrixTests(unittest.TestCase):
+    def test_component_presence_uses_segment_labels(self):
+        result = matrix.component_presence({"segments": [
+            {"label": "skills-catalogue"}, {"label": "recommended-plugins"},
+        ]})
+        self.assertTrue(result["skillsCatalogue"])
+        self.assertTrue(result["recommendedPlugins"])
+        self.assertFalse(result["appsInstructions"])
+
+    def test_zero_threshold_comparison_reports_observation(self):
+        result = matrix.comparison(100, 40)
+        self.assertEqual(result["textTokenDeltaFromDefault"], -60)
+        self.assertEqual(result["textTokenReductionPercentFromDefault"], 60.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/codex_prompt_token_report.py
+++ b/scripts/codex_prompt_token_report.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Tokenize model-visible Codex prompt segments without emitting their text."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+
+class Encoder(Protocol):
+    def encode(self, text: str, **kwargs: Any) -> list[int]: ...
+
+
+def canonical(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+
+
+def digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def label(text: str, role: str, item_index: int, segment_index: int) -> str:
+    markers = (
+        ("<skills_instructions>", "skills-catalogue"),
+        ("<permissions instructions>", "permissions"),
+        ("<collaboration_mode>", "collaboration-mode"),
+        ("<apps_instructions>", "apps-instructions"),
+        ("<plugins_instructions>", "plugins-instructions"),
+        ("You are `/root`", "team-orchestration"),
+        ("<multi_agent_mode>", "multi-agent-mode"),
+        ("<recommended_plugins>", "recommended-plugins"),
+        ("<environment_context>", "environment-context"),
+    )
+    for marker, name in markers:
+        if marker in text:
+            return name
+    return f"{role}-item-{item_index}-segment-{segment_index}"
+
+
+def extract_segments(raw: Any, encoder: Encoder) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        raise ValueError("prompt input must be a JSON list")
+    segments: list[dict[str, Any]] = []
+    for item_index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("role") or "unknown")
+        content = item.get("content")
+        values = content if isinstance(content, list) else [content]
+        for segment_index, value in enumerate(values):
+            text = value.get("text") if isinstance(value, dict) else value
+            if not isinstance(text, str):
+                continue
+            encoded = text.encode("utf-8")
+            segments.append({
+                "label": label(text, role, item_index, segment_index),
+                "role": role,
+                "itemIndex": item_index,
+                "segmentIndex": segment_index,
+                "characters": len(text),
+                "utf8Bytes": len(encoded),
+                "tokens": len(encoder.encode(text, disallowed_special=())),
+                "sha256": digest(encoded),
+            })
+    return segments
+
+
+def arm(raw: Any, encoder: Encoder) -> dict[str, Any]:
+    segments = extract_segments(raw, encoder)
+    return {
+        "segments": segments,
+        "segmentCount": len(segments),
+        "characters": sum(row["characters"] for row in segments),
+        "utf8Bytes": sum(row["utf8Bytes"] for row in segments),
+        "textTokens": sum(row["tokens"] for row in segments),
+    }
+
+
+def compare(control: dict[str, Any], treatment: dict[str, Any]) -> dict[str, Any]:
+    treatment_hashes = {row["sha256"] for row in treatment["segments"]}
+    control_hashes = {row["sha256"] for row in control["segments"]}
+    retired = [row for row in control["segments"] if row["sha256"] not in treatment_hashes]
+    added = [row for row in treatment["segments"] if row["sha256"] not in control_hashes]
+    delta = treatment["textTokens"] - control["textTokens"]
+    return {
+        "textTokenDelta": delta,
+        "textTokenReductionPercent": round(
+            -delta * 100 / control["textTokens"], 3
+        ) if control["textTokens"] else 0.0,
+        "retiredSegments": retired,
+        "addedSegments": added,
+        "unchangedSegmentCount": len(control_hashes & treatment_hashes),
+    }
+
+
+def private_write(path: Path, value: bytes) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "wb") as sink:
+        sink.write(value)
+        sink.flush()
+        os.fsync(sink.fileno())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--control", type=Path, required=True)
+    parser.add_argument("--treatment", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--encoding", default="o200k_base")
+    args = parser.parse_args()
+    try:
+        import tiktoken
+    except ImportError as error:
+        raise SystemExit("tiktoken is required for an OpenAI-tokenizer report") from error
+    encoder = tiktoken.get_encoding(args.encoding)
+    control = arm(json.loads(args.control.read_text(encoding="utf-8")), encoder)
+    treatment = arm(json.loads(args.treatment.read_text(encoding="utf-8")), encoder)
+    result = {
+        "schema": "cultist-codex-prompt-token-report/v1",
+        "recordedAt": datetime.now(timezone.utc).isoformat(),
+        "encoding": args.encoding,
+        "control": control,
+        "treatment": treatment,
+        "comparison": compare(control, treatment),
+        "countsTextSegmentsOnly": True,
+        "countsProtocolOverhead": False,
+        "rawContentEmitted": False,
+        "authorizesCapabilityRetirement": False,
+        "authorizesProductionPromotion": False,
+    }
+    payload = canonical(result) + b"\n"
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    private_write(args.output, payload)
+    print(json.dumps({
+        "schema": "cultist-codex-prompt-token-report-receipt/v1",
+        "resultSha256": digest(payload),
+        "encoding": args.encoding,
+        "controlTextTokens": control["textTokens"],
+        "treatmentTextTokens": treatment["textTokens"],
+        "textTokenDelta": result["comparison"]["textTokenDelta"],
+        "textTokenReductionPercent": result["comparison"]["textTokenReductionPercent"],
+        "rawContentEmitted": False,
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/codex_prompt_token_report_test.py
+++ b/scripts/codex_prompt_token_report_test.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import codex_prompt_token_report as report
+
+
+class CharacterEncoder:
+    def encode(self, text, **kwargs):
+        return list(text)
+
+
+class PromptTokenReportTests(unittest.TestCase):
+    def test_segments_are_labeled_and_text_is_not_retained(self):
+        raw = [{"role": "developer", "content": [
+            {"type": "input_text", "text": "<skills_instructions>abc"},
+            {"type": "input_text", "text": "<permissions instructions>ok"},
+        ]}]
+        result = report.arm(raw, CharacterEncoder())
+        self.assertEqual([row["label"] for row in result["segments"]], [
+            "skills-catalogue", "permissions",
+        ])
+        self.assertNotIn("text", result["segments"][0])
+        self.assertEqual(result["textTokens"], 52)
+
+    def test_comparison_retains_exact_retired_segment(self):
+        encoder = CharacterEncoder()
+        control = report.arm([{"role": "developer", "content": [
+            {"text": "<skills_instructions>abc"}, {"text": "keep"},
+        ]}], encoder)
+        treatment = report.arm([{"role": "developer", "content": [{"text": "keep"}]}], encoder)
+        comparison = report.compare(control, treatment)
+        self.assertEqual(comparison["textTokenDelta"], -24)
+        self.assertEqual(comparison["retiredSegments"][0]["label"], "skills-catalogue")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Purpose: advance #371 with a current Codex context-efficiency result rather than treating the historical ~17.7K Luna pair as the target.

Change:
- add private-raw, content-minimised prompt-input and OpenAI-tokenizer probes;
- measure task-scoped skill/plugin/app surface profiles;
- retain three quiet first-action nulls, token variance, the multi-agent flag no-op, and the explicit-skill renderer no-op;
- publish the bounded current result and authority limits.

Proof:
- 11 focused Python tests pass;
- current text surface: 4,152 -> 753 o200k_base tokens for the explicit closed-task profile;
- live provider microtask: 19,471 -> 10,712 input tokens (-8,759; 45.0%) with identical exact output;
- broad profiles explicitly remain capability changes and do not authorize a global default.

Next: use the typed Stensibly runner profile for tasks that explicitly declare no plugin/app need; test real explicit-skill progressive disclosure separately.