### PR TITLE
research: prove explicit skill progressive disclosure

### DIFF
--- a/research/context-efficiency/2026-08-31-codex-current-prompt-surface/README.md
+++ b/research/context-efficiency/2026-08-31-codex-current-prompt-surface/README.md
@@ -38,6 +38,15 @@ output. The run used the Codex client's built-in default model under
 does not invent a model name. This microtask validates the real request-envelope
 saving, not broad engineering capability preservation.
 
+The explicit-skill gate also passed on a live `gpt-5.6-sol:xhigh` run. Both the
+ordinary and catalogue-muted arms issued two command executions referencing the
+named `lazy-commander` skill and `SKILL.md`, read the file, and returned the same
+structured observation with the exact `# Lazy Commander` heading. Muting the eager
+catalogue reduced provider-reported input from 43,062 to 30,759 tokens (-12,303;
+28.6%). This establishes progressive disclosure for this named installed skill on
+the pinned client/machine path; it does not establish every skill or broad plugin/app
+retirement.
+
 Three fresh behavioral replays with only the skills catalogue muted preserved the
 same first justified action. Provider input-token savings were -698, -698, and -490,
 so the useful conclusion is a non-zero saving with a retained first-action null—not
@@ -64,3 +73,5 @@ tool schemas, or other server-side overhead. A debug renderer probe using a lite
 `$lazy-commander` did not expose the skill body after catalogue suppression. That is
 a retained negative result for the probe method, not evidence that real runtime
 explicit-skill invocation works or fails.
+The live command-event replay supersedes that method limitation for the one pinned
+`lazy-commander` case while retaining the renderer null as evidence about the probe.

--- a/research/context-efficiency/2026-08-31-codex-current-prompt-surface/result.json
+++ b/research/context-efficiency/2026-08-31-codex-current-prompt-surface/result.json
@@ -52,6 +52,20 @@
     "same_exact_output": true,
     "output": "OK"
   },
+  "explicit_skill_provider_replay": {
+    "model": "gpt-5.6-sol",
+    "reasoning_effort": "xhigh",
+    "skill": "lazy-commander",
+    "control_input_tokens": 43062,
+    "treatment_input_tokens": 30759,
+    "input_token_delta": -12303,
+    "input_token_reduction_percent": 28.570,
+    "control_command_executions": 2,
+    "treatment_command_executions": 2,
+    "both_commands_referenced_skill_and_skill_md": true,
+    "same_structured_observation": true,
+    "effective_progressive_disclosure": true
+  },
   "quiet_results": [
     "The behavioral action did not change in any of three current pairs.",
     "The provider input-token delta varied; an exact 698-token claim is rejected.",
@@ -68,7 +82,8 @@
     "surface_matrix": "2297fee23eee2056c4292bcc32b74ead3af8982c23978076e80206c48cbf88e1",
     "behavioral_aggregate": "86c0c8b6345f8c596aef10d683378f31dbe94cfdaedda059c8faf548f042490e",
     "baseline_packet_token_report": "ecf19c15ea5900e22fed8816b0417d2eeb0f472a958e8fb9d7ca671bcdbfd3c7",
-    "current_closed_task_provider_receipt": "1f2bd6581f10eabd7cefa8d4772b179dfec8ce7b29a02c0ffe34b6c4848fd23e"
+    "current_closed_task_provider_receipt": "1f2bd6581f10eabd7cefa8d4772b179dfec8ce7b29a02c0ffe34b6c4848fd23e",
+    "explicit_skill_provider_receipt": "9a17cb685e8cb45a2cf50ad52b952ea94fd0b37f543dae56a45106cb5f892fd7"
   },
   "raw_content_emitted": false
 }


### PR DESCRIPTION
Purpose: complete Cultist #371's explicit-skill gate with command-event evidence, not a model self-report.

Change:
- bind one live gpt-5.6-sol:xhigh control/treatment replay to the current prompt-surface result;
- retain the earlier debug-renderer no-op and invalid-schema setup failure as method/setup nulls;
- record exact usage and authority limits.

Proof:
- both arms issued two command executions referencing lazy-commander and SKILL.md;
- both read the skill and returned the identical structured observation with # Lazy Commander;
- catalogue muting reduced provider input 43,062 -> 30,759 tokens (-12,303; 28.6%).

Limit: this proves progressive disclosure for one pinned installed skill/client/machine path. It does not authorize broad plugin/app retirement or a global default.