### PR TITLE
research: record worker brief policy density

### DIFF
--- a/research/context-efficiency/2026-08-31-stensibly-worker-brief-density/README.md
+++ b/research/context-efficiency/2026-08-31-stensibly-worker-brief-density/README.md
@@ -1,0 +1,44 @@
+# Stensibly worker-brief density
+
+## Result
+
+Current issue-1616 fixture, `o200k_base`:
+
+| presentation | tokens | vs explicit |
+|---|---:|---:|
+| explicit | 1,000 | — |
+| terse before duplicate-digest cleanup | 653 | -34.7% |
+| terse | 608 | -39.2% |
+| terse, lazy policy | 397 | -60.3% |
+
+The first change was pure duplicate removal: one semantic digest already printed at
+the top of the brief. It saved 45 tokens without changing the presentation invariant.
+
+The policy pointer is conditional, not a new default. Fresh provider sessions gave:
+
+- policy irrelevant: same JSON, no tools, exactly 183 fewer input tokens;
+- policy required: same JSON, one policy read, 12,591 more input tokens.
+
+So: use the pointer only when the dispatch is already typed as policy-independent.
+Keep policy eager for authority, validation, evidence, and escalation work. Do not
+guess from task prose.
+
+Stensibly implementation: [PR #1768](https://github.com/teamleaderleo/stensibly/pull/1768)
+and [PR #1770](https://github.com/teamleaderleo/stensibly/pull/1770).
+
+## Controls
+
+- Codex CLI `0.151.0`
+- model `gpt-5.6-sol`, reasoning `low`
+- fresh ephemeral sessions
+- closed-task prompt-surface profile
+- same schema and task within each pair
+- only the operating-policy block changed
+- raw prompts/events remain in the private workstation lane
+- quiet losing result retained
+
+Private receipt SHA-256:
+`f9d4f5b34021b05b79c118723fcaf5af648a0e71c7c7f646f6bf768db7eba89e`.
+
+This result does not authorize automatic policy deferral or a global presentation
+change.

--- a/research/context-efficiency/2026-08-31-stensibly-worker-brief-density/result.json
+++ b/research/context-efficiency/2026-08-31-stensibly-worker-brief-density/result.json
@@ -1,0 +1,42 @@
+{
+  "schema": "cultist-stensibly-worker-brief-density/v1",
+  "recordedAt": "2026-08-31",
+  "tokenizer": {
+    "implementation": "tiktoken 0.14.0",
+    "encoding": "o200k_base"
+  },
+  "fixture": "issue-1616",
+  "presentations": {
+    "explicit": { "tokens": 1000 },
+    "terseBeforeDeduplication": { "tokens": 653, "reductionPercent": 34.7 },
+    "terse": { "tokens": 608, "reductionPercent": 39.2 },
+    "terseLazyPolicy": { "tokens": 397, "reductionPercent": 60.3 }
+  },
+  "provider": {
+    "codexVersion": "codex-cli 0.151.0",
+    "model": "gpt-5.6-sol",
+    "reasoningEffort": "low",
+    "promptSurfaceProfile": "closed-task",
+    "policyIrrelevant": {
+      "sameStructuredOutput": true,
+      "eagerInputTokens": 11378,
+      "pointerInputTokens": 11195,
+      "inputTokenDelta": -183,
+      "eagerCommandExecutions": 0,
+      "pointerCommandExecutions": 0
+    },
+    "policyRequired": {
+      "sameStructuredOutput": true,
+      "eagerInputTokens": 11436,
+      "pointerInputTokens": 24027,
+      "inputTokenDelta": 12591,
+      "eagerCommandExecutions": 0,
+      "pointerCommandExecutions": 1,
+      "pointerReadPolicySource": true
+    }
+  },
+  "privateProviderReceiptSha256": "f9d4f5b34021b05b79c118723fcaf5af648a0e71c7c7f646f6bf768db7eba89e",
+  "rawContentEmitted": false,
+  "authorizesAutomaticPolicyDeferral": false,
+  "authorizesGlobalDefaultChange": false
+}


### PR DESCRIPTION
Records the controlled Stensibly worker-brief density experiment without promoting private raw prompts or events.

Key result: policy pointers save 183 provider input tokens when policy is irrelevant, but cost 12,591 extra tokens and one read when policy is required. The record therefore authorizes only an explicit policy-independent presentation, not automatic deferral or a new default.

Also records the deterministic duplicate-digest cleanup and exact tokenizer counts.