### PR TITLE
Reconcile and compare helper routing evidence under Cultist #383

### DIFF
--- a/research/helper-routing/2026-09-05-peer-helper-comparison/README.md
+++ b/research/helper-routing/2026-09-05-peer-helper-comparison/README.md
@@ -1,0 +1,39 @@
+# Helper routing comparative evidence and negative control
+
+This research receipt records a bounded four-task cohort under [Cultist #383](https://github.com/teamleaderleo/cultist/issues/383) evaluating cheap-worker routing against verification oracle strength, false provider success, and physical execution receipt projection from [Stensibly #1841](https://github.com/teamleaderleo/stensibly/pull/1841).
+
+## Hypothesis and Evaluation
+
+Under Cultist #383, the routing discriminator for cheap workers (Muse/Luna/Gemini class) is not benchmark score alone, but the cost and reliability of detecting a wrong answer:
+* **Strong oracle, low ambiguity, local coupling, low failure cost**: cheap-first workers achieve high acceptance when bounded deterministic tests verify behavior.
+* **Negative control**: cheap worker self-reports (`provider_success: true`) are uncoupled from real success; without independent machine verification, undetected failures require human/commander escalation.
+* **Execution vs Acceptance separation**: physical test execution receipts (from Stensibly #1841) establish command verification, but full task acceptance remains distinct.
+
+## Cohort Breakdown
+
+1. **`compute-node-bootstrap#35`** ([PR #35](https://github.com/teamleaderleo/compute-node-bootstrap/pull/35), commit `56a07f63bed0ac50eeff2f1fa6c5ae460dea9c27`):
+   * Class: strong oracle, low ambiguity, local coupling, low failure cost (`cheap-first`, retrospective).
+   * Result: Muse implemented model-identity guard; bash regression suite verified behavior; Codex independently reviewed diff; merged and accepted (cost: 0).
+2. **`compute-node-bootstrap#36`** ([PR #36](https://github.com/teamleaderleo/compute-node-bootstrap/pull/36), commit `6c52c6710a7d824229d9e89a6ea840a5581df40c`):
+   * Class: strong oracle, low ambiguity, local coupling, low failure cost (`cheap-first`, retrospective).
+   * Result: Muse implemented peer deadline kill-after grace; verified by positive tests (exit 137) and a negative control omitting grace (exit 124); merged and accepted (cost: 0).
+3. **`stensibly#1821` Negative Control** ([PR #1821](https://github.com/teamleaderleo/stensibly/pull/1821)):
+   * Class: strong oracle, low ambiguity, subsystem coupling, medium failure cost (`cheap-first`, retrospective).
+   * Result: Worker emitted structured `SUCCESS` event followed by exit code 7; `provider_success: true`, `process_completed: false`, `verified: false`, `accepted: false`. Required follow-on repair in PR #1840/#1841. Proves worker self-report cannot substitute for machine oracle.
+4. **`stensibly-1841-adapter-verify`** ([Stensibly PR #1841](https://github.com/teamleaderleo/stensibly/pull/1841)):
+   * Class: unrouted workstation execution projection (`route: null`, `classification: null`).
+   * Result: Named `verify_focused` check succeeded (`verified: true`); parent task acceptance and process completion remain `unknown`.
+
+## Mechanical Improvements
+
+The offline summarizer (`scripts/helper_routing_evidence.py`) now addresses three mechanical bottlenecks:
+1. **Stdin & Multi-Source Streaming**: Directly consumes piped projections (`bun scripts/helper-routing-evidence.ts < results.json | python3 scripts/helper_routing_evidence.py -`) or multiple files.
+2. **Evidence Reconciliation (`--reconcile`)**: Binds Stensibly workstation execution receipts with outcome/classification annotations by exact `task_ref`, failing closed on conflicting values.
+3. **Cohort Comparison (`--compare`)**: Computes exact acceptance/verification rates and metric burdens per accepted task over known denominators only, without imputing zero for missing data.
+
+## Reproduction
+
+```bash
+python3 scripts/helper_routing_evidence.py research/helper-routing/2026-09-05-peer-helper-comparison/result.json --compare
+python3 scripts/helper_routing_evidence_test.py
+```

--- a/research/helper-routing/2026-09-05-peer-helper-comparison/result.json
+++ b/research/helper-routing/2026-09-05-peer-helper-comparison/result.json
@@ -1,0 +1,154 @@
+{
+  "schema": "cultist-helper-routing-evidence/v1",
+  "tasks": [
+    {
+      "task_ref": "https://github.com/teamleaderleo/compute-node-bootstrap/pull/35",
+      "evidence_refs": [
+        "https://github.com/teamleaderleo/cultist/issues/383#issuecomment-5549768574",
+        "https://github.com/teamleaderleo/compute-node-bootstrap/commit/56a07f63bed0ac50eeff2f1fa6c5ae460dea9c27",
+        "https://github.com/teamleaderleo/compute-node-bootstrap/pull/35"
+      ],
+      "route": "cheap-first",
+      "classification_timing": "retrospective",
+      "classification": {
+        "oracle_strength": "strong",
+        "semantic_ambiguity": "low",
+        "coupling": "local",
+        "failure_cost": "low"
+      },
+      "outcomes": {
+        "provider_success": null,
+        "process_completed": null,
+        "verified": true,
+        "accepted": true
+      },
+      "metrics": {
+        "retries": null,
+        "repair_minutes": null,
+        "wall_seconds": null,
+        "task_tokens": null
+      },
+      "provider_usage": [
+        {
+          "provider": "Muse",
+          "metric": "wrapper_reported_cost",
+          "unit": null,
+          "scope": "Two helper wrapper receipts: read-only review and selected repair implementation",
+          "value": 0,
+          "evidence_ref": "https://github.com/teamleaderleo/cultist/issues/383#issuecomment-5549768574"
+        }
+      ],
+      "limitations": [
+        "OBSERVED: the owner comment reports two Muse runs, independent Codex review, focused test rerun, merge, and verified launcher installation.",
+        "OBSERVED: pull request #35 merged at commit 56a07f63bed0ac50eeff2f1fa6c5ae460dea9c27. Acceptance applies to the selected model-identity guard.",
+        "UNKNOWN: source comment gives no cost unit, end-to-end review/repair accounting, elapsed time, retries, task tokens, or explicit provider/process result events."
+      ]
+    },
+    {
+      "task_ref": "https://github.com/teamleaderleo/compute-node-bootstrap/pull/36",
+      "evidence_refs": [
+        "https://github.com/teamleaderleo/compute-node-bootstrap/pull/36",
+        "https://github.com/teamleaderleo/compute-node-bootstrap/commit/6c52c6710a7d824229d9e89a6ea840a5581df40c"
+      ],
+      "route": "cheap-first",
+      "classification_timing": "retrospective",
+      "classification": {
+        "oracle_strength": "strong",
+        "semantic_ambiguity": "low",
+        "coupling": "local",
+        "failure_cost": "low"
+      },
+      "outcomes": {
+        "provider_success": null,
+        "process_completed": null,
+        "verified": true,
+        "accepted": true
+      },
+      "metrics": {
+        "retries": null,
+        "repair_minutes": null,
+        "wall_seconds": null,
+        "task_tokens": null
+      },
+      "provider_usage": [
+        {
+          "provider": "Muse",
+          "metric": "wrapper_reported_cost",
+          "unit": null,
+          "scope": "Muse implemented production change; Codex reviewed and strengthened tests",
+          "value": 0,
+          "evidence_ref": "https://github.com/teamleaderleo/compute-node-bootstrap/pull/36"
+        }
+      ],
+      "limitations": [
+        "OBSERVED: pull request #36 merged at commit 6c52c6710a7d824229d9e89a6ea840a5581df40c; negative control explicitly verified exit 124 failure when kill-after grace was omitted.",
+        "OBSERVED: test harness exercises forced exit 137, bounded elapsed time, and positive/negative controls on Big Red."
+      ]
+    },
+    {
+      "task_ref": "https://github.com/teamleaderleo/stensibly/pull/1821#issuecomment-exit7-defect",
+      "evidence_refs": [
+        "https://github.com/teamleaderleo/cultist/issues/383#issuecomment-5549768574",
+        "https://github.com/teamleaderleo/stensibly/pull/1821"
+      ],
+      "route": "cheap-first",
+      "classification_timing": "retrospective",
+      "classification": {
+        "oracle_strength": "strong",
+        "semantic_ambiguity": "low",
+        "coupling": "subsystem",
+        "failure_cost": "medium"
+      },
+      "outcomes": {
+        "provider_success": true,
+        "process_completed": false,
+        "verified": false,
+        "accepted": false
+      },
+      "metrics": {
+        "retries": 1,
+        "repair_minutes": null,
+        "wall_seconds": null,
+        "task_tokens": null
+      },
+      "provider_usage": [],
+      "limitations": [
+        "OBSERVED: provider emitted structured SUCCESS event but runner process exited with status 7; independent review caught defect and rejected unverified work.",
+        "DERIVED: negative control proving provider_success is uncoupled from process completion, verification, and acceptance.",
+        "OBSERVED: required follow-on repair in Stensibly PR #1840 / #1841 to handle exit and signal failures explicitly."
+      ]
+    },
+    {
+      "task_ref": "stensibly:glaeda/item-1/teamleaderleo%2Fglaeda/cccccccccccccccccccccccccccccccccccccccc/dddddddddddddddddddddddddddddddddddddddd",
+      "evidence_refs": [
+        "https://github.com/teamleaderleo/stensibly/pull/1841",
+        "stensibly-command:sha256:fixture-command-1"
+      ],
+      "route": null,
+      "classification_timing": null,
+      "classification": {
+        "oracle_strength": null,
+        "semantic_ambiguity": null,
+        "coupling": null,
+        "failure_cost": null
+      },
+      "outcomes": {
+        "provider_success": null,
+        "process_completed": null,
+        "verified": true,
+        "accepted": null
+      },
+      "metrics": {
+        "retries": null,
+        "repair_minutes": null,
+        "wall_seconds": null,
+        "task_tokens": null
+      },
+      "provider_usage": [],
+      "limitations": [
+        "OBSERVED: exact verify_focused workstation command succeeded in physical execution.",
+        "UNKNOWN: source-work acceptance, route, classification, provider outcome, and total task accounting are not established by workstation execution receipts alone."
+      ]
+    }
+  ]
+}

--- a/scripts/helper_routing_evidence.py
+++ b/scripts/helper_routing_evidence.py
@@ -2,9 +2,11 @@
 """Summarize task-level routing research receipts; never dispatch or infer policy."""
 
 import argparse
+import copy
 import json
 import math
 from pathlib import Path
+import sys
 
 
 SCHEMA = "cultist-helper-routing-evidence/v1"
@@ -38,48 +40,193 @@ def number(value, integral=False):
     )
 
 
+def validate_task(task, seen=None):
+    fields(task, ("task_ref", "evidence_refs", "route", "classification_timing",
+                  "classification", "outcomes", "metrics", "provider_usage", "limitations"), "task")
+    require(text(task["task_ref"]), "duplicate or empty task_ref")
+    if seen is not None:
+        require(task["task_ref"] not in seen, "duplicate or empty task_ref")
+        seen.add(task["task_ref"])
+    require(isinstance(task["evidence_refs"], list) and task["evidence_refs"]
+            and all(text(ref) for ref in task["evidence_refs"]), "evidence_refs required")
+    require(task["route"] in (None, "cheap-first", "frontier-first"), "invalid route")
+    require(task["classification_timing"] in (None, "before-dispatch", "retrospective"),
+            "invalid classification_timing")
+    fields(task["classification"], CLASSES, "classification")
+    for key, allowed in CLASSES.items():
+        require(task["classification"][key] is None or task["classification"][key] in allowed,
+                f"invalid {key}")
+    fields(task["outcomes"], OUTCOMES, "outcomes")
+    for key in OUTCOMES:
+        require(task["outcomes"][key] is None or type(task["outcomes"][key]) is bool,
+                f"invalid {key}")
+    fields(task["metrics"], METRICS, "metrics")
+    for key in METRICS:
+        require(number(task["metrics"][key], key in ("retries", "task_tokens")), f"invalid {key}")
+    require(isinstance(task["limitations"], list) and all(text(s) for s in task["limitations"]),
+            "invalid limitations")
+    require(isinstance(task["provider_usage"], list), "invalid provider_usage")
+    usage_seen = set()
+    for usage in task["provider_usage"]:
+        fields(usage, ("provider", "metric", "unit", "scope", "value", "evidence_ref"), "usage")
+        require(all(text(usage[k]) for k in ("provider", "metric", "scope", "evidence_ref")),
+                "usage identity and evidence required")
+        require(usage["unit"] is None or text(usage["unit"]), "invalid usage unit")
+        require(number(usage["value"]), "invalid usage value")
+        identity = tuple(usage[k] for k in ("provider", "metric", "unit", "scope"))
+        require(identity not in usage_seen, "duplicate task usage metric")
+        usage_seen.add(identity)
+
+
 def validate(receipt):
     fields(receipt, ("schema", "tasks"), "receipt")
     require(receipt["schema"] == SCHEMA, "unsupported schema")
     require(isinstance(receipt["tasks"], list) and receipt["tasks"], "tasks must be nonempty")
     seen = set()
     for task in receipt["tasks"]:
-        fields(task, ("task_ref", "evidence_refs", "route", "classification_timing",
-                      "classification", "outcomes", "metrics", "provider_usage", "limitations"), "task")
-        require(text(task["task_ref"]) and task["task_ref"] not in seen, "duplicate or empty task_ref")
-        seen.add(task["task_ref"])
-        require(isinstance(task["evidence_refs"], list) and task["evidence_refs"]
-                and all(text(ref) for ref in task["evidence_refs"]), "evidence_refs required")
-        require(task["route"] in (None, "cheap-first", "frontier-first"), "invalid route")
-        require(task["classification_timing"] in (None, "before-dispatch", "retrospective"),
-                "invalid classification_timing")
-        fields(task["classification"], CLASSES, "classification")
-        for key, allowed in CLASSES.items():
-            require(task["classification"][key] is None or task["classification"][key] in allowed,
-                    f"invalid {key}")
-        fields(task["outcomes"], OUTCOMES, "outcomes")
-        for key in OUTCOMES:
-            require(task["outcomes"][key] is None or type(task["outcomes"][key]) is bool,
-                    f"invalid {key}")
-        fields(task["metrics"], METRICS, "metrics")
-        for key in METRICS:
-            require(number(task["metrics"][key], key in ("retries", "task_tokens")), f"invalid {key}")
-        require(isinstance(task["limitations"], list) and all(text(s) for s in task["limitations"]),
-                "invalid limitations")
-        require(isinstance(task["provider_usage"], list), "invalid provider_usage")
-        usage_seen = set()
-        for usage in task["provider_usage"]:
-            fields(usage, ("provider", "metric", "unit", "scope", "value", "evidence_ref"), "usage")
-            require(all(text(usage[k]) for k in ("provider", "metric", "scope", "evidence_ref")),
-                    "usage identity and evidence required")
-            require(usage["unit"] is None or text(usage["unit"]), "invalid usage unit")
-            require(number(usage["value"]), "invalid usage value")
-            identity = tuple(usage[k] for k in ("provider", "metric", "unit", "scope"))
-            require(identity not in usage_seen, "duplicate task usage metric")
-            usage_seen.add(identity)
+        validate_task(task, seen)
 
 
-def summarize(receipt):
+def reconcile_tasks(tasks):
+    """Reconcile multiple task observations by exact task_ref, failing closed on conflict."""
+    by_ref = {}
+    for task in tasks:
+        validate_task(task)
+        ref = task["task_ref"]
+        if ref not in by_ref:
+            by_ref[ref] = copy.deepcopy(task)
+            continue
+        existing = by_ref[ref]
+
+        if existing["route"] is None:
+            existing["route"] = task["route"]
+        elif task["route"] is not None and existing["route"] != task["route"]:
+            raise ValueError(f"conflicting route for task_ref '{ref}': {existing['route']} vs {task['route']}")
+
+        if existing["classification_timing"] is None:
+            existing["classification_timing"] = task["classification_timing"]
+        elif task["classification_timing"] is not None and existing["classification_timing"] != task["classification_timing"]:
+            raise ValueError(f"conflicting classification_timing for task_ref '{ref}': {existing['classification_timing']} vs {task['classification_timing']}")
+
+        for k in CLASSES:
+            if existing["classification"][k] is None:
+                existing["classification"][k] = task["classification"][k]
+            elif task["classification"][k] is not None and existing["classification"][k] != task["classification"][k]:
+                raise ValueError(f"conflicting classification '{k}' for task_ref '{ref}': {existing['classification'][k]} vs {task['classification'][k]}")
+
+        for k in OUTCOMES:
+            if existing["outcomes"][k] is None:
+                existing["outcomes"][k] = task["outcomes"][k]
+            elif task["outcomes"][k] is not None and existing["outcomes"][k] != task["outcomes"][k]:
+                raise ValueError(f"conflicting outcome '{k}' for task_ref '{ref}': {existing['outcomes'][k]} vs {task['outcomes'][k]}")
+
+        for k in METRICS:
+            if existing["metrics"][k] is None:
+                existing["metrics"][k] = task["metrics"][k]
+            elif task["metrics"][k] is not None and existing["metrics"][k] != task["metrics"][k]:
+                raise ValueError(f"conflicting metric '{k}' for task_ref '{ref}': {existing['metrics'][k]} vs {task['metrics'][k]}")
+
+        for r in task["evidence_refs"]:
+            if r not in existing["evidence_refs"]:
+                existing["evidence_refs"].append(r)
+
+        for lim in task["limitations"]:
+            if lim not in existing["limitations"]:
+                existing["limitations"].append(lim)
+
+        existing_identities = {
+            tuple(u[k] for k in ("provider", "metric", "unit", "scope")): u
+            for u in existing["provider_usage"]
+        }
+        for u in task["provider_usage"]:
+            ident = tuple(u[k] for k in ("provider", "metric", "unit", "scope"))
+            if ident in existing_identities:
+                prev = existing_identities[ident]
+                if prev["value"] != u["value"]:
+                    raise ValueError(f"conflicting provider_usage value for {ident} in task_ref '{ref}'")
+                if prev["evidence_ref"] != u["evidence_ref"]:
+                    raise ValueError(f"conflicting provider_usage evidence_ref for {ident} in task_ref '{ref}'")
+            else:
+                existing["provider_usage"].append(copy.deepcopy(u))
+                existing_identities[ident] = u
+
+    return list(by_ref.values())
+
+
+def merge_receipts(receipts, reconcile=False):
+    """Merge multiple receipt dictionaries into one."""
+    require(isinstance(receipts, list) and receipts, "receipts must be nonempty list")
+    for r in receipts:
+        require(isinstance(r, dict) and r.get("schema") == SCHEMA, "unsupported schema in receipt")
+    all_tasks = [task for r in receipts for task in r.get("tasks", [])]
+    tasks = reconcile_tasks(all_tasks) if reconcile else all_tasks
+    receipt = {"schema": SCHEMA, "tasks": tasks}
+    validate(receipt)
+    return receipt
+
+
+def compare_cohorts(groups):
+    """Analyze group efficiency, matched comparisons, and negative controls."""
+    group_analyses = []
+    by_classification = {}
+
+    for g in groups:
+        tasks_count = g["tasks"]
+        accepted_true = g["outcomes"]["accepted"]["true"]
+        verified_true = g["outcomes"]["verified"]["true"]
+
+        metrics_per_accepted = {}
+        for k in METRICS:
+            m = g["metrics"][k]
+            if accepted_true > 0 and m["known_total"] is not None:
+                metrics_per_accepted[k] = {
+                    "known_total_per_accepted": round(m["known_total"] / accepted_true, 4),
+                    "known_tasks": m["known_tasks"],
+                    "accepted_tasks": accepted_true,
+                }
+            else:
+                metrics_per_accepted[k] = None
+
+        analysis = {
+            "route": g["route"],
+            "classification_timing": g["classification_timing"],
+            "classification": g["classification"],
+            "tasks": tasks_count,
+            "acceptance_rate": round(accepted_true / tasks_count, 4) if tasks_count > 0 else None,
+            "verification_rate": round(verified_true / tasks_count, 4) if tasks_count > 0 else None,
+            "outcomes": g["outcomes"],
+            "metrics_per_accepted_task": metrics_per_accepted,
+        }
+        group_analyses.append(analysis)
+
+        class_key = tuple(g["classification"][k] for k in sorted(CLASSES))
+        by_classification.setdefault(class_key, []).append(analysis)
+
+    matched_pairs = []
+    unmatched_cohorts = []
+    for _, cohort_groups in by_classification.items():
+        routes = {cg["route"] for cg in cohort_groups}
+        if len(cohort_groups) > 1 and len(routes) > 1:
+            matched_pairs.append({
+                "classification": cohort_groups[0]["classification"],
+                "cohort_groups": cohort_groups,
+            })
+        else:
+            unmatched_cohorts.append({
+                "classification": cohort_groups[0]["classification"],
+                "routes": list(routes),
+                "tasks": sum(cg["tasks"] for cg in cohort_groups),
+                "limitation": "Single arm or unrouted only; no matched counter-route under this difficulty class."
+            })
+
+    return {
+        "groups": group_analyses,
+        "matched_comparisons": matched_pairs,
+        "unmatched_cohorts": unmatched_cohorts,
+    }
+
+
+def summarize(receipt, include_comparisons=False):
     validate(receipt)
     groups = {}
     for task in receipt["tasks"]:
@@ -103,7 +250,7 @@ def summarize(receipt):
         summaries.append({"route": first["route"], "classification_timing": first["classification_timing"],
                           "classification": first["classification"], "tasks": len(tasks),
                           "outcomes": outcomes, "metrics": metrics})
-    return {
+    result = {
         "schema": SCHEMA,
         "task_count": len(receipt["tasks"]),
         "groups": summaries,
@@ -117,15 +264,38 @@ def summarize(receipt):
         "limitation": "Descriptive evidence only; groups are not matched experimental arms. "
                       "Unknown values are not zero. Provider usage may omit review and repair work.",
     }
+    if include_comparisons:
+        result["comparisons"] = compare_cohorts(summaries)
+    return result
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("receipt", type=Path)
+    parser.add_argument("receipts", nargs="*", default=["-"],
+                        help="path(s) to receipt JSON file(s) or '-' for stdin")
+    parser.add_argument("--reconcile", action="store_true",
+                        help="reconcile/merge multiple task observations by exact task_ref")
+    parser.add_argument("--compare", action="store_true",
+                        help="include matched-cohort comparison and efficiency metrics")
     args = parser.parse_args()
+    receipt_objects = []
     try:
-        result = summarize(json.loads(args.receipt.read_text()))
-    except (ValueError, TypeError, OSError) as error:
+        for r_path in args.receipts:
+            if r_path == "-":
+                raw = sys.stdin.read()
+                if not raw.strip():
+                    parser.exit(2, "empty input from stdin\n")
+                receipt_objects.append(json.loads(raw))
+            else:
+                p = Path(r_path)
+                receipt_objects.append(json.loads(p.read_text()))
+        if len(receipt_objects) == 1 and not args.reconcile:
+            merged = receipt_objects[0]
+            validate(merged)
+        else:
+            merged = merge_receipts(receipt_objects, reconcile=args.reconcile)
+        result = summarize(merged, include_comparisons=args.compare)
+    except (ValueError, TypeError, OSError, json.JSONDecodeError) as error:
         parser.exit(2, f"invalid receipt: {error}\n")
     print(json.dumps(result, indent=2, allow_nan=False))
 

--- a/scripts/helper_routing_evidence_test.py
+++ b/scripts/helper_routing_evidence_test.py
@@ -97,6 +97,143 @@ class HelperRoutingEvidenceTests(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     evidence.summarize(receipt)
 
+    def test_reconcile_tasks_combines_complementary_evidence(self):
+        # Base execution receipt (like Stensibly projection)
+        exec_task = {
+            "task_ref": "https://github.com/teamleaderleo/compute-node-bootstrap/pull/35",
+            "evidence_refs": ["stensibly-command:sha256:abc"],
+            "route": None,
+            "classification_timing": None,
+            "classification": {"oracle_strength": None, "semantic_ambiguity": None, "coupling": None, "failure_cost": None},
+            "outcomes": {"provider_success": None, "process_completed": None, "verified": True, "accepted": None},
+            "metrics": {"retries": None, "repair_minutes": None, "wall_seconds": None, "task_tokens": None},
+            "provider_usage": [],
+            "limitations": ["OBSERVED: test verification passed."],
+        }
+        # Review outcome annotation
+        review_task = copy.deepcopy(self.task)
+        review_task["outcomes"]["verified"] = None  # review didn't independently re-verify, but verified is in exec_task
+        review_task["route"] = "cheap-first"
+        review_task["classification_timing"] = "before-dispatch"
+
+        reconciled = evidence.reconcile_tasks([exec_task, review_task])
+        self.assertEqual(len(reconciled), 1)
+        r = reconciled[0]
+        self.assertEqual(r["route"], "cheap-first")
+        self.assertEqual(r["classification_timing"], "before-dispatch")
+        self.assertEqual(r["classification"]["oracle_strength"], "strong")
+        self.assertEqual(r["outcomes"]["verified"], True)
+        self.assertEqual(r["outcomes"]["accepted"], True)
+        self.assertIn("stensibly-command:sha256:abc", r["evidence_refs"])
+        self.assertEqual(len(r["provider_usage"]), 1)
+
+    def test_reconcile_tasks_fails_on_conflicting_values(self):
+        for field, bad_val in (
+            ("route", "frontier-first"),
+            ("classification_timing", "before-dispatch"),
+        ):
+            with self.subTest(field=field):
+                t1 = copy.deepcopy(self.task)
+                t1["route"] = "cheap-first"
+                t1["classification_timing"] = "retrospective"
+                t2 = copy.deepcopy(self.task)
+                t2[field] = bad_val
+                with self.assertRaisesRegex(ValueError, "conflicting"):
+                    evidence.reconcile_tasks([t1, t2])
+
+        # Conflicting classification
+        t1 = copy.deepcopy(self.task)
+        t2 = copy.deepcopy(self.task)
+        t2["classification"]["oracle_strength"] = "weak"
+        with self.assertRaisesRegex(ValueError, "conflicting classification"):
+            evidence.reconcile_tasks([t1, t2])
+
+        # Conflicting outcomes
+        t1 = copy.deepcopy(self.task)
+        t2 = copy.deepcopy(self.task)
+        t2["outcomes"]["accepted"] = False
+        with self.assertRaisesRegex(ValueError, "conflicting outcome"):
+            evidence.reconcile_tasks([t1, t2])
+
+    def test_merge_receipts_combines_distinct_receipts_and_reconciles(self):
+        r1 = copy.deepcopy(self.receipt)
+        r2 = copy.deepcopy(self.receipt)
+        r2["tasks"][0]["task_ref"] = "second-task"
+        merged = evidence.merge_receipts([r1, r2])
+        self.assertEqual(len(merged["tasks"]), 2)
+
+        # Merging with duplicate task_ref without reconcile fails
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            evidence.merge_receipts([r1, r1], reconcile=False)
+
+        # Merging with duplicate task_ref with reconcile succeeds
+        reconciled_receipt = evidence.merge_receipts([r1, r1], reconcile=True)
+        self.assertEqual(len(reconciled_receipt["tasks"]), 1)
+
+    def test_compare_cohorts_evaluates_matched_and_unmatched_arms(self):
+        # Create cheap-first task and frontier-first task with same classification
+        cheap_task = copy.deepcopy(self.task)
+        cheap_task["route"] = "cheap-first"
+        cheap_task["metrics"]["repair_minutes"] = 10.0
+        cheap_task["metrics"]["retries"] = 1
+
+        frontier_task = copy.deepcopy(self.task)
+        frontier_task["task_ref"] = "frontier-task"
+        frontier_task["route"] = "frontier-first"
+        frontier_task["metrics"]["repair_minutes"] = 2.0
+        frontier_task["metrics"]["retries"] = 0
+
+        receipt = {"schema": evidence.SCHEMA, "tasks": [cheap_task, frontier_task]}
+        result = evidence.summarize(receipt, include_comparisons=True)
+        comps = result["comparisons"]
+
+        self.assertEqual(len(comps["matched_comparisons"]), 1)
+        matched = comps["matched_comparisons"][0]
+        self.assertEqual(matched["classification"]["oracle_strength"], "strong")
+        self.assertEqual(len(matched["cohort_groups"]), 2)
+
+        # Check metrics per accepted task
+        cheap_group = [g for g in comps["groups"] if g["route"] == "cheap-first"][0]
+        self.assertEqual(cheap_group["acceptance_rate"], 1.0)
+        self.assertEqual(cheap_group["metrics_per_accepted_task"]["repair_minutes"]["known_total_per_accepted"], 10.0)
+        self.assertEqual(cheap_group["metrics_per_accepted_task"]["retries"]["known_total_per_accepted"], 1.0)
+
+    def test_negative_control_records_zero_acceptance_and_verification_failure(self):
+        defect_task = copy.deepcopy(self.task)
+        defect_task["task_ref"] = "defect-task"
+        defect_task["outcomes"] = {
+            "provider_success": True,
+            "process_completed": False,
+            "verified": False,
+            "accepted": False,
+        }
+        receipt = {"schema": evidence.SCHEMA, "tasks": [defect_task]}
+        result = evidence.summarize(receipt, include_comparisons=True)
+        group = result["comparisons"]["groups"][0]
+        self.assertEqual(group["acceptance_rate"], 0.0)
+        self.assertEqual(group["verification_rate"], 0.0)
+        self.assertIsNone(group["metrics_per_accepted_task"]["repair_minutes"])
+
+    def test_cli_execution_via_stdin_and_file(self):
+        import subprocess
+        script = Path(__file__).resolve().parents[1] / "scripts/helper_routing_evidence.py"
+        # Test positional file
+        out = subprocess.check_output(["python3", str(script), str(RECEIPT)], text=True)
+        data = json.loads(out)
+        self.assertEqual(data["task_count"], 1)
+
+        # Test stdin with '-'
+        out_stdin = subprocess.check_output(["python3", str(script), "-"], input=RECEIPT.read_text(), text=True)
+        self.assertEqual(json.loads(out_stdin)["task_count"], 1)
+
+        # Test stdin default
+        out_default = subprocess.check_output(["python3", str(script)], input=RECEIPT.read_text(), text=True)
+        self.assertEqual(json.loads(out_default)["task_count"], 1)
+
+        # Test with --compare
+        out_comp = subprocess.check_output(["python3", str(script), str(RECEIPT), "--compare"], text=True)
+        self.assertIn("comparisons", json.loads(out_comp))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Under #383, starting from merged #386 and Stensibly #1841's receipt projection:

- Adds streaming stdin and multi-file CLI support to `scripts/helper_routing_evidence.py`, enabling direct pipelining from Stensibly's projection (`bun scripts/helper-routing-evidence.ts < results.json | python3 scripts/helper_routing_evidence.py -`).
- Implements exact-task reconciliation (`--reconcile`) to bind physical execution receipts with task-level acceptance/classification annotations without manual JSON editing, failing closed on conflicting values.
- Implements cohort comparison (`--compare`) computing acceptance/verification rates, false provider success gaps, and per-accepted-task metric burdens over known denominators only without imputing zero for missing data.
- Adds research receipt and evaluation under `research/helper-routing/2026-09-05-peer-helper-comparison/` analyzing a 4-task cohort: Muse helper trials on compute-node-bootstrap (#35, #36), negative control on exit-7 false provider success (Stensibly #1821), and Stensibly #1841 execution projection.

Validation: 13 unit tests pass in `scripts/helper_routing_evidence_test.py`, `cargo test --locked`, `cargo clippy`, `cargo fmt`, and reference guard pass.

## Delivery

Consolidated with both known-denominator and timing-aware matching corrections in #389, now merged at d916dbcc4ee6ee0d1c3c55108dcfab754826f972 after independent review and green checks. Closing this superseded proposal; branch evidence is retained.