### PR TITLE
Fix known-denominator rates and timing-aware matching (follow-up to #387)

### DIFF
--- a/research/helper-routing/2026-09-05-peer-helper-comparison/README.md
+++ b/research/helper-routing/2026-09-05-peer-helper-comparison/README.md
@@ -5,7 +5,7 @@ This research receipt records a bounded four-task cohort under [Cultist #383](ht
 ## Hypothesis and Evaluation
 
 Under Cultist #383, the routing discriminator for cheap workers (Muse/Luna/Gemini class) is not benchmark score alone, but the cost and reliability of detecting a wrong answer:
-* **Strong oracle, low ambiguity, local coupling, low failure cost**: cheap-first workers achieve high acceptance when bounded deterministic tests verify behavior.
+* **Strong oracle, low ambiguity, local coupling, low failure cost**: observed 2/2 acceptance in this single-arm retrospective cell when bounded deterministic tests verified behavior; no matched counter-route, so no causal routing claim.
 * **Negative control**: cheap worker self-reports (`provider_success: true`) are uncoupled from real success; without independent machine verification, undetected failures require human/commander escalation.
 * **Execution vs Acceptance separation**: physical test execution receipts (from Stensibly #1841) establish command verification, but full task acceptance remains distinct.
 
@@ -19,7 +19,7 @@ Under Cultist #383, the routing discriminator for cheap workers (Muse/Luna/Gemin
    * Result: Muse implemented peer deadline kill-after grace; verified by positive tests (exit 137) and a negative control omitting grace (exit 124); merged and accepted (cost: 0).
 3. **`stensibly#1821` Negative Control** ([PR #1821](https://github.com/teamleaderleo/stensibly/pull/1821)):
    * Class: strong oracle, low ambiguity, subsystem coupling, medium failure cost (`cheap-first`, retrospective).
-   * Result: Worker emitted structured `SUCCESS` event followed by exit code 7; `provider_success: true`, `process_completed: false`, `verified: false`, `accepted: false`. Required follow-on repair in PR #1840/#1841. Proves worker self-report cannot substitute for machine oracle.
+   * Result: Defective attempt (task_ref attempt-scoped) emitted structured `SUCCESS` event followed by exit code 7; `provider_success: true`, `process_completed: false`, `verified: false`, `accepted: false`. Required follow-on repair in PR #1840/#1841. This attempt-level rejection is distinct from the PR's final merge state. Proves worker self-report cannot substitute for machine oracle.
 4. **`stensibly-1841-adapter-verify`** ([Stensibly PR #1841](https://github.com/teamleaderleo/stensibly/pull/1841)):
    * Class: unrouted workstation execution projection (`route: null`, `classification: null`).
    * Result: Named `verify_focused` check succeeded (`verified: true`); parent task acceptance and process completion remain `unknown`.

--- a/scripts/helper_routing_evidence.py
+++ b/scripts/helper_routing_evidence.py
@@ -171,9 +171,12 @@ def compare_cohorts(groups):
     by_classification = {}
 
     for g in groups:
-        tasks_count = g["tasks"]
-        accepted_true = g["outcomes"]["accepted"]["true"]
-        verified_true = g["outcomes"]["verified"]["true"]
+        accepted = g["outcomes"]["accepted"]
+        verified = g["outcomes"]["verified"]
+        accepted_true = accepted["true"]
+        accepted_known = accepted["true"] + accepted["false"]
+        verified_true = verified["true"]
+        verified_known = verified["true"] + verified["false"]
 
         metrics_per_accepted = {}
         for k in METRICS:
@@ -191,15 +194,18 @@ def compare_cohorts(groups):
             "route": g["route"],
             "classification_timing": g["classification_timing"],
             "classification": g["classification"],
-            "tasks": tasks_count,
-            "acceptance_rate": round(accepted_true / tasks_count, 4) if tasks_count > 0 else None,
-            "verification_rate": round(verified_true / tasks_count, 4) if tasks_count > 0 else None,
+            "tasks": g["tasks"],
+            "acceptance_rate": round(accepted_true / accepted_known, 4) if accepted_known > 0 else None,
+            "verification_rate": round(verified_true / verified_known, 4) if verified_known > 0 else None,
             "outcomes": g["outcomes"],
             "metrics_per_accepted_task": metrics_per_accepted,
         }
         group_analyses.append(analysis)
 
-        class_key = tuple(g["classification"][k] for k in sorted(CLASSES))
+        # Match only within identical difficulty class AND classification timing;
+        # retrospective tags must never pool with before-dispatch arms.
+        class_key = (g["classification_timing"],
+                     tuple(g["classification"][k] for k in sorted(CLASSES)))
         by_classification.setdefault(class_key, []).append(analysis)
 
     matched_pairs = []
@@ -209,14 +215,16 @@ def compare_cohorts(groups):
         if len(cohort_groups) > 1 and len(routes) > 1:
             matched_pairs.append({
                 "classification": cohort_groups[0]["classification"],
+                "classification_timing": cohort_groups[0]["classification_timing"],
                 "cohort_groups": cohort_groups,
             })
         else:
             unmatched_cohorts.append({
                 "classification": cohort_groups[0]["classification"],
+                "classification_timing": cohort_groups[0]["classification_timing"],
                 "routes": list(routes),
                 "tasks": sum(cg["tasks"] for cg in cohort_groups),
-                "limitation": "Single arm or unrouted only; no matched counter-route under this difficulty class."
+                "limitation": "Single arm, unrouted only, or timing-mismatched; no matched counter-route under this difficulty class and classification timing."
             })
 
     return {

--- a/scripts/helper_routing_evidence_test.py
+++ b/scripts/helper_routing_evidence_test.py
@@ -214,6 +214,60 @@ class HelperRoutingEvidenceTests(unittest.TestCase):
         self.assertEqual(group["verification_rate"], 0.0)
         self.assertIsNone(group["metrics_per_accepted_task"]["repair_minutes"])
 
+    def test_unknown_only_outcomes_yield_null_rates_not_zero(self):
+        unknown_task = copy.deepcopy(self.task)
+        unknown_task["task_ref"] = "unknown-task"
+        unknown_task["outcomes"] = {
+            "provider_success": None,
+            "process_completed": None,
+            "verified": None,
+            "accepted": None,
+        }
+        receipt = {"schema": evidence.SCHEMA, "tasks": [unknown_task]}
+        result = evidence.summarize(receipt, include_comparisons=True)
+        group = result["comparisons"]["groups"][0]
+        self.assertIsNone(group["acceptance_rate"])
+        self.assertIsNone(group["verification_rate"])
+
+    def test_mixed_known_unknown_rates_use_known_denominator(self):
+        known_task = copy.deepcopy(self.task)
+        known_task["task_ref"] = "known-task"
+        known_task["outcomes"] = {
+            "provider_success": None,
+            "process_completed": None,
+            "verified": True,
+            "accepted": True,
+        }
+        unknown_task = copy.deepcopy(self.task)
+        unknown_task["task_ref"] = "unknown-task-2"
+        unknown_task["outcomes"] = {
+            "provider_success": None,
+            "process_completed": None,
+            "verified": None,
+            "accepted": None,
+        }
+        # Same route/timing/classification so both land in one group.
+        receipt = {"schema": evidence.SCHEMA, "tasks": [known_task, unknown_task]}
+        result = evidence.summarize(receipt, include_comparisons=True)
+        group = result["comparisons"]["groups"][0]
+        self.assertEqual(group["tasks"], 2)
+        self.assertEqual(group["acceptance_rate"], 1.0)
+        self.assertEqual(group["verification_rate"], 1.0)
+
+    def test_timing_mismatch_is_not_a_matched_comparison(self):
+        cheap_task = copy.deepcopy(self.task)
+        cheap_task["route"] = "cheap-first"
+        cheap_task["classification_timing"] = "retrospective"
+        frontier_task = copy.deepcopy(self.task)
+        frontier_task["task_ref"] = "frontier-task"
+        frontier_task["route"] = "frontier-first"
+        frontier_task["classification_timing"] = "before-dispatch"
+        receipt = {"schema": evidence.SCHEMA, "tasks": [cheap_task, frontier_task]}
+        result = evidence.summarize(receipt, include_comparisons=True)
+        comps = result["comparisons"]
+        self.assertEqual(len(comps["matched_comparisons"]), 0)
+        self.assertEqual(len(comps["unmatched_cohorts"]), 2)
+
     def test_cli_execution_via_stdin_and_file(self):
         import subprocess
         script = Path(__file__).resolve().parents[1] / "scripts/helper_routing_evidence.py"


### PR DESCRIPTION
Follow-up to #387 under Cultist #383.

Independent review of exact head 9ba4e7e1d4c444bd1e6451153f46792d2690f2bf found two defects in the new --compare path:

- acceptance_rate/verification_rate divided by total tasks including unknowns, so the unrouted stensibly-1841 projection (accepted unknown) reported acceptance_rate 0.0 instead of null, contradicting the known-denominators-only claim.
- compare_cohorts matched on classification alone, pooling retrospective with before-dispatch arms despite summarize() never pooling across timing tags.

This PR computes rates over known (true+false) denominators only (null when nothing known) and keys matches on (classification_timing, classification), carrying timing through matched/unmatched outputs. Adds three regression tests (unknown-only null rates, mixed known/unknown denominator, timing-mismatch non-match) and softens the README causal bullet to single-arm observational language with attempt-scope clarification for the stensibly 1821 negative control.

Validation: scripts/helper_routing_evidence_test.py 16 passed; external guard 9 passed; git diff --check clean.

## Delivery

Consolidated with both known-denominator and timing-aware matching corrections in #389, now merged at d916dbcc4ee6ee0d1c3c55108dcfab754826f972 after independent review and green checks. Closing this superseded proposal; branch evidence is retained.