### PR TITLE
Project noisy Codex exec event logs

### DIFF
--- a/research/context-efficiency/2026-08-31-glaeda-agent-entrypoint/README.md
+++ b/research/context-efficiency/2026-08-31-glaeda-agent-entrypoint/README.md
@@ -1,0 +1,87 @@
+# Glaeda agent-entrypoint compression
+
+## Result
+
+Move cold rules. Keep the router and universal invariants hot. Replay behavior.
+
+Glaeda candidate `d3f0f67` reduced its automatically loaded `AGENTS.md` from
+4,246 to 1,218 `o200k_base` text tokens: **-3,028 (-71.314%)**. A host-mutation
+task also loaded the 1,001-token safety reference, for 2,219 tokens total:
+**-2,027 (-47.739%)** versus the current-main root.
+
+The change did three things:
+
+- deleted mutable priorities from the automatic entrypoint; current issues own
+  them;
+- stopped restating the eight commands already owned by
+  `./scripts/verify required`;
+- moved ownership, persistence, repair, subprocess, and physical-experiment
+  detail to one explicit cold reference.
+
+## Controlled replay
+
+Fresh ephemeral `gpt-5.6-sol` low-reasoning sessions used the same read-only
+task, schema, host, closed-task prompt-surface profile, and source tree except
+for the documentation treatment.
+
+### Ordinary documentation task
+
+Both arms selected bootstrap, scoped README/workflow inspection,
+documentation-only verification, and self-review. Command count was noisy across
+fresh runs (3 control, 7 treatment). An earlier treatment opened the coordination
+reference only because the first router wrongly mapped generic review work to it.
+The router was narrowed and replayed. Retain command-count parity as
+**inconclusive**, not a compression claim.
+
+### Safety-critical automatic repair
+
+The treatment explicitly opened `docs/AGENT_EXECUTION_SAFETY.md`. Both arms
+preserved blockers for exact ownership, atomic durable state, root separation,
+empty/allowlisted child environments, no implicit shell, repair budget and
+circuit breaker, pre/post observation, journal recovery, rollback/compensation,
+physical verification, and independent exact-head acceptance.
+
+| Measure | Control | Treatment | Delta |
+| --- | ---: | ---: | ---: |
+| provider input tokens | 107,229 | 95,871 | -11,358 (-10.592%) |
+| completed commands | 4 | 3 | -1 |
+| mixed raw event-log bytes | 921,686 | 30,510 | -891,176 (-96.690%) |
+
+One pair proves this task instance, not universal behavioral equivalence.
+
+## Event projection
+
+The replay reproduced another hotspot: one final structured decision sat inside
+a 922 KB mixed Codex event log. `scripts/codex_exec_event_view.py` now
+projects that log to:
+
+- 1,227 bytes content-free; or
+- 5,059 bytes when the exact final structured result is requested.
+
+It omits warning text, command strings, command output, and intermediate agent
+messages while retaining counts, byte totals, digests, event classes, and usage.
+Raw logs stay private.
+
+## Research boundary
+
+This treatment follows evidence that natural-language prompts contain large
+removable regions, but it does not assume all prose is equally disposable:
+
+- [Yin et al.](https://aclanthology.org/2023.acl-long.172/) found task
+  definitions could lose 60% of tokens without worse performance, while output
+  and label information mattered most.
+- [LLMLingua](https://aclanthology.org/2023.emnlp-main.825/) demonstrated high
+  prompt compression with a budgeted, coarse-to-fine selector rather than blind
+  truncation.
+- [Gist Tokens](https://arxiv.org/abs/2304.08467) targeted repeated prompt
+  encoding directly, motivating a small reusable router plus cold expansion.
+- [Deng et al.](https://arxiv.org/abs/2412.17483) reported compression failures
+  around boundaries and surprising information. That supports task-specific
+  replay and explicit cold-reference routing.
+- [Hakim](https://arxiv.org/abs/2604.00025) found brevity constraints improved
+  accuracy on a particular inverse-scaling subset. Treat that as evidence
+  against reflexive verbosity, not a universal instruction to hide reasoning.
+
+Rule: compress repeated agent-facing transmission. Preserve decisions,
+invariants, authority, output contracts, unknowns, and recovery. Human-facing
+prose keeps the project's normal voice.

--- a/research/context-efficiency/2026-08-31-glaeda-agent-entrypoint/result.json
+++ b/research/context-efficiency/2026-08-31-glaeda-agent-entrypoint/result.json
@@ -1,0 +1,43 @@
+{
+  "schema": "cultist-context-efficiency-result/v1",
+  "date": "2026-08-31",
+  "encoding": "o200k_base",
+  "glaeda": {
+    "base": "a7343f85b5fd3dcf840f10c94c7884b050b66617",
+    "candidate": "d3f0f67637ce00a5528bd00d7086c5af02c1512c",
+    "oldRootTokens": 4246,
+    "newRootTokens": 1218,
+    "coldReferenceTokens": 1001,
+    "automaticRootTokenDelta": -3028,
+    "automaticRootReductionPercent": 71.314,
+    "rootPlusReferenceTokens": 2219,
+    "rootPlusReferenceDelta": -2027,
+    "rootPlusReferenceReductionPercent": 47.739
+  },
+  "safetyReplay": {
+    "controlInputTokens": 107229,
+    "treatmentInputTokens": 95871,
+    "inputTokenDelta": -11358,
+    "inputTokenReductionPercent": 10.592,
+    "controlCommands": 4,
+    "treatmentCommands": 3,
+    "controlRawEventBytes": 921686,
+    "treatmentRawEventBytes": 30510,
+    "rawEventByteDelta": -891176,
+    "rawEventByteReductionPercent": 96.69,
+    "behavioralOutcome": "same safety decision class and critical blockers"
+  },
+  "ordinaryReplay": {
+    "behavioralOutcome": "same decision class",
+    "commandCountOutcome": "inconclusive fresh-run variance",
+    "retainedNegative": true
+  },
+  "eventProjection": {
+    "controlRawBytes": 921686,
+    "contentFreeViewBytes": 1227,
+    "finalStructuredViewBytes": 5059,
+    "rawContentDefault": false
+  },
+  "rawLogsPublished": false,
+  "authorizesGeneralCompression": false
+}

--- a/scripts/codex_exec_event_view.py
+++ b/scripts/codex_exec_event_view.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Project a mixed Codex ``exec --json`` log without emitting tool payloads."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+def digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def encoded_size(value: Any) -> int:
+    if not isinstance(value, str):
+        return 0
+    return len(value.encode("utf-8"))
+
+
+def project(raw: bytes, *, include_final: bool, max_final_chars: int) -> dict[str, Any]:
+    event_types: Counter[str] = Counter()
+    item_types: Counter[str] = Counter()
+    item_statuses: Counter[str] = Counter()
+    non_json_lines = 0
+    non_json_bytes = 0
+    malformed_json_lines = 0
+    command_count = 0
+    command_output_bytes = 0
+    command_text_bytes = 0
+    agent_messages: list[str] = []
+    usage: dict[str, Any] | None = None
+
+    lines = raw.splitlines()
+    for line in lines:
+        try:
+            value = json.loads(line)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            non_json_lines += 1
+            non_json_bytes += len(line)
+            if line.lstrip().startswith((b"{", b"[")):
+                malformed_json_lines += 1
+            continue
+        if not isinstance(value, dict):
+            continue
+        event_type = str(value.get("type") or "unknown")
+        event_types[event_type] += 1
+        item = value.get("item")
+        if isinstance(item, dict):
+            item_type = str(item.get("type") or "unknown")
+            item_types[item_type] += 1
+            status = item.get("status")
+            if isinstance(status, str):
+                item_statuses[status] += 1
+            if event_type == "item.completed" and item_type == "command_execution":
+                command_count += 1
+                command_text_bytes += encoded_size(item.get("command"))
+                command_output_bytes += encoded_size(item.get("aggregated_output"))
+            if event_type == "item.completed" and item_type == "agent_message":
+                text = item.get("text")
+                if isinstance(text, str):
+                    agent_messages.append(text)
+        if event_type == "turn.completed" and isinstance(value.get("usage"), dict):
+            usage = value["usage"]
+
+    final_text = agent_messages[-1] if agent_messages else None
+    result: dict[str, Any] = {
+        "schema": "cultist-codex-exec-event-view/v1",
+        "source": {
+            "utf8Bytes": len(raw),
+            "lines": len(lines),
+            "sha256": digest(raw),
+        },
+        "parse": {
+            "jsonEvents": sum(event_types.values()),
+            "nonJsonLines": non_json_lines,
+            "nonJsonBytes": non_json_bytes,
+            "malformedJsonLines": malformed_json_lines,
+        },
+        "eventTypes": dict(sorted(event_types.items())),
+        "itemTypes": dict(sorted(item_types.items())),
+        "itemStatuses": dict(sorted(item_statuses.items())),
+        "commands": {
+            "completed": command_count,
+            "commandTextBytesOmitted": command_text_bytes,
+            "aggregatedOutputBytesOmitted": command_output_bytes,
+        },
+        "agentMessages": {
+            "completed": len(agent_messages),
+            "finalAvailable": final_text is not None,
+            "finalUtf8Bytes": encoded_size(final_text),
+            "finalSha256": digest(final_text.encode()) if final_text is not None else None,
+        },
+        "usage": usage,
+        "omittedClasses": [
+            "non-json-lines",
+            "command-text",
+            "command-output",
+            "agent-message-content",
+        ],
+        "rawContentEmitted": False,
+    }
+    if include_final and final_text is not None:
+        if len(final_text) > max_final_chars:
+            result["finalText"] = final_text[:max_final_chars]
+            result["finalTruncated"] = True
+        else:
+            try:
+                result["finalStructured"] = json.loads(final_text)
+                result["finalTruncated"] = False
+            except json.JSONDecodeError:
+                result["finalText"] = final_text
+                result["finalTruncated"] = False
+        result["rawContentEmitted"] = True
+        result["omittedClasses"].remove("agent-message-content")
+        if len(agent_messages) > 1:
+            result["omittedClasses"].append("intermediate-agent-messages")
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", type=Path)
+    parser.add_argument(
+        "--include-final",
+        action="store_true",
+        help="emit only the final agent message; structured JSON is preserved",
+    )
+    parser.add_argument("--max-final-chars", type=int, default=8_000)
+    args = parser.parse_args()
+    if args.max_final_chars < 1:
+        parser.error("--max-final-chars must be positive")
+    print(json.dumps(
+        project(
+            args.log.read_bytes(),
+            include_final=args.include_final,
+            max_final_chars=args.max_final_chars,
+        ),
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    ))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/codex_exec_event_view_test.py
+++ b/scripts/codex_exec_event_view_test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import json
+import unittest
+
+import codex_exec_event_view as view
+
+
+def line(value):
+    return json.dumps(value, separators=(",", ":")).encode() + b"\n"
+
+
+class CodexExecEventViewTests(unittest.TestCase):
+    def fixture(self):
+        return b"warning: private path\n" + b"".join([
+            line({
+                "type": "item.completed",
+                "item": {
+                    "type": "command_execution",
+                    "status": "completed",
+                    "command": "secret-command",
+                    "aggregated_output": "huge private output",
+                },
+            }),
+            line({
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": "secret-intermediate"},
+            }),
+            line({
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": '{"answer":"ok"}'},
+            }),
+            line({
+                "type": "turn.completed",
+                "usage": {"input_tokens": 123, "output_tokens": 7},
+            }),
+        ])
+
+    def test_default_is_content_free(self):
+        result = view.project(self.fixture(), include_final=False, max_final_chars=80)
+        rendered = json.dumps(result)
+        self.assertNotIn("secret-command", rendered)
+        self.assertNotIn("private output", rendered)
+        self.assertNotIn("secret-intermediate", rendered)
+        self.assertNotIn('"answer": "ok"', rendered)
+        self.assertEqual(result["commands"]["completed"], 1)
+        self.assertEqual(result["commands"]["aggregatedOutputBytesOmitted"], 19)
+        self.assertEqual(result["parse"]["nonJsonLines"], 1)
+        self.assertEqual(result["usage"]["input_tokens"], 123)
+        self.assertFalse(result["rawContentEmitted"])
+
+    def test_explicit_final_preserves_structured_result_only(self):
+        result = view.project(self.fixture(), include_final=True, max_final_chars=80)
+        self.assertEqual(result["finalStructured"], {"answer": "ok"})
+        self.assertFalse(result["finalTruncated"])
+        rendered = json.dumps(result)
+        self.assertNotIn("secret-command", rendered)
+        self.assertNotIn("private output", rendered)
+        self.assertNotIn("secret-intermediate", rendered)
+        self.assertTrue(result["rawContentEmitted"])
+        self.assertIn("intermediate-agent-messages", result["omittedClasses"])
+
+    def test_unstructured_final_is_bounded(self):
+        raw = line({
+            "type": "item.completed",
+            "item": {"type": "agent_message", "text": "abcdefgh"},
+        })
+        result = view.project(raw, include_final=True, max_final_chars=4)
+        self.assertEqual(result["finalText"], "abcd")
+        self.assertTrue(result["finalTruncated"])
+
+    def test_oversized_structured_final_does_not_bypass_bound(self):
+        raw = line({
+            "type": "item.completed",
+            "item": {"type": "agent_message", "text": '{"answer":"abcdefgh"}'},
+        })
+        result = view.project(raw, include_final=True, max_final_chars=8)
+        self.assertNotIn("finalStructured", result)
+        self.assertEqual(result["finalText"], '{"answer')
+        self.assertTrue(result["finalTruncated"])
+
+    def test_json_shaped_noise_is_counted_as_malformed(self):
+        result = view.project(b"{broken}\nplain\n", include_final=False, max_final_chars=80)
+        self.assertEqual(result["parse"]["nonJsonLines"], 2)
+        self.assertEqual(result["parse"]["malformedJsonLines"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Add a content-free-by-default projector for mixed `codex exec --json` logs. It retains event/item counts, omitted byte totals, digests, provider usage, and final-result identity while omitting warning text, command strings, command output, and agent content. `--include-final` admits only the bounded final result; structured JSON is preserved only inside the same character ceiling.

The real Glaeda replay input was 921,686 bytes. Projection is 1,227 bytes content-free or 5,059 bytes with the bounded final structured result. Raw logs remain private.

Also retain the controlled Glaeda entrypoint result and the ordinary-task command-count null in a compact public research receipt.

## Checks

- 5 new projector tests
- 2 prompt-token-report tests
- 2 prompt-surface-matrix tests
- 2 context-ablation aggregate tests
- JSON validation and `git diff --check`

The projector is read-only and grants no capability retirement or production-promotion authority.