### PR TITLE
Preserve unknowns and task outcomes in helper routing research

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
             scripts/project_memory_github_lineage.py \
             scripts/project_memory_github_lineage_test.py
           python scripts/project_memory_github_lineage_test.py
+      - name: Helper routing research evidence controls
+        run: python scripts/helper_routing_evidence_test.py
       - name: GitHub review-memory adapter controls
         run: |
           python -m py_compile \

--- a/research/helper-routing/2026-09-05-muse-launcher-guard/README.md
+++ b/research/helper-routing/2026-09-05-muse-launcher-guard/README.md
@@ -1,0 +1,50 @@
+# First Muse helper routing receipt
+
+The selected launcher model-identity repair was accepted after independent review and a focused
+test rerun. The owner reports zero cost in two helper wrapper receipts. End-to-end cost, repair
+effort, time, and task tokens remain **UNKNOWN**. This is one accepted task, not evidence that a
+routing strategy wins.
+
+Source: [Cultist #383 first trial](https://github.com/teamleaderleo/cultist/issues/383#issuecomment-5549768574).
+The [merged repair](https://github.com/teamleaderleo/compute-node-bootstrap/pull/35) was checked
+against merge commit `56a07f63bed0ac50eeff2f1fa6c5ae460dea9c27` when retaining this receipt.
+The provider/process fields remain unknown because the comment does not supply those events;
+accepted work does not retroactively prove each intermediate process succeeded.
+
+## Reuse
+
+From the repository root:
+
+```bash
+python3 scripts/helper_routing_evidence.py research/helper-routing/2026-09-05-muse-launcher-guard/result.json
+python3 scripts/helper_routing_evidence_test.py
+```
+
+The offline summarizer consumes `result.json` research receipts and prints descriptive JSON. It
+does not dispatch, poll, change a ledger, fetch sources, or infer a routing policy. This receipt
+is the capture example: retain exact task/evidence references; use JSON `null` for unknowns;
+record the four classes already specified by #383; and distinguish classifications made before
+dispatch from retrospective judgments. Future cohorts can place multiple task records in one
+receipt. Each canonical task reference must occur once so repeated attempts do not inflate the
+accepted-task denominator.
+
+The four outcome fields are independent observations: explicit provider success, process
+completion, independent verification, and acceptance. Record process failure even when a provider
+emits success. A rejected or unverified proposal does not become accepted because another proposal
+from the same worker did.
+
+For each task, capture retry count, human/agent repair minutes, end-to-end wall seconds, and total
+task tokens only when evidence establishes their scope. A follow-on implementation after review
+is not necessarily a retry. Provider usage retains its own metric, unit, scope, and evidence;
+an empty list means no observed usage, not free work. Unknown units stay null. Include reviewer
+and repair consumption when measuring end-to-end efficiency, and avoid overlapping usage rows.
+
+Groups separate route, classification timing, and all four difficulty classes. Metric totals
+cover known observations only and include known/unknown task counts; an all-unknown total remains
+null. Provider usage is retained per task rather than combined across currencies, units, or
+partial scopes. Source records and limitations survive aggregation. Even fully populated groups
+are descriptive, not matched experimental arms: comparisons still need predeclared cohorts and
+review of confounding factors.
+
+The next useful experiment is a small real-task cohort with pre-dispatch classification and
+complete review/repair accounting. Preserve failures and missing data alongside accepted work.

--- a/research/helper-routing/2026-09-05-muse-launcher-guard/result.json
+++ b/research/helper-routing/2026-09-05-muse-launcher-guard/result.json
@@ -1,0 +1,48 @@
+{
+  "schema": "cultist-helper-routing-evidence/v1",
+  "tasks": [
+    {
+      "task_ref": "https://github.com/teamleaderleo/compute-node-bootstrap/pull/35",
+      "evidence_refs": [
+        "https://github.com/teamleaderleo/cultist/issues/383#issuecomment-5549768574",
+        "https://github.com/teamleaderleo/compute-node-bootstrap/commit/56a07f63bed0ac50eeff2f1fa6c5ae460dea9c27"
+      ],
+      "route": null,
+      "classification_timing": "retrospective",
+      "classification": {
+        "oracle_strength": "strong",
+        "semantic_ambiguity": "low",
+        "coupling": "local",
+        "failure_cost": "low"
+      },
+      "outcomes": {
+        "provider_success": null,
+        "process_completed": null,
+        "verified": true,
+        "accepted": true
+      },
+      "metrics": {
+        "retries": null,
+        "repair_minutes": null,
+        "wall_seconds": null,
+        "task_tokens": null
+      },
+      "provider_usage": [
+        {
+          "provider": "Muse",
+          "metric": "wrapper_reported_cost",
+          "unit": null,
+          "scope": "Two helper wrapper receipts: read-only review and selected repair implementation",
+          "value": 0,
+          "evidence_ref": "https://github.com/teamleaderleo/cultist/issues/383#issuecomment-5549768574"
+        }
+      ],
+      "limitations": [
+        "OBSERVED: the owner comment reports two Muse runs, independent Codex review, a focused test rerun, merge, and verified launcher installation; this receipt does not independently replay the run logs.",
+        "OBSERVED: the pull request is merged at the recorded commit. Acceptance applies to the selected model-identity guard, not every proposal in the initial review.",
+        "UNKNOWN: source comment gives no cost unit, end-to-end review/repair accounting, elapsed time, retries, task tokens, or explicit provider/process result events. Two runs with different purposes are not automatically one retry.",
+        "INFERRED: classification is provisional and retrospective. The source does not establish a predeclared cheap-first/frontier-first arm or matched control. One accepted task cannot establish routing superiority."
+      ]
+    }
+  ]
+}

--- a/scripts/helper_routing_evidence.py
+++ b/scripts/helper_routing_evidence.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Summarize task-level routing research receipts; never dispatch or infer policy."""
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+
+SCHEMA = "cultist-helper-routing-evidence/v1"
+CLASSES = {
+    "oracle_strength": {"strong", "moderate", "weak"},
+    "semantic_ambiguity": {"low", "medium", "high"},
+    "coupling": {"local", "subsystem", "cross_system"},
+    "failure_cost": {"low", "medium", "high"},
+}
+OUTCOMES = ("provider_success", "process_completed", "verified", "accepted")
+METRICS = ("retries", "repair_minutes", "wall_seconds", "task_tokens")
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def fields(value, names, label):
+    require(isinstance(value, dict) and set(value) == set(names), f"invalid {label} fields")
+
+
+def text(value):
+    return isinstance(value, str) and bool(value.strip())
+
+
+def number(value, integral=False):
+    return value is None or (
+        type(value) in (int, float) and math.isfinite(value) and value >= 0
+        and (not integral or type(value) is int)
+    )
+
+
+def validate(receipt):
+    fields(receipt, ("schema", "tasks"), "receipt")
+    require(receipt["schema"] == SCHEMA, "unsupported schema")
+    require(isinstance(receipt["tasks"], list) and receipt["tasks"], "tasks must be nonempty")
+    seen = set()
+    for task in receipt["tasks"]:
+        fields(task, ("task_ref", "evidence_refs", "route", "classification_timing",
+                      "classification", "outcomes", "metrics", "provider_usage", "limitations"), "task")
+        require(text(task["task_ref"]) and task["task_ref"] not in seen, "duplicate or empty task_ref")
+        seen.add(task["task_ref"])
+        require(isinstance(task["evidence_refs"], list) and task["evidence_refs"]
+                and all(text(ref) for ref in task["evidence_refs"]), "evidence_refs required")
+        require(task["route"] in (None, "cheap-first", "frontier-first"), "invalid route")
+        require(task["classification_timing"] in (None, "before-dispatch", "retrospective"),
+                "invalid classification_timing")
+        fields(task["classification"], CLASSES, "classification")
+        for key, allowed in CLASSES.items():
+            require(task["classification"][key] is None or task["classification"][key] in allowed,
+                    f"invalid {key}")
+        fields(task["outcomes"], OUTCOMES, "outcomes")
+        for key in OUTCOMES:
+            require(task["outcomes"][key] is None or type(task["outcomes"][key]) is bool,
+                    f"invalid {key}")
+        fields(task["metrics"], METRICS, "metrics")
+        for key in METRICS:
+            require(number(task["metrics"][key], key in ("retries", "task_tokens")), f"invalid {key}")
+        require(isinstance(task["limitations"], list) and all(text(s) for s in task["limitations"]),
+                "invalid limitations")
+        require(isinstance(task["provider_usage"], list), "invalid provider_usage")
+        usage_seen = set()
+        for usage in task["provider_usage"]:
+            fields(usage, ("provider", "metric", "unit", "scope", "value", "evidence_ref"), "usage")
+            require(all(text(usage[k]) for k in ("provider", "metric", "scope", "evidence_ref")),
+                    "usage identity and evidence required")
+            require(usage["unit"] is None or text(usage["unit"]), "invalid usage unit")
+            require(number(usage["value"]), "invalid usage value")
+            identity = tuple(usage[k] for k in ("provider", "metric", "unit", "scope"))
+            require(identity not in usage_seen, "duplicate task usage metric")
+            usage_seen.add(identity)
+
+
+def summarize(receipt):
+    validate(receipt)
+    groups = {}
+    for task in receipt["tasks"]:
+        # Never pool tasks with different verification difficulty or retrospective tags.
+        identity = (task["route"], task["classification_timing"],
+                    *(task["classification"][key] for key in CLASSES))
+        groups.setdefault(identity, []).append(task)
+    summaries = []
+    for tasks in groups.values():
+        first = tasks[0]
+        metrics = {}
+        for key in METRICS:
+            known = [task["metrics"][key] for task in tasks if task["metrics"][key] is not None]
+            metrics[key] = {"known_tasks": len(known), "unknown_tasks": len(tasks) - len(known),
+                            "known_total": sum(known) if known else None}
+        outcomes = {key: {
+            "true": sum(task["outcomes"][key] is True for task in tasks),
+            "false": sum(task["outcomes"][key] is False for task in tasks),
+            "unknown": sum(task["outcomes"][key] is None for task in tasks),
+        } for key in OUTCOMES}
+        summaries.append({"route": first["route"], "classification_timing": first["classification_timing"],
+                          "classification": first["classification"], "tasks": len(tasks),
+                          "outcomes": outcomes, "metrics": metrics})
+    return {
+        "schema": SCHEMA,
+        "task_count": len(receipt["tasks"]),
+        "groups": summaries,
+        # Preserve units, scope, provenance and missingness; no currency conversion or
+        # cost-per-accepted-task estimate from partial helper-only accounting.
+        "provider_usage": [{"task_ref": task["task_ref"], **usage}
+                           for task in receipt["tasks"] for usage in task["provider_usage"]],
+        "tasks_without_provider_usage": sum(not task["provider_usage"] for task in receipt["tasks"]),
+        "source_tasks": receipt["tasks"],
+        "routing_conclusion": None,
+        "limitation": "Descriptive evidence only; groups are not matched experimental arms. "
+                      "Unknown values are not zero. Provider usage may omit review and repair work.",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("receipt", type=Path)
+    args = parser.parse_args()
+    try:
+        result = summarize(json.loads(args.receipt.read_text()))
+    except (ValueError, TypeError, OSError) as error:
+        parser.exit(2, f"invalid receipt: {error}\n")
+    print(json.dumps(result, indent=2, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/helper_routing_evidence_test.py
+++ b/scripts/helper_routing_evidence_test.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+import copy
+import json
+from pathlib import Path
+import unittest
+
+import helper_routing_evidence as evidence
+
+
+RECEIPT = Path(__file__).resolve().parents[1] / "research/helper-routing/2026-09-05-muse-launcher-guard/result.json"
+
+
+class HelperRoutingEvidenceTests(unittest.TestCase):
+    def setUp(self):
+        self.receipt = json.loads(RECEIPT.read_text())
+        self.task = self.receipt["tasks"][0]
+
+    def test_real_receipt_does_not_invent_comparison_or_free_end_to_end_work(self):
+        result = evidence.summarize(self.receipt)
+        group = result["groups"][0]
+        self.assertIsNone(result["routing_conclusion"])
+        self.assertIsNone(group["route"])
+        self.assertEqual(group["classification_timing"], "retrospective")
+        self.assertEqual(group["outcomes"]["accepted"], {"true": 1, "false": 0, "unknown": 0})
+        self.assertEqual(group["outcomes"]["process_completed"]["unknown"], 1)
+        self.assertEqual(group["metrics"]["retries"], {"known_tasks": 0, "unknown_tasks": 1, "known_total": None})
+        self.assertIsNone(result["provider_usage"][0]["unit"])
+        self.assertEqual(result["source_tasks"], self.receipt["tasks"])
+
+    def test_provider_success_does_not_override_failed_process_or_rejected_work(self):
+        self.task["outcomes"] = {"provider_success": True, "process_completed": False,
+                                 "verified": False, "accepted": False}
+        outcomes = evidence.summarize(self.receipt)["groups"][0]["outcomes"]
+        self.assertEqual(outcomes["provider_success"]["true"], 1)
+        self.assertEqual(outcomes["process_completed"]["false"], 1)
+        self.assertEqual(outcomes["accepted"]["true"], 0)
+
+    def test_unknown_metrics_do_not_become_zero_or_enter_known_denominator(self):
+        other = copy.deepcopy(self.task)
+        other["task_ref"] = "second-task"
+        other["metrics"]["retries"] = 0
+        other["metrics"]["repair_minutes"] = 7.5
+        other["outcomes"]["accepted"] = None
+        other["provider_usage"] = []
+        self.receipt["tasks"].append(other)
+        result = evidence.summarize(self.receipt)
+        group = result["groups"][0]
+        self.assertEqual(group["metrics"]["repair_minutes"], {"known_tasks": 1, "unknown_tasks": 1, "known_total": 7.5})
+        self.assertEqual(group["outcomes"]["accepted"]["unknown"], 1)
+        self.assertEqual(result["tasks_without_provider_usage"], 1)
+
+    def test_difficulty_timing_and_route_are_not_pooled(self):
+        for key, value in (("route", "cheap-first"), ("classification_timing", "before-dispatch"),
+                           ("oracle_strength", "weak")):
+            with self.subTest(key=key):
+                receipt = copy.deepcopy(self.receipt)
+                other = copy.deepcopy(self.task)
+                other["task_ref"] = "other"
+                (other["classification"] if key == "oracle_strength" else other)[key] = value
+                receipt["tasks"].append(other)
+                self.assertEqual(len(evidence.summarize(receipt)["groups"]), 2)
+
+    def test_partial_usage_and_different_units_remain_separate(self):
+        other = copy.deepcopy(self.task["provider_usage"][0])
+        other.update(provider="reviewer", unit="USD", value=1.5, scope="review only")
+        self.task["provider_usage"].append(other)
+        usage = evidence.summarize(self.receipt)["provider_usage"]
+        self.assertEqual([row["unit"] for row in usage], [None, "USD"])
+        self.assertEqual([row["value"] for row in usage], [0, 1.5])
+
+    def test_duplicate_task_and_usage_are_rejected(self):
+        self.receipt["tasks"].append(copy.deepcopy(self.task))
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            evidence.summarize(self.receipt)
+        self.receipt["tasks"].pop()
+        self.task["provider_usage"].append(copy.deepcopy(self.task["provider_usage"][0]))
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            evidence.summarize(self.receipt)
+
+    def test_malformed_observations_fail_closed(self):
+        mutations = [
+            lambda t: t["metrics"].update(retries=True),
+            lambda t: t["metrics"].update(retries=1.5),
+            lambda t: t["metrics"].update(wall_seconds=-1),
+            lambda t: t["metrics"].update(repair_minutes=float("nan")),
+            lambda t: t["provider_usage"][0].update(value=float("inf")),
+            lambda t: t["outcomes"].update(accepted="true"),
+            lambda t: t["classification"].update(oracle_strength="excellent"),
+            lambda t: t.update(evidence_refs=[]),
+            lambda t: t.update(extra="ignored?"),
+        ]
+        for mutation in mutations:
+            with self.subTest(mutation=mutation):
+                receipt = copy.deepcopy(self.receipt)
+                mutation(receipt["tasks"][0])
+                with self.assertRaises(ValueError):
+                    evidence.summarize(receipt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The first Muse repair was accepted, but its two zero-cost wrapper receipts do not establish total task cost or a better routing strategy. This adds an offline research-receipt summarizer that preserves unknown metrics, separate provider/process/verification/acceptance outcomes, classification timing, and per-task provider units and scope.

The checked-in first-trial receipt cites the original owner observation and merged repair. Descriptive groups retain missing-value counts and source limitations; they never infer a routing policy. This supports #383 without adding dispatch or work-state machinery.

Validation: seven focused tests cover failed processes after provider success, rejected work, partial/unknown accounting, mixed units, cohort separation, duplicate tasks, and malformed values. The example CLI ran successfully and `git diff --check` passed. CI now runs the focused tests.
